### PR TITLE
Support multiple primary keys in insert result

### DIFF
--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/db/insert.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/db/insert.ts
@@ -19,7 +19,7 @@ export interface InsertParameter {
 
 export class Insert {
 
-	public static execute(sql: string, parameters?: (string | number | boolean | Date | InsertParameter)[], datasourceName?: string): number {
+	public static execute(sql: string, parameters?: (string | number | boolean | Date | InsertParameter)[], datasourceName?: string):  Array<Record<string, any>> {
 		return DatabaseFacade.insert(sql, parameters ? JSON.stringify(parameters) : undefined, datasourceName);
 	}
 }


### PR DESCRIPTION
Currently, the code assumes that there would be only one primary key column and its type will be long.
In cases where there are multiple PK columns of this type, the code fails.
Example failure:
```log
2025-05-02 14:04:26.168 [ERROR] [flowable-task-Executor-1] [background] o.e.d.c.base.logging.LoggingExecutor - Failed to execute a code [org.eclipse.dirigible.components.api.db.DatabaseFacade$$Lambda/0x0000007002ad9778@3391a0f1] for data source [DirigibleDataSourceImpl{name='DefaultDB', connectionEnhancers=[], originalDataSource=HikariDataSource (DefaultDB), databaseSystem=H2, transactionManager=org.springframework.jdbc.support.JdbcTransactionManager@b5c07cf}]
org.h2.jdbc.JdbcSQLDataException: Data conversion error converting "DATE to BIGINT" [22018-232]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:518) ~[h2-2.3.232.jar!/:na]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:489) ~[h2-2.3.232.jar!/:na]
	at org.h2.message.DbException.get(DbException.java:223) ~[h2-2.3.232.jar!/:na]
	at org.h2.message.DbException.get(DbException.java:199) ~[h2-2.3.232.jar!/:na]
	at org.h2.value.Value.getDataConversionError(Value.java:2591) ~[h2-2.3.232.jar!/:na]
	at org.h2.value.Value.convertToBigint(Value.java:1687) ~[h2-2.3.232.jar!/:na]
	at org.h2.value.Value.getLong(Value.java:887) ~[h2-2.3.232.jar!/:na]
	at org.h2.jdbc.JdbcResultSet.getLongInternal(JdbcResultSet.java:756) ~[h2-2.3.232.jar!/:na]
	at org.h2.jdbc.JdbcResultSet.getLong(JdbcResultSet.java:727) ~[h2-2.3.232.jar!/:na]
	at com.zaxxer.hikari.pool.HikariProxyResultSet.getLong(HikariProxyResultSet.java) ~[HikariCP-5.1.0.jar!/:na]
	at org.eclipse.dirigible.components.api.db.DatabaseFacade.lambda$insert$6(DatabaseFacade.java:374) ~[dirigible-components-api-database-11.44.0.jar!/:na]
	at org.eclipse.dirigible.components.base.logging.LoggingExecutor.executeWithException(LoggingExecutor.java:36) ~[dirigible-components-core-base-11.44.0.jar!/:na]
	at org.eclipse.dirigible.components.api.db.DatabaseFacade.insert(DatabaseFacade.java:361) ~[dirigible-components-api-database-11.44.0.jar!/:na]
	at com.oracle.truffle.host.HostMethodDesc$SingleMethod$MHBase.invokeHandle(HostMethodDesc.java:372) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.GuestToHostCodeCache$GuestToHostInvokeHandle.executeImpl(GuestToHostCodeCache.java:88) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.GuestToHostRootNode.execute(GuestToHostRootNode.java:80) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:118) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultRuntimeAccessor$DefaultRuntimeSupport.callInlined(DefaultRuntimeAccessor.java:201) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.GuestToHostRootNode.guestToHostCall(GuestToHostRootNode.java:102) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.HostMethodDesc$SingleMethod$MHBase.invokeGuestToHost(HostMethodDesc.java:408) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.HostExecuteNode.doInvoke(HostExecuteNode.java:877) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.HostExecuteNode.doFixed(HostExecuteNode.java:140) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.HostExecuteNodeGen$Inlined.executeAndSpecialize(HostExecuteNodeGen.java:385) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.HostExecuteNodeGen$Inlined.execute(HostExecuteNodeGen.java:345) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.HostObject.invokeMember(HostObject.java:465) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.HostObjectGen$InteropLibraryExports$Cached.invokeMemberNode_AndSpecialize(HostObjectGen.java:7007) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.HostObjectGen$InteropLibraryExports$Cached.invokeMember(HostObjectGen.java:6993) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.interop.InteropLibraryGen$CachedDispatch.invokeMember(InteropLibraryGen.java:8497) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$ForeignInvokeNode.executeCall(JSFunctionCallNode.java:1548) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeAndSpecialize(JSFunctionCallNode.java:308) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeCall(JSFunctionCallNode.java:253) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$InvokeNode.execute(JSFunctionCallNode.java:723) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.ReturnNode$TerminalPositionReturnNode.execute(ReturnNode.java:178) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeGeneric(AbstractBlockNode.java:83) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeGeneric(AbstractBlockNode.java:53) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultBlockNode.executeGeneric(DefaultBlockNode.java:65) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.execute(AbstractBlockNode.java:73) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.FunctionBodyNode.execute(FunctionBodyNode.java:70) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.FunctionRootNode.executeInRealm(FunctionRootNode.java:155) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.JavaScriptRealmBoundaryRootNode.execute(JavaScriptRealmBoundaryRootNode.java:96) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:118) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultDirectCallNode.call(DefaultDirectCallNode.java:59) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$DirectJSFunctionCacheNode.executeCall(JSFunctionCallNode.java:1330) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeAndSpecialize(JSFunctionCallNode.java:308) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeCall(JSFunctionCallNode.java:253) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$InvokeNode.execute(JSFunctionCallNode.java:723) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.access.JSWriteCurrentFrameSlotNodeGen.execute_generic3(JSWriteCurrentFrameSlotNodeGen.java:136) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.access.JSWriteCurrentFrameSlotNodeGen.execute(JSWriteCurrentFrameSlotNodeGen.java:67) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.access.JSWriteCurrentFrameSlotNodeGen.executeVoid(JSWriteCurrentFrameSlotNodeGen.java:319) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:78) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:53) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultBlockNode.executeVoid(DefaultBlockNode.java:73) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:68) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.VoidBlockNode.execute(VoidBlockNode.java:61) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeGeneric(AbstractBlockNode.java:83) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeGeneric(AbstractBlockNode.java:53) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultBlockNode.executeGeneric(DefaultBlockNode.java:65) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.execute(AbstractBlockNode.java:73) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.BlockScopeNode.execute(BlockScopeNode.java:87) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.binary.DualNode.execute(DualNode.java:116) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.FunctionBodyNode.execute(FunctionBodyNode.java:70) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.FunctionRootNode.executeInRealm(FunctionRootNode.java:155) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.JavaScriptRealmBoundaryRootNode.execute(JavaScriptRealmBoundaryRootNode.java:96) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:118) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultDirectCallNode.call(DefaultDirectCallNode.java:59) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$DirectJSFunctionCacheNode.executeCall(JSFunctionCallNode.java:1330) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeAndSpecialize(JSFunctionCallNode.java:308) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeCall(JSFunctionCallNode.java:253) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.interop.JSInteropExecuteNode.doDefault(JSInteropExecuteNode.java:68) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.interop.JSInteropExecuteNodeGen.executeAndSpecialize(JSInteropExecuteNodeGen.java:92) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.interop.JSInteropExecuteNodeGen.execute(JSInteropExecuteNodeGen.java:73) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.builtins.JSFunctionObject.execute(JSFunctionObject.java:145) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.builtins.JSFunctionObjectGen$InteropLibraryExports$Cached.executeNode_AndSpecialize(JSFunctionObjectGen.java:198) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.builtins.JSFunctionObjectGen$InteropLibraryExports$Cached.execute(JSFunctionObjectGen.java:170) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.interop.InteropLibraryGen.genericDispatch(InteropLibraryGen.java:256) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.library.ReflectionLibraryDefault$Send.doSendCached(ReflectionLibrary.java:182) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.library.ReflectionLibraryDefaultGen$ReflectionLibraryExports$Cached.executeAndSpecialize(ReflectionLibraryDefaultGen.java:138) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.library.ReflectionLibraryDefaultGen$ReflectionLibraryExports$Cached.send(ReflectionLibraryDefaultGen.java:104) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.library.ReflectionLibraryGen$CachedDispatch.send(ReflectionLibraryGen.java:248) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.polyglot.OtherContextGuestObject.sendImpl(OtherContextGuestObject.java:157) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.polyglot.OtherContextGuestObject$Send.doCached(OtherContextGuestObject.java:115) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.polyglot.OtherContextGuestObjectGen$ReflectionLibraryExports$Cached.executeAndSpecialize(OtherContextGuestObjectGen.java:177) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.polyglot.OtherContextGuestObjectGen$ReflectionLibraryExports$Cached.send(OtherContextGuestObjectGen.java:132) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.interop.InteropLibraryGen$Proxy.execute(InteropLibraryGen.java:2512) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.interop.InteropLibraryGen$CachedDispatch.execute(InteropLibraryGen.java:7900) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$ForeignExecuteNode.executeCall(JSFunctionCallNode.java:1508) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeAndSpecialize(JSFunctionCallNode.java:308) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeCall(JSFunctionCallNode.java:253) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.builtins.ArrayPrototypeBuiltins$ArrayForEachIndexCallOperation$DefaultCallbackNode.apply(ArrayPrototypeBuiltins.java:2221) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.access.ForEachIndexCallNode.callback(ForEachIndexCallNode.java:205) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.access.ForEachIndexCallNode$ForwardForEachIndexCallNode.executeForEachIndexFast(ForEachIndexCallNode.java:241) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.access.ForEachIndexCallNode.executeForEachIndex(ForEachIndexCallNode.java:140) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.builtins.ArrayPrototypeBuiltins$ArrayForEachIndexCallOperation.forEachIndexCall(ArrayPrototypeBuiltins.java:2236) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.builtins.ArrayPrototypeBuiltins$JSArrayForEachNode.forEach(ArrayPrototypeBuiltins.java:2364) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.builtins.ArrayPrototypeBuiltinsFactory$JSArrayForEachNodeGen.execute(ArrayPrototypeBuiltinsFactory.java:2111) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.FunctionRootNode.executeInRealm(FunctionRootNode.java:155) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.JavaScriptRealmBoundaryRootNode.execute(JavaScriptRealmBoundaryRootNode.java:96) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:118) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultDirectCallNode.call(DefaultDirectCallNode.java:59) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$DirectJSFunctionCacheNode.executeCall(JSFunctionCallNode.java:1330) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeAndSpecialize(JSFunctionCallNode.java:308) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeCall(JSFunctionCallNode.java:253) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.interop.JSInteropInvokeNode.doCached(JSInteropInvokeNode.java:79) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.interop.JSInteropInvokeNodeGen.executeAndSpecialize(JSInteropInvokeNodeGen.java:209) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.interop.JSInteropInvokeNodeGen.execute(JSInteropInvokeNodeGen.java:119) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.objects.JSObject.invokeMember(JSObject.java:256) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.objects.JSObjectGen$InteropLibraryExports$Cached.invokeMemberNode_AndSpecialize(JSObjectGen.java:547) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.objects.JSObjectGen$InteropLibraryExports$Cached.invokeMember(JSObjectGen.java:515) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.interop.InteropLibraryGen.genericDispatch(InteropLibraryGen.java:328) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.library.ReflectionLibraryDefault$Send.doSendCached(ReflectionLibrary.java:182) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.library.ReflectionLibraryDefaultGen$ReflectionLibraryExports$Cached.executeAndSpecialize(ReflectionLibraryDefaultGen.java:138) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.library.ReflectionLibraryDefaultGen$ReflectionLibraryExports$Cached.send(ReflectionLibraryDefaultGen.java:104) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.library.ReflectionLibraryGen$CachedDispatch.send(ReflectionLibraryGen.java:248) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.polyglot.OtherContextGuestObject.sendImpl(OtherContextGuestObject.java:157) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.polyglot.OtherContextGuestObject$Send.doCached(OtherContextGuestObject.java:115) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.polyglot.OtherContextGuestObjectGen$ReflectionLibraryExports$Cached.send(OtherContextGuestObjectGen.java:119) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.interop.InteropLibraryGen$Proxy.invokeMember(InteropLibraryGen.java:2899) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.interop.InteropLibraryGen$CachedDispatch.invokeMember(InteropLibraryGen.java:8497) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$ForeignInvokeNode.executeCall(JSFunctionCallNode.java:1548) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeAndSpecialize(JSFunctionCallNode.java:308) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeCall(JSFunctionCallNode.java:253) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$InvokeNode.execute(JSFunctionCallNode.java:723) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.JavaScriptNode.executeVoid(JavaScriptNode.java:183) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:78) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:53) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultBlockNode.executeVoid(DefaultBlockNode.java:73) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:68) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.VoidBlockNode.execute(VoidBlockNode.java:61) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.binary.DualNode.execute(DualNode.java:116) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.FunctionBodyNode.execute(FunctionBodyNode.java:70) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.FunctionRootNode.executeInRealm(FunctionRootNode.java:155) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.JavaScriptRealmBoundaryRootNode.execute(JavaScriptRealmBoundaryRootNode.java:96) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:118) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultDirectCallNode.call(DefaultDirectCallNode.java:59) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$DirectJSFunctionCacheNode.executeCall(JSFunctionCallNode.java:1330) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeAndSpecialize(JSFunctionCallNode.java:308) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeCall(JSFunctionCallNode.java:253) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$CallNode.execute(JSFunctionCallNode.java:527) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.JavaScriptNode.executeVoid(JavaScriptNode.java:183) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:78) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:53) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultBlockNode.executeGeneric(DefaultBlockNode.java:63) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.execute(AbstractBlockNode.java:73) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeGeneric(AbstractBlockNode.java:83) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeGeneric(AbstractBlockNode.java:53) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultBlockNode.executeGeneric(DefaultBlockNode.java:65) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.execute(AbstractBlockNode.java:73) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.FunctionBodyNode.execute(FunctionBodyNode.java:70) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.FunctionRootNode.executeInRealm(FunctionRootNode.java:155) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.JavaScriptRealmBoundaryRootNode.execute(JavaScriptRealmBoundaryRootNode.java:96) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:118) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultDirectCallNode.call(DefaultDirectCallNode.java:59) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$DirectJSFunctionCacheNode.executeCall(JSFunctionCallNode.java:1330) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeAndSpecialize(JSFunctionCallNode.java:308) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeCall(JSFunctionCallNode.java:253) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.interop.JSInteropExecuteNode.doDefault(JSInteropExecuteNode.java:68) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.interop.JSInteropExecuteNodeGen.execute(JSInteropExecuteNodeGen.java:66) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.interop.InteropBoundFunction.execute(InteropBoundFunction.java:111) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.interop.InteropBoundFunctionGen$InteropLibraryExports$Cached.execute(InteropBoundFunctionGen.java:202) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.interop.InteropLibraryGen$Delegate.execute(InteropLibraryGen.java:3971) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.polyglot.PolyglotValueDispatch$InteropValue$SharedExecuteNode.doDefault(PolyglotValueDispatch.java:4649) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.polyglot.PolyglotValueDispatchFactory$InteropValueFactory$SharedExecuteNodeGen$Inlined.executeShared(PolyglotValueDispatchFactory.java:8259) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.polyglot.PolyglotValueDispatch$InteropValue$ExecuteNode.doDefault(PolyglotValueDispatch.java:4731) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.polyglot.PolyglotValueDispatchFactory$InteropValueFactory$ExecuteNodeGen.executeImpl(PolyglotValueDispatchFactory.java:8627) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.polyglot.HostToGuestRootNode.execute(HostToGuestRootNode.java:124) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:118) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultRuntimeAccessor$DefaultRuntimeSupport.callProfiled(DefaultRuntimeAccessor.java:206) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.polyglot.PolyglotValueDispatch$InteropValue.execute(PolyglotValueDispatch.java:2657) ~[truffle-api-24.2.1.jar!/:na]
	at org.graalvm.polyglot.Value.execute(Value.java:1049) ~[polyglot-24.2.1.jar!/:na]
	at org.eclipse.dirigible.graalium.core.DirigibleJavascriptCodeRunner.runEsmMethod(DirigibleJavascriptCodeRunner.java:224) ~[dirigible-engine-graalium-execution-core-11.44.0.jar!/:na]
	at org.eclipse.dirigible.graalium.core.DirigibleJavascriptCodeRunner.runMethod(DirigibleJavascriptCodeRunner.java:217) ~[dirigible-engine-graalium-execution-core-11.44.0.jar!/:na]
	at org.eclipse.dirigible.components.engine.camel.invoke.DirigibleJavaScriptInvokerImpl.invoke(DirigibleJavaScriptInvokerImpl.java:48) ~[dirigible-components-engine-camel-11.44.0.jar!/:na]
	at org.eclipse.dirigible.components.engine.camel.components.DirigibleJavaScriptProcessor.process(DirigibleJavaScriptProcessor.java:47) ~[dirigible-components-engine-camel-11.44.0.jar!/:na]
	at org.apache.camel.support.AsyncProcessorConverterHelper$ProcessorToAsyncProcessorBridge.process(AsyncProcessorConverterHelper.java:65) ~[camel-support-4.10.2.jar!/:4.10.2]
	at org.eclipse.dirigible.components.engine.camel.components.DirigibleJavaScriptProducer.process(DirigibleJavaScriptProducer.java:31) ~[dirigible-components-engine-camel-11.44.0.jar!/:na]
	at org.apache.camel.processor.SendProcessor.sendUsingProducer(SendProcessor.java:252) ~[camel-core-processor-4.10.2.jar!/:4.10.2]
	at org.apache.camel.processor.SendProcessor.process(SendProcessor.java:157) ~[camel-core-processor-4.10.2.jar!/:4.10.2]
	at org.apache.camel.processor.errorhandler.RedeliveryErrorHandler$SimpleTask.handleFirst(RedeliveryErrorHandler.java:440) ~[camel-core-processor-4.10.2.jar!/:4.10.2]
	at org.apache.camel.processor.errorhandler.RedeliveryErrorHandler$SimpleTask.run(RedeliveryErrorHandler.java:416) ~[camel-core-processor-4.10.2.jar!/:4.10.2]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.doRun(DefaultReactiveExecutor.java:199) ~[camel-base-engine-4.10.2.jar!/:4.10.2]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.executeReactiveWork(DefaultReactiveExecutor.java:189) ~[camel-base-engine-4.10.2.jar!/:4.10.2]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.tryExecuteReactiveWork(DefaultReactiveExecutor.java:166) ~[camel-base-engine-4.10.2.jar!/:4.10.2]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.schedule(DefaultReactiveExecutor.java:148) ~[camel-base-engine-4.10.2.jar!/:4.10.2]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor.scheduleMain(DefaultReactiveExecutor.java:59) ~[camel-base-engine-4.10.2.jar!/:4.10.2]
	at org.apache.camel.processor.Pipeline.process(Pipeline.java:163) ~[camel-core-processor-4.10.2.jar!/:4.10.2]
	at org.apache.camel.impl.engine.CamelInternalProcessor.processNonTransacted(CamelInternalProcessor.java:347) ~[camel-base-engine-4.10.2.jar!/:4.10.2]
	at org.apache.camel.impl.engine.CamelInternalProcessor.process(CamelInternalProcessor.java:323) ~[camel-base-engine-4.10.2.jar!/:4.10.2]
	at org.apache.camel.impl.engine.DefaultAsyncProcessorAwaitManager.process(DefaultAsyncProcessorAwaitManager.java:82) ~[camel-base-engine-4.10.2.jar!/:4.10.2]
	at org.apache.camel.support.AsyncProcessorSupport.process(AsyncProcessorSupport.java:32) ~[camel-support-4.10.2.jar!/:4.10.2]
	at org.apache.camel.component.platform.http.springboot.SpringBootPlatformHttpConsumer.handleService(SpringBootPlatformHttpConsumer.java:146) ~[camel-platform-http-starter-4.10.2.jar!/:4.10.2]
	at org.apache.camel.component.platform.http.springboot.SpringBootPlatformHttpConsumer.lambda$service$0(SpringBootPlatformHttpConsumer.java:95) ~[camel-platform-http-starter-4.10.2.jar!/:4.10.2]
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[na:na]
```
Change the response so that it returns all PK columns with their values.
Example for insert of two entries where PK columns are `PK_COLUMN1`, `PK_COLUMN2` and `PK_COLUMN3`:
```json
[
    {
        "PK_COLUMN1": 1,
        "PK_COLUMN2": "5710d304-c863-4746-9ab6-b921fdb9284a",
        "PK_COLUMN3": 11.11
    },
    {
        "PK_COLUMN1": 2,
        "PK_COLUMN2": "27a8db0b-8d3e-4595-8498-c0d0a240562f",
        "PK_COLUMN3": 22.22
    }
]
```