### PR TITLE
Fix CsvimIT execution stability  - improve files watching reset

### DIFF
--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationProcessor.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationProcessor.java
@@ -167,9 +167,7 @@ public class SynchronizationProcessor implements SynchronizationWalkerCallback, 
         }
 
         processing.set(true);
-        if (synchronizationWatcher.isModified()) {
-            synchronizationWatcher.reset();
-        }
+        synchronizationWatcher.reset();
 
         try {
 

--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationProcessor.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationProcessor.java
@@ -167,6 +167,9 @@ public class SynchronizationProcessor implements SynchronizationWalkerCallback, 
         }
 
         processing.set(true);
+        if (synchronizationWatcher.isModified()) {
+            synchronizationWatcher.reset();
+        }
 
         try {
 
@@ -397,7 +400,6 @@ public class SynchronizationProcessor implements SynchronizationWalkerCallback, 
             definitions.clear();
             artefacts.clear();
 
-            synchronizationWatcher.reset();
             initialized.set(true);
             processing.set(false);
         }

--- a/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/api/java/CsvimIT.java
+++ b/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/api/java/CsvimIT.java
@@ -120,7 +120,7 @@ public class CsvimIT extends UserInterfaceIntegrationTest {
     }
 
     private void verifyDataInTable(String tableName, List<Reader> expectedReaders) {
-        await().atMost(60, TimeUnit.SECONDS)
+        await().atMost(30, TimeUnit.SECONDS)
                .pollInterval(1, TimeUnit.SECONDS)
                .until(() -> {
                    try {


### PR DESCRIPTION
Reset synchronization watcher when starting synch processing instead of doing it after the sync execution is completed.

The previous approach leads to skipped file modifications synchronizations, which occur during long synchronization executions. 
Example: if a long running synchronization is executing and a file change is executed in parallel, when the running synchronization complete, it will reset the synch watcher. This will lead to skipped synch execution when the next processing is triggered .

This issue was found when investigating the instability of CsvimIT test execution.