### PR TITLE
Allow registering Snowflake datasources from UI + enhancements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,4 +323,3 @@ Unicons by IconScout: [https://github.com/Iconscout/unicons](https://github.com/
 - Mailing List: [https://dev.eclipse.org/mailman/listinfo/dirigible-dev](https://dev.eclipse.org/mailman/listinfo/dirigible-dev)
 - Issues: [https://github.com/eclipse/dirigible/issues](https://github.com/eclipse/dirigible/issues)
 - Eclipse Foundation Help Desk: https://gitlab.eclipse.org/eclipsefdn/helpdesk
-

--- a/components/data/data-sources/src/main/java/org/eclipse/dirigible/components/data/sources/domain/DataSource.java
+++ b/components/data/data-sources/src/main/java/org/eclipse/dirigible/components/data/sources/domain/DataSource.java
@@ -9,22 +9,15 @@
  */
 package org.eclipse.dirigible.components.data.sources.domain;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.google.gson.annotations.Expose;
+import jakarta.persistence.*;
 import org.eclipse.dirigible.components.base.artefact.Artefact;
 import org.eclipse.dirigible.components.base.encryption.Encrypted;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
-import com.google.gson.annotations.Expose;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The Class DataSource.
@@ -53,12 +46,12 @@ public class DataSource extends Artefact {
     private String url;
 
     /** The username. */
-    @Column(name = "DS_USERNAME", columnDefinition = "VARCHAR", nullable = false, length = 255)
+    @Column(name = "DS_USERNAME", columnDefinition = "VARCHAR", nullable = true, length = 255)
     @Expose
     private String username;
 
     /** The password. */
-    @Column(name = "DS_PASSWORD", columnDefinition = "VARCHAR", nullable = false, length = 255)
+    @Column(name = "DS_PASSWORD", columnDefinition = "VARCHAR", nullable = true, length = 255)
     @Expose
     @Encrypted
     private String password;

--- a/components/data/data-sources/src/main/java/org/eclipse/dirigible/components/data/sources/service/CustomDataSourcesService.java
+++ b/components/data/data-sources/src/main/java/org/eclipse/dirigible/components/data/sources/service/CustomDataSourcesService.java
@@ -38,57 +38,65 @@ public class CustomDataSourcesService {
     public void initialize() {
         String customDataSourcesList = Configuration.get("DIRIGIBLE_DATABASE_CUSTOM_DATASOURCES");
         if ((customDataSourcesList != null) && !"".equals(customDataSourcesList)) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("Custom datasources list: " + customDataSourcesList);
-            }
+            logger.trace("Custom datasources list: [{}]", customDataSourcesList);
             StringTokenizer tokens = new StringTokenizer(customDataSourcesList, ",");
             while (tokens.hasMoreTokens()) {
                 String name = tokens.nextToken();
-                if (logger.isInfoEnabled()) {
-                    logger.info("Initializing a custom datasource with name: " + name);
-                }
+                logger.info("Initializing a custom datasource with name [{}]", name);
                 saveDataSource(name);
             }
         } else {
-            if (logger.isTraceEnabled()) {
-                logger.trace("No custom datasources configured");
-            }
+            logger.trace("No custom datasources configured");
         }
-        if (logger.isDebugEnabled()) {
-            logger.debug(this.getClass()
-                             .getCanonicalName()
-                    + " module initialized.");
-        }
+        logger.debug("[{}] module initialized.", this.getClass()
+                                                     .getCanonicalName());
     }
 
     /**
      * Save data source model.
      *
      * @param name the name
-     * @return the data source
      */
     private void saveDataSource(String name) {
-        String databaseDriver = Configuration.get(name + "_DRIVER");
-        String databaseUrl = Configuration.get(name + "_URL");
-        String databaseUsername = Configuration.get(name + "_USERNAME");
-        String databasePassword = Configuration.get(name + "_PASSWORD");
-        String databaseSchema = Configuration.get(name + "_SCHEMA");
+        String databaseDriver = getRequiredParameter(name, "DRIVER");
+        String databaseUrl = getRequiredParameter(name, "URL");
+        String databaseUsername = getOptionalParameter(name, "USERNAME");
+        String databasePassword = getOptionalParameter(name, "PASSWORD");
+        String databaseSchema = getOptionalParameter(name, "SCHEMA");
 
-        if ((databaseDriver != null) && (databaseUrl != null) && (databaseUsername != null) && (databasePassword != null)) {
-            org.eclipse.dirigible.components.data.sources.domain.DataSource ds =
-                    new org.eclipse.dirigible.components.data.sources.domain.DataSource("ENV_" + name, name, null, databaseDriver,
-                            databaseUrl, databaseUsername, databasePassword);
-            ds.setSchema(databaseSchema);
-            ds.updateKey();
-            ds.setLifecycle(ArtefactLifecycle.NEW);
-            DataSource maybe = dataSourceService.findByKey(ds.getKey());
-            if (maybe != null) {
-                dataSourceService.delete(maybe);
-            }
-            dataSourceService.save(ds);
-        } else {
-            throw new IllegalArgumentException("Invalid configuration for the custom datasource: " + name);
+        org.eclipse.dirigible.components.data.sources.domain.DataSource ds =
+                new org.eclipse.dirigible.components.data.sources.domain.DataSource("ENV_" + name, name, null, databaseDriver, databaseUrl,
+                        databaseUsername, databasePassword);
+        ds.setSchema(databaseSchema);
+        ds.updateKey();
+        ds.setLifecycle(ArtefactLifecycle.NEW);
+        DataSource maybe = dataSourceService.findByKey(ds.getKey());
+        if (maybe != null) {
+            dataSourceService.delete(maybe);
         }
+        dataSourceService.save(ds);
+    }
+
+    private String getRequiredParameter(String dataSourceName, String suffix) {
+        String configName = dataSourceName + "_" + suffix;
+        String value = Configuration.get(configName);
+        if (null == value || value.trim()
+                                  .isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Missing required configuration parameter [" + configName + "] for data source [" + dataSourceName + "]. The value is: "
+                            + value);
+        }
+        return value;
+    }
+
+    private String getOptionalParameter(String dataSourceName, String suffix) {
+        String configName = dataSourceName + "_" + suffix;
+        String value = Configuration.get(configName);
+        if (null == value || value.trim()
+                                  .isEmpty()) {
+            logger.info("Optional parameter [{}] for data source [{}] is missing. The value is: [{}]", configName, dataSourceName, value);
+        }
+        return value;
     }
 
 }

--- a/components/data/data-sources/src/main/java/org/eclipse/dirigible/components/data/sources/service/CustomDataSourcesService.java
+++ b/components/data/data-sources/src/main/java/org/eclipse/dirigible/components/data/sources/service/CustomDataSourcesService.java
@@ -78,19 +78,22 @@ public class CustomDataSourcesService {
     }
 
     private String getRequiredParameter(String dataSourceName, String suffix) {
-        String configName = dataSourceName + "_" + suffix;
+        String configName = createConfigName(dataSourceName, suffix);
         String value = Configuration.get(configName);
         if (null == value || value.trim()
                                   .isEmpty()) {
-            throw new IllegalArgumentException(
-                    "Missing required configuration parameter [" + configName + "] for data source [" + dataSourceName + "]. The value is: "
-                            + value);
+            throw new IllegalArgumentException("Missing required configuration parameter [" + configName + "] for data source ["
+                    + dataSourceName + "]. The value is: " + value);
         }
         return value;
     }
 
+    private String createConfigName(String dataSourceName, String suffix) {
+        return dataSourceName + "_" + suffix;
+    }
+
     private String getOptionalParameter(String dataSourceName, String suffix) {
-        String configName = dataSourceName + "_" + suffix;
+        String configName = createConfigName(dataSourceName, suffix);
         String value = Configuration.get(configName);
         if (null == value || value.trim()
                                   .isEmpty()) {

--- a/components/ide/ide-ui-databases/src/main/resources/META-INF/dirigible/ide-databases/dialogs/database-dialog.html
+++ b/components/ide/ide-ui-databases/src/main/resources/META-INF/dirigible/ide-databases/dialogs/database-dialog.html
@@ -59,10 +59,9 @@
                 </fd-form-group>
                 <fd-form-group>
                     <fd-form-item>
-                        <fd-form-label for="username" dg-colon="true" dg-required="true">Username</fd-form-label>
+                        <fd-form-label for="username" dg-colon="true">Username</fd-form-label>
                         <fd-input id="username" name="username" type="text" placeholder="Enter username"
-                            ng-model="database.username" dg-input-rules="inputRules" ng-trim="false"
-                            state="{{ forms.dbForm['username'].$valid ? '' : 'error' }}" ng-required="true"></fd-input>
+                            ng-model="database.username"></fd-input>
                     </fd-form-item>
                 </fd-form-group>
                 <fd-form-group>

--- a/components/ide/ide-ui-databases/src/main/resources/META-INF/dirigible/ide-databases/dialogs/database-dialog.html
+++ b/components/ide/ide-ui-databases/src/main/resources/META-INF/dirigible/ide-databases/dialogs/database-dialog.html
@@ -77,7 +77,7 @@
                         <fd-form-label for="parameters" dg-colon="true">Parameters</fd-form-label>
                         <fd-input id="parameters" name="parameters" type="text"
                             state="{{ forms.dbForm['parameters'].$valid ? '' : 'error' }}"
-                            dg-input-rules="{patterns: ['^([A-Za-z0-9=,]+)=([A-Za-z0-9]+?)(?=,[^,]+=|$)$']}"
+                            dg-input-rules="{patterns: ['^([A-Za-z0-9._-]+=[A-Za-z0-9._-]+)(,[A-Za-z0-9._-]+=[A-Za-z0-9._-]+)*$']}"
                             placeholder="Enter parameters, e.g. name1=value1,name2=value2 ..."
                             ng-model="database.parameters" ng-minlength="3"></fd-input>
                     </fd-form-item>

--- a/components/ide/ide-ui-databases/src/main/resources/META-INF/dirigible/ide-databases/dialogs/database-dialog.js
+++ b/components/ide/ide-ui-databases/src/main/resources/META-INF/dirigible/ide-databases/dialogs/database-dialog.js
@@ -29,13 +29,23 @@ dbdialog.controller('DBDialogController', ['$scope', 'messageHub', 'ViewParamete
     $scope.editMode = false;
 
     $scope.urls = {
-        "org.h2.Driver": "jdbc:h2:path/name",
-        "org.postgresql.Driver": "jdbc:postgresql://host:port/database",
-        "com.mysql.cj.jdbc.Driver": "jdbc:mysql://host:port/database",
-        "org.mariadb.jdbc.Driver": "jdbc:mariadb://host:port/database",
-        "com.sap.db.jdbc.Driver": "jdbc:sap://host:port/?encrypt=true&validateCertificate=false",
-        "net.snowflake.client.jdbc.SnowflakeDriver": "jdbc:snowflake://account_identifier.snowflakecomputing.com/?db=SNOWFLAKE_SAMPLE_DATA&schema=TPCH_SF1000",
-        "org.eclipse.dirigible.mongodb.jdbc.Driver": "jdbc:mongodb://host:port/database",
+        "org.h2.Driver": "jdbc:h2:<path>/<name>",
+        "org.postgresql.Driver": "jdbc:postgresql://<host>:<port>/<database>",
+        "com.mysql.cj.jdbc.Driver": "jdbc:mysql://<host>:<port>/<database>",
+        "org.mariadb.jdbc.Driver": "jdbc:mariadb://<host>:<port>/<database>",
+        "com.sap.db.jdbc.Driver": "jdbc:sap://<host>:<port>/?encrypt=true&validateCertificate=false",
+        "net.snowflake.client.jdbc.SnowflakeDriver": "jdbc:snowflake://<account_identifier>.snowflakecomputing.com",
+        "org.eclipse.dirigible.mongodb.jdbc.Driver": "jdbc:mongodb://<host>:<port>/<database>",
+    };
+
+    $scope.parameters = {
+        'org.h2.Driver': '',
+        'org.postgresql.Driver': '',
+        'com.mysql.cj.jdbc.Driver': '',
+        'org.mariadb.jdbc.Driver': '',
+        'com.sap.db.jdbc.Driver': '',
+        'net.snowflake.client.jdbc.SnowflakeDriver': 'db=<database>,schema=<schema>',
+        'org.eclipse.dirigible.mongodb.jdbc.Driver': '',
     };
 
     $scope.drivers = [
@@ -61,6 +71,7 @@ dbdialog.controller('DBDialogController', ['$scope', 'messageHub', 'ViewParamete
         $scope.database.url = $scope.urls[$scope.database.driver];
         $scope.database.username = "";
         $scope.database.password = "";
+        $scope.database.parameters = $scope.parameters[$scope.database.driver];
     };
 
     function getTopic() {

--- a/components/platform-ide/view-databases/src/main/resources/META-INF/dirigible/view-databases/dialogs/database-dialog.html
+++ b/components/platform-ide/view-databases/src/main/resources/META-INF/dirigible/view-databases/dialogs/database-dialog.html
@@ -51,9 +51,8 @@
                 </bk-form-group>
                 <bk-form-group>
                     <bk-form-item>
-                        <bk-form-label for="username" colon="true" required>Username</bk-form-label>
-                        <bk-input id="username" name="username" type="text" placeholder="Enter username" ng-model="database.username" input-rules="inputRules" ng-trim="false" state="{{ forms.dbForm['username'].$valid ? '' : 'error' }}"
-                            ng-required="true"></bk-input>
+                        <bk-form-label for="username" colon="true">Username</bk-form-label>
+                        <bk-input id="username" name="username" type="text" placeholder="Enter username" ng-model="database.username"></bk-input>
                     </bk-form-item>
                 </bk-form-group>
                 <bk-form-group>

--- a/components/platform-ide/view-databases/src/main/resources/META-INF/dirigible/view-databases/dialogs/database-dialog.html
+++ b/components/platform-ide/view-databases/src/main/resources/META-INF/dirigible/view-databases/dialogs/database-dialog.html
@@ -65,7 +65,7 @@
                 <bk-form-group>
                     <bk-form-item>
                         <bk-form-label for="parameters" colon="true">Parameters</bk-form-label>
-                        <bk-input id="parameters" name="parameters" type="text" state="{{ forms.dbForm['parameters'].$valid ? '' : 'error' }}" input-rules="{patterns: ['^([A-Za-z0-9=,]+)=([A-Za-z0-9]+?)(?=,[^,]+=|$)$']}"
+                        <bk-input id="parameters" name="parameters" type="text" state="{{ forms.dbForm['parameters'].$valid ? '' : 'error' }}" input-rules="{patterns: ['^([A-Za-z0-9._-]+=[A-Za-z0-9._-]+)(,[A-Za-z0-9._-]+=[A-Za-z0-9._-]+)*$']}"
                             placeholder="Enter parameters, e.g. name1=value1,name2=value2 ..." ng-model="database.parameters" ng-minlength="3"></bk-input>
                     </bk-form-item>
                 </bk-form-group>

--- a/components/platform-ide/view-databases/src/main/resources/META-INF/dirigible/view-databases/dialogs/database-dialog.js
+++ b/components/platform-ide/view-databases/src/main/resources/META-INF/dirigible/view-databases/dialogs/database-dialog.js
@@ -27,13 +27,23 @@ dbdialog.controller('DBDialogController', ($scope, ViewParameters, Dialogs) => {
     };
 
     $scope.urls = {
-        'org.h2.Driver': 'jdbc:h2:path/name',
-        'org.postgresql.Driver': 'jdbc:postgresql://host:port/database',
-        'com.mysql.cj.jdbc.Driver': 'jdbc:mysql://host:port/database',
-        'org.mariadb.jdbc.Driver': 'jdbc:mariadb://host:port/database',
-        'com.sap.db.jdbc.Driver': 'jdbc:sap://host:port/?encrypt=true&validateCertificate=false',
-        'net.snowflake.client.jdbc.SnowflakeDriver': 'jdbc:snowflake://account_identifier.snowflakecomputing.com/?db=SNOWFLAKE_SAMPLE_DATA&schema=TPCH_SF1000',
-        'org.eclipse.dirigible.mongodb.jdbc.Driver': 'jdbc:mongodb://host:port/database',
+        "org.h2.Driver": "jdbc:h2:<path>/<name>",
+        "org.postgresql.Driver": "jdbc:postgresql://<host>:<port>/<database>",
+        "com.mysql.cj.jdbc.Driver": "jdbc:mysql://<host>:<port>/<database>",
+        "org.mariadb.jdbc.Driver": "jdbc:mariadb://<host>:<port>/<database>",
+        "com.sap.db.jdbc.Driver": "jdbc:sap://<host>:<port>/?encrypt=true&validateCertificate=false",
+        "net.snowflake.client.jdbc.SnowflakeDriver": "jdbc:snowflake://<account_identifier>.snowflakecomputing.com",
+        "org.eclipse.dirigible.mongodb.jdbc.Driver": "jdbc:mongodb://<host>:<port>/<database>",
+    };
+
+    $scope.parameters = {
+        'org.h2.Driver': '',
+        'org.postgresql.Driver': '',
+        'com.mysql.cj.jdbc.Driver': '',
+        'org.mariadb.jdbc.Driver': '',
+        'com.sap.db.jdbc.Driver': '',
+        'net.snowflake.client.jdbc.SnowflakeDriver': 'db=<database>,schema=<schema>',
+        'org.eclipse.dirigible.mongodb.jdbc.Driver': '',
     };
 
     $scope.drivers = [
@@ -59,6 +69,7 @@ dbdialog.controller('DBDialogController', ($scope, ViewParameters, Dialogs) => {
         $scope.database.url = $scope.urls[$scope.database.driver];
         $scope.database.username = '';
         $scope.database.password = '';
+        $scope.database.parameters = $scope.parameters[$scope.database.driver];
     };
 
     $scope.save = () => {


### PR DESCRIPTION
- Support more advanced datasource properties
   Like the one in snowflake - https://docs.snowflake.com/en/developer-guide/jdbc/jdbc-parameters
   Example params: `stringsQuotedForColumnDef=false,net.snowflake.jdbc.objectMapper.maxJsonStringLength=180000000,JDBC_GET_DATE_USE_NULL_TIMEZONE=true,enablePatternSearch=true,net.snowflake.jdbc.http_client_socket_timeout_in_ms=300000`

- Update Snowflake database registration template
![image](https://github.com/user-attachments/assets/ecf04981-75e9-4207-beb5-c892e3fd81e5)

- Make datasource  user and password optional.
   There are scenarios where user and password are optional. For example in Snowflake where token file could be used instead.
- user/pass no longer required param for env data sources