### PR TITLE
CSV import improvements

### DIFF
--- a/components/data/data-csvim/src/main/java/org/eclipse/dirigible/components/data/csvim/domain/CsvFile.java
+++ b/components/data/data-csvim/src/main/java/org/eclipse/dirigible/components/data/csvim/domain/CsvFile.java
@@ -65,6 +65,10 @@ public class CsvFile extends Artefact {
     @Expose
     private Boolean header;
 
+    @Column(name = "CSV_FILE_TRIM", columnDefinition = "BOOLEAN")
+    @Expose
+    private Boolean trim;
+
     /**
      * The use header names.
      */
@@ -108,7 +112,6 @@ public class CsvFile extends Artefact {
     @Column(name = "CSV_FILE_UPSERT", columnDefinition = "boolean", nullable = false)
     @Expose
     private Boolean upsert = true; // default true
-
     /**
      * The csvim.
      */
@@ -189,6 +192,14 @@ public class CsvFile extends Artefact {
      */
     public CsvFile() {
 
+    }
+
+    public Boolean getTrim() {
+        return trim;
+    }
+
+    public void setTrim(Boolean trim) {
+        this.trim = trim;
     }
 
     /**

--- a/components/data/data-csvim/src/main/java/org/eclipse/dirigible/components/data/csvim/domain/CsvRecord.java
+++ b/components/data/data-csvim/src/main/java/org/eclipse/dirigible/components/data/csvim/domain/CsvRecord.java
@@ -9,36 +9,40 @@
  */
 package org.eclipse.dirigible.components.data.csvim.domain;
 
-import java.util.List;
-
 import org.apache.commons.csv.CSVRecord;
 import org.eclipse.dirigible.components.data.management.domain.ColumnMetadata;
 import org.eclipse.dirigible.components.data.management.domain.TableMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /**
  * The Class CsvRecord.
  */
 public class CsvRecord {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CsvRecord.class);
+
     /**
      * The csv record.
      */
-    private CSVRecord csvRecord;
+    private final CSVRecord csvRecord;
 
     /**
      * The table metadata model.
      */
-    private TableMetadata table;
+    private final TableMetadata table;
 
     /**
      * The header names.
      */
-    private List<String> headerNames;
+    private final List<String> headerNames;
 
     /**
      * The distinguish empty from null.
      */
-    private boolean distinguishEmptyFromNull;
+    private final boolean distinguishEmptyFromNull;
 
     /**
      * The pk column name.
@@ -66,6 +70,21 @@ public class CsvRecord {
     }
 
     /**
+     * Gets the csv record pk value.
+     *
+     * @return the csv record pk value
+     */
+    public String getCsvRecordPkValue() {
+        if (csvRecordPkValue == null && headerNames.size() > 0) {
+            csvRecordPkValue = getCsvValueForColumn(getPkColumnName());
+        } else if (csvRecordPkValue == null) {
+            csvRecordPkValue = csvRecord.get(0);
+        }
+
+        return csvRecordPkValue;
+    }
+
+    /**
      * Gets the csv value for column.
      *
      * @param columnName the column name
@@ -77,6 +96,13 @@ public class CsvRecord {
             if (csvValueIndex == -1) {
                 return null;
             }
+
+            if (!csvRecord.isSet(csvValueIndex)) {
+                LOGGER.debug("Missing value with index [{}] for column [{}] in csv record {}. Will return null.", csvValueIndex, columnName,
+                        csvRecord);
+                return null;
+            }
+
             return csvRecord.get(csvValueIndex);
         }
 
@@ -99,21 +125,6 @@ public class CsvRecord {
         }
 
         return pkColumnName;
-    }
-
-    /**
-     * Gets the csv record pk value.
-     *
-     * @return the csv record pk value
-     */
-    public String getCsvRecordPkValue() {
-        if (csvRecordPkValue == null && headerNames.size() > 0) {
-            csvRecordPkValue = getCsvValueForColumn(getPkColumnName());
-        } else if (csvRecordPkValue == null) {
-            csvRecordPkValue = csvRecord.get(0);
-        }
-
-        return csvRecordPkValue;
     }
 
     /**

--- a/components/data/data-csvim/src/main/java/org/eclipse/dirigible/components/data/csvim/processor/CsvimProcessor.java
+++ b/components/data/data-csvim/src/main/java/org/eclipse/dirigible/components/data/csvim/processor/CsvimProcessor.java
@@ -137,8 +137,7 @@ public class CsvimProcessor {
      *
      * @param csvFile the csv file
      * @param content the content
-     * @param dataSourceName the dataSourceName, if a null is passed, the default DataSource will be
-     *        used
+     * @param dataSourceName the dataSourceName, if a null is passed, the default DataSource will be used
      * @throws Exception the exception
      */
     public void process(CsvFile csvFile, InputStream content, String dataSourceName) throws Exception {
@@ -306,10 +305,10 @@ public class CsvimProcessor {
      */
     private CSVFormat createCSVFormat(CsvFile csvFile) throws Exception {
         if (csvFile.getDelimField() != null && (!csvFile.getDelimField()
-                                                        .equals(",")
-                && !csvFile.getDelimField()
-                           .equals(";"))) {
-            String errorMessage = "Only ';' or ',' characters are supported as delimiters for CSV files.";
+                                                        .equals(",") && !csvFile.getDelimField()
+                                                                                .equals(";") && !csvFile.getDelimField()
+                                                                                                        .equals("\t"))) {
+            String errorMessage = "Only ';', ',' or tab characters are supported as delimiters for CSV files.";
             CsvimUtils.logProcessorErrors(errorMessage, ERROR_TYPE_PROCESSOR, csvFile.getFile(), CsvFile.ARTEFACT_TYPE, MODULE);
             throw new Exception(errorMessage);
         }
@@ -320,10 +319,12 @@ public class CsvimProcessor {
             throw new Exception(errorMessage);
         }
 
-        char delimiter = Objects.isNull(csvFile.getDelimField()) ? ','
+        char delimiter = Objects.isNull(csvFile.getDelimField())
+                ? ','
                 : csvFile.getDelimField()
                          .charAt(0);
-        char quote = Objects.isNull(csvFile.getDelimEnclosing()) ? '"'
+        char quote = Objects.isNull(csvFile.getDelimEnclosing())
+                ? '"'
                 : csvFile.getDelimEnclosing()
                          .charAt(0);
         CSVFormat csvFormat = CSVFormat.newFormat(delimiter)
@@ -334,6 +335,10 @@ public class CsvimProcessor {
         boolean useHeader = !Objects.isNull(csvFile.getHeader()) && csvFile.getHeader();
         if (useHeader) {
             csvFormat = csvFormat.withFirstRecordAsHeader();
+        }
+        boolean trim = !Objects.isNull(csvFile.getTrim()) && csvFile.getTrim();
+        if (trim) {
+            csvFormat = csvFormat.withTrim(trim);
         }
 
         return csvFormat;
@@ -509,7 +514,7 @@ public class CsvimProcessor {
         boolean exists = false;
         SelectBuilder selectBuilder = new SelectBuilder(SqlFactory.deriveDialect(connection));
         String sql = selectBuilder.distinct()
-                                  .column("1 " + pkNameForCSVRecord)
+                                  .column("1")
                                   .from(tableName)
                                   .schema(schema)
                                   .where(pkNameForCSVRecord + " = ?")

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/AbstractSqlBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/AbstractSqlBuilder.java
@@ -22,8 +22,16 @@ import java.util.regex.Pattern;
  */
 public abstract class AbstractSqlBuilder implements ISqlBuilder {
 
+    /**
+     * The Regex find the content between single quotes.
+     */
+    private static final Pattern contentBetweenSingleQuotes = Pattern.compile("'([^']*?)'");
     /** The dialect. */
     private final ISqlDialect dialect;
+    /** The column pattern. */
+    private final Pattern columnPattern = Pattern.compile("^(?![0-9]*$)[a-zA-Z0-9_#$]+$");
+    /** The numeric pattern. */
+    private final Pattern numericPattern = Pattern.compile("-?\\d+(\\.\\d+)?");
 
     /**
      * Instantiates a new abstract sql builder.
@@ -32,15 +40,6 @@ public abstract class AbstractSqlBuilder implements ISqlBuilder {
      */
     protected AbstractSqlBuilder(ISqlDialect dialect) {
         this.dialect = dialect;
-    }
-
-    /**
-     * Gets the dialect.
-     *
-     * @return the dialect
-     */
-    protected ISqlDialect getDialect() {
-        return dialect;
     }
 
     /**
@@ -97,9 +96,6 @@ public abstract class AbstractSqlBuilder implements ISqlBuilder {
         return name;
     }
 
-    /** The column pattern. */
-    private final Pattern columnPattern = Pattern.compile("^(?![0-9]*$)[a-zA-Z0-9_#$]+$");
-
     /**
      * Gets the escape symbol.
      *
@@ -107,6 +103,15 @@ public abstract class AbstractSqlBuilder implements ISqlBuilder {
      */
     public char getEscapeSymbol() {
         return getDialect().getEscapeSymbol();
+    }
+
+    /**
+     * Gets the dialect.
+     *
+     * @return the dialect
+     */
+    protected ISqlDialect getDialect() {
+        return dialect;
     }
 
     /**
@@ -135,16 +140,6 @@ public abstract class AbstractSqlBuilder implements ISqlBuilder {
     }
 
     /**
-     * Encapsulate where.
-     *
-     * @param where the where
-     * @return the string
-     */
-    protected String encapsulateWhere(String where) {
-        return encapsulateMany(where, getEscapeSymbol());
-    }
-
-    /**
      * Encapsulate many.
      *
      * @param line the line
@@ -153,7 +148,7 @@ public abstract class AbstractSqlBuilder implements ISqlBuilder {
      */
     protected String encapsulateMany(String line, char escapeChar) {
         String lineWithoughContentBetweenSingleQuotes = String.join("", line.split(contentBetweenSingleQuotes.toString()));
-        String regex = "([^a-zA-Z0-9_#$::']+)'*\\1*";
+        String regex = "([^a-zA-Z0-9_#$::'/]+)'*\\1*";
         String[] words = lineWithoughContentBetweenSingleQuotes.split(regex);
         Set<String> wordsSet = new HashSet<>(Arrays.asList(words));
         Set<Set> functionsNames = getDialect().getFunctionsNames();
@@ -167,14 +162,6 @@ public abstract class AbstractSqlBuilder implements ISqlBuilder {
         }
         return line;
     }
-
-    /**
-     * The Regex find the content between single quotes.
-     */
-    private final Pattern contentBetweenSingleQuotes = Pattern.compile("'([^']*?)'");
-
-    /** The numeric pattern. */
-    private final Pattern numericPattern = Pattern.compile("-?\\d+(\\.\\d+)?");
 
     /**
      * Check whether the string is a number.
@@ -201,5 +188,15 @@ public abstract class AbstractSqlBuilder implements ISqlBuilder {
             return false;
         }
         return s.startsWith("'") || s.endsWith("'");
+    }
+
+    /**
+     * Encapsulate where.
+     *
+     * @param where the where
+     * @return the string
+     */
+    protected String encapsulateWhere(String where) {
+        return encapsulateMany(where, getEscapeSymbol());
     }
 }

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/records/SelectBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/records/SelectBuilder.java
@@ -128,7 +128,7 @@ public class SelectBuilder extends AbstractQuerySqlBuilder {
     public SelectBuilder from(String table, String alias) {
         logger.trace("from: [{}], alias: [{}]", table, alias);
         StringBuilder snippet = new StringBuilder();
-        snippet.append(encapsulate(table));
+        snippet.append(encapsulate(table, true));
         if (alias != null) {
             snippet.append(SPACE)
                    .append(KEYWORD_AS)


### PR DESCRIPTION
Add CSV import improvements:

- Backend support import of CSV files delimited by tabs (`\t`)
- Fix import issues for tables with forward slash (`/`) in their names like: `/BIC/TMD_CURR`
- Fix import issues for columns with forward slash (`/`) in their names like: `/BIC/MD_CURR`
- Add `trim` flag in csvim file to control whether values should be trimmed. 
    For example for values row like `    test,  test2  ,test3  `:
        - if `trim=true`, values will be inserted as `test`, `test2` and `test3`
        - if `trim=false`, values will be inserted as `    test`, `  test2  ` and `test3  `

    Example CSVIM file:
    ```yaml
    {
        "files": [
            {
                "table": "/BIC/TMD_CURR",
                "schema": "PUBLIC",
                "file": "/sales/db/master-data/Currency MD (MD_CURR) - TEXTS - Content-formatted.csv",
                "header": true,
                "useHeaderNames": true,
                "delimField": "\t",
                "delimEnclosing": "\"",
                "distinguishEmptyFromNull": true,
                "trim": true,
                "version": "1.0",
                "upsert": false
            }
        ]
    }
    ```

- support int column values in format like `30.000` which is treated as `30`
- support decimals in display format for locales like Germany not just the default US format
- allow importing CSV files with arbitrary value row counts
    Example:
        - csv file with 10 headers
        - first value row with 10 values
        - second value row with 8 values - last two values will be treated as null instead of throwing an exception
        - third value row with 10 values
- etc.
