### PR TITLE
[API] BPM - Adds Execution Variables

### DIFF
--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/bpm/process.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/bpm/process.ts
@@ -242,6 +242,14 @@ class ExecutionContext {
 		return this.data.callbackType ?? undefined;
 	}
 
+	public getVariable(variableName: string): any | undefined {
+		return this.getVariables()[variableName];
+	}
+
+	public getVariables(): Record<string, any> {
+		return this.data.variables ?? {};
+	}
+
 }
 
 // @ts-ignore

--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/delegate/DirigibleCallDelegate.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/delegate/DirigibleCallDelegate.java
@@ -9,10 +9,12 @@
  */
 package org.eclipse.dirigible.components.engine.bpm.flowable.delegate;
 
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.context.Scope;
-import jakarta.annotation.Nullable;
+import static org.eclipse.dirigible.components.engine.bpm.flowable.dto.ActionData.Action.SKIP;
+import static org.eclipse.dirigible.components.engine.bpm.flowable.service.BpmService.DIRIGIBLE_BPM_INTERNAL_SKIP_STEP;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
 import org.eclipse.dirigible.commons.api.helpers.GsonHelper;
 import org.eclipse.dirigible.components.engine.bpm.flowable.dto.ExecutionData;
 import org.eclipse.dirigible.components.open.telemetry.OpenTelemetryProvider;
@@ -26,14 +28,10 @@ import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Component;
-
-import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Pattern;
-
-import static org.eclipse.dirigible.components.engine.bpm.flowable.dto.ActionData.Action.SKIP;
-import static org.eclipse.dirigible.components.engine.bpm.flowable.service.BpmService.DIRIGIBLE_BPM_INTERNAL_SKIP_STEP;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import jakarta.annotation.Nullable;
 
 /**
  * The Class DirigibleCallDelegate.

--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/dto/ExecutionData.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/dto/ExecutionData.java
@@ -1019,7 +1019,7 @@ public class ExecutionData {
     /**
      * Sets the variables.
      *
-     * @param callbackType the new callback type
+     * @param variables the new callback type
      */
     public void setVariables(Map<String, Object> variables) {
         this.variables = variables;

--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/dto/ExecutionData.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/dto/ExecutionData.java
@@ -10,6 +10,7 @@
 package org.eclipse.dirigible.components.engine.bpm.flowable.dto;
 
 import java.util.Date;
+import java.util.Map;
 
 /**
  * The Class ExecutionData.
@@ -156,6 +157,9 @@ public class ExecutionData {
 
     /** The callback type. */
     protected String callbackType;
+
+    /** The variables. */
+    protected Map<String, Object> variables;
 
     /**
      * Gets the id.
@@ -1001,6 +1005,24 @@ public class ExecutionData {
      */
     public void setCallbackType(String callbackType) {
         this.callbackType = callbackType;
+    }
+
+    /**
+     * Gets the variables.
+     *
+     * @return the variables
+     */
+    public Map<String, Object> getVariables() {
+        return variables;
+    }
+
+    /**
+     * Sets the variables.
+     *
+     * @param callbackType the new callback type
+     */
+    public void setVariables(Map<String, Object> variables) {
+        this.variables = variables;
     }
 
 }


### PR DESCRIPTION
Now the execution variables can be accessed as follows:
```ts
import { Process } from "sdk/bpm"

const variables = Process.getExecutionContext().getVariables();
const variable1 = Process.getExecutionContext().getVariable("variableName");
```

Fixes: #4602