### PR TITLE
Enhance logging API with isXxxEnabled functions

### DIFF
--- a/components/api/api-log/src/main/java/org/eclipse/dirigible/components/api/log/LogFacade.java
+++ b/components/api/api-log/src/main/java/org/eclipse/dirigible/components/api/log/LogFacade.java
@@ -120,6 +120,31 @@ public class LogFacade {
         return LoggerFactory.getLogger(appLoggerName);
     }
 
+    public static boolean isDebugEnabled(String loggerName) throws IOException {
+        Logger logger = getLogger(loggerName);
+        return logger.isDebugEnabled();
+    }
+
+    public static boolean isErrorEnabled(String loggerName) throws IOException {
+        Logger logger = getLogger(loggerName);
+        return logger.isErrorEnabled();
+    }
+
+    public static boolean isWarnEnabled(String loggerName) throws IOException {
+        Logger logger = getLogger(loggerName);
+        return logger.isWarnEnabled();
+    }
+
+    public static boolean isInfoEnabled(String loggerName) throws IOException {
+        Logger logger = getLogger(loggerName);
+        return logger.isInfoEnabled();
+    }
+
+    public static boolean isTraceEnabled(String loggerName) throws IOException {
+        Logger logger = getLogger(loggerName);
+        return logger.isTraceEnabled();
+    }
+
     /**
      * Log.
      *

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/log/logging.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/log/logging.ts
@@ -106,6 +106,26 @@ class Logger {
 		return this;
 	}
 
+    public isDebugEnabled(): boolean {
+        return LogFacade.isDebugEnabled(this.loggerName);
+    }
+
+    public isErrorEnabled(): boolean {
+        return LogFacade.isErrorEnabled(this.loggerName);
+    }
+
+    public isWarnEnabled(): boolean {
+        return LogFacade.isWarnEnabled(this.loggerName);
+    }
+
+    public isInfoEnabled(): boolean {
+        return LogFacade.isInfoEnabled(this.loggerName);
+    }
+
+    public isTraceEnabled(): boolean {
+        return LogFacade.isTraceEnabled(this.loggerName);
+    }
+
 	public log(msg: string, level: string): void {
 		const args = Array.prototype.slice.call(arguments);
 		let msgParameters = [];


### PR DESCRIPTION
Enhance logging API with isXxxEnabled functions:
- `isDebugEnabled`
- `isErrorEnabled`
- `isWarnEnabled`
- `isInfoEnabled`
- `isTraceEnabled`

Issue: https://github.com/eclipse-dirigible/dirigible/issues/5244