### PR TITLE
[IDE] Preformatted Alert Dialog

### DIFF
--- a/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/templates/ideDialogs.html
+++ b/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/templates/ideDialogs.html
@@ -10,7 +10,7 @@
                     </div>
                 </div>
             </header>
-            <div class="fd-message-box__body">{{ alert.message }}</div>
+            <pre class="fd-message-box__body">{{ alert.message }}</pre>
             <footer class="fd-bar fd-bar--compact fd-bar--footer fd-message-box__footer">
                 <div class="fd-bar__right">
                     <div class="fd-bar__element">


### PR DESCRIPTION
Set the text of the alert dialog to be always preformatted _(using the `<pre>` instead of the `<div>` tag)_.

Without Formatting:
<img width="1920" alt="without-format" src="https://github.com/user-attachments/assets/48059d14-6e54-48d1-bd09-a9a1d5d54b2c" />

Preformatted:
<img width="1920" alt="preformatted" src="https://github.com/user-attachments/assets/97a9267a-fe55-41be-bfc9-d77935273299" />
