### PR TITLE
Fix async camel java script steps execution handling

### DIFF
--- a/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/DirigibleJavaScriptInvokerImpl.java
+++ b/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/DirigibleJavaScriptInvokerImpl.java
@@ -143,7 +143,7 @@ class DirigibleJavaScriptInvokerImpl implements DirigibleJavaScriptInvoker {
                 if (isIntegrationMessage(result)) {
                     resultRef.set(result.asHostObject());
                 } else {
-                    IllegalArgumentException ex = new IllegalArgumentException("Unexpected values is returned from promise [" + promise
+                    IllegalArgumentException ex = new IllegalArgumentException("Unexpected value is returned from promise [" + promise
                             + "] Expected return type [" + IntegrationMessage.class + "]. Returned result [" + result + "]");
                     resultRef.set(ex);
                 }

--- a/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/DirigibleJavaScriptInvokerImpl.java
+++ b/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/DirigibleJavaScriptInvokerImpl.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Component;
 
 import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Component
@@ -123,27 +124,81 @@ class DirigibleJavaScriptInvokerImpl implements DirigibleJavaScriptInvoker {
 
     private IntegrationMessage executePromise(Value promise) {
         CountDownLatch latch = new CountDownLatch(1);
-        AtomicReference<IntegrationMessage> resultRef = new AtomicReference<>();
+        AtomicReference<Object> resultRef = new AtomicReference<>();
 
-        promise.invokeMember("then", (ProxyExecutable) args -> {
-            Value result = args[0];
-            if (!isIntegrationMessage(result)) {
-                throw new IllegalArgumentException("Unexpected values is returned from promise [" + promise + "] Expected return type ["
-                        + IntegrationMessage.class + "]. Returned result [" + result + "]");
-            }
-            resultRef.set(result.asHostObject());
-            latch.countDown();
-            return null;
-        });
-
+        // note that throwing an exceptions in these functions (onFulfilled, onRejected) will not be logged
+        // anywhere
+        // that's why the errors are propagated to the AtomicReference and thrown there
+        promise.invokeMember("then", onFulfilled(promise, resultRef, latch), onRejected(promise, resultRef, latch));
         waitForPromiseToResolve(promise, latch);
 
-        return resultRef.get();
+        return handlePromiseResult(promise, resultRef);
+    }
+
+    private ProxyExecutable onFulfilled(Value promise, AtomicReference<Object> resultRef, CountDownLatch latch) {
+        return args -> {
+            LOGGER.debug("Calling onFulfilled for promise {}", promise);
+            try {
+                Value result = args[0];
+                if (isIntegrationMessage(result)) {
+                    resultRef.set(result.asHostObject());
+                } else {
+                    IllegalArgumentException ex = new IllegalArgumentException("Unexpected values is returned from promise [" + promise
+                            + "] Expected return type [" + IntegrationMessage.class + "]. Returned result [" + result + "]");
+                    resultRef.set(ex);
+                }
+                return null;
+            } finally {
+                latch.countDown();
+            }
+        };
+    }
+
+    private ProxyExecutable onRejected(Value promise, AtomicReference<Object> resultRef, CountDownLatch latch) {
+        return args -> {
+            LOGGER.debug("Calling onRejected for promise {}", promise);
+            try {
+                Value reason = args[0];
+
+                if (!reason.isException()) {
+                    IllegalStateException ex =
+                            new IllegalStateException("Promise [" + promise + "] was rejected with non-exception reason: " + reason);
+                    resultRef.set(ex);
+                }
+
+                try {
+                    // the invocation of this method throws an exception with java script stack trace
+                    reason.throwException();
+                } catch (Throwable reasonException) {
+                    resultRef.set(reasonException);
+                }
+
+                return null;
+            } finally {
+                latch.countDown();
+            }
+        };
+    }
+
+    private IntegrationMessage handlePromiseResult(Value promise, AtomicReference<Object> resultRef) {
+        Object result = resultRef.get();
+        if (null == result) {
+            throw new IllegalStateException(
+                    "Missing integration message in the result of the execution of promise: " + promise + ". Check logs for more details.");
+        }
+        if (result instanceof IntegrationMessage integrationMessage) {
+            return integrationMessage;
+        }
+        if (result instanceof Exception ex) {
+            throw new IllegalStateException("An error occurred during execution of promise: " + promise, ex);
+        }
+
+        throw new IllegalStateException("An invalid result [" + result + "] returned by the execution of promise: " + promise);
     }
 
     private void waitForPromiseToResolve(Value promise, CountDownLatch latch) {
         try {
-            latch.await();
+            latch.await(15, TimeUnit.MINUTES);
         } catch (InterruptedException e) {
             throw new IllegalStateException("Failed to await for promise execution for: " + promise, e);
         }


### PR DESCRIPTION
Fix async camel java script steps execution handling.

Currently, when an error occur in the async execution, the execution looks like "stuck"(running) without any errors/warnings in the logs.

Fix this by:
- Handle promise errors properly in the java code
- Add JS stacktrace to the logs so that issues could be investigated  
- Add async execution timeout - at most 15 minutes

An example failure log:
```log
2025-08-07 15:54:25.975 [ERROR] [flowable-async-job-executor-thread-24] [default-tenant] o.a.c.p.e.DefaultErrorHandler - Failed delivery for (MessageId: 33359D19B1D9808-0000000000000008 on ExchangeId: 33359D19B1D9808-0000000000000008). Exhausted after delivery attempt: 1 caught: org.eclipse.dirigible.components.engine.camel.components.DirigibleJavaScriptException: Exception during invocation of: interface org.eclipse.dirigible.components.engine.camel.components.DirigibleJavaScriptInvoker

Message History (complete message history is disabled)
---------------------------------------------------------------------------------------------------------------------------------------
Source                                   ID                             Processor                                          Elapsed (ms)
any:8                                    http-route-b0a6/http-route-b0a from[direct://etl-route]                                    292
	...
any:24                                   http-route-b0a6/to-crt4        dirigible-java-script:sales/etl/transform-entries.            0

Stacktrace
---------------------------------------------------------------------------------------------------------------------------------------
org.eclipse.dirigible.components.engine.camel.components.DirigibleJavaScriptException: Exception during invocation of: interface org.eclipse.dirigible.components.engine.camel.components.DirigibleJavaScriptInvoker
	at org.eclipse.dirigible.components.engine.camel.components.DirigibleJavaScriptProcessor.process(DirigibleJavaScriptProcessor.java:59) ~[dirigible-components-engine-camel-13.0.0-SNAPSHOT.jar!/:na]
	at org.apache.camel.support.AsyncProcessorConverterHelper$ProcessorToAsyncProcessorBridge.process(AsyncProcessorConverterHelper.java:65) ~[camel-support-4.12.0.jar!/:4.12.0]
	at org.eclipse.dirigible.components.engine.camel.components.DirigibleJavaScriptProducer.process(DirigibleJavaScriptProducer.java:31) ~[dirigible-components-engine-camel-13.0.0-SNAPSHOT.jar!/:na]
	at org.apache.camel.processor.SendProcessor.sendUsingProducer(SendProcessor.java:252) ~[camel-core-processor-4.12.0.jar!/:4.12.0]
	at org.apache.camel.processor.SendProcessor.process(SendProcessor.java:157) ~[camel-core-processor-4.12.0.jar!/:4.12.0]
	at org.apache.camel.processor.errorhandler.RedeliveryErrorHandler$SimpleTask.handleFirst(RedeliveryErrorHandler.java:440) ~[camel-core-processor-4.12.0.jar!/:4.12.0]
	at org.apache.camel.processor.errorhandler.RedeliveryErrorHandler$SimpleTask.run(RedeliveryErrorHandler.java:416) ~[camel-core-processor-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.doRun(DefaultReactiveExecutor.java:199) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.executeReactiveWork(DefaultReactiveExecutor.java:189) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.tryExecuteReactiveWork(DefaultReactiveExecutor.java:166) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.schedule(DefaultReactiveExecutor.java:148) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor.scheduleMain(DefaultReactiveExecutor.java:59) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.processor.Pipeline.process(Pipeline.java:163) ~[camel-core-processor-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.CamelInternalProcessor.processNonTransacted(CamelInternalProcessor.java:347) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.CamelInternalProcessor.process(CamelInternalProcessor.java:323) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.component.direct.DirectProducer.process(DirectProducer.java:102) ~[camel-direct-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.SharedCamelInternalProcessor.processNonTransacted(SharedCamelInternalProcessor.java:156) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.SharedCamelInternalProcessor.process(SharedCamelInternalProcessor.java:133) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.SharedCamelInternalProcessor$1.process(SharedCamelInternalProcessor.java:89) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultAsyncProcessorAwaitManager.process(DefaultAsyncProcessorAwaitManager.java:82) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.SharedCamelInternalProcessor.process(SharedCamelInternalProcessor.java:86) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.support.cache.DefaultProducerCache.send(DefaultProducerCache.java:178) ~[camel-support-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultProducerTemplate.send(DefaultProducerTemplate.java:175) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultProducerTemplate.send(DefaultProducerTemplate.java:171) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultFluentProducerTemplate.request(DefaultFluentProducerTemplate.java:431) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultFluentProducerTemplate.request(DefaultFluentProducerTemplate.java:404) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.eclipse.dirigible.components.engine.camel.processor.CamelProcessor.invokeRoute(CamelProcessor.java:124) ~[dirigible-components-engine-camel-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.camel.invoke.Invoker.invokeRoute(Invoker.java:60) ~[dirigible-components-engine-camel-13.0.0-SNAPSHOT.jar!/:na]
	at com.oracle.truffle.host.HostMethodDesc$SingleMethod$MHBase.invokeHandle(HostMethodDesc.java:372) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.GuestToHostCodeCache$GuestToHostInvokeHandle.executeImpl(GuestToHostCodeCache.java:88) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.GuestToHostRootNode.execute(GuestToHostRootNode.java:80) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:118) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultRuntimeAccessor$DefaultRuntimeSupport.callInlined(DefaultRuntimeAccessor.java:201) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.GuestToHostRootNode.guestToHostCall(GuestToHostRootNode.java:102) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.HostMethodDesc$SingleMethod$MHBase.invokeGuestToHost(HostMethodDesc.java:408) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.HostExecuteNode.doInvoke(HostExecuteNode.java:877) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.HostExecuteNode.doFixed(HostExecuteNode.java:140) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.HostExecuteNodeGen$Inlined.executeAndSpecialize(HostExecuteNodeGen.java:385) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.HostExecuteNodeGen$Inlined.execute(HostExecuteNodeGen.java:345) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.HostObject.invokeMember(HostObject.java:465) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.HostObjectGen$InteropLibraryExports$Cached.invokeMemberNode_AndSpecialize(HostObjectGen.java:7007) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.host.HostObjectGen$InteropLibraryExports$Cached.invokeMember(HostObjectGen.java:6993) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.interop.InteropLibraryGen$CachedDispatch.invokeMember(InteropLibraryGen.java:8497) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$ForeignInvokeNode.executeCall(JSFunctionCallNode.java:1548) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeAndSpecialize(JSFunctionCallNode.java:308) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeCall(JSFunctionCallNode.java:253) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$InvokeNode.execute(JSFunctionCallNode.java:723) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.ReturnNode$TerminalPositionReturnNode.execute(ReturnNode.java:178) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeGeneric(AbstractBlockNode.java:83) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeGeneric(AbstractBlockNode.java:53) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultBlockNode.executeGeneric(DefaultBlockNode.java:65) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.execute(AbstractBlockNode.java:73) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.FunctionBodyNode.execute(FunctionBodyNode.java:70) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.FunctionRootNode.executeInRealm(FunctionRootNode.java:155) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.JavaScriptRealmBoundaryRootNode.execute(JavaScriptRealmBoundaryRootNode.java:96) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:118) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultDirectCallNode.call(DefaultDirectCallNode.java:59) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$DirectJSFunctionCacheNode.executeCall(JSFunctionCallNode.java:1330) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeAndSpecialize(JSFunctionCallNode.java:308) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeCall(JSFunctionCallNode.java:253) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$InvokeNode.execute(JSFunctionCallNode.java:723) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.access.JSWriteCurrentFrameSlotNodeGen.execute_generic3(JSWriteCurrentFrameSlotNodeGen.java:136) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.access.JSWriteCurrentFrameSlotNodeGen.execute(JSWriteCurrentFrameSlotNodeGen.java:67) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.access.JSWriteCurrentFrameSlotNodeGen.executeVoid(JSWriteCurrentFrameSlotNodeGen.java:319) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:78) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:53) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultBlockNode.executeGeneric(DefaultBlockNode.java:63) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.execute(AbstractBlockNode.java:73) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.ModuleBodyNode.execute(ModuleBodyNode.java:75) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.FunctionBodyNode.execute(FunctionBodyNode.java:70) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.FunctionRootNode.executeInRealm(FunctionRootNode.java:155) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.JavaScriptRealmBoundaryRootNode.execute(JavaScriptRealmBoundaryRootNode.java:96) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:97) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.builtins.JSFunction.call(JSFunction.java:315) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.objects.JSModuleRecord.executeModule(JSModuleRecord.java:269) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.parser.GraalJSEvaluator.innerModuleEvaluation(GraalJSEvaluator.java:818) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.parser.GraalJSEvaluator.moduleEvaluation(GraalJSEvaluator.java:717) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.runtime.objects.CyclicModuleRecord.evaluate(CyclicModuleRecord.java:144) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.parser.GraalJSEvaluator$ModuleScriptRoot.evalModule(GraalJSEvaluator.java:309) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.js.parser.GraalJSEvaluator$ModuleScriptRoot.execute(GraalJSEvaluator.java:294) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:118) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultDirectCallNode.call(DefaultDirectCallNode.java:59) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.js.lang.JavaScriptLanguage$ParsedProgramRoot.execute(JavaScriptLanguage.java:256) ~[js-language-24.2.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:118) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.polyglot.PolyglotContextImpl.eval(PolyglotContextImpl.java:1894) ~[truffle-api-24.2.1.jar!/:na]
	at com.oracle.truffle.polyglot.PolyglotContextDispatch.eval(PolyglotContextDispatch.java:62) ~[truffle-api-24.2.1.jar!/:na]
	at org.graalvm.polyglot.Context.eval(Context.java:416) ~[polyglot-24.2.1.jar!/:na]
	at org.eclipse.dirigible.graalium.core.javascript.GraalJSCodeRunner.run(GraalJSCodeRunner.java:385) ~[dirigible-engine-graalium-execution-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.graalium.core.DirigibleJavascriptCodeRunner.run(DirigibleJavascriptCodeRunner.java:207) ~[dirigible-engine-graalium-execution-core-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.bpm.flowable.delegate.DirigibleCallDelegate.executeJSHandler(DirigibleCallDelegate.java:327) ~[dirigible-components-engine-bpm-flowable-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.bpm.flowable.delegate.DirigibleCallDelegate.lambda$executeJSHandlerInTenantContext$0(DirigibleCallDelegate.java:306) ~[dirigible-components-engine-bpm-flowable-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.tenants.tenant.TenantContextImpl.execute(TenantContextImpl.java:67) ~[dirigible-components-core-tenants-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.tenants.tenant.TenantContextImpl.execute(TenantContextImpl.java:59) ~[dirigible-components-core-tenants-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.bpm.flowable.delegate.DirigibleCallDelegate.executeJSHandlerInTenantContext(DirigibleCallDelegate.java:305) ~[dirigible-components-engine-bpm-flowable-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.bpm.flowable.delegate.DirigibleCallDelegate.executeInternal(DirigibleCallDelegate.java:289) ~[dirigible-components-engine-bpm-flowable-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.bpm.flowable.delegate.DirigibleCallDelegate.execute(DirigibleCallDelegate.java:238) ~[dirigible-components-engine-bpm-flowable-13.0.0-SNAPSHOT.jar!/:na]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:359) ~[spring-aop-6.2.7.jar!/:6.2.7]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196) ~[spring-aop-6.2.7.jar!/:6.2.7]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-6.2.7.jar!/:6.2.7]
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:380) ~[spring-tx-6.2.7.jar!/:6.2.7]
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119) ~[spring-tx-6.2.7.jar!/:6.2.7]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.2.7.jar!/:6.2.7]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:728) ~[spring-aop-6.2.7.jar!/:6.2.7]
	at org.eclipse.dirigible.components.engine.bpm.flowable.delegate.DirigibleCallDelegate$$SpringCGLIB$$0.execute(<generated>) ~[dirigible-components-engine-bpm-flowable-13.0.0-SNAPSHOT.jar!/:na]
	at org.flowable.engine.impl.delegate.invocation.JavaDelegateInvocation.invoke(JavaDelegateInvocation.java:35) ~[flowable-engine-7.1.0.jar!/:7.1.0]
	at org.flowable.engine.impl.delegate.invocation.DelegateInvocation.proceed(DelegateInvocation.java:32) ~[flowable-engine-7.1.0.jar!/:7.1.0]
	at org.flowable.engine.impl.delegate.invocation.DefaultDelegateInterceptor.handleInvocation(DefaultDelegateInterceptor.java:26) ~[flowable-engine-7.1.0.jar!/:7.1.0]
	at org.flowable.engine.impl.bpmn.behavior.ServiceTaskDelegateExpressionActivityBehavior.execute(ServiceTaskDelegateExpressionActivityBehavior.java:177) ~[flowable-engine-7.1.0.jar!/:7.1.0]
	at org.flowable.engine.impl.agenda.ContinueProcessOperation.executeActivityBehavior(ContinueProcessOperation.java:298) ~[flowable-engine-7.1.0.jar!/:7.1.0]
	at org.flowable.engine.impl.agenda.ContinueProcessOperation.executeSynchronous(ContinueProcessOperation.java:175) ~[flowable-engine-7.1.0.jar!/:7.1.0]
	at org.flowable.engine.impl.agenda.ContinueProcessOperation.continueThroughFlowNode(ContinueProcessOperation.java:125) ~[flowable-engine-7.1.0.jar!/:7.1.0]
	at org.flowable.engine.impl.agenda.ContinueProcessOperation.run(ContinueProcessOperation.java:88) ~[flowable-engine-7.1.0.jar!/:7.1.0]
	at org.flowable.common.engine.impl.AbstractEngineConfiguration.lambda$new$0(AbstractEngineConfiguration.java:196) ~[flowable-engine-common-7.1.0.jar!/:7.1.0]
	at org.flowable.engine.impl.interceptor.CommandInvoker.executeOperation(CommandInvoker.java:169) ~[flowable-engine-7.1.0.jar!/:7.1.0]
	at org.flowable.engine.impl.interceptor.CommandInvoker.executeOperations(CommandInvoker.java:124) ~[flowable-engine-7.1.0.jar!/:7.1.0]
	at org.flowable.engine.impl.interceptor.CommandInvoker.execute(CommandInvoker.java:78) ~[flowable-engine-7.1.0.jar!/:7.1.0]
	at org.flowable.engine.impl.interceptor.BpmnOverrideContextInterceptor.execute(BpmnOverrideContextInterceptor.java:26) ~[flowable-engine-7.1.0.jar!/:7.1.0]
	at org.flowable.common.engine.impl.interceptor.TransactionContextInterceptor.execute(TransactionContextInterceptor.java:53) ~[flowable-engine-common-7.1.0.jar!/:7.1.0]
	at org.flowable.common.engine.impl.interceptor.CommandContextInterceptor.execute(CommandContextInterceptor.java:105) ~[flowable-engine-common-7.1.0.jar!/:7.1.0]
	at org.flowable.common.spring.SpringTransactionInterceptor.lambda$execute$0(SpringTransactionInterceptor.java:57) ~[flowable-spring-common-7.1.0.jar!/:7.1.0]
	at org.springframework.transaction.support.TransactionTemplate.execute(TransactionTemplate.java:140) ~[spring-tx-6.2.7.jar!/:6.2.7]
	at org.flowable.common.spring.SpringTransactionInterceptor.execute(SpringTransactionInterceptor.java:57) ~[flowable-spring-common-7.1.0.jar!/:7.1.0]
	at org.flowable.common.engine.impl.interceptor.LogInterceptor.execute(LogInterceptor.java:30) ~[flowable-engine-common-7.1.0.jar!/:7.1.0]
	at org.flowable.common.engine.impl.cfg.CommandExecutorImpl.execute(CommandExecutorImpl.java:56) ~[flowable-engine-common-7.1.0.jar!/:7.1.0]
	at org.flowable.common.engine.impl.cfg.CommandExecutorImpl.execute(CommandExecutorImpl.java:51) ~[flowable-engine-common-7.1.0.jar!/:7.1.0]
	at org.flowable.job.service.impl.asyncexecutor.ExecuteAsyncRunnable.executeJob(ExecuteAsyncRunnable.java:119) ~[flowable-job-service-7.1.0.jar!/:7.1.0]
	at org.flowable.job.service.impl.asyncexecutor.ExecuteAsyncRunnable.runInternally(ExecuteAsyncRunnable.java:107) ~[flowable-job-service-7.1.0.jar!/:7.1.0]
	at org.flowable.job.service.impl.asyncexecutor.ExecuteAsyncRunnable.run(ExecuteAsyncRunnable.java:82) ~[flowable-job-service-7.1.0.jar!/:7.1.0]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[na:na]
Caused by: java.lang.IllegalStateException: An error occurred during execution of promise: Promise{[[PromiseStatus]]: "rejected", [[PromiseValue]]: [object Error]}
	at org.eclipse.dirigible.components.engine.camel.invoke.DirigibleJavaScriptInvokerImpl.handlePromiseResult(DirigibleJavaScriptInvokerImpl.java:193) ~[dirigible-components-engine-camel-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.camel.invoke.DirigibleJavaScriptInvokerImpl.executePromise(DirigibleJavaScriptInvokerImpl.java:134) ~[dirigible-components-engine-camel-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.camel.invoke.DirigibleJavaScriptInvokerImpl.exctractIntegrationMessage(DirigibleJavaScriptInvokerImpl.java:102) ~[dirigible-components-engine-camel-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.camel.invoke.DirigibleJavaScriptInvokerImpl.unwrapCamelMessage(DirigibleJavaScriptInvokerImpl.java:89) ~[dirigible-components-engine-camel-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.camel.invoke.DirigibleJavaScriptInvokerImpl.invoke(DirigibleJavaScriptInvokerImpl.java:53) ~[dirigible-components-engine-camel-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.camel.components.DirigibleJavaScriptProcessor.process(DirigibleJavaScriptProcessor.java:47) ~[dirigible-components-engine-camel-13.0.0-SNAPSHOT.jar!/:na]
	... 132 common frames omitted
Caused by: org.graalvm.polyglot.PolyglotException: TypeError: undefined is not a function
	at <js>.setTrace(/sales/dist/abap-transformation-executor.mjs:12553) ~[na:na]
	at <js>._setTrace(/sales/dist/abap-transformation-executor.mjs:12723) ~[na:na]
	at <js>.transform_v2(/sales/dist/abap-transformation-executor.mjs:70999) ~[na:na]
	at <js>.transform_v2(/sales/dist/abap-transformation-executor.mjs:70957) ~[na:na]
	at <js>.transformEntries(/sales/dist/abap-transformation-executor.mjs:75024) ~[na:na]
	at org.graalvm.polyglot.Value.execute(Value.java:1049) ~[polyglot-24.2.1.jar!/:na]
	at org.eclipse.dirigible.graalium.core.DirigibleJavascriptCodeRunner.runEsmMethod(DirigibleJavascriptCodeRunner.java:224) ~[dirigible-engine-graalium-execution-core-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.graalium.core.DirigibleJavascriptCodeRunner.runMethod(DirigibleJavascriptCodeRunner.java:217) ~[dirigible-engine-graalium-execution-core-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.camel.invoke.DirigibleJavaScriptInvokerImpl.invoke(DirigibleJavaScriptInvokerImpl.java:49) ~[dirigible-components-engine-camel-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.camel.components.DirigibleJavaScriptProcessor.process(DirigibleJavaScriptProcessor.java:47) ~[dirigible-components-engine-camel-13.0.0-SNAPSHOT.jar!/:na]
	at org.apache.camel.support.AsyncProcessorConverterHelper$ProcessorToAsyncProcessorBridge.process(AsyncProcessorConverterHelper.java:65) ~[camel-support-4.12.0.jar!/:4.12.0]
	at org.eclipse.dirigible.components.engine.camel.components.DirigibleJavaScriptProducer.process(DirigibleJavaScriptProducer.java:31) ~[dirigible-components-engine-camel-13.0.0-SNAPSHOT.jar!/:na]
	at org.apache.camel.processor.SendProcessor.sendUsingProducer(SendProcessor.java:252) ~[camel-core-processor-4.12.0.jar!/:4.12.0]
	at org.apache.camel.processor.SendProcessor.process(SendProcessor.java:157) ~[camel-core-processor-4.12.0.jar!/:4.12.0]
	at org.apache.camel.processor.errorhandler.RedeliveryErrorHandler$SimpleTask.handleFirst(RedeliveryErrorHandler.java:440) ~[camel-core-processor-4.12.0.jar!/:4.12.0]
	at org.apache.camel.processor.errorhandler.RedeliveryErrorHandler$SimpleTask.run(RedeliveryErrorHandler.java:416) ~[camel-core-processor-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.doRun(DefaultReactiveExecutor.java:199) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.executeReactiveWork(DefaultReactiveExecutor.java:189) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.tryExecuteReactiveWork(DefaultReactiveExecutor.java:166) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.schedule(DefaultReactiveExecutor.java:148) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor.scheduleMain(DefaultReactiveExecutor.java:59) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.processor.Pipeline.process(Pipeline.java:163) ~[camel-core-processor-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.CamelInternalProcessor.processNonTransacted(CamelInternalProcessor.java:347) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.CamelInternalProcessor.process(CamelInternalProcessor.java:323) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.component.direct.DirectProducer.process(DirectProducer.java:102) ~[camel-direct-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.SharedCamelInternalProcessor.processNonTransacted(SharedCamelInternalProcessor.java:156) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.SharedCamelInternalProcessor.process(SharedCamelInternalProcessor.java:133) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.SharedCamelInternalProcessor$1.process(SharedCamelInternalProcessor.java:89) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultAsyncProcessorAwaitManager.process(DefaultAsyncProcessorAwaitManager.java:82) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.SharedCamelInternalProcessor.process(SharedCamelInternalProcessor.java:86) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.support.cache.DefaultProducerCache.send(DefaultProducerCache.java:178) ~[camel-support-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultProducerTemplate.send(DefaultProducerTemplate.java:175) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultProducerTemplate.send(DefaultProducerTemplate.java:171) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultFluentProducerTemplate.request(DefaultFluentProducerTemplate.java:431) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.apache.camel.impl.engine.DefaultFluentProducerTemplate.request(DefaultFluentProducerTemplate.java:404) ~[camel-base-engine-4.12.0.jar!/:4.12.0]
	at org.eclipse.dirigible.components.engine.camel.processor.CamelProcessor.invokeRoute(CamelProcessor.java:124) ~[dirigible-components-engine-camel-13.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.camel.invoke.Invoker.invokeRoute(Invoker.java:60) ~[dirigible-components-engine-camel-13.0.0-SNAPSHOT.jar!/:na]
	at <js>.invokeRoute(sdk/integrations:7) ~[na:na]
	at <js>.:module:eval(trigger-ds_is_td-to-td_is-task.ts:21) ~[na:na]
	... 47 common frames omitted
```