### PR TITLE
Handle RETURN_GENERATED_KEYS not supported during insert by some databases

### DIFF
--- a/components/api/api-database/src/main/java/org/eclipse/dirigible/components/api/db/DatabaseFacade.java
+++ b/components/api/api-database/src/main/java/org/eclipse/dirigible/components/api/db/DatabaseFacade.java
@@ -396,8 +396,8 @@ public class DatabaseFacade implements InitializingBean {
                         return generatedKeysList;
                     }
                 } catch (SQLFeatureNotSupportedException ex) {
-                    logger.warn("RETURN_GENERATED_KEYS not supported for connection [{}]. Will execute insert without this option.",
-                            connection, ex);
+                    logger.debug("RETURN_GENERATED_KEYS not supported for connection [{}]. Will execute insert without this option.",
+                            connection, ex.getMessage());
                     insertWithoutResult(sql, parameters, connection);
                     return Collections.emptyList();
                 }

--- a/components/api/api-database/src/main/java/org/eclipse/dirigible/components/api/db/DatabaseFacade.java
+++ b/components/api/api-database/src/main/java/org/eclipse/dirigible/components/api/db/DatabaseFacade.java
@@ -9,25 +9,6 @@
  */
 package org.eclipse.dirigible.components.api.db;
 
-import static java.text.MessageFormat.format;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import javax.sql.DataSource;
 import org.apache.commons.io.output.WriterOutputStream;
 import org.eclipse.dirigible.commons.api.helpers.GsonHelper;
 import org.eclipse.dirigible.components.base.logging.LoggingExecutor;
@@ -47,6 +28,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.sql.*;
+import java.util.*;
+
+import static java.text.MessageFormat.format;
 
 /**
  * The Class DatabaseFacade.
@@ -379,38 +368,55 @@ public class DatabaseFacade implements InitializingBean {
 
         return LoggingExecutor.executeWithException(dataSource, () -> {
 
-            try (Connection connection = dataSource.getConnection();
-                    PreparedStatement preparedStatement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            try (Connection connection = dataSource.getConnection()) {
+                try (PreparedStatement preparedStatement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
 
-                if (parameters != null) {
-                    IndexedOrNamedStatement statement = new IndexedOrNamedStatement(preparedStatement);
-                    ParametersSetter.setParameters(parameters, statement);
-                }
-
-                int updatedRows = preparedStatement.executeUpdate();
-                List<Map<String, Object>> generatedKeysList = new ArrayList<>(updatedRows);
-
-                try (ResultSet generatedKeys = preparedStatement.getGeneratedKeys()) {
-                    ResultSetMetaData metaData = generatedKeys.getMetaData();
-                    int columnCount = metaData.getColumnCount();
-
-                    while (generatedKeys.next()) {
-                        Map<String, Object> keyRow = new LinkedHashMap<>();
-                        for (int i = 1; i <= columnCount; i++) {
-                            String columnName = metaData.getColumnLabel(i);
-                            Object value = generatedKeys.getObject(i);
-                            keyRow.put(columnName, value);
-                        }
-                        generatedKeysList.add(keyRow);
+                    if (parameters != null) {
+                        IndexedOrNamedStatement statement = new IndexedOrNamedStatement(preparedStatement);
+                        ParametersSetter.setParameters(parameters, statement);
                     }
 
-                    return generatedKeysList;
+                    int updatedRows = preparedStatement.executeUpdate();
+                    List<Map<String, Object>> generatedKeysList = new ArrayList<>(updatedRows);
+
+                    try (ResultSet generatedKeys = preparedStatement.getGeneratedKeys()) {
+                        ResultSetMetaData metaData = generatedKeys.getMetaData();
+                        int columnCount = metaData.getColumnCount();
+
+                        while (generatedKeys.next()) {
+                            Map<String, Object> keyRow = new LinkedHashMap<>();
+                            for (int i = 1; i <= columnCount; i++) {
+                                String columnName = metaData.getColumnLabel(i);
+                                Object value = generatedKeys.getObject(i);
+                                keyRow.put(columnName, value);
+                            }
+                            generatedKeysList.add(keyRow);
+                        }
+
+                        return generatedKeysList;
+                    }
+                } catch (SQLFeatureNotSupportedException ex) {
+                    logger.warn("RETURN_GENERATED_KEYS not supported for connection [{}]. Will execute insert without this option.",
+                            connection, ex);
+                    insertWithoutResult(sql, parameters, connection);
+                    return Collections.emptyList();
                 }
             } catch (SQLException | RuntimeException ex) {
                 logger.error("Failed to execute insert statement [{}] in data source [{}].", sql, datasourceName, ex);
                 throw ex;
             }
+
         });
+    }
+
+    private static void insertWithoutResult(String sql, String parameters, Connection connection) throws SQLException {
+        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            if (parameters != null) {
+                IndexedOrNamedStatement statement = new IndexedOrNamedStatement(preparedStatement);
+                ParametersSetter.setParameters(parameters, statement);
+            }
+            preparedStatement.executeUpdate();
+        }
     }
 
     // =========== Insert ===========

--- a/components/api/api-database/src/main/java/org/eclipse/dirigible/components/api/db/DatabaseFacade.java
+++ b/components/api/api-database/src/main/java/org/eclipse/dirigible/components/api/db/DatabaseFacade.java
@@ -397,7 +397,7 @@ public class DatabaseFacade implements InitializingBean {
                     }
                 } catch (SQLFeatureNotSupportedException ex) {
                     logger.debug("RETURN_GENERATED_KEYS not supported for connection [{}]. Will execute insert without this option.",
-                            connection, ex.getMessage());
+                            connection, ex);
                     insertWithoutResult(sql, parameters, connection);
                     return Collections.emptyList();
                 }


### PR DESCRIPTION
Handle the cases where  `RETURN_GENERATED_KEYS ` is not supported by some DB like Snowflake
Example error:
```log
2025-05-05 14:35:44,508 ERROR [flowable-task-Executor-3] [background] o.e.d.c.a.d.DatabaseFacade [DatabaseFacade.java:398] Failed to execute insert statement [INSERT INTO ***].
net.snowflake.client.jdbc.SnowflakeLoggedFeatureNotSupportedException: null
	at net.snowflake.client.jdbc.SnowflakeConnectionV1.prepareStatement(SnowflakeConnectionV1.java:526) ~[snowflake-jdbc-3.23.2.jar!/:3.23.2]
	at com.zaxxer.hikari.pool.ProxyConnection.prepareStatement(ProxyConnection.java:335) ~[HikariCP-5.1.0.jar!/:na]
	at com.zaxxer.hikari.pool.HikariProxyConnection.prepareStatement(HikariProxyConnection.java) ~[HikariCP-5.1.0.jar!/:na]
	at org.eclipse.dirigible.components.data.sources.manager.DirigibleConnectionImpl.prepareStatement(DirigibleConnectionImpl.java:201) ~[dirigible-components-data-sources-11.45.4.jar!/:na]
	at org.eclipse.dirigible.components.api.db.DatabaseFacade.lambda$insert$6(DatabaseFacade.java:371) ~[dirigible-components-api-database-11.45.4.jar!/:na]
	at org.eclipse.dirigible.components.base.logging.LoggingExecutor.executeWithException(LoggingExecutor.java:36) ~[dirigible-components-core-base-11.45.4.jar!/:na]
	at org.eclipse.dirigible.components.api.db.DatabaseFacade.insert(DatabaseFacade.java:368) ~[dirigible-..........
```

For this cases, execute insert without this option and return empty result.

Snowflake improvement has been created - https://github.com/snowflakedb/snowflake-jdbc/issues/2176