### PR TITLE
[UI] Notifications should autohide after a while

### DIFF
--- a/components/ui/platform-core/src/main/resources/META-INF/dirigible/platform-core/ui/platform/shell.js
+++ b/components/ui/platform-core/src/main/resources/META-INF/dirigible/platform-core/ui/platform/shell.js
@@ -386,6 +386,7 @@ if (window !== top) {
         replace: true,
         link: (scope) => {
             const notificationHub = new NotificationHub();
+            let to = 0;
             scope.notification = {
                 type: '',
                 title: '',
@@ -403,6 +404,13 @@ if (window !== top) {
                     title: data.title,
                     description: data.description,
                 });
+                if (to) clearTimeout(to);
+                to = setTimeout(() => {
+                    scope.$evalAsync(() => {
+                        scope.hide();
+                    });
+                }, 4000);
+                scope.clearTimeout = () => clearTimeout(to);
             });
             scope.hide = () => {
                 scope.notification.type = '';
@@ -410,7 +418,7 @@ if (window !== top) {
             scope.$on('$destroy', () => notificationHub.removeMessageListener(onNotificationListener));
         },
         template: `<div ng-if="notification.type" class="notification-overlay">
-            <bk-notification is-banner="true" style="width: 100%; max-width:33rem">
+            <bk-notification is-banner="true" style="width: 100%; max-width:33rem" ng-mouseenter="clearTimeout()" ng-mouseleave="hide()">
                 <div bk-notification-content>
                     <div bk-notification-header>
                         <span bk-notification-icon="{{notification.type}}"></span>
@@ -419,8 +427,7 @@ if (window !== top) {
                     <p bk-notification-paragraph="">{{notification.description}}</p>
                 </div>
                 <div bk-notification-actions>
-                    <bk-button aria-label="Close" state="transparent" glyph="sap-icon--decline" ng-click="hide()">
-                    </bk-button>
+                    <bk-button aria-label="Close" state="transparent" glyph="sap-icon--decline" ng-click="hide()"></bk-button>
                 </div>
             </bk-notification>
         </div>`,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Dirigible's Contributing Guide: https://github.com/eclipse/dirigible/blob/master/CONTRIBUTING.md

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/dirigible/labels
-->

### What does this PR do?

Introduces autohide for notifications. When a notifications is shown, it will stay for 4 seconds after which it will be hidden. If the user hovers over the notification, the timer is cancelled and the notification will hide after the mouse pointer leaves the notification.

### What issues does this PR fix or reference?

#5041 
