### PR TITLE
Remove Spring devtools

### DIFF
--- a/build/application/pom.xml
+++ b/build/application/pom.xml
@@ -210,12 +210,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<scope>runtime</scope>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
 		</dependency>

--- a/build/application/src/main/resources/application.properties
+++ b/build/application/src/main/resources/application.properties
@@ -32,9 +32,6 @@ terminal.enabled=${DIRIGIBLE_TERMINAL_ENABLED:true}
 management.metrics.mongo.command.enabled=false
 management.metrics.mongo.connectionpool.enabled=false
 
-spring.devtools.restart.poll-interval=6s
-spring.devtools.restart.quiet-period=5s
-
 cxf.path=/odata/v2
 
 management.endpoints.web.exposure.include=*


### PR DESCRIPTION
Remove Spring devtools since sometimes it doesn't work due to classloader issues (most probably caused by the Graal).
