### PR TITLE
Refactor export/import schema dependency

### DIFF
--- a/build/application/pom.xml
+++ b/build/application/pom.xml
@@ -172,6 +172,10 @@
             <artifactId>dirigible-components-group-database</artifactId>
             <type>pom</type>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-data-processes</artifactId>
+        </dependency>
 
         <!-- Engine -->
         <dependency>

--- a/components/group/group-database/pom.xml
+++ b/components/group/group-database/pom.xml
@@ -41,10 +41,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.dirigible</groupId>
-            <artifactId>dirigible-components-data-processes</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.dirigible</groupId>
             <artifactId>dirigible-components-data-import</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Remove schema export/import processes from **dirigible-components-group-database** dependency so that it id not automatically included in the projects.

It should be explicitly added in the projects where it is needed since it depends on CMIS, BPM, etc.