### PR TITLE
[Form Builder] Add table widget

### DIFF
--- a/components/template/template-form-builder-angularjs/src/main/resources/META-INF/dirigible/template-form-builder-angularjs/ui/controller.js.template
+++ b/components/template/template-form-builder-angularjs/src/main/resources/META-INF/dirigible/template-form-builder-angularjs/ui/controller.js.template
@@ -15,7 +15,7 @@ angular.module('forms', ['blimpKit', 'platformView']).controller('FormController
     $scope.model = {};
 #macro(formWidgets $elements)
 #foreach($element in $elements)
-	#if($element.controlId == "input-number")
+    #if($element.controlId == "input-number")
     $scope.model.$element.model = 0;
 	#elseif($element.controlId == "input-checkbox")
     $scope.model.$element.model = false;
@@ -51,9 +51,9 @@ angular.module('forms', ['blimpKit', 'platformView']).controller('FormController
     $scope.model.$element.model = '#ffbe6f';
 	#elseif($element.controlId == "paragraph")
     #if($element.model && $element.text)
-        $scope.model.$element.model = `$element.text`;
+    $scope.model.$element.model = `$element.text`;
     #elseif($element.model)
-        $scope.model.$element.model = null;
+    $scope.model.$element.model = null;
     #end
 	#end
     #if($element.children)

--- a/components/template/template-form-builder-angularjs/src/main/resources/META-INF/dirigible/template-form-builder-angularjs/ui/index.html.template
+++ b/components/template/template-form-builder-angularjs/src/main/resources/META-INF/dirigible/template-form-builder-angularjs/ui/index.html.template
@@ -133,6 +133,19 @@
 					</bk-form-item>
 		#end
 				</bk-form-group>
+	#elseif($element.controlId == "table")
+				<table bk-table fixed="$element.isFixed" display-mode="$element.displayMode" outer-borders="$element.outerBorders" inner-borders="$element.innerBorders">
+					<thead bk-table-header interactive="false">
+						<tr bk-table-row>
+							<th bk-table-header-cell ng-repeat="header in ${element.model}.headers track by $index">{{header}}</th>
+						</tr>
+					</thead>
+					<tbody bk-table-body>
+						<tr bk-table-row hoverable="false" activable="false" ng-repeat="cell in ${element.model}.rows track by $index">
+							<td bk-table-cell ng-repeat="next in cell">{{next}}</td>
+						</tr>
+					</tbody>
+				</table>
 	#elseif($element.controlId == "button")
 				<div>
 					<bk-button#if($element.sizeToText) class="bk-float-right"#else class="bk-full-width"#end #if($element.isSubmit)type="submit" ng-disabled="!forms.form.$valid"#end label="$element.label" compact="$element.isCompact" state="$element.type"#if($element.callback) ng-click="$element.callback"#end></bk-button>

--- a/components/template/template-form-builder-angularjs/src/main/resources/META-INF/dirigible/template-form-builder-angularjs/ui/index.html.template
+++ b/components/template/template-form-builder-angularjs/src/main/resources/META-INF/dirigible/template-form-builder-angularjs/ui/index.html.template
@@ -137,12 +137,16 @@
 				<table bk-table fixed="$element.isFixed" display-mode="$element.displayMode" outer-borders="$element.outerBorders" inner-borders="$element.innerBorders">
 					<thead bk-table-header interactive="false">
 						<tr bk-table-row>
-							<th bk-table-header-cell ng-repeat="header in ${element.model}.headers track by $index">{{header}}</th>
+		#foreach($header in $element.headers)
+							<th bk-table-header-cell>$header.label</th>
+		#end
 						</tr>
 					</thead>
 					<tbody bk-table-body>
-						<tr bk-table-row hoverable="false" activable="false" ng-repeat="cell in ${element.model}.rows track by $index">
-							<td bk-table-cell ng-repeat="next in cell">{{next}}</td>
+						<tr bk-table-row hoverable="false" activable="false" ng-repeat="cell in ${element.model} track by $index">
+		#foreach($header in $element.headers)
+							<td bk-table-cell>{{cell['$header.value']}}</td>
+		#end
 						</tr>
 					</tbody>
 				</table>

--- a/components/ui/editor-form-builder/src/main/resources/META-INF/dirigible/editor-form-builder/editor.html
+++ b/components/ui/editor-form-builder/src/main/resources/META-INF/dirigible/editor-form-builder/editor.html
@@ -99,6 +99,11 @@
                                         </bk-form-input-message>
                                     </bk-form-item>
 
+                                    <bk-form-item ng-if="item.type === 'textinfo'">
+                                        <bk-form-label colon="true" for="{{ 'p' + key }}">{{ item.label }}</bk-form-label>
+                                        <bk-textarea id="{{ item.id }}" style="min-height:12rem" name="{{ 'p' + key }}" ng-model="item.value" ng-readonly="true"></bk-textarea>
+                                    </bk-form-item>
+
                                     <bk-form-item ng-if="item.type === 'number' && isPropEnabled(item.enabledOn)">
                                         <bk-form-label colon="true" required="item.required" for="{{ 'p' + key }}">{{ item.label }}</bk-form-label>
                                         <bk-step-input input-id="{{ 'p' + key }}" ng-model="item.value" state="{{ item.error ? 'error' : '' }}" name="{{ 'p' + key }}" ng-required="item.required" ng-attr-min="item.min" ng-attr-max="item.max"
@@ -124,7 +129,7 @@
                                             <bk-button glyph="sap-icon--add" compact="true" title="Add option to list" state="transparent" label="Add" aria-label="Add option to list" ng-click="addListItem(item)"></bk-button>
                                         </div>
                                         <table bk-table display-mode="compact">
-                                            <thead bk-table-header>
+                                            <thead bk-table-header interactive="false">
                                                 <tr bk-table-row>
                                                     <th bk-table-header-cell content-type="checkbox"></th>
                                                     <th bk-table-header-cell>Label</th>
@@ -133,14 +138,14 @@
                                                 </tr>
                                             </thead>
                                             <tbody bk-table-body>
-                                                <tr bk-table-row hoverable="true" ng-repeat="listItem in item.value track by $index">
-                                                    <td bk-table-cell content-type="checkbox">
+                                                <tr bk-table-row hoverable="false" ng-repeat="listItem in item.value track by $index">
+                                                    <td bk-table-cell interactive="false" content-type="checkbox">
                                                         <bk-checkbox id="{{listItem + $index}}" ng-checked="item.defaultValue === listItem.value" ng-click="setListDefault(item, $index)"></bk-checkbox>
                                                         <bk-checkbox-label empty="true" for="{{listItem + $index}}"></bk-checkbox-label>
                                                     </td>
-                                                    <td bk-table-cell>{{listItem.label}}</td>
-                                                    <td bk-table-cell>{{listItem.value}}</td>
-                                                    <td bk-table-cell fit-content="true">
+                                                    <td bk-table-cell interactive="false">{{listItem.label}}</td>
+                                                    <td bk-table-cell interactive="false">{{listItem.value}}</td>
+                                                    <td bk-table-cell interactive="false" fit-content="true">
                                                         <bk-button glyph="sap-icon--edit" title="Edit option" state="transparent" aria-label="Edit option" ng-click="editListItem(listItem)"></bk-button>
                                                         <bk-button glyph="sap-icon--delete" title="Delete option" state="transparent" aria-label="Delete option" ng-click="deleteListItem(item.value, $index)"></bk-button>
                                                     </td>

--- a/components/ui/editor-form-builder/src/main/resources/META-INF/dirigible/editor-form-builder/editor.html
+++ b/components/ui/editor-form-builder/src/main/resources/META-INF/dirigible/editor-form-builder/editor.html
@@ -101,7 +101,7 @@
 
                                     <bk-form-item ng-if="item.type === 'textinfo'">
                                         <bk-form-label colon="true" for="{{ 'p' + key }}">{{ item.label }}</bk-form-label>
-                                        <bk-textarea id="{{ item.id }}" style="min-height:12rem" name="{{ 'p' + key }}" ng-model="item.value" ng-readonly="true"></bk-textarea>
+                                        <bk-textarea id="{{ item.id }}" style="min-height:14.25rem" name="{{ 'p' + key }}" ng-model="item.value" ng-readonly="true"></bk-textarea>
                                     </bk-form-item>
 
                                     <bk-form-item ng-if="item.type === 'number' && isPropEnabled(item.enabledOn)">
@@ -131,22 +131,22 @@
                                         <table bk-table display-mode="compact">
                                             <thead bk-table-header interactive="false">
                                                 <tr bk-table-row>
-                                                    <th bk-table-header-cell content-type="checkbox"></th>
-                                                    <th bk-table-header-cell>Label</th>
-                                                    <th bk-table-header-cell>Value</th>
+                                                    <th ng-if="item.defaultValue" bk-table-header-cell content-type="checkbox"></th>
+                                                    <th bk-table-header-cell>{{ item.labelText }}</th>
+                                                    <th bk-table-header-cell>{{ item.valueText }}</th>
                                                     <th bk-table-header-cell></th>
                                                 </tr>
                                             </thead>
                                             <tbody bk-table-body>
                                                 <tr bk-table-row hoverable="false" ng-repeat="listItem in item.value track by $index">
-                                                    <td bk-table-cell interactive="false" content-type="checkbox">
+                                                    <td ng-if="item.defaultValue" bk-table-cell interactive="false" content-type="checkbox">
                                                         <bk-checkbox id="{{listItem + $index}}" ng-checked="item.defaultValue === listItem.value" ng-click="setListDefault(item, $index)"></bk-checkbox>
                                                         <bk-checkbox-label empty="true" for="{{listItem + $index}}"></bk-checkbox-label>
                                                     </td>
                                                     <td bk-table-cell interactive="false">{{listItem.label}}</td>
                                                     <td bk-table-cell interactive="false">{{listItem.value}}</td>
                                                     <td bk-table-cell interactive="false" fit-content="true">
-                                                        <bk-button glyph="sap-icon--edit" title="Edit option" state="transparent" aria-label="Edit option" ng-click="editListItem(listItem)"></bk-button>
+                                                        <bk-button glyph="sap-icon--edit" title="Edit option" state="transparent" aria-label="Edit option" ng-click="editListItem(listItem, item.labelText, item.valueText)"></bk-button>
                                                         <bk-button glyph="sap-icon--delete" title="Delete option" state="transparent" aria-label="Delete option" ng-click="deleteListItem(item.value, $index)"></bk-button>
                                                     </td>
                                                 </tr>

--- a/components/ui/editor-form-builder/src/main/resources/META-INF/dirigible/editor-form-builder/js/editor.js
+++ b/components/ui/editor-form-builder/src/main/resources/META-INF/dirigible/editor-form-builder/js/editor.js
@@ -722,6 +722,8 @@ editorView.controller('DesignerController', ($scope, $window, $document, $timeou
                             enabledOn: { key: 'staticData', value: true },
                             type: 'list',
                             label: 'Options',
+                            labelText: 'Label',
+                            valueText: 'Value',
                             defaultValue: '',
                             value: [
                                 { label: 'Item 1', value: 'item1' },
@@ -833,6 +835,8 @@ editorView.controller('DesignerController', ($scope, $window, $document, $timeou
                             enabledOn: { key: 'staticData', value: true },
                             type: 'list',
                             label: 'Options',
+                            labelText: 'Label',
+                            valueText: 'Value',
                             defaultValue: '',
                             value: [
                                 { label: 'Item 1', value: 'item1' },
@@ -956,18 +960,12 @@ editorView.controller('DesignerController', ($scope, $window, $document, $timeou
                         <table bk-table fixed="props.isFixed.value" display-mode="{{props.displayMode.value}}" outer-borders="{{props.outerBorders.value}}" inner-borders="{{props.innerBorders.value}}">
                             <thead bk-table-header interactive="false">
                                 <tr bk-table-row>
-                                    <th bk-table-header-cell>Name</th>
-                                    <th bk-table-header-cell>Age</th>
+                                    <th bk-table-header-cell ng-repeat="header in props.headers.value track by $index">{{header.label}}</th>
                                 </tr>
                             </thead>
                             <tbody bk-table-body>
                                 <tr bk-table-row hoverable="false" activable="false">
-                                    <td bk-table-cell>Ivan</td>
-                                    <td bk-table-cell>34</td>
-                                </tr>
-                                <tr bk-table-row hoverable="false" activable="false">
-                                    <td bk-table-cell>John</td>
-                                    <td bk-table-cell>46</td>
+                                    <td bk-table-cell ng-repeat="header in props.headers.value track by $index">row['{{header.value}}']</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -1062,6 +1060,16 @@ editorView.controller('DesignerController', ($scope, $window, $document, $timeou
                                 },
                             ]
                         },
+                        headers: {
+                            type: 'list',
+                            label: 'Headers',
+                            labelText: 'Label',
+                            valueText: 'Key',
+                            value: [
+                                { label: 'Name', value: 'name' },
+                                { label: 'Age', value: 'age' }
+                            ]
+                        },
                         model: {
                             type: 'text',
                             label: 'Model',
@@ -1071,7 +1079,7 @@ editorView.controller('DesignerController', ($scope, $window, $document, $timeou
                         info: {
                             type: 'textinfo',
                             label: 'Example model data',
-                            value: `{\n  headers: ['Name', 'Age'],\n  rows: [\n    ['Ivan', 34],\n    ['John', 46]\n  ]\n}`,
+                            value: `[\n   {\n      "name":"John Doe",\n      "age":34\n   },\n   {\n      "name":"Jane Doe",\n      "age":35\n   }\n]`,
                         },
                     },
                 },
@@ -1345,7 +1353,7 @@ editorView.controller('DesignerController', ($scope, $window, $document, $timeou
             title: 'Add item',
             form: {
                 'aliLabel': {
-                    label: 'Label',
+                    label: item.labelText,
                     controlType: 'input',
                     placeholder: '',
                     type: 'text',
@@ -1354,7 +1362,7 @@ editorView.controller('DesignerController', ($scope, $window, $document, $timeou
                     required: true
                 },
                 'aliValue': {
-                    label: 'Value',
+                    label: item.valueText,
                     controlType: 'input',
                     placeholder: '',
                     type: 'text',
@@ -1395,12 +1403,12 @@ editorView.controller('DesignerController', ($scope, $window, $document, $timeou
         });
     };
 
-    $scope.editListItem = (listItem) => {
+    $scope.editListItem = (listItem, labelText, valueText) => {
         dialogHub.showFormDialog({
             title: 'Edit item',
             form: {
                 'aliLabel': {
-                    label: 'Label',
+                    label: labelText,
                     controlType: 'input',
                     placeholder: '',
                     type: 'text',
@@ -1410,7 +1418,7 @@ editorView.controller('DesignerController', ($scope, $window, $document, $timeou
                     required: true
                 },
                 'aliValue': {
-                    label: 'Value',
+                    label: valueText,
                     controlType: 'input',
                     placeholder: '',
                     type: 'text',

--- a/components/ui/editor-form-builder/src/main/resources/META-INF/dirigible/editor-form-builder/js/editor.js
+++ b/components/ui/editor-form-builder/src/main/resources/META-INF/dirigible/editor-form-builder/js/editor.js
@@ -947,6 +947,134 @@ editorView.controller('DesignerController', ($scope, $window, $document, $timeou
                         },
                     },
                 },
+                {
+                    controlId: 'table',
+                    label: 'Table',
+                    icon: 'sap-icon--table-view',
+                    description: 'Table container',
+                    template: `<div class="fb-control-wrapper" ng-click="showProps($event)" data-id="{{id}}"><bk-form-item horizontal="false">
+                        <table bk-table fixed="props.isFixed.value" display-mode="{{props.displayMode.value}}" outer-borders="{{props.outerBorders.value}}" inner-borders="{{props.innerBorders.value}}">
+                            <thead bk-table-header interactive="false">
+                                <tr bk-table-row>
+                                    <th bk-table-header-cell>Name</th>
+                                    <th bk-table-header-cell>Age</th>
+                                </tr>
+                            </thead>
+                            <tbody bk-table-body>
+                                <tr bk-table-row hoverable="false" activable="false">
+                                    <td bk-table-cell>Ivan</td>
+                                    <td bk-table-cell>34</td>
+                                </tr>
+                                <tr bk-table-row hoverable="false" activable="false">
+                                    <td bk-table-cell>John</td>
+                                    <td bk-table-cell>46</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </bk-form-item></div>`,
+                    props: {
+                        id: {
+                            type: 'text',
+                            label: 'ID',
+                            placeholder: 'Form Item ID',
+                            value: '',
+                            required: true,
+                        },
+                        isFixed: {
+                            type: 'checkbox',
+                            label: 'Fixed',
+                            value: false,
+                        },
+                        displayMode: {
+                            type: 'dropdown',
+                            label: 'Display mode',
+                            value: '',
+                            items: [
+                                {
+                                    label: 'Default',
+                                    value: '',
+                                },
+                                {
+                                    label: 'Compact',
+                                    value: 'compact',
+                                },
+                                {
+                                    label: 'Condensed',
+                                    value: 'condensed',
+                                },
+                            ]
+                        },
+                        outerBorders: {
+                            type: 'dropdown',
+                            label: 'Outer borders',
+                            value: '',
+                            items: [
+                                {
+                                    label: 'All',
+                                    value: '',
+                                },
+                                {
+                                    label: 'Horizontal',
+                                    value: 'horizontal',
+                                },
+                                {
+                                    label: 'Vertical',
+                                    value: 'vertical',
+                                },
+                                {
+                                    label: 'Top',
+                                    value: 'top',
+                                },
+                                {
+                                    label: 'Bottom',
+                                    value: 'bottom',
+                                },
+                                {
+                                    label: 'None',
+                                    value: 'none',
+                                },
+                            ]
+                        },
+                        innerBorders: {
+                            type: 'dropdown',
+                            label: 'Inner borders',
+                            value: '',
+                            items: [
+                                {
+                                    label: 'All',
+                                    value: '',
+                                },
+                                {
+                                    label: 'Horizontal',
+                                    value: 'horizontal',
+                                },
+                                {
+                                    label: 'Vertical',
+                                    value: 'vertical',
+                                },
+                                {
+                                    label: 'Top',
+                                    value: 'top',
+                                },
+                                {
+                                    label: 'None',
+                                    value: 'none',
+                                },
+                            ]
+                        },
+                        model: {
+                            type: 'text',
+                            label: 'Model',
+                            value: '',
+                            placeholder: 'tableData',
+                        },
+                        info: {
+                            type: 'textinfo',
+                            label: 'Example model data',
+                            value: `{\n  headers: ['Name', 'Age'],\n  rows: [\n    ['Ivan', 34],\n    ['John', 46]\n  ]\n}`,
+                        },
+                    },
+                },
             ]
         },
         {
@@ -1646,12 +1774,14 @@ editorView.controller('DesignerController', ($scope, $window, $document, $timeou
                     groupId: model[i].groupId
                 };
                 for (const key in model[i].$scope.props) {
-                    if (model[i].$scope.props[key].enabledOn) {
-                        if (model[i].$scope.props[model[i].$scope.props[key].enabledOn.key].value === model[i].$scope.props[key].enabledOn.value)
-                            //@ts-ignore
+                    if (model[i].$scope.props[key].type !== 'textinfo') {
+                        if (model[i].$scope.props[key].enabledOn) {
+                            if (model[i].$scope.props[model[i].$scope.props[key].enabledOn.key].value === model[i].$scope.props[key].enabledOn.value)
+                                //@ts-ignore
+                                controlObj[key] = model[i].$scope.props[key].value;
+                        } else { //@ts-ignore
                             controlObj[key] = model[i].$scope.props[key].value;
-                    } else { //@ts-ignore
-                        controlObj[key] = model[i].$scope.props[key].value;
+                        }
                     }
                 }
                 formJson.push(controlObj);

--- a/components/ui/platform-core/src/main/resources/META-INF/dirigible/platform-core/ui/blimpkit/blimpkit.js
+++ b/components/ui/platform-core/src/main/resources/META-INF/dirigible/platform-core/ui/blimpkit/blimpkit.js
@@ -10,7 +10,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 const blimpkit = angular.module('blimpKit', ['ngAria'])
-    .info({ version: '1.4.3' })
+    .info({ version: '1.4.4' })
     .constant('ScreenEdgeMargin', {
         FULL: 16,
         DOUBLE: 32,

--- a/components/ui/platform-core/src/main/resources/META-INF/dirigible/platform-core/ui/blimpkit/table.js
+++ b/components/ui/platform-core/src/main/resources/META-INF/dirigible/platform-core/ui/blimpkit/table.js
@@ -26,8 +26,8 @@ blimpkit.directive('bkTable', (classNames) => ({
         $scope.getClasses = () => classNames('fd-table', {
             'fd-table--top-border fd-table--no-horizontal-borders fd-table--no-vertical-borders': $scope.innerBorders === 'top',
             'fd-table--no-horizontal-borders fd-table--no-vertical-borders': $scope.innerBorders === 'none',
-            'fd-table--no-horizontal-borders': $scope.innerBorders === 'horizontal',
-            'fd-table--no-vertical-borders': $scope.innerBorders === 'vertical',
+            'fd-table--no-horizontal-borders': $scope.innerBorders === 'vertical',
+            'fd-table--no-vertical-borders': $scope.innerBorders === 'horizontal',
             'fd-table--compact': $scope.displayMode === 'compact',
             'fd-table--condensed': $scope.displayMode === 'condensed',
             'bk-table--no-outer-horizontal-borders': $scope.outerBorders === 'vertical',


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Dirigible's Contributing Guide: https://github.com/eclipse/dirigible/blob/master/CONTRIBUTING.md

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/dirigible/labels
-->

### What does this PR do?

Adds a table widget to the form editor.
There is a difference between the feature request and the implementation.
It proved to be rather complicated to fill an HTML table using separate column data lists, so the table model has to be represented by a JSON/JS object with specific structure and properties. Example:

```javascript
$scope.tableData = [
   {
      "name":"John Doe",
      "age":34
   },
   {
      "name":"Jane Doe",
      "age":35
   }
];
```

The column headers and row keys are set inside the editor.

![Screen Shot 2025-05-05 at 15 10 24](https://github.com/user-attachments/assets/0fc52f55-db23-435e-aa24-f30fb8cef869)

### What issues does this PR fix or reference?

#4926 
