### PR TITLE
[IDE] Processes - Content of Jobs Incidents to be Preformatted

### DIFF
--- a/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/js/bpm-process-jobs.js
+++ b/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/js/bpm-process-jobs.js
@@ -36,7 +36,7 @@ ideBpmProcessJobsView.controller('IDEBpmProcessJobsViewController', ['$scope', '
     }
 
     $scope.openDialog = function(job) {
-        messageHub.showAlertError(job.exceptionMessage, job.exceptionStacktrace);
+        messageHub.showAlertError(job.exceptionMessage, job.exceptionStacktrace, true);
     }
 
     messageHub.onDidReceiveMessage('instance.selected', function (msg) {


### PR DESCRIPTION
Set the text of the alert dialog to be preformatted _(using the `<pre>` instead of the `<div>` tag)_.

Without Formatting:
<img width="1920" alt="without-format" src="https://github.com/user-attachments/assets/48059d14-6e54-48d1-bd09-a9a1d5d54b2c" />

Preformatted:
<img width="1920" alt="preformatted" src="https://github.com/user-attachments/assets/97a9267a-fe55-41be-bfc9-d77935273299" />
