### PR TITLE
TypeScript logging API - fix logging ex/error stack traces

### DIFF
--- a/components/api/api-log/pom.xml
+++ b/components/api/api-log/pom.xml
@@ -1,41 +1,48 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.eclipse.dirigible</groupId>
-		<artifactId>dirigible-components-parent</artifactId>
-		<version>13.0.0-SNAPSHOT</version>
-		<relativePath>../../pom.xml</relativePath>
-	</parent>
+    <parent>
+        <groupId>org.eclipse.dirigible</groupId>
+        <artifactId>dirigible-components-parent</artifactId>
+        <version>13.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
 
-	<name>Components - API - Logging</name>
-	<artifactId>dirigible-components-api-log</artifactId>
-	<packaging>jar</packaging>
+    <name>Components - API - Logging</name>
+    <artifactId>dirigible-components-api-log</artifactId>
+    <packaging>jar</packaging>
 
-	<dependencies>
-		<!-- JS sources -->
-		<dependency>
-			<groupId>org.eclipse.dirigible</groupId>
-			<artifactId>dirigible-components-api-modules-javascript</artifactId>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js-language</artifactId>
+            <version>${graalvm.version}</version>
+        </dependency>
 
-		<!-- Helpers -->
-		<dependency>
-			<groupId>org.eclipse.dirigible</groupId>
-			<artifactId>dirigible-commons-helpers</artifactId>
-		</dependency>
-		
-		<!-- Test -->
-		<dependency>
-			<groupId>org.eclipse.dirigible</groupId>
-			<artifactId>dirigible-components-api-test</artifactId>
-		</dependency>
-		
-	</dependencies>
+        <!-- JS sources -->
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-api-modules-javascript</artifactId>
+        </dependency>
 
-	<properties>
-		<license.header.location>../../../licensing-header.txt</license.header.location>
-		<parent.pom.folder>../../../</parent.pom.folder>
-	</properties>
+        <!-- Helpers -->
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-commons-helpers</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-api-test</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <properties>
+        <license.header.location>../../../licensing-header.txt</license.header.location>
+        <parent.pom.folder>../../../</parent.pom.folder>
+    </properties>
 
 </project>

--- a/components/api/api-log/src/main/java/org/eclipse/dirigible/components/api/log/LogFacade.java
+++ b/components/api/api-log/src/main/java/org/eclipse/dirigible/components/api/log/LogFacade.java
@@ -9,17 +9,21 @@
  */
 package org.eclipse.dirigible.components.api.log;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.ArrayType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.oracle.truffle.js.runtime.GraalJSException;
+import com.oracle.truffle.js.runtime.Strings;
+import com.oracle.truffle.js.runtime.builtins.JSErrorObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Optional;
 
 /**
  * The Class LogFacade.
@@ -41,44 +45,6 @@ public class LogFacade {
     /** The Constant objectArrayType. */
     private static final ArrayType objectArrayType = TypeFactory.defaultInstance()
                                                                 .constructArrayType(Object.class);
-
-
-    /**
-     * The Class ErrorObject.
-     */
-    static class ErrorObject {
-
-        /** The error message. */
-        @JsonProperty("message")
-        public String message;
-
-        /** The error stack. */
-        @JsonProperty("stack")
-        public StackTraceEl[] stack;
-    }
-
-
-    /**
-     * The Class StackTraceEl.
-     */
-    static class StackTraceEl {
-
-        /** The file name. */
-        @JsonProperty("fileName")
-        public String fileName;
-
-        /** The line number. */
-        @JsonProperty("lineNumber")
-        public int lineNumber;
-
-        /** The declaring class. */
-        @JsonProperty("declaringClass")
-        public String declaringClass;
-
-        /** The method name. */
-        @JsonProperty("methodName")
-        public String methodName;
-    }
 
     /**
      * Sets the logging level.
@@ -152,45 +118,44 @@ public class LogFacade {
      * @param level the level
      * @param message the message
      * @param logArguments the log arguments
-     * @param errorJson the error json
+     * @param rawError the error json
      * @throws IOException Signals that an I/O exception has occurred.
      */
-    public static void log(String loggerName, String level, String message, String logArguments, String errorJson) throws IOException {
+    public static void log(String loggerName, String level, String message, String logArguments, Object rawError) throws IOException {
 
         final Logger logger = getLogger(loggerName);
 
         if (ch.qos.logback.classic.Level.DEBUG.toString()
                                               .equalsIgnoreCase(level)
                 && logger.isDebugEnabled()) {
-            Object[] args = getMessageArgs(loggerName, level, message, logArguments, errorJson);
+            Object[] args = getMessageArgs(loggerName, level, message, logArguments, rawError);
             logger.debug(message, args);
         } else if (ch.qos.logback.classic.Level.TRACE.toString()
                                                      .equalsIgnoreCase(level)
                 && logger.isTraceEnabled()) {
-            Object[] args = getMessageArgs(loggerName, level, message, logArguments, errorJson);
+            Object[] args = getMessageArgs(loggerName, level, message, logArguments, rawError);
             logger.trace(message, args);
         } else if (ch.qos.logback.classic.Level.INFO.toString()
                                                     .equalsIgnoreCase(level)
                 && logger.isInfoEnabled()) {
-            Object[] args = getMessageArgs(loggerName, level, message, logArguments, errorJson);
+            Object[] args = getMessageArgs(loggerName, level, message, logArguments, rawError);
             logger.info(message, args);
         } else if (ch.qos.logback.classic.Level.WARN.toString()
                                                     .equalsIgnoreCase(level)
                 && logger.isWarnEnabled()) {
-            Object[] args = getMessageArgs(loggerName, level, message, logArguments, errorJson);
+            Object[] args = getMessageArgs(loggerName, level, message, logArguments, rawError);
             logger.warn(message, args);
         } else if (ch.qos.logback.classic.Level.ERROR.toString()
                                                      .equalsIgnoreCase(level)
                 && logger.isErrorEnabled()) {
-            Object[] args = getMessageArgs(loggerName, level, message, logArguments, errorJson);
+            Object[] args = getMessageArgs(loggerName, level, message, logArguments, rawError);
             logger.error(message, args);
         } else {
             LOGGER.debug("Logging using logger [{}] for message [{}] will be skipped. Log level level [{}].", loggerName, message, level);
         }
     }
 
-    private static Object[] getMessageArgs(String loggerName, String level, String message, String logArguments, String errorJson)
-            throws IOException {
+    private static Object[] getMessageArgs(String loggerName, String level, String message, String logArguments, Object rawError) {
         Object[] args = null;
         if (logArguments != null) {
             try {
@@ -202,60 +167,90 @@ public class LogFacade {
                 LOGGER.error("Cannot parse log arguments for logger [{}] for message [{}] at level [{}]", loggerName, message, level, e);
             }
         }
-        // https://www.slf4j.org/faq.html#paramException
-        if (errorJson != null) {
-            Exception ex = toException(errorJson);
+
+        Throwable error = extractError(rawError);
+        if (error != null) {
             if (args == null) {
-                args = new Object[] {ex};
+                args = new Object[] {error};
             } else {
                 args = Arrays.copyOf(args, args.length + 1);
-                args[args.length - 1] = ex;
+                args[args.length - 1] = error;
             }
         }
+
         return args;
     }
 
-    /**
-     * Creates a JSServiceException from JSON.
-     *
-     * @param errorJson the error json
-     * @return the JS service exception
-     * @throws JsonMappingException the json mapping exception
-     * @throws IOException Signals that an I/O exception has occurred.
-     */
-    private static Exception toException(String errorJson) throws JsonMappingException, IOException {
-
-        Exception ex;
-
-        if (errorJson != null) {
-
-            ErrorObject errObj = om.readValue(errorJson, ErrorObject.class);
-
-            if (errObj.message == null) {
-                ex = new Exception();
-            } else {
-                ex = new Exception(errObj.message);
-            }
-
-            if (errObj.stack != null) {
-                StackTraceElement[] stackTraceElementArray = new StackTraceElement[errObj.stack.length];
-                for (int i = 0; i < errObj.stack.length; i++) {
-                    StackTraceEl customStackTraceElement = errObj.stack[i];
-                    StackTraceElement stackTraceElement = new StackTraceElement(customStackTraceElement.declaringClass,
-                            customStackTraceElement.methodName, customStackTraceElement.fileName, customStackTraceElement.lineNumber);
-                    stackTraceElementArray[i] = stackTraceElement;
-                }
-                ex.setStackTrace(stackTraceElementArray);
-            } else {
-                ex.setStackTrace(new StackTraceElement[] {new StackTraceElement("", "", null, 1)});
-            }
-
-        } else {
-            ex = new Exception();
-            ex.setStackTrace(new StackTraceElement[0]);
+    private static Throwable extractError(Object rawError) {
+        if (null == rawError) {
+            return null;
         }
 
-        return ex;
+        // in case the error is thrown in a java code (called by script code)
+        if (rawError instanceof Throwable throwable) {
+            return throwable;
+        }
+
+        // in case the error is thrown in a script code
+        Optional<Method> guestObjectMethod = getPublicMethod(rawError, "getGuestObject");
+        if (guestObjectMethod.isPresent()) {
+            Object guestObject = invokeMethod(guestObjectMethod.get(), rawError);
+            if (guestObject instanceof JSErrorObject jsErrorObject) {
+                if (jsErrorObject.isException()) {
+                    GraalJSException graalJSException = jsErrorObject.getException();
+                    GraalJSException.JSStackTraceElement[] jsStackTrace = graalJSException.getJSStackTrace();
+                    StackTraceElement[] jsStackTraceInJavaFormat = toJavaStackTrace(jsStackTrace);
+
+                    LOGGER.debug("A script error occurred (before changing the trace)", graalJSException);
+                    // set js stack trace to be printed when logged
+                    graalJSException.setStackTrace(jsStackTraceInJavaFormat);
+
+                    return graalJSException;
+                }
+            }
+        }
+
+        LOGGER.warn("An error cannot be extracted from [{}] of class [{}]", rawError, rawError.getClass());
+
+        return null;
+    }
+
+    private static StackTraceElement[] toJavaStackTrace(GraalJSException.JSStackTraceElement[] jsStackTrace) {
+        if (null == jsStackTrace) {
+            return null;
+        }
+
+        return Arrays.stream(jsStackTrace)
+                     .map(LogFacade::toJavaStackTrace)
+                     .toArray(StackTraceElement[]::new);
+    }
+
+    private static StackTraceElement toJavaStackTrace(GraalJSException.JSStackTraceElement jsStackTrace) {
+        String declaringClass = Strings.toJavaString(jsStackTrace.getClassName());
+        String methodName = jsStackTrace.getMethodName();
+        String fileName = Strings.toJavaString(jsStackTrace.getFileName());
+        int lineNumber = jsStackTrace.getLineNumber();
+
+        return new StackTraceElement(declaringClass, methodName, fileName, lineNumber);
+    }
+
+    private static Object invokeMethod(Method method, Object object) {
+        try {
+            method.trySetAccessible();
+            return method.invoke(object);
+        } catch (IllegalAccessException | InvocationTargetException ex) {
+            throw new IllegalStateException("Failed to call method " + method + " in object " + object, ex);
+        }
+    }
+
+    private static Optional<Method> getPublicMethod(Object obj, String methodName) {
+        try {
+            return Optional.of(obj.getClass()
+                                  .getMethod(methodName));
+        } catch (NoSuchMethodException e) {
+            LOGGER.debug("Missing method [{}] in object [{}]", methodName, obj);
+            return Optional.empty();
+        }
     }
 
 }

--- a/components/api/api-log/src/main/java/org/eclipse/dirigible/components/api/log/LogFacade.java
+++ b/components/api/api-log/src/main/java/org/eclipse/dirigible/components/api/log/LogFacade.java
@@ -226,7 +226,7 @@ public class LogFacade {
     }
 
     private static StackTraceElement toJavaStackTrace(GraalJSException.JSStackTraceElement jsStackTrace) {
-        String declaringClass = Strings.toJavaString(jsStackTrace.getClassName());
+        String declaringClass = "<js>";
         String methodName = jsStackTrace.getMethodName();
         String fileName = Strings.toJavaString(jsStackTrace.getFileName());
         int lineNumber = jsStackTrace.getLineNumber();

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/db/dao.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/db/dao.ts
@@ -410,7 +410,7 @@ DAO.prototype.insert = function (_entity) {
 				try {
 					this.remove(dbEntity[this.orm.getPrimaryKey().name]);
 				} catch (err) {
-					this.$log.error('Could not rollback changes after failed {}[{}}] insert. ', err, this.orm.table, dbEntity[this.orm.getPrimaryKey().name]);
+					this.$log.error('Could not rollback changes after failed {}[{}] insert. ', this.orm.table, dbEntity[this.orm.getPrimaryKey().name], err);
 				}
 			}
 			throw e;
@@ -462,7 +462,7 @@ DAO.prototype.update = function (entity) {
 		return this;
 
 	} catch (e) {
-		this.$log.error('Updating {}[{}] failed', e, this.orm.table, entity !== undefined ? entity[this.orm.getPrimaryKey().name] : entity);
+		this.$log.error('Updating {}[{}] failed', this.orm.table, entity !== undefined ? entity[this.orm.getPrimaryKey().name] : entity, e);
 		throw e;
 	}
 };
@@ -555,7 +555,7 @@ DAO.prototype.remove = function () {
 				this.$log.trace('No changes incurred in {}', this.orm.table);
 
 		} catch (e) {
-			this.$log.error('Deleting {}[{}] entity failed', e, this.orm.table, id);
+			this.$log.error('Deleting {}[{}] entity failed',this.orm.table, id, e);
 			throw e;
 		}
 
@@ -742,7 +742,7 @@ DAO.prototype.find = function (id, expand, select) {
 		}
 		return entity;
 	} catch (e) {
-		this.$log.error("Finding {}[{}] entitiy failed.", e, this.orm.table, id);
+		this.$log.error("Finding {}[{}] entity failed.", this.orm.table, id, e);
 		throw e;
 	}
 };
@@ -762,7 +762,7 @@ DAO.prototype.count = function (settings?) {
 			count = parseInt(rs[0][key], 10);
 		}
 	} catch (e) {
-		this.$log.error('Counting {} entities failed', e, this.orm.table);
+		this.$log.error('Counting {} entities failed', this.orm.table, e);
 		e.errContext = parametericStatement.toString();
 		throw e;
 	}
@@ -863,7 +863,7 @@ DAO.prototype.list = function (settings) {
 
 		return entities;
 	} catch (e) {
-		this.$log.error("Listing {} entities failed.", e, this.orm.table);
+		this.$log.error("Listing {} entities failed.", this.orm.table, e);
 		throw e;
 	}
 };
@@ -887,7 +887,7 @@ DAO.prototype.createTable = function () {
 		this.$log.trace('{} table created', this.orm.table);
 		return this;
 	} catch (e) {
-		this.$log.error("Create table {} failed", e, this.orm.table);
+		this.$log.error("Create table {} failed", this.orm.table, e);
 		throw e;
 	}
 };
@@ -899,7 +899,7 @@ DAO.prototype.dropTable = function (dropIdSequence) {
 		this.execute(parametericStatement);
 		this.$log.trace('Table {} dropped.', this.orm.table);
 	} catch (e) {
-		this.$log.error("Dropping table {} failed.", e, this.orm.table);
+		this.$log.error("Dropping table {} failed.", this.orm.table, e);
 		throw e;
 	}
 
@@ -909,7 +909,7 @@ DAO.prototype.dropTable = function (dropIdSequence) {
 			this.dropIdGenerator();
 			this.$log.trace('Table {} sequence {} dropped.', this.orm.table, this.sequenceName);
 		} catch (e) {
-			this.$log.error("Dropping table {} sequence {} failed.", e, this.orm.table, this.sequenceName);
+			this.$log.error("Dropping table {} sequence {} failed.", this.orm.table, this.sequenceName, e);
 			throw e;
 		}
 	}

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/http/rs/resource-http-controller.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/http/rs/resource-http-controller.ts
@@ -147,7 +147,7 @@ export class HttpController {
                 }
             }
         } else {
-            logger.error('No suitable resource handler for Resource[' + resourcePath + '], Method[' + method.toUpperCase() + '], Content-Type[' + contentTypeHeader + '], Accept[' + acceptsHeader + '] found');
+            logger.error('No suitable resource handler for Resource[{}], Method[{}], Content-Type[{}], Accept[{}] found', resourcePath, method.toUpperCase(), contentTypeHeader, acceptsHeader);
             this.sendError(response.BAD_REQUEST, undefined, 'Bad Request', 'No suitable processor for this request.');
         }
     }
@@ -257,7 +257,7 @@ const catchErrorHandler = function (logctx, ctx, err, request, response) {
         const detailsMsg = (ctx.errorName || "") + (ctx.errorCode ? " [" + ctx.errorCode + "]" : "") + (ctx.errorMessage ? ": " + ctx.errorMessage : "");
         logger.info('Serving resource[{}], Verb[{}], Content-Type[{}], Accept[{}] finished in error. {}', logctx.path, logctx.method, logctx.contentType, logctx.accepts, detailsMsg);
     } else
-        logger.error('Serving resource[' + logctx.path + '], Verb[' + logctx.method + '], Content-Type[' + logctx.contentType + '], Accept[' + logctx.accepts + '] finished in error', err);
+        logger.error('Serving resource[{}], Verb[{}], Content-Type[{}], Accept[{}] finished in error', logctx.path, logctx.method, logctx.contentType, logctx.accepts, err);
 
     const httpErrorCode = ctx.httpErrorCode || response.INTERNAL_SERVER_ERROR;
     const errorMessage = ctx.errorMessage || (err && err.message);

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/log/logging.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/log/logging.ts
@@ -28,79 +28,6 @@ class Logger {
 		this.loggerName = loggerName;
 	}
 
-	private resolveError(err: Error): { message: string, stack: any[] } {
-		let stack = [];
-		if (__engine === 'v8') {
-			stack = this.parseIntoStackTraceElementsV8(err.stack);
-		} else if (__engine === 'rhino' && err.stack) {
-			stack = this.parseIntoStackTraceElementsRhino(err.stack);
-		}
-		return {
-			message: err.message,
-			stack: stack
-		};
-	}
-
-	private parseIntoStackTraceElementsV8(stack: string): { fileName: string; lineNumber: string; declaringClass: any; methodName: string; }[] {
-		//"at obj.f2 (:29:9)" - length 8
-		//"at :36:4"		  - length 8
-		//"at Error (native)" - length 6
-		const v8_stack_el_regex = /^\s*at ?(.*?) ((.*?)\s*(?:\()?(?:(.*?))(?::(\d+))?(?::(\d+))(?:\))?|\((native)\))$/;
-		let lines_string = stack.split("\n");
-		let stackLineIdx = 0;
-		let lines = lines_string.map(line => {
-			if (stackLineIdx > 0 || line.trim().length < 1) {
-				const _segmenets = line.trim().match(v8_stack_el_regex);
-				if (_segmenets === null)
-					return;
-				//resolve object and function if specified
-				let _obj, _m;
-				if (_segmenets[1]) {
-					const _idx = _segmenets[1].lastIndexOf('.');
-					if (_idx < 0)
-						_m = _segmenets[1];
-					else {
-						_m = _segmenets[1].substring(_idx + 1, _segmenets[1].length);
-						_obj = _segmenets[1].substring(0, _segmenets[1].length - _m.length - 1);
-					}
-				}
-				return {
-					fileName: _segmenets.length < 8 ? _segmenets[3] : _segmenets[4],
-					lineNumber: _segmenets.length < 8 ? _segmenets[4] : _segmenets[5],
-					declaringClass: _obj || "?",
-					methodName: _m || "?"
-				};
-			}
-			stackLineIdx++;
-			return;
-		}).filter((el) => {
-			return el !== undefined;
-		});
-		return lines;
-	}
-
-	private parseIntoStackTraceElementsRhino(stack) {
-		//at prj1/svc/a.js:28 (anonymous)
-		//at prj1/svc/a.js:36
-		const rhino_stack_el_regex = /^\s*at (.*?) ?(.*?)(?::(\d+))?(?::(\d+))?\s*(\((.*?)\))?\s*$/;
-		let lines = stack.split("\n");
-		lines = lines.map(function (line) {
-			if (line.trim().length < 1)
-				return;
-			const _lineSegments = line.match(rhino_stack_el_regex);
-			return {
-				fileName: _lineSegments[2],
-				lineNumber: _lineSegments[3],
-				declaringClass: "?",
-				methodName: _lineSegments[6] || '?'
-			};
-		}).filter(function (el) {
-			return el !== undefined;
-		});
-		return lines;
-
-	}
-
 	public setLevel(level: string) {
 		LogFacade.setLevel(this.loggerName, level);
 		return this;
@@ -129,20 +56,19 @@ class Logger {
 	public log(msg: string, level: string): void {
 		const args = Array.prototype.slice.call(arguments);
 		let msgParameters = [];
-		let errObjectJson = null;
+
+		let rawError = null;
 		if (args.length > 2) {
 			if (args[2] instanceof Error) {
-				const errObject = this.resolveError(args[2]);
-				if (errObject) {
-					errObjectJson = JSON.stringify(errObject);
-				}
+                rawError = args[2];
 			}
-			const sliceIndex = errObjectJson ? 3 : 2;
+			const sliceIndex = rawError ? 3 : 2;
 			msgParameters = args.slice(sliceIndex).map(function (param) {
 				return typeof param === 'object' ? JSON.stringify(param) : param;
 			});
 		}
-		LogFacade.log(this.loggerName, level, msg, JSON.stringify(msgParameters), errObjectJson);
+
+		LogFacade.log(this.loggerName, level, msg, JSON.stringify(msgParameters), rawError);
 	}
 
 	public debug(msg: string, ..._): void {

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/log/logging.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/log/logging.ts
@@ -59,11 +59,15 @@ class Logger {
 
 		let rawError = null;
 		if (args.length > 2) {
-			if (args[2] instanceof Error) {
-                rawError = args[2];
+			if (args[args.length-1] instanceof Error) {
+                rawError = args[args.length-1];
+
+                if (rawError.stack) {
+                    console.debug("Handling error with stack:\n" + rawError.stack);
+                }
 			}
-			const sliceIndex = rawError ? 3 : 2;
-			msgParameters = args.slice(sliceIndex).map(function (param) {
+			const endIndex = rawError ? (args.length - 1) : args.length;
+			msgParameters = args.slice(2, endIndex).map(function (param) {
 				return typeof param === 'object' ? JSON.stringify(param) : param;
 			});
 		}

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/mongodb/dao.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/mongodb/dao.ts
@@ -144,7 +144,7 @@ export class DAO {
                     try {
                         this.remove(dbEntity[this.orm.getPrimaryKey().name]);
                     } catch (err) {
-                        this.$log.error('Could not rollback changes after failed {}[{}}] insert. ', this.orm.table, dbEntity[this.orm.getPrimaryKey().name]);
+                        this.$log.error('Could not rollback changes after failed {}[{}] insert. ', this.orm.table, dbEntity[this.orm.getPrimaryKey().name], err);
                     }
                 }
                 throw e;
@@ -189,7 +189,7 @@ export class DAO {
     
             return this;
         } catch (e) {
-            this.$log.error('Updating {}[{}] failed', this.orm.table, entity !== undefined ? entity[this.orm.getPrimaryKey().name] : entity);
+            this.$log.error('Updating {}[{}] failed', this.orm.table, entity !== undefined ? entity[this.orm.getPrimaryKey().name] : entity, e);
             throw e;
         }
     };
@@ -234,7 +234,7 @@ export class DAO {
                 collection.remove({ "_id": id });
     
             } catch (e) {
-                this.$log.error('Deleting {}[{}] entity failed', this.orm.table, id);
+                this.$log.error('Deleting {}[{}] entity failed', this.orm.table, id, e);
                 throw e;
             }
     
@@ -305,7 +305,7 @@ export class DAO {
             }
             return entity;
         } catch (e) {
-            this.$log.error("Finding {}[{}] entitiy failed.", this.orm.table, id);
+            this.$log.error("Finding {}[{}] entitiy failed.", this.orm.table, id, e);
             throw e;
         }
     }
@@ -319,7 +319,7 @@ export class DAO {
             var collection = db.getCollection(this.orm.table);
             count = collection.count();
         } catch (e) {
-            this.$log.error('Counting {} entities failed', e, this.orm.table);
+            this.$log.error('Counting {} entities failed', this.orm.table, e);
             // e.errContext = parametericStatement.toString(); // TODO: parametericStatement?
             throw e;
         }
@@ -420,7 +420,7 @@ export class DAO {
     
             return entities;
         } catch (e) {
-            this.$log.error("Listing {} entities failed.", this.orm.table);
+            this.$log.error("Listing {} entities failed.", this.orm.table, e);
             throw e;
         }
     }

--- a/components/engine/engine-javascript/src/main/java/org/eclipse/dirigible/components/engine/javascript/service/JavascriptHandler.java
+++ b/components/engine/engine-javascript/src/main/java/org/eclipse/dirigible/components/engine/javascript/service/JavascriptHandler.java
@@ -139,9 +139,9 @@ public class JavascriptHandler {
                 logger.error(ex.getMessage());
                 return ex.getMessage();
             }
-            String errorMessage =
-                    String.format("Error on processing JavaScript service from project: [%s], and path: [%s], with parameters: [%s]",
-                            projectName, projectFilePath, projectFilePathParam);
+            String errorMessage = String.format(
+                    "Error on processing JavaScript service from project: [%s], path: [%s], project file path param [%s] with parameters: [%s]",
+                    projectName, projectFilePath, projectFilePathParam, parameters);
             throw new RuntimeException(errorMessage, ex);
         }
     }

--- a/modules/engines/engine-graalium/execution/src/main/java/org/eclipse/dirigible/graalium/core/javascript/GraalJSCodeRunner.java
+++ b/modules/engines/engine-graalium/execution/src/main/java/org/eclipse/dirigible/graalium/core/javascript/GraalJSCodeRunner.java
@@ -396,12 +396,12 @@ public class GraalJSCodeRunner implements CodeRunner<Source, Value> {
                 if (guestObject.isException()) {
                     String exMessage = getExceptionMessage(guestObject);
                     String exClassName = getExceptionClass(guestObject);
+                    Throwable exCause = getExceptionCause(guestObject);
                     StackTraceElement[] stackTrace = getExceptionStackTrace(guestObject);
                     if (exMessage != null || exClassName != null || (null != stackTrace && stackTrace.length > 0)) {
                         GuestLanguageException guestLanguageException =
-                                new GuestLanguageException(codeSource.getPath(), exMessage, exClassName);
+                                new GuestLanguageException(codeSource.getPath(), exMessage, exClassName, exCause);
                         guestLanguageException.setStackTrace(stackTrace);
-
                         e.addSuppressed(guestLanguageException);
                     }
                 }
@@ -441,6 +441,18 @@ public class GraalJSCodeRunner implements CodeRunner<Source, Value> {
             if (classValue.canInvokeMember(getNameMethodName)) {
                 return classValue.invokeMember(getNameMethodName)
                                  .asString();
+            }
+        }
+        return null;
+    }
+
+    private Throwable getExceptionCause(Value value) {
+
+        String getCauseMethodName = "getCause";
+        if (value.isException() && value.canInvokeMember(getCauseMethodName)) {
+            Value causeValue = value.invokeMember(getCauseMethodName);
+            if (null != causeValue && causeValue.isException()) {
+                return causeValue.as(Throwable.class);
             }
         }
         return null;

--- a/modules/engines/engine-graalium/execution/src/main/java/org/eclipse/dirigible/graalium/core/javascript/GuestLanguageException.java
+++ b/modules/engines/engine-graalium/execution/src/main/java/org/eclipse/dirigible/graalium/core/javascript/GuestLanguageException.java
@@ -2,7 +2,7 @@ package org.eclipse.dirigible.graalium.core.javascript;
 
 public class GuestLanguageException extends RuntimeException {
 
-    public GuestLanguageException(String path, String exMessage, String exClassName) {
-        super("Exception in file [" + path + "] - exception class [" + exClassName + "], exception message [" + exMessage + "]");
+    public GuestLanguageException(String path, String exMessage, String exClassName, Throwable cause) {
+        super("Exception in file [" + path + "] - exception class [" + exClassName + "], exception message [" + exMessage + "]", cause);
     }
 }


### PR DESCRIPTION
## Scenarios
Enhance logging in the different scenarios by fixing the logged messages, exceptions and adding stack traces to the logs.
Compare the master and PR logs to see the difference.

### On error thrown in script code
- Test files
```javascript
# test-failure.ts
import { throwErr } from "test/my-lib"
import { logging } from "sdk/log";

const logger = logging.getLogger("org.eclipse.dirigible.testlogger");

try {
    throwErr();
} catch (e) {
    logger.error("An error occurred ", e)
}

# my-lib.ts
export function throwErr() {
    throw new Error("My intentional error.");
}

```

- Traces in **master** branch:

  <details>
    <summary>Expand logs</summary>

    ```log
    2025-09-18 13:47:51.314 [ERROR] [http-nio-8080-exec-6] [default-tenant] a.org.eclipse.dirigible.testlogger - An error occurred 
    java.lang.Exception: My intentional error.
    ```
  </details>

- Traces in the **current PR**
  <details>
    <summary>Expand logs</summary>

    ```log
    2025-09-18 16:29:47.827 [ERROR] [http-nio-8080-exec-5] [default-tenant] a.org.eclipse.dirigible.testlogger - An error occurred 
    com.oracle.truffle.js.runtime.JSException: Error: My intentional error.
      at <js>.throwErr(/Users/iliyan/work/dirigible-workspaces/dirigible/dirigible/repository/root/registry/public/test/my-lib.js:2) ~[na:na]
      at <js>.<program>(/Users/iliyan/work/dirigible-workspaces/dirigible/dirigible/repository/root/registry/public/test/test-failure.js:5) ~[na:na]
    ```
  </details>

### On error thrown in java code (called by script code)
- Test files
  ```javascript
  # test-failure.ts
  import { response } from "sdk/http";
  import { database } from "sdk/db";
  import { logging } from "sdk/log";

  const logger = logging.getLogger("org.eclipse.dirigible.testlogger");

  try {
      const throwError = true;
      const testValue = database.test(throwError);
      response.println("testValue: " + testValue);
  } catch (e) {
      logger.error("An error occurred ", e)
  }

  # database.ts
    public static test(throwError: boolean): string {
      return DatabaseFacade.test(throwError);
    }

  # DatabaseFacade.java
      public static String test(boolean throwError) throws Throwable {
          try {
              anotherTestMethod(throwError);
          } catch (RuntimeException ex) {
              throw new MyCustomException("Test custom exception!", ex);
          }
          return "Test value";
      }

      private static void anotherTestMethod(boolean throwError) {
          if (throwError) {
              throw new AnotherCustomException("Another exception with a message!");
          }
      }
  ```

- Traces in **master** branch:
  <details>
    <summary>Expand logs</summary>

    ```log
    2025-09-18 13:48:50.664 [ERROR] [http-nio-8080-exec-5] [default-tenant] a.org.eclipse.dirigible.testlogger - An error occurred 
    java.lang.Exception: Test custom exception!
    ```
  </details>

- Traces in the **current PR**
  <details>
    <summary>Expand logs</summary>

    ```log
    2025-09-18 16:31:04.762 [INFO ] [http-nio-8080-exec-7] [default-tenant] app.out - Handling error with stack:
    Test custom exception!
        at org.eclipse.dirigible.components.api.db.DatabaseFacade.test (DatabaseFacade.java:198:0)
        at test (./database:59:2182-2212)
        at :module:eval (test-failure.js:7:234-258)

    2025-09-18 16:31:04.763 [ERROR] [http-nio-8080-exec-7] [default-tenant] a.org.eclipse.dirigible.testlogger - An error occurred 
    org.eclipse.dirigible.components.api.db.MyCustomException: Test custom exception!
      at org.eclipse.dirigible.components.api.db.DatabaseFacade.test(DatabaseFacade.java:198) ~[dirigible-components-api-database-13.0.0-SNAPSHOT.jar!/:na]
      at com.oracle.truffle.host.HostMethodDesc$SingleMethod$MHBase.invokeHandle(HostMethodDesc.java:372) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.host.GuestToHostCodeCache$GuestToHostInvokeHandle.executeImpl(GuestToHostCodeCache.java:88) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.host.GuestToHostRootNode.execute(GuestToHostRootNode.java:80) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:118) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.api.impl.DefaultRuntimeAccessor$DefaultRuntimeSupport.callInlined(DefaultRuntimeAccessor.java:201) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.host.GuestToHostRootNode.guestToHostCall(GuestToHostRootNode.java:102) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.host.HostMethodDesc$SingleMethod$MHBase.invokeGuestToHost(HostMethodDesc.java:408) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.host.HostExecuteNode.doInvoke(HostExecuteNode.java:877) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.host.HostExecuteNode.doFixed(HostExecuteNode.java:140) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.host.HostExecuteNodeGen$Inlined.executeAndSpecialize(HostExecuteNodeGen.java:385) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.host.HostExecuteNodeGen$Inlined.execute(HostExecuteNodeGen.java:345) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.host.HostObject.invokeMember(HostObject.java:465) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.host.HostObjectGen$InteropLibraryExports$Cached.invokeMemberNode_AndSpecialize(HostObjectGen.java:7007) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.host.HostObjectGen$InteropLibraryExports$Cached.invokeMember(HostObjectGen.java:6993) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.api.interop.InteropLibraryGen$CachedDispatch.invokeMember(InteropLibraryGen.java:8497) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$ForeignInvokeNode.executeCall(JSFunctionCallNode.java:1548) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeAndSpecialize(JSFunctionCallNode.java:308) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeCall(JSFunctionCallNode.java:253) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$InvokeNode.execute(JSFunctionCallNode.java:723) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.control.ReturnNode$TerminalPositionReturnNode.execute(ReturnNode.java:178) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.binary.DualNode.execute(DualNode.java:116) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.function.FunctionBodyNode.execute(FunctionBodyNode.java:70) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.function.FunctionRootNode.executeInRealm(FunctionRootNode.java:155) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.runtime.JavaScriptRealmBoundaryRootNode.execute(JavaScriptRealmBoundaryRootNode.java:96) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:118) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.api.impl.DefaultDirectCallNode.call(DefaultDirectCallNode.java:59) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$DirectJSFunctionCacheNode.executeCall(JSFunctionCallNode.java:1330) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeAndSpecialize(JSFunctionCallNode.java:308) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeCall(JSFunctionCallNode.java:253) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$InvokeNode.execute(JSFunctionCallNode.java:723) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.access.JSWriteCurrentFrameSlotNodeGen.execute_generic3(JSWriteCurrentFrameSlotNodeGen.java:136) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.access.JSWriteCurrentFrameSlotNodeGen.execute(JSWriteCurrentFrameSlotNodeGen.java:67) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.access.JSWriteCurrentFrameSlotNodeGen.executeVoid(JSWriteCurrentFrameSlotNodeGen.java:319) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:78) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:53) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.api.impl.DefaultBlockNode.executeVoid(DefaultBlockNode.java:73) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:68) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.function.BlockScopeNode.executeVoid(BlockScopeNode.java:96) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.control.TryCatchNode.executeVoid(TryCatchNode.java:154) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:78) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:53) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.api.impl.DefaultBlockNode.executeGeneric(DefaultBlockNode.java:63) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.control.AbstractBlockNode.execute(AbstractBlockNode.java:73) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.access.JSWriteCurrentFrameSlotNodeGen.execute_generic3(JSWriteCurrentFrameSlotNodeGen.java:136) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.access.JSWriteCurrentFrameSlotNodeGen.execute(JSWriteCurrentFrameSlotNodeGen.java:67) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.access.JSWriteCurrentFrameSlotNodeGen.executeVoid(JSWriteCurrentFrameSlotNodeGen.java:319) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:78) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:53) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.api.impl.DefaultBlockNode.executeGeneric(DefaultBlockNode.java:63) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.control.AbstractBlockNode.execute(AbstractBlockNode.java:73) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.control.ModuleBodyNode.execute(ModuleBodyNode.java:75) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.function.FunctionBodyNode.execute(FunctionBodyNode.java:70) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.nodes.function.FunctionRootNode.executeInRealm(FunctionRootNode.java:155) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.runtime.JavaScriptRealmBoundaryRootNode.execute(JavaScriptRealmBoundaryRootNode.java:96) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:97) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.js.runtime.builtins.JSFunction.call(JSFunction.java:315) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.runtime.objects.JSModuleRecord.executeModule(JSModuleRecord.java:269) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.parser.GraalJSEvaluator.innerModuleEvaluation(GraalJSEvaluator.java:818) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.parser.GraalJSEvaluator.moduleEvaluation(GraalJSEvaluator.java:717) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.runtime.objects.CyclicModuleRecord.evaluate(CyclicModuleRecord.java:147) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.parser.GraalJSEvaluator$ModuleScriptRoot.evalModule(GraalJSEvaluator.java:309) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.js.parser.GraalJSEvaluator$ModuleScriptRoot.execute(GraalJSEvaluator.java:294) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:118) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.api.impl.DefaultDirectCallNode.call(DefaultDirectCallNode.java:59) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.js.lang.JavaScriptLanguage$ParsedProgramRoot.execute(JavaScriptLanguage.java:256) ~[js-language-24.2.2.jar!/:na]
      at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:118) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.polyglot.PolyglotContextImpl.eval(PolyglotContextImpl.java:1894) ~[truffle-api-24.2.2.jar!/:na]
      at com.oracle.truffle.polyglot.PolyglotContextDispatch.eval(PolyglotContextDispatch.java:62) ~[truffle-api-24.2.2.jar!/:na]
      at org.graalvm.polyglot.Context.eval(Context.java:416) ~[polyglot-24.2.2.jar!/:na]
      at org.eclipse.dirigible.graalium.core.javascript.GraalJSCodeRunner.run(GraalJSCodeRunner.java:382) ~[dirigible-engine-graalium-execution-13.0.0-SNAPSHOT.jar!/:na]
      at org.eclipse.dirigible.graalium.core.DirigibleJavascriptCodeRunner.run(DirigibleJavascriptCodeRunner.java:207) ~[dirigible-engine-graalium-execution-core-13.0.0-SNAPSHOT.jar!/:na]
      at org.eclipse.dirigible.components.engine.javascript.service.JavascriptHandler.handleRequest(JavascriptHandler.java:125) ~[dirigible-components-engine-javascript-13.0.0-SNAPSHOT.jar!/:na]
      at org.eclipse.dirigible.components.engine.javascript.service.JavascriptService.handleRequest(JavascriptService.java:92) ~[dirigible-components-engine-javascript-13.0.0-SNAPSHOT.jar!/:na]
      at org.eclipse.dirigible.components.engine.javascript.endpoint.JavascriptEndpoint.executeJavaScript(JavascriptEndpoint.java:234) ~[dirigible-components-engine-javascript-13.0.0-SNAPSHOT.jar!/:na]
      at org.eclipse.dirigible.components.engine.javascript.endpoint.JavascriptEndpoint.executeJavaScript(JavascriptEndpoint.java:169) ~[dirigible-components-engine-javascript-13.0.0-SNAPSHOT.jar!/:na]
      at org.eclipse.dirigible.components.engine.javascript.endpoint.JavascriptEndpoint.get(JavascriptEndpoint.java:153) ~[dirigible-components-engine-javascript-13.0.0-SNAPSHOT.jar!/:na]
      at org.eclipse.dirigible.components.engine.typescript.TypeScriptEndpoint.get(TypeScriptEndpoint.java:60) ~[dirigible-components-engine-typescript-13.0.0-SNAPSHOT.jar!/:na]
      at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
      at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
      at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:258) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:191) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:118) ~[spring-webmvc-6.2.7.jar!/:6.2.7]
      at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:986) ~[spring-webmvc-6.2.7.jar!/:6.2.7]
      at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:891) ~[spring-webmvc-6.2.7.jar!/:6.2.7]
      at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87) ~[spring-webmvc-6.2.7.jar!/:6.2.7]
      at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1089) ~[spring-webmvc-6.2.7.jar!/:6.2.7]
      at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:979) ~[spring-webmvc-6.2.7.jar!/:6.2.7]
      at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1014) ~[spring-webmvc-6.2.7.jar!/:6.2.7]
      at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:903) ~[spring-webmvc-6.2.7.jar!/:6.2.7]
      at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:564) ~[tomcat-embed-core-10.1.41.jar!/:6.0.0]
      at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:885) ~[spring-webmvc-6.2.7.jar!/:6.2.7]
      at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:658) ~[tomcat-embed-core-10.1.41.jar!/:6.0.0]
      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:195) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51) ~[tomcat-embed-websocket-10.1.41.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.eclipse.dirigible.components.engine.cms.filter.CmsClientSideRoutingFilter.doFilter(CmsClientSideRoutingFilter.java:113) ~[dirigible-components-engine-cms-13.0.0-SNAPSHOT.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.eclipse.dirigible.components.engine.web.filter.WebClientSideRoutingFilter.doFilter(WebClientSideRoutingFilter.java:118) ~[dirigible-components-engine-web-13.0.0-SNAPSHOT.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:110) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.springframework.web.servlet.resource.ResourceUrlEncodingFilter.doFilter(ResourceUrlEncodingFilter.java:66) ~[spring-webmvc-6.2.7.jar!/:6.2.7]
      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.eclipse.dirigible.components.security.filter.SecurityFilter.doFilter(SecurityFilter.java:161) ~[dirigible-components-engine-security-13.0.0-SNAPSHOT.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.eclipse.dirigible.components.base.healthcheck.filter.HealthCheckFilter.doFilter(HealthCheckFilter.java:66) ~[dirigible-components-core-healthcheck-13.0.0-SNAPSHOT.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.eclipse.dirigible.components.base.endpoint.HttpContextFilter.doFilter(HttpContextFilter.java:65) ~[dirigible-components-core-base-13.0.0-SNAPSHOT.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:108) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:108) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.security.web.FilterChainProxy.lambda$doFilterInternal$3(FilterChainProxy.java:231) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$FilterObservation$SimpleFilterObservation.lambda$wrap$1(ObservationFilterChainDecorator.java:479) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$AroundFilterObservation$SimpleAroundFilterObservation.lambda$wrap$1(ObservationFilterChainDecorator.java:340) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator.lambda$wrapSecured$0(ObservationFilterChainDecorator.java:82) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:128) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.access.intercept.AuthorizationFilter.doFilter(AuthorizationFilter.java:101) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:125) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:119) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.authentication.AnonymousAuthenticationFilter.doFilter(AnonymousAuthenticationFilter.java:100) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter.doFilter(SecurityContextHolderAwareRequestFilter.java:179) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.savedrequest.RequestCacheAwareFilter.doFilter(RequestCacheAwareFilter.java:63) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.authentication.www.BasicAuthenticationFilter.doFilterInternal(BasicAuthenticationFilter.java:181) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.authentication.ui.DefaultLogoutPageGeneratingFilter.doFilterInternal(DefaultLogoutPageGeneratingFilter.java:59) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.authentication.ui.DefaultLoginPageGeneratingFilter.doFilter(DefaultLoginPageGeneratingFilter.java:216) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.authentication.ui.DefaultLoginPageGeneratingFilter.doFilter(DefaultLoginPageGeneratingFilter.java:202) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.authentication.ui.DefaultResourcesFilter.doFilter(DefaultResourcesFilter.java:72) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:235) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:229) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.eclipse.dirigible.components.tenants.tenant.TenantContextInitFilter.lambda$doFilterInternal$0(TenantContextInitFilter.java:84) ~[dirigible-components-core-tenants-13.0.0-SNAPSHOT.jar!/:na]
      at org.eclipse.dirigible.components.tenants.tenant.TenantContextImpl.execute(TenantContextImpl.java:67) ~[dirigible-components-core-tenants-13.0.0-SNAPSHOT.jar!/:na]
      at org.eclipse.dirigible.components.tenants.tenant.TenantContextInitFilter.doFilterInternal(TenantContextInitFilter.java:83) ~[dirigible-components-core-tenants-13.0.0-SNAPSHOT.jar!/:na]
      at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:107) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:93) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.web.filter.CorsFilter.doFilterInternal(CorsFilter.java:91) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.header.HeaderWriterFilter.doHeadersAfter(HeaderWriterFilter.java:90) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.header.HeaderWriterFilter.doFilterInternal(HeaderWriterFilter.java:75) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.context.SecurityContextHolderFilter.doFilter(SecurityContextHolderFilter.java:82) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.context.SecurityContextHolderFilter.doFilter(SecurityContextHolderFilter.java:69) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter.doFilterInternal(WebAsyncManagerIntegrationFilter.java:62) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.session.DisableEncodeUrlFilter.doFilterInternal(DisableEncodeUrlFilter.java:42) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$AroundFilterObservation$SimpleAroundFilterObservation.lambda$wrap$0(ObservationFilterChainDecorator.java:323) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:224) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:233) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:191) ~[spring-security-web-6.5.0.jar!/:6.5.0]
      at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.web.filter.ServletRequestPathFilter.doFilter(ServletRequestPathFilter.java:52) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.web.filter.CompositeFilter.doFilter(CompositeFilter.java:74) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration$CompositeFilterChainProxy.doFilter(WebSecurityConfiguration.java:319) ~[spring-security-config-6.5.0.jar!/:6.5.0]
      at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.web.servlet.handler.HandlerMappingIntrospector.lambda$createCacheFilter$3(HandlerMappingIntrospector.java:243) ~[spring-webmvc-6.2.7.jar!/:6.2.7]
      at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.web.filter.CompositeFilter.doFilter(CompositeFilter.java:74) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.security.config.annotation.web.configuration.WebMvcSecurityConfiguration$CompositeFilterChainProxy.doFilter(WebMvcSecurityConfiguration.java:240) ~[spring-security-config-6.5.0.jar!/:6.5.0]
      at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:362) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:278) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.springframework.web.filter.ServerHttpObservationFilter.doFilterInternal(ServerHttpObservationFilter.java:114) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.7.jar!/:6.2.7]
      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:167) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:483) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:116) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:344) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:398) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:903) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1740) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1189) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:658) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63) ~[tomcat-embed-core-10.1.41.jar!/:na]
      at java.base/java.lang.Thread.run(Thread.java:1583) ~[na:na]
      Suppressed: com.oracle.truffle.api.TruffleStackTrace$LazyStackTrace: null
    Caused by: org.eclipse.dirigible.components.api.db.AnotherCustomException: Another exception with a message!
      at org.eclipse.dirigible.components.api.db.DatabaseFacade.anotherTestMethod(DatabaseFacade.java:205) ~[dirigible-components-api-database-13.0.0-SNAPSHOT.jar!/:na]
      at org.eclipse.dirigible.components.api.db.DatabaseFacade.test(DatabaseFacade.java:196) ~[dirigible-components-api-database-13.0.0-SNAPSHOT.jar!/:na]
      ... 257 common frames omitted

    ```
  </details>
