### PR TITLE
Feature/develocity build cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ package.json
 package-lock.json
 **/logs
 /ttyd.sh
+
+# Develocity
+.mvn/.develocity/develocity-workspace-id

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -18,7 +18,7 @@
   <server>
     <url>https://develocity-staging.eclipse.org</url>
   </server>
-  <projectId>ecd.che</projectId>
+  <projectId>ecd.dirigible</projectId>
   <buildScan>
     <obfuscation>
       <ipAddresses>0.0.0.0</ipAddresses>
@@ -32,10 +32,10 @@
   </buildScan>
   <buildCache>
     <local>
-      <enabled>false</enabled>
+      <enabled>#{isFalse(env['CI'])}</enabled>
     </local>
     <remote>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
       <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
     </remote>
   </buildCache>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<!--
+
+    Copyright (c) 2012-2025 Red Hat, Inc. and others.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Gasper Kojek
+
+-->
+<develocity
+  xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <server>
+    <url>https://develocity-staging.eclipse.org</url>
+  </server>
+  <projectId>ecd.che</projectId>
+  <buildScan>
+    <obfuscation>
+      <ipAddresses>0.0.0.0</ipAddresses>
+    </obfuscation>
+    <publishing>
+      <onlyIf>
+        <![CDATA[authenticated]]>
+      </onlyIf>
+    </publishing>
+    <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>false</enabled>
+    </local>
+    <remote>
+      <enabled>false</enabled>
+      <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
+    </remote>
+  </buildCache>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2025 Red Hat, Inc. and others.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Gasper Kojek
+
+-->
+<extensions>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>develocity-maven-extension</artifactId>
+		<version>1.23.1</version>
+	</extension>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>common-custom-user-data-maven-extension</artifactId>
+		<version>2.0.1</version>
+	</extension>
+</extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,9 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
 					<version>${maven-javadoc-plugin.version}</version>
+					<configuration>
+						<detectOfflineLinks>false</detectOfflineLinks>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Dirigible's Contributing Guide: https://github.com/eclipse/dirigible/blob/master/CONTRIBUTING.md

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/dirigible/labels
-->

### What does this PR do?
This PR will enable you to publish Build Scans to [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org) as explained in the issue https://github.com/eclipse-dirigible/dirigible/issues/4687.

#### Description
This PR publishes a build scan for every CI build and for every local build from an authenticated Eclipse committer. The build will not fail if publishing fails. Setting the access key env var was added in relevant CI pipelines, however, the secret will need to be set by Eclipse infra - you can initiate that by opening a [helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) ticket.

The build scans of the Eclipse Dirigible project are published to the Develocity instance at [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), hosted by the Eclipse Foundation and run in partnership between the Eclipse and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Eclipse Dirigible project and all other Eclipse projects.

On this Develocity instance, the Eclipse Dirigible project will have access not only to all of the published build scans but also to other aggregate data features such as:

* Dashboards to view all historical build scans, along with performance [trends](https://develocity-staging.eclipse.org/scans/trends?search.relativeStartTime=P28D&trends.timeResolution=week) over time. For example, look at the [Quarkus instance trends dashboard](https://ge.quarkus.io/scans/trends?search.relativeStartTime=P28D&search.tags=ci&search.timeZoneId=Europe%2FLjubljana) with the `ci` filter applied.
* [Build failure analytics](https://develocity-staging.eclipse.org/scans/failures?search.relativeStartTime=P28D) for enhanced investigation and diagnosis of build failures. You can also explore the [Quarkus instance](https://ge.quarkus.io/scans/failures?search.relativeStartTime=P28D&search.timeZoneId=Europe%2FLjubljana) for example of a different OSS projects Develocity instance.
* [Test failure analytics](https://develocity-staging.eclipse.org/scans/tests?search.relativeStartTime=P28D) to better understand trends and causes around slow, failing, and flaky tests. Going to the [Quarkus instance](https://ge.quarkus.io/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Europe%2FLjubljana) again, this will probably give you a better representation of the type of data available. You can also order it by flakiness, which is a good starting point when deciding which tests need fixing the most.

This will also enable you to (optionally) use build time optimization features, such as (remote) build caching and Predictive Test Selection. In this PR, build caching is enabled, with the local cache being disabled on CI and only allowing CI to write to the remote cache, as per the general recommendations.

As explained in the [Eclipse Develocity documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration), you can start publishing scans locally if you run the `mvn develocity:provision-access-key` goal, which will take you to [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), where you can log in with your eclipse account and confirm access key generation. All the subsequent builds will be published.

Caching can be tested without setting up the Develocity credentials - simply run 2 or more builds (the first one will fill the local cache, next ones can use it).

More information can be read in the [Eclipse announcement](https://www.eclipse.org/lists/cross-project-issues-dev/msg20000.html). 

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.

#### IMPORTANT
**To get scans publishing on CI, a [helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) ticket needs to be opened in order for those credentials to be created, as explained in the [initiative documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration).**

### What issues does this PR fix or reference?

This is related to issue https://github.com/eclipse-dirigible/dirigible/issues/4687.


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A
