### PR TITLE
docs: AWS deployment architecture proposals (subdomain and single-host tenant-picker variants)

### DIFF
--- a/AWS_COGNITO_TENANT_ROLES_LIMITS.md
+++ b/AWS_COGNITO_TENANT_ROLES_LIMITS.md
@@ -57,8 +57,9 @@ All values from the [Amazon Cognito quotas page](https://docs.aws.amazon.com/cog
 | --- | --- | --- | --- |
 | **Groups to which each user can belong** | **100** | **No** | Groups as membership storage — **the binding limit** |
 | Groups per user pool | 10,000 | No | Total (tenants × roles defined) |
+| Characters in a group **name** † | 1–128 | No | Group naming schemes — the *only* size limit on the group side |
 | Custom attributes per user pool | 50 | No | Attribute-based storage (how many you can shard across) |
-| **Characters per attribute** | **2,048 bytes** | **No** | Attribute-based storage — the payload ceiling |
+| **Characters per attribute** | **2,048 bytes** | **No** | Attribute-based storage **only** — see the note below: this quota does **not** apply to groups |
 | Characters in custom attribute name | 20 | No | Attribute naming schemes |
 | Scopes per resource server | 100 | No | Scope-based (M2M) role modelling |
 | Scopes per app client | 50 | No | Scope-based (M2M) role modelling |
@@ -68,6 +69,22 @@ All values from the [Amazon Cognito quotas page](https://docs.aws.amazon.com/cog
 | Identity providers per user pool | 300 | Yes → 1,000 | Per-tenant federation |
 | Users per user pool | 40,000,000 | Yes | Not a constraint here |
 | Identities linked to a user | 5 | No | Federated identity linking |
+
+† Every value above comes from the quotas page **except the 128-character group-name bound**, which is a `CreateGroup` API constraint (`GroupName`: minimum length 1, maximum length 128, pattern `[\p{L}\p{M}\p{S}\p{N}\p{P}]+`) and does not appear on the quotas page at all.
+
+### Groups are not attributes — the 2,048-byte limit does not apply to them
+
+Worth stating plainly, because the two are easy to conflate and the consequences are opposite:
+
+- **Attributes** are name/value pairs stored on the user record — the standard ones (`email`, `name`) and custom ones (`custom:tenant`). The **2,048-byte** quota bounds a single attribute *value*.
+- **Groups** are a separate first-class user-pool resource, created with `CreateGroup` and assigned with `AdminAddUserToGroup`. The `cognito:groups` claim is **computed at token-issuance time** from the user's memberships — it is never read from a stored attribute, so the attribute quota never touches it.
+
+**Is there an aggregate size limit on a user's groups? No — AWS publishes none.** The group side is bounded only by *counts* (100 per user, 10,000 per pool) and by the length of each individual *name* (128 characters). The theoretical worst case is therefore 100 × 128 ≈ **12.8 KB** of names plus JSON overhead, and there is neither a documented cap on the claim as a whole nor a published token-size quota (§4.3 explains what does bound it in practice).
+
+Two consequences:
+
+1. **The 2,048-byte limit constrains Option 4 alone** — the packed custom attribute (§6) — which is exactly why that option tops out near 250 tenants. It says nothing about the group-based options.
+2. **Group names have ample room.** At 128 characters, a `t:<tenant>:<role>` scheme is nowhere near constrained; tenant and role names can be long and legible. **The wall in the group model is purely the count of 100, never the size.**
 
 ### Token-shaping quotas
 
@@ -140,7 +157,7 @@ A group name `t:<tenant>:<role>` with a ~10-character tenant id and a ~12-charac
 | 90 | ~2.7 KB | ~3.6 KB | ID + access token |
 | 300 | **~9 KB** | **~12 KB** | ID + access token (≈ 24 KB combined) |
 
-No Cognito quota is breached (the pre-token Lambda's 5,000 limit is a *count*), and Dirigible's server-side code flow means these tokens never travel in browser headers. But a 12 KB token per request-issuance, twice, is a design smell — and it is fatal for any future consumer that puts a token in a cookie (4 KB) or through a gateway with an 8–10 KB header cap.
+**These figures are a practical concern, not a quota violation.** No Cognito quota is breached at any size: the pre-token Lambda's 5,000 limit is a *count* of claims, the 2,048-byte attribute quota does not apply to groups (§3), and no aggregate `cognito:groups` or token-size cap is published. The size dimension of groups is effectively unbounded by Cognito — what bounds it is whatever carries the token. Dirigible's server-side code flow means these tokens never travel in browser headers, which softens the concern here; even so, a 12 KB token minted twice per sign-in is a design smell, and it is fatal for any future consumer that puts a token in a cookie (4 KB) or through a gateway with an 8–10 KB header cap.
 
 ### 4.4 Membership administration throughput
 
@@ -224,7 +241,7 @@ One group per tenant, carrying membership and nothing else; roles live in an ext
 
 Encode the whole graph into one custom attribute, e.g. `custom:tenroles = "a1:3ff,b7:005,c2:180"` — a short tenant id and a hex bitmask of that tenant's roles (10 roles = 10 bits = 3 hex characters).
 
-- **Arithmetic:** ~7–8 characters per tenant → 30 tenants ≈ **210–240 bytes**, against 2,048 bytes ⇒ fits, up to **~250–290 tenants** in a single attribute; shardable across up to 50 attributes.
+- **Arithmetic:** ~7–8 characters per tenant → 30 tenants ≈ **210–240 bytes**, against the **2,048-byte per-attribute ceiling** ⇒ fits, up to **~250–290 tenants** in a single attribute; shardable across up to 50 attributes. (This is the one option that quota governs — it does not apply to any of the group-based options; see §3.)
 - **Pros:** no group-count ceiling at all; one compact claim; no extra store or Lambda; survives the stated scale with room to spare.
 - **Cons:** **opaque** — support and audit require decoding; needs a versioned registry mapping tenant → short id and role → bit position, and any role added or removed in a tenant re-numbers bits; updates are **read-modify-write with no atomicity**, so two concurrent grants silently clobber each other; **no reverse query** at all (§4.5); writes still bounded by the 25 RPS UserUpdate quota; custom attributes **cannot be deleted or renamed** once added to a pool (verify — §10).
 - **Verdict:** ⚠️ Fits the numbers, but **operationally hostile.** Document it, do not ship it unless an external store is genuinely impossible.
@@ -310,7 +327,7 @@ Recorded as implications only — no document is changed by this analysis.
 
 1. **Re-read the quotas page** at decision time — <https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html>. All figures here were read on 2026-07-29; the non-adjustable ones (100 groups/user, 2,048 bytes/attribute, 50 custom attributes, 25 RPS UserUpdate) are the ones that matter.
 2. **Prove the ceiling in your own pool:** create a test user, add 100 groups, attempt the 101st, and record the exact error and where it surfaces in your onboarding flow.
-3. **Measure a real token** with a representative membership set — decode it and check the `cognito:groups` claim size against whatever will carry it.
+3. **Measure a real token** with a representative membership set — decode it and check the `cognito:groups` claim size against whatever will carry it. While there, confirm the two group-side bounds in your own Region: the **128-character group-name** constraint (`CreateGroup`), and that **no aggregate `cognito:groups` size cap** exists — the count of 100 should be the only thing that stops you.
 4. **Confirm the custom-attribute constraints** if Option 4 is under serious consideration: that attributes cannot be deleted or renamed after creation, and that `ListUsers` cannot filter on the packed value (both are the basis of that option's ❌ on reverse queries).
 5. **Time a bulk grant** against the 25 RPS UserUpdate quota in a non-production account, and confirm what else in your estate shares that quota.
 6. **Decide the granularity question explicitly** — whether users genuinely need arbitrary role combinations per tenant, or whether 3–4 personas per tenant would do. That single answer decides between Option 2 and Option 5.

--- a/AWS_COGNITO_TENANT_ROLES_LIMITS.md
+++ b/AWS_COGNITO_TENANT_ROLES_LIMITS.md
@@ -9,7 +9,9 @@
 
 - [1. The short answer](#1-the-short-answer)
 - [2. What counts against what — two different quotas](#2-what-counts-against-what--two-different-quotas)
-- [3. Every limit that applies](#3-every-limit-that-applies)
+- [3. Every limit that applies, and what the tokens contain](#3-every-limit-that-applies-and-what-the-tokens-contain)
+  - [Groups are not attributes](#groups-are-not-attributes--the-2048-byte-limit-does-not-apply-to-them)
+  - [What the tokens actually look like](#what-the-tokens-actually-look-like)
 - [4. Arithmetic of the current model](#4-arithmetic-of-the-current-model)
 - [5. Why the failure mode is the real problem](#5-why-the-failure-mode-is-the-real-problem)
 - [6. The options](#6-the-options)
@@ -47,9 +49,9 @@ A tenant *defining* 10 roles is harmless. A user *holding* many of them across m
 
 ---
 
-## 3. Every limit that applies
+## 3. Every limit that applies, and what the tokens contain
 
-All values from the [Amazon Cognito quotas page](https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html). "Adjustable" means AWS can raise it on request.
+All values from the [Amazon Cognito quotas page](https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html) unless marked otherwise. "Adjustable" means AWS can raise it on request.
 
 ### Storage-shaping quotas
 
@@ -85,6 +87,83 @@ Two consequences:
 
 1. **The 2,048-byte limit constrains Option 4 alone** — the packed custom attribute (§6) — which is exactly why that option tops out near 250 tenants. It says nothing about the group-based options.
 2. **Group names have ample room.** At 128 characters, a `t:<tenant>:<role>` scheme is nowhere near constrained; tenant and role names can be long and legible. **The wall in the group model is purely the count of 100, never the size.**
+
+### What the tokens actually look like
+
+Anna is a member of three tenants and holds different roles in each: `ADMINISTRATOR`, `order-manager` and `invoice-approver` in **acme**; `viewer` in **globex**; `order-manager` and `invoice-approver` in **initech**. Six group memberships in total.
+
+**ID token payload — the picker model (no pre-token Lambda; the token carries everything).** Claim names and envelope match Cognito's documented default payload:
+
+```json
+{
+  "sub": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+  "cognito:groups": [
+    "t:acme:ADMINISTRATOR",
+    "t:acme:order-manager",
+    "t:acme:invoice-approver",
+    "t:globex:viewer",
+    "t:initech:order-manager",
+    "t:initech:invoice-approver"
+  ],
+  "email_verified": true,
+  "iss": "https://cognito-idp.eu-central-1.amazonaws.com/eu-central-1_EXAMPLE",
+  "cognito:username": "anna@example.com",
+  "origin_jti": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+  "aud": "1example23456789clientid",
+  "event_id": "64f513be-32db-42b0-b78e-b02127b4f463",
+  "token_use": "id",
+  "auth_time": 1785312777,
+  "exp": 1785316377,
+  "iat": 1785312777,
+  "jti": "cccccccc-dddd-eeee-ffff-000000000000",
+  "email": "anna@example.com"
+}
+```
+
+**Access token payload — same session, same groups, different envelope.** This is the point most people miss: `cognito:groups` is in **both** tokens, so the membership list is paid for twice per sign-in. Note there is no `email` here, and `client_id` carries what the ID token calls `aud`:
+
+```json
+{
+  "sub": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+  "cognito:groups": [
+    "t:acme:ADMINISTRATOR",
+    "t:acme:order-manager",
+    "t:acme:invoice-approver",
+    "t:globex:viewer",
+    "t:initech:order-manager",
+    "t:initech:invoice-approver"
+  ],
+  "iss": "https://cognito-idp.eu-central-1.amazonaws.com/eu-central-1_EXAMPLE",
+  "version": 2,
+  "client_id": "1example23456789clientid",
+  "origin_jti": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+  "token_use": "access",
+  "scope": "openid email profile",
+  "auth_time": 1785312777,
+  "exp": 1785316377,
+  "iat": 1785312777,
+  "jti": "dddddddd-eeee-ffff-0000-111111111111",
+  "username": "anna@example.com"
+}
+```
+
+**The same person under the subdomain model** — the pre-token-generation Lambda keys on the app client (`acme`), filters the groups to that tenant's prefix, strips it, and adds the tenant assertion. Only the changed claims are shown:
+
+```json
+{
+  "cognito:groups": ["ADMINISTRATOR", "order-manager", "invoice-approver"],
+  "dirigible:tenant": "acme",
+  "aud": "acmeclientid00000000",
+  "token_use": "id"
+}
+```
+
+Four things this makes concrete:
+
+1. **`cognito:groups` is a flat array of name strings.** There is no nesting, no per-tenant object, no roles-within-tenant structure — the tenant dimension exists only because it is *encoded into the name*. That is the entire reason for the `t:<tenant>:<role>` convention, and it is why the application must parse prefixes to reconstruct "which roles do I have in acme?".
+2. **Both tokens carry it**, so the claim-size cost in §4.3 is doubled per sign-in.
+3. **`cognito:roles` and `cognito:preferred_role` are absent** in these examples because they appear only when groups have IAM role ARNs attached — that is the identity-pool use case, which this design does not use. A group here is a pure label.
+4. **Six entries are readable; three hundred are not.** At the stated scale that array runs to ~300 strings of ~25 characters — roughly 9 KB of JSON inside one claim, before the envelope, in both tokens. That is the shape of the problem the rest of this document quantifies. (It is also, per the note above, still not a *quota* violation — merely unwise.)
 
 ### Token-shaping quotas
 

--- a/AWS_COGNITO_TENANT_ROLES_LIMITS.md
+++ b/AWS_COGNITO_TENANT_ROLES_LIMITS.md
@@ -1,0 +1,316 @@
+# Storing Tenant Membership and Roles in Amazon Cognito — Limits and Options
+
+**Status:** analysis. Standalone — this document changes nothing in the existing proposals; §9 records what it would imply for them.
+**Date:** 2026-07-29
+**Question it answers:** *a user may belong to 20–30 tenants, and each tenant may define ~10 roles, with different roles per tenant — how should that be stored in Cognito?*
+**Related (unchanged by this document):** [`AWS_DEPLOYMENT_PROPOSAL.md`](AWS_DEPLOYMENT_PROPOSAL.md) · [`AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md`](AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md) · [`AWS_TENANCY_MODELS_COMPARISON.md`](AWS_TENANCY_MODELS_COMPARISON.md)
+
+**Contents**
+
+- [1. The short answer](#1-the-short-answer)
+- [2. What counts against what — two different quotas](#2-what-counts-against-what--two-different-quotas)
+- [3. Every limit that applies](#3-every-limit-that-applies)
+- [4. Arithmetic of the current model](#4-arithmetic-of-the-current-model)
+- [5. Why the failure mode is the real problem](#5-why-the-failure-mode-is-the-real-problem)
+- [6. The options](#6-the-options)
+- [7. Options at a glance](#7-options-at-a-glance)
+- [8. Recommendation](#8-recommendation)
+- [9. What this would imply for the existing proposals](#9-what-this-would-imply-for-the-existing-proposals)
+- [10. Verify before committing](#10-verify-before-committing)
+
+---
+
+## 1. The short answer
+
+The model in the current proposals — one Cognito group per (tenant, role), named `t:<tenant>:<role>` — **does not survive these numbers.**
+
+> **Groups to which each user can belong: 100. Not adjustable.**
+
+A user in 30 tenants can therefore hold an average of **at most 3 roles per tenant**, and that is at the ceiling with zero headroom. Four roles each is 120 and fails. The stated worst case — 10 roles in each of 30 tenants — is 300, which fails by 3×.
+
+Three further limits push in the same direction even below the ceiling: the `cognito:groups` claim becomes multi-kilobyte, every membership write is throttled by a **non-adjustable 25 RPS account-wide** quota shared with ordinary user updates, and Cognito cannot answer "which users are in tenant X, with what roles?" without enumerating users.
+
+**Cognito is an excellent identity provider and a poor membership database.** The recommendation (§8) is to keep authentication in Cognito and move the tenant ↔ user ↔ roles graph to a store that is designed for it.
+
+---
+
+## 2. What counts against what — two different quotas
+
+The single most common confusion here is treating "roles per tenant" as one number. Two independent Cognito quotas are loaded by two different things:
+
+| | Loaded by | Quota | Consequence |
+| --- | --- | --- | --- |
+| **Groups per user pool** | **Definitions** — every (tenant, role) pair that *exists*: `tenants × roles defined per tenant` | **10,000**, not adjustable | With 10 roles per tenant, the platform tops out at **~1,000 tenants**. Comfortable now, but it is a real platform ceiling |
+| **Groups per user** | **Assignments** — every (tenant, role) pair one person *holds*: `tenants that user belongs to × roles held in each` | **100**, not adjustable | With 30 tenants per user, that is **~3 held roles per tenant, maximum**. This is the wall |
+
+A tenant *defining* 10 roles is harmless. A user *holding* many of them across many tenants is what breaks. Everything in §4 follows from that distinction.
+
+---
+
+## 3. Every limit that applies
+
+All values from the [Amazon Cognito quotas page](https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html). "Adjustable" means AWS can raise it on request.
+
+### Storage-shaping quotas
+
+| Quota | Value | Adjustable | Constrains |
+| --- | --- | --- | --- |
+| **Groups to which each user can belong** | **100** | **No** | Groups as membership storage — **the binding limit** |
+| Groups per user pool | 10,000 | No | Total (tenants × roles defined) |
+| Custom attributes per user pool | 50 | No | Attribute-based storage (how many you can shard across) |
+| **Characters per attribute** | **2,048 bytes** | **No** | Attribute-based storage — the payload ceiling |
+| Characters in custom attribute name | 20 | No | Attribute naming schemes |
+| Scopes per resource server | 100 | No | Scope-based (M2M) role modelling |
+| Scopes per app client | 50 | No | Scope-based (M2M) role modelling |
+| Resource servers per user pool | 25 | Yes → 300 | One resource server per tenant (M2M) |
+| App clients per user pool | 1,000 | Yes → 10,000 | One app client per tenant (subdomain model) |
+| Callback / logout URLs per app client | 100 each | No | Shared-app-client topologies |
+| Identity providers per user pool | 300 | Yes → 1,000 | Per-tenant federation |
+| Users per user pool | 40,000,000 | Yes | Not a constraint here |
+| Identities linked to a user | 5 | No | Federated identity linking |
+
+### Token-shaping quotas
+
+| Quota | Value | Adjustable | Note |
+| --- | --- | --- | --- |
+| Combined claim + scope changes in the pre-token-generation Lambda | 5,000 | Yes | A *count*, not bytes — 300 groups is numerically fine |
+| ID token / access token validity | 5 min – 1 day | — | Sets the role-change propagation delay |
+| Refresh token validity | 1 hour – 3,650 days | — | |
+| Hosted-UI (managed login) session cookie | 1 hour | fixed | The cross-tenant SSO window |
+| Token **size** | *not published* | — | No Cognito quota; the binding limits are downstream (browser cookies ~4 KB each; proxy/gateway header limits typically 8–16 KB). In Dirigible's server-side authorization-code flow the token does not ride in browser headers, which softens this — but it does not make a 9 KB claim wise |
+
+Note that `cognito:groups` appears in **both** the ID token and the access token, so a fat groups claim is paid twice.
+
+### Rate quotas that bite membership administration
+
+These are **per AWS account, per Region — shared across all user pools in that account**.
+
+| Category | Operations | Rate | Adjustable |
+| --- | --- | --- | --- |
+| **UserUpdate** | `AdminAddUserToGroup`, `AdminRemoveUserFromGroup`, `AdminUpdateUserAttributes`, `UpdateUserAttributes`, `AdminDisableUser`, `AdminUserGlobalSignOut`, … | **25 RPS** | **No** |
+| UserResourceRead | `AdminListGroupsForUser`, … | 50 RPS | Yes |
+| UserList | `ListUsers`, `ListUsersInGroup` | 30 RPS | No |
+| UserPoolResourceUpdate | `CreateGroup`, `DeleteGroup`, `AddCustomAttributes`, `CreateResourceServer`, … | 15 RPS | No |
+
+The critical one is **UserUpdate at 25 RPS, non-adjustable**: it covers *both* group assignment and custom-attribute writes, so it constrains every "store membership in Cognito" option equally — and it is shared with routine operations like password changes, MFA setup and forced sign-outs.
+
+---
+
+## 4. Arithmetic of the current model
+
+Assumptions used throughout, matching the stated scale: **20–30 tenants per user**, **~10 roles defined per tenant**, group naming `t:<tenant>:<role>`.
+
+### 4.1 Groups per user — the wall
+
+`groups held = tenants × roles held per tenant`, against the hard ceiling of **100**.
+
+| Roles held per tenant ↓ / Tenants per user → | 10 | 20 | **30** | 50 |
+| --- | --- | --- | --- | --- |
+| 1 | 10 ✅ | 20 ✅ | **30 ✅** | 50 ✅ |
+| 2 | 20 ✅ | 40 ✅ | **60 ✅** | 100 ⚠️ at limit |
+| 3 | 30 ✅ | 60 ✅ | **90 ⚠️ no headroom** | 150 ❌ |
+| 4 | 40 ✅ | 80 ⚠️ | **120 ❌** | 200 ❌ |
+| 5 | 50 ✅ | 100 ⚠️ at limit | **150 ❌** | 250 ❌ |
+| 8 | 80 ⚠️ | 160 ❌ | **240 ❌** | 400 ❌ |
+| 10 (all roles) | 100 ⚠️ at limit | 200 ❌ | **300 ❌ — 3× over** | 500 ❌ |
+
+✅ ≤ 70 (≥30 % headroom) · ⚠️ 71–100 (no meaningful headroom) · ❌ > 100 (impossible)
+
+**Reading of the target column:** at 30 tenants the model works only while users average **2–3 roles per tenant**, and there is no headroom left for a tenant that adds roles, a user who joins a 31st tenant, or an administrator who legitimately holds several roles.
+
+### 4.2 Groups per user pool — the platform ceiling
+
+`groups defined = tenants × roles defined per tenant`, against **10,000**.
+
+| Tenants | × 10 roles | vs 10,000 |
+| --- | --- | --- |
+| 100 | 1,000 | ✅ 10 % used |
+| 500 | 5,000 | ⚠️ 50 % used |
+| **1,000** | **10,000** | ❌ **at the ceiling** |
+
+So the group model also caps the *platform* at roughly 1,000 tenants at 10 roles each — far away, but worth knowing it exists and is not adjustable.
+
+### 4.3 Claim size
+
+A group name `t:<tenant>:<role>` with a ~10-character tenant id and a ~12-character role name is ~25 characters; inside a JSON array, with quotes and comma, ~28–30 bytes.
+
+| Groups held | `cognito:groups` claim | JWT payload after base64url (≈ ×1.34) | Carried in |
+| --- | --- | --- | --- |
+| 30 | ~0.9 KB | ~1.2 KB | ID + access token |
+| 90 | ~2.7 KB | ~3.6 KB | ID + access token |
+| 300 | **~9 KB** | **~12 KB** | ID + access token (≈ 24 KB combined) |
+
+No Cognito quota is breached (the pre-token Lambda's 5,000 limit is a *count*), and Dirigible's server-side code flow means these tokens never travel in browser headers. But a 12 KB token per request-issuance, twice, is a design smell — and it is fatal for any future consumer that puts a token in a cookie (4 KB) or through a gateway with an 8–10 KB header cap.
+
+### 4.4 Membership administration throughput
+
+Every grant or revoke is one `AdminAddUserToGroup` / `AdminRemoveUserFromGroup` call in the **UserUpdate** category: **25 RPS, non-adjustable, account-wide**.
+
+| Operation | API calls | Time at 25 RPS (quota fully consumed) |
+| --- | --- | --- |
+| Onboard one user into 30 tenants × 3 roles | 90 | ~3.6 s |
+| Onboard one power user into 30 tenants × 10 roles | 300 | ~12 s |
+| Roll a new tenant out to 100 users × 5 roles | 500 | ~20 s |
+| Initial migration: 1,000 users × 30 memberships | 30,000 | **~20 minutes** |
+
+During those windows the same 25 RPS is unavailable for password changes, MFA enrolment, attribute updates and forced sign-outs across *every* user pool in the account. A relational or DynamoDB write path has no such shared ceiling and completes the same migration in seconds.
+
+### 4.5 Reverse queries — "who is in tenant X?"
+
+Every admin UI needs this, and it is where attribute-based storage collapses entirely.
+
+| Storage | How you answer it | Practicality |
+| --- | --- | --- |
+| Groups | `ListUsersInGroup` per tenant-role group (10 calls per tenant), paginated, 30 RPS non-adjustable | Workable but slow; must be merged client-side to reconstruct per-user role sets |
+| Custom attribute | `ListUsers` cannot filter on arbitrary substrings of a custom attribute — you enumerate the entire pool and decode each user | **Not practical** beyond a few thousand users |
+| External store | One indexed query (SQL) or a GSI lookup (DynamoDB) | Trivial |
+
+### 4.6 Propagation delay
+
+| Storage | A role change takes effect | Immediate-revoke path |
+| --- | --- | --- |
+| Groups / attributes (claims) | At the **next token refresh** — up to the access-token lifetime (60 min typical), plus the application session | `AdminUserGlobalSignOut` + invalidate the app session |
+| External store, read per login/switch/request | **Immediately** | Delete the row |
+
+The claim-based options force a "role changes land within the hour" SLA on the product. The external store removes that caveat entirely.
+
+---
+
+## 5. Why the failure mode is the real problem
+
+The 100-group ceiling would be tolerable if it failed early and visibly. It does the opposite:
+
+1. The design review passes — 30 tenants × 2 roles = 60 groups, comfortably inside the limit.
+2. Production runs fine for months, for almost every user.
+3. A consultant, a support engineer or a platform administrator accumulates memberships — the exact people who legitimately belong to many tenants.
+4. Their **101st grant fails** at `AdminAddUserToGroup`, in production, in an onboarding flow, for one user, with a quota error that cannot be raised by a support ticket.
+
+The blast radius is small but the fix is not: by then, membership is *in* Cognito groups, and migrating to another store means re-plumbing the token contract, the login mapper and the administration path. The limit is non-adjustable, so there is no operational escape — only a redesign.
+
+Choosing storage that has no such ceiling costs very little now and removes the failure mode entirely.
+
+---
+
+## 6. The options
+
+### Option 1 — Flat role groups: `t:<tenant>:<role>`
+
+*The model in the current proposals.* One group per (tenant, role); membership is implied by holding at least one.
+
+- **Hits:** groups per user **100** (❌ at the stated scale), claim size, 25 RPS writes.
+- **Pros:** single source of truth in the IdP; roles arrive in the token with no lookup; non-members deniable at issuance.
+- **Cons:** fails above ~3 held roles per tenant at 30 tenants; late, user-specific failure; multi-KB claims; slow bulk administration; awkward reverse queries; no place for role metadata.
+- **Verdict:** ❌ **Not viable at 20–30 tenants with granular roles.** Viable only for small memberships (≤ ~10 tenants) or coarse roles.
+
+### Option 2 — Persona / bundle groups: `t:<tenant>:<persona>`
+
+Collapse the ~10 granular roles into 3–4 personas (e.g. `admin`, `manager`, `member`, `viewer`); a user holds one, occasionally two, per tenant. The persona → granular-roles expansion happens in the application (or in the pre-token Lambda) from a mapping held outside Cognito.
+
+- **Arithmetic:** 30 tenants × 1 = **30 groups** ✅ (headroom to ~100 tenants). Pool: 3–4 groups × tenants → ~2,500–3,300 tenants before the 10,000 ceiling.
+- **Pros:** keeps the IdP authoritative; large reduction in both group count and claim size; deny-at-issuance retained; simple to administer.
+- **Cons:** **forfeits arbitrary per-user role combinations** — a user can only hold predefined bundles, which conflicts with "different roles for each tenant" if that means granular mix-and-match; changing a persona's contents silently re-permissions everyone holding it; still a hard 100-tenant ceiling per user; the persona→roles mapping is a second artifact to version.
+- **Verdict:** ⚠️ **Viable if the product can live with predefined role bundles.** The cheapest fix if granularity is negotiable.
+
+### Option 3 — Membership-only groups + roles elsewhere: `t:<tenant>`
+
+One group per tenant, carrying membership and nothing else; roles live in an external store, resolved after authentication.
+
+- **Arithmetic:** 30 groups per user ✅; pool: 1 group per tenant → 10,000 tenants.
+- **Pros:** the token carries a cheap, accurate membership list (useful for a tenant picker); non-members still deniable at token issuance; roles unlimited and granular.
+- **Cons:** two stores for one concept — membership in Cognito, roles outside — which is precisely the drift risk that got the `custom:tenant` attribute rejected in the existing proposals, in milder form; still a 100-tenant-per-user ceiling; membership writes still cost UserUpdate quota.
+- **Verdict:** ⚠️ **A reasonable middle ground**, mainly when deny-at-the-IdP is worth keeping a second store for.
+
+### Option 4 — Packed custom attribute (tenant id + role bitmask)
+
+Encode the whole graph into one custom attribute, e.g. `custom:tenroles = "a1:3ff,b7:005,c2:180"` — a short tenant id and a hex bitmask of that tenant's roles (10 roles = 10 bits = 3 hex characters).
+
+- **Arithmetic:** ~7–8 characters per tenant → 30 tenants ≈ **210–240 bytes**, against 2,048 bytes ⇒ fits, up to **~250–290 tenants** in a single attribute; shardable across up to 50 attributes.
+- **Pros:** no group-count ceiling at all; one compact claim; no extra store or Lambda; survives the stated scale with room to spare.
+- **Cons:** **opaque** — support and audit require decoding; needs a versioned registry mapping tenant → short id and role → bit position, and any role added or removed in a tenant re-numbers bits; updates are **read-modify-write with no atomicity**, so two concurrent grants silently clobber each other; **no reverse query** at all (§4.5); writes still bounded by the 25 RPS UserUpdate quota; custom attributes **cannot be deleted or renamed** once added to a pool (verify — §10).
+- **Verdict:** ⚠️ Fits the numbers, but **operationally hostile.** Document it, do not ship it unless an external store is genuinely impossible.
+
+### Option 5 — External membership store, Cognito for identity only ★
+
+Cognito authenticates (identity, MFA, federation, `sub`). The tenant ↔ user ↔ roles graph lives in a store built for it. Two variants:
+
+**5a — Dirigible-side membership table** (natural fit for the tenant-picker model):
+
+```sql
+DIRIGIBLE_TENANT_MEMBERSHIPS (
+  SUBJECT    VARCHAR   -- the IdP 'sub' (stable, immutable)
+  TENANT_ID  VARCHAR   -- FK → DIRIGIBLE_TENANTS
+  ROLE_NAME  VARCHAR   -- FK → DIRIGIBLE_SECURITY_ROLES (defined by .roles artefacts)
+  PRIMARY KEY (SUBJECT, TENANT_ID, ROLE_NAME)
+)
+-- index on (SUBJECT) for login; on (TENANT_ID) for admin screens
+```
+
+At login one indexed query by `sub` builds the membership map; a tenant switch reads the roles for `(sub, tenant)`.
+
+**5b — DynamoDB + the pre-token-generation Lambda** (fit for the subdomain model, where the token must carry that tenant's roles): `PK USER#<sub>` / `SK TENANT#<t>` → `roles: [...]`, with a GSI on the tenant for reverse lookups. The Lambda injects only the current tenant's roles (≤ 10), keeping tokens small and tenant-scoped.
+
+- **Hits:** no Cognito quota whatsoever.
+- **Pros:** unlimited tenants and granular roles; **immediate propagation** (removes the "role changes land at the next token refresh" caveat); trivial reverse queries for admin UIs; atomic, high-throughput writes with no shared account quota; room for metadata (granted-by, granted-at, expiry) and real audit; in 5a, referential integrity with the role names that `.roles` artefacts already define, and a natural in-app administration screen with no extra AWS service.
+- **Cons:** it is a store to own — schema, admin API/UI, and backups (5a rides on the existing database backups; 5b needs its own); the platform (or DynamoDB) becomes the authorization source rather than the IdP; in 5b the Lambda sits in the authentication path (latency, availability); with 5a in the subdomain model the Lambda cannot easily read the app's database, so tokens carry no roles and the application resolves them per session — which also means losing deny-at-issuance.
+- **Verdict:** ★ **Recommended.** The only option with no ceiling anywhere near the stated scale.
+
+### Option 6 — AWS Verified Permissions (or another external authorization service)
+
+Model tenants, users and roles as Cedar policies and ask the service for decisions.
+
+- **Pros:** purpose-built for fine-grained, multi-tenant authorization; policy-as-code; centralised audit.
+- **Cons:** Dirigible enforces on **role names** (`ROLE_*` authorities from `.roles`/`.access` artefacts), so a policy engine would sit awkwardly beside the platform's own model rather than replacing it; adds a service, a policy language and a per-request call for what is fundamentally a membership lookup. AWS also notes that group identifiers are not processed by `IsAuthorizedWithToken` and need custom token-parsing code.
+- **Verdict:** ❌ **Overkill here.** Revisit only if authorization needs grow beyond role names into attribute- or resource-level policy.
+
+---
+
+## 7. Options at a glance
+
+| # | Option | Groups/user at 30 tenants | Granular per-user roles | Reverse query | Propagation | Verdict |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | Flat role groups | **300 ❌** (limit 100) | ✅ | awkward | ≤ 1 h | ❌ Not viable |
+| 2 | Persona / bundle groups | 30 ✅ | ❌ bundles only | awkward | ≤ 1 h | ⚠️ If bundles acceptable |
+| 3 | Membership-only groups + roles outside | 30 ✅ | ✅ | ✅ (in the store) | immediate (roles) | ⚠️ Middle ground |
+| 4 | Packed custom attribute | n/a (≈240 B of 2,048) | ✅ | ❌ none | ≤ 1 h | ⚠️ Fits, hostile |
+| 5 | **External store, Cognito = identity** | **n/a — no quota** | ✅ | ✅ | **immediate** | ★ **Recommended** |
+| 6 | Verified Permissions | n/a | ✅ | ✅ | immediate | ❌ Overkill |
+
+---
+
+## 8. Recommendation
+
+**Keep Cognito for what it is excellent at — authentication, MFA, federation, one identity per person — and move the tenant ↔ user ↔ roles graph into a store designed for a graph.**
+
+Concretely:
+
+1. **Cognito holds:** `sub`, email, credentials, MFA, federation, and nothing tenant-related.
+2. **The membership store holds:** `(sub, tenant, role)` — Option 5a's `DIRIGIBLE_TENANT_MEMBERSHIPS` table for the tenant-picker model (it needs no Lambda at all), or Option 5b's DynamoDB table where the pre-token Lambda must mint role-bearing tenant-scoped tokens for the subdomain model.
+3. **Optionally keep one membership-only group per tenant** (`t:<tenant>`, ~30 per user — comfortably inside the 100 limit) purely so the subdomain model can still refuse a token to a non-member at the IdP. This is Option 3 layered on Option 5, and it is the only reason to keep any tenant data in Cognito.
+4. **If an external store is politically or operationally impossible**, take Option 2 (personas) and accept predefined role bundles — not Option 1, and not Option 4.
+
+Sizing sanity check for the recommendation: 30 tenants × 10 roles = at most 300 rows per user; 10,000 users × 30 memberships = 300,000 rows — a trivially small table, indexed, answering both directions in one query.
+
+---
+
+## 9. What this would imply for the existing proposals
+
+Recorded as implications only — no document is changed by this analysis.
+
+**Both proposals** currently state that membership and roles live in prefixed Cognito groups and that the 100-group limit is a distant growth watchpoint. Under this analysis it is not distant: it is reached inside the stated requirements, so that decision and its "watchpoint" framing would need revisiting in both.
+
+**`AWS_DEPLOYMENT_PROPOSAL.md` (subdomain):** the pre-token-generation Lambda stops filtering groups by prefix and instead reads the membership store for `(sub, tenant)` — the token contract (`cognito:groups` = roles for this tenant, plus `dirigible:tenant`) is **unchanged**, so nothing downstream in the platform moves. Onboarding gains a membership-store write instead of group creation.
+
+**`AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md` (picker):** the improvement is larger. The token no longer needs to carry the membership graph at all — it carries identity, and the application builds the membership map with one query at login. Fork change **S2 gets simpler** (no group-name parsing), and the "role changes take effect at the next login" caveat in §3.5 disappears, because the store is read at login and at every switch.
+
+**`AWS_TENANCY_MODELS_COMPARISON.md`:** its "identical in both models" section lists the groups-only membership model as shared — it would instead be "an external membership store, shared", which is still identical across the two models and remains an argument that the choice between them is purely an identity/UX decision.
+
+---
+
+## 10. Verify before committing
+
+1. **Re-read the quotas page** at decision time — <https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html>. All figures here were read on 2026-07-29; the non-adjustable ones (100 groups/user, 2,048 bytes/attribute, 50 custom attributes, 25 RPS UserUpdate) are the ones that matter.
+2. **Prove the ceiling in your own pool:** create a test user, add 100 groups, attempt the 101st, and record the exact error and where it surfaces in your onboarding flow.
+3. **Measure a real token** with a representative membership set — decode it and check the `cognito:groups` claim size against whatever will carry it.
+4. **Confirm the custom-attribute constraints** if Option 4 is under serious consideration: that attributes cannot be deleted or renamed after creation, and that `ListUsers` cannot filter on the packed value (both are the basis of that option's ❌ on reverse queries).
+5. **Time a bulk grant** against the 25 RPS UserUpdate quota in a non-production account, and confirm what else in your estate shares that quota.
+6. **Decide the granularity question explicitly** — whether users genuinely need arbitrary role combinations per tenant, or whether 3–4 personas per tenant would do. That single answer decides between Option 2 and Option 5.

--- a/AWS_DEPLOYMENT_PROPOSAL.md
+++ b/AWS_DEPLOYMENT_PROPOSAL.md
@@ -5,6 +5,28 @@
 **Scope:** one production deployment ("unit") of a multitenant Dirigible application on ECS, sized for ~50–100 tenants, with subdomain-per-tenant addressing and cross-tenant login (one identity, different roles per tenant).
 **Independence note:** this document was designed independently from the earlier research on branch `docs/aws-multitenancy-research`, from the code and AWS constraints alone; §10 records where the two efforts agree and differ.
 
+**Contents**
+
+- [0. Decisions at a glance](#0-decisions-at-a-glance)
+- [1. Requirements](#1-requirements)
+- [2. What the platform gives you and what it imposes](#2-what-the-platform-gives-you-and-what-it-imposes)
+- [3. Topology — one production unit](#3-topology--one-production-unit)
+- [4. Identity — one pool, per-tenant app clients, roles as prefixed groups](#4-identity--one-pool-per-tenant-app-clients-roles-as-prefixed-groups)
+  - [4.1 Why Cognito (and not Keycloak on ECS)](#41-why-cognito-and-not-keycloak-on-ecs)
+  - [4.2 One app client for all tenants, or one per tenant? — the decision](#42-one-app-client-for-all-tenants-or-one-per-tenant--the-decision)
+  - [4.3 The topology](#43-the-topology)
+  - [4.4 Membership and roles: prefixed Cognito groups](#44-membership-and-roles-prefixed-cognito-groups)
+  - [4.5 The pre-token-generation Lambda (V2_0) — the per-tenant lens](#45-the-pre-token-generation-lambda-v2_0--the-per-tenant-lens)
+  - [4.6 Flows](#46-flows)
+- [5. Isolation summary](#5-isolation-summary)
+- [6. Fork changes (minimal set)](#6-fork-changes-minimal-set)
+- [7. Tenant onboarding (automation runbook)](#7-tenant-onboarding-automation-runbook)
+- [8. Security hardening checklist](#8-security-hardening-checklist)
+- [9. Operations](#9-operations)
+- [10. Where this agrees / differs with `docs/aws-multitenancy-research`](#10-where-this-agrees--differs-with-docsaws-multitenancy-research)
+- [11. How it grows](#11-how-it-grows)
+- [12. Hypotheses to verify before go-live](#12-hypotheses-to-verify-before-go-live)
+
 ---
 
 ## 0. Decisions at a glance

--- a/AWS_DEPLOYMENT_PROPOSAL.md
+++ b/AWS_DEPLOYMENT_PROPOSAL.md
@@ -369,6 +369,7 @@ Past what one unit sustains (connection budget, CPU, or blast-radius tolerance):
 - **DNS changes shape once:** wildcard-to-one-ALB becomes a per-tenant Route 53 alias created at onboarding, pointing at the tenant's unit. (Keep the wildcard as a catch-all to a "no such tenant" page.)
 - **What stays shared:** the Cognito user pool (identity, SSO and per-tenant roles are unit-agnostic), the pre-token Lambda + client map, the image pipeline, WAF rules, the wildcard certificate.
 - **Watchpoints on the way:** the 100-groups-per-user Cognito hard limit (a person in ~30+ tenants — that is the trigger to move the membership graph to a store, per the research branch's model); per-unit connection budget; and only if a *single tenant* outgrows a unit does the deep fork surgery (external broker, non-local repository) become worth discussing.
+- **True horizontal scaling** (more than one task per unit) is blocked by the platform, not by this model — the layer-by-layer analysis of what blocks it today and what enabling it would take (external broker, per-node synchronizer replay, boot-race fixes, cache invalidation, external sessions) lives in [`AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md`](AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md) §10; items 1–5 there apply to both models verbatim.
 
 ---
 

--- a/AWS_DEPLOYMENT_PROPOSAL.md
+++ b/AWS_DEPLOYMENT_PROPOSAL.md
@@ -227,7 +227,10 @@ Roles live in Cognito as groups named **`t:<subdomain>:<roleName>`** — e.g. `t
 
 Arithmetic at target scale: 100 tenants × ~5 roles = ~500 groups (pool limit 10,000). The **non-adjustable 100-groups-per-user** limit caps one person at ~100 tenant-role pairs — a non-issue for a person in a handful of tenants; flagged as a growth watchpoint (§11).
 
-The `custom:tenant` user attribute that the shipped `CognitoTenantFilter` reads is **retired** — a user-global comma-separated attribute is a second source of truth that drifts, and it carries no per-tenant roles.
+The `custom:tenant` user attribute that the shipped `CognitoTenantFilter` reads is **retired** — a user-global comma-separated attribute is a second source of truth that drifts, and it carries no per-tenant roles. There is **no tenant user attribute at all** in this design: a user's tenants are *derived* from the group pattern, nowhere stored as a separate fact. Two consequences:
+
+- **Administration is a single operation surface.** Add someone to a tenant = add a group; change their roles = change groups; remove them = delete their `t:<sub>:*` groups. Nothing else to keep in sync.
+- **A "member with zero roles" state does not exist** — removing someone's last `t:<sub>:*` group removes the membership itself (the Lambda finds no matching groups and denies the token). If "belongs, but no permissions yet" is ever needed, adopt a conventional marker role (e.g. `t:<sub>:member`).
 
 ### 4.5 The pre-token-generation Lambda (V2_0) — the per-tenant lens
 

--- a/AWS_DEPLOYMENT_PROPOSAL.md
+++ b/AWS_DEPLOYMENT_PROPOSAL.md
@@ -1,0 +1,384 @@
+# Multitenant Dirigible on AWS — Deployment Proposal
+
+**Status:** architecture proposal. Nothing here is deployed or implemented.
+**Date:** 2026-07-28
+**Scope:** one production deployment ("unit") of a multitenant Dirigible application on ECS, sized for ~50–100 tenants, with subdomain-per-tenant addressing and cross-tenant login (one identity, different roles per tenant).
+**Independence note:** this document was designed independently from the earlier research on branch `docs/aws-multitenancy-research`, from the code and AWS constraints alone; §10 records where the two efforts agree and differ.
+
+---
+
+## 0. Decisions at a glance
+
+| Concern | Decision | Why (short) |
+| --- | --- | --- |
+| Tenant addressing | Wildcard subdomain `*.app.com` → one ALB | `TenantExtractor` already resolves tenants from `host`/`x-forwarded-host`; onboarding needs no DNS change |
+| Compute | ECS **Fargate**, one service, **desiredCount = 1**, stop-then-start deploys | The runtime is single-writer by construction (§2.2) — this is a property of the platform, not a choice |
+| Database | **RDS PostgreSQL, Multi-AZ** (e.g. `db.r6g.large`); SystemDB + DefaultDB with one schema + DB user per tenant | Matches what Dirigible's provisioner does; Multi-AZ compensates for single-task compute |
+| Documents/CMS | **S3** via `engine-cms-s3`, tenant-prefixed keys | Removes the biggest stateful-filesystem need; isolation ships in `TenantPathResolver` |
+| Registry/content | **Baked into the image** (`META-INF/dirigible/**`), `DIRIGIBLE_PUBLISH_DISABLED=true` | Production is runtime-only and content-immutable; no EFS |
+| Identity | **Amazon Cognito**: ONE user pool | One pool = one identity per person = same credentials everywhere |
+| OAuth clients | **ONE confidential app client per tenant** — decided on merit in §4.2, single-client alternative analysed there | Tenant-scoped tokens at issuance, deny-at-IdP, no 100-callback ceiling, per-tenant federation |
+| Client resolution in the app | **Fork-built host-keyed `ClientRegistrationRepository`** (secrets from Secrets Manager) | Specified fresh; the shipped `security-client-registration` module is deliberately **not** assumed (§2.5) |
+| Membership & roles | **Cognito groups named `t:<subdomain>:<role>`**, projected per token by a pre-token-generation Lambda | Single source of truth in the IdP, no extra membership database at this scale |
+| Local user tables | **Not used in production** (`basic.enabled=false` under the cognito profile) | The requirement said they need not stay; under OIDC profiles they are already bypassed |
+| Fork changes | Six small, targeted changes (§6) — no redesign of the multitenancy model | The shipped cognito profile is 80 % of the design already |
+
+---
+
+## 1. Requirements
+
+1. One Dirigible application, multiple tenants, isolated from each other.
+2. Tenant access by subdomain: `tenant1.app.com`, `tenant2.app.com`, …
+3. Compute on ECS.
+4. **A user logs into several tenants with the same credentials and holds different roles in each.**
+5. User/role assignments need not live in the local `DIRIGIBLE_USERS` / `DIRIGIBLE_USER_ROLE_ASSIGNMENTS` tables — tokens may carry them.
+6. Changing the multitenancy implementation is allowed (this is a fork).
+7. Production quality: hardened, observable, operable.
+
+---
+
+## 2. What the platform gives you and what it imposes
+
+Everything below is read out of this repository, with file references, because these facts dictate the architecture.
+
+### 2.1 Multitenancy that already works
+
+- **Subdomain → tenant.** `TenantExtractor` (`components/core/core-tenants/.../tenant/TenantExtractor.java`) matches `host` and `x-forwarded-host` against `DIRIGIBLE_TENANT_SUBDOMAIN_REGEX` (default `^([^\.]+)\..+$`); `TenantContextInitFilter` wraps every request in a `ThreadLocal` tenant scope. An unknown subdomain is a hard **404** — wildcard DNS is safe because unprovisioned hosts are rejected, not silently served. The `x-forwarded-host` support means it works behind an ALB unmodified. Lookups sit in a static Caffeine cache: 10-minute TTL, `maximumSize(100)` (`TenantExtractor.java:44`) — note that 100 is exactly our target tenant count (§6, fix 6).
+- **Data isolation = schema per tenant.** Inside a tenant scope every `getDefaultDataSource()` is name-rewritten to `<tenantId>_DefaultDB` (`components/data/data-sources/.../manager/TenantDataSourceNameManager.java`). Provisioning (`DefaultDataSourceProvisioning.java`) executes `CREATE USER <uuid>` + `CREATE SCHEMA <TENANT> AUTHORIZATION <user>` and clones the datasource row — so **the connecting DB credential must hold `CREATEROLE` and `CREATE SCHEMA`**. The platform's own tables (tenants, users, roles, Quartz, ActiveMQ store, Flowable) live in a shared, never-prefixed **SystemDB**.
+- **Per-tenant runtime replay.** The registry (`/registry/public`) is shared; eight multitenant synchronizers (tables, views, schemas, csvim, jobs, listeners, bpmn, cms-seed) replay their side effects once per provisioned tenant, and a post-provisioning step retriggers them for new tenants (`RetriggerSynchronizersTenantPostProvisioningStep`). Quartz jobs and JMS destinations are `<tenantId>###<name>`-prefixed; Flowable uses its native `tenantId`; CMS paths get a `<tenantId>/` prefix (`engine-cms/.../TenantPathResolver.java`).
+- **Provisioning cadence.** Tenants are created `INITIAL` and flipped to `PROVISIONED` by a job that runs 30 s after boot and then every `DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS` (**default 900 s** — lower it, §7). There is no `FAILED` state and no de-provisioning: a failing step is retried whole (leaving orphan DB users/schemas), and `DELETE` on a `PROVISIONED` tenant returns 400.
+- **Tenant-tagged logs for free.** `TenantConverter` (`core-base/.../logging/TenantConverter.java`) stamps the tenant id into every log line — per-tenant observability costs nothing (§9).
+
+### 2.2 The single-writer constraint (dictates desiredCount = 1)
+
+You cannot run two Dirigible tasks against one database/filesystem. Four independent, code-verified reasons:
+
+1. **Embedded ActiveMQ.** `engine-listeners/.../config/MessagingConfig.java` builds the broker on the hardcoded `vm://localhost` transport with `setPersistent(true)` and a `JDBCPersistenceAdapter` on SystemDB. ActiveMQ's JDBC locker takes an exclusive lock and `broker.start()` blocks until it wins — a second instance never finishes booting.
+2. **Node-local synchronization.** The Quartz `SynchronizationJob` is a cluster singleton (clustered job store), but what it does — reconciling the registry into Camel routes, listeners, scheduled jobs, compiled classes — is state **inside one JVM**. A second instance would simply never reconcile.
+3. **Filesystem repository.** `RepositoryConfig` unconditionally constructs a `LocalRepository`; the registry, workspaces and Lucene indexes are local files with `WatchService`-based change detection (which degrades on NFS/EFS).
+4. **Boot-time DDL.** Quartz `initialize-schema=always` drops and recreates the `QRTZ_*` tables at startup; several initializers are check-then-insert. A rolling deploy where old and new overlap corrupts shared state.
+
+**Consequences, stated honestly:** ECS `desiredCount=1`, `minimumHealthyPercent=0`, `maximumPercent=100` (stop-then-start). Every deploy and every task crash is an outage of boot time + the first synchronization pass — minutes, not seconds. Fargate restarts the task in another AZ on failure and RDS Multi-AZ fails over independently, but the realistic availability target is **~99.5 %**, not 99.99 %. If that is unacceptable, the answer is a second unit (§11), not a replica.
+
+### 2.3 The capacity ceiling is database connections
+
+`DataSourceInitializer.java:155-159` calls `config.setSchema(schema)`, `config.setMaximumPoolSize(20)`, `config.setMinimumIdle(10)` **after** the properties-based constructor — so the `*_HIKARI_*` env overrides are silently discarded and every tenant that has served one request holds **10 idle connections forever**. 100 active tenants ≈ 1,000+ idle connections, which no reasonable RDS class tolerates. This is the single most important fork fix (§6, fix 1). RDS Proxy is **not** an alternative: `setSchema` makes pgjdbc emit `SET search_path`, which pins proxy sessions and disables multiplexing — the proxy's entire value.
+
+### 2.4 In-System Programming is a security boundary
+
+A user holding the `DEVELOPER` role can execute arbitrary JavaScript/Java in the JVM and spawn OS processes. On ECS that means "whoever can author code holds the task role." Production must therefore be **runtime-only**: no DEVELOPER role is grantable, publishing is disabled, and content arrives baked into the image. Authoring (the IDE) runs on a separate, internal, IP-restricted instance with its own small database. This split is a security control, not an operational preference.
+
+### 2.5 What the cognito profile contributes — and what this proposal deliberately does not build on
+
+Shipped in `components/security/security-cognito/` and used by this design:
+
+- `CognitoSecurityConfiguration.userAuthoritiesMapper()` maps the **`cognito:groups`** claim to `ROLE_*` authorities.
+- `CognitoLoginController` exposes `GET /login/{registrationId}`, validating the id against **provisioned tenant subdomains** and redirecting to `/oauth2/authorization/{registrationId}` — a useful per-tenant entry point, independent of how registrations are stored.
+- `ScopeRoleJwtAuthoritiesConverter` maps M2M `scope` claims (segment after the last `/`) to roles.
+- `application-cognito.properties` sets `basic.enabled=false` — the local user tables are already bypassed under this profile; no `DIRIGIBLE_USERS` row is consulted or created.
+
+**Deliberately not assumed:** the `security-client-registration` module (`DynamicClientRegistrationRepository`, its REST CRUD and env seeding). The single-vs-per-tenant OAuth client decision in §4.2 is made on its own merits, and the component that resolves per-tenant registrations — if the per-tenant answer wins — is specified fresh in §6 (fix 7). Whether its implementation reworks or replaces the existing module is an implementation detail, not a design input.
+
+What the profile does **not** yet do correctly is tenant-scope the authorization — the gaps are precisely the fork changes in §6.
+
+---
+
+## 3. Topology — one production unit
+
+```
+                  Route 53   *.app.com  ──alias──┐
+                                                  │
+             ┌────────────────────────────────────▼─────────────────────────────┐
+             │  AWS WAF  →  ALB  (HTTPS, ACM *.app.com)                          │
+             │  health check: /services/core/healthcheck                         │
+             └──────────────┬───────────────────────────────┬────────────────────┘
+                            │ *.app.com                     │ authoring.internal (internal ALB,
+     ═══ private subnets ═══╪═════════════════════════════  │  office CIDR / VPN only)
+                            ▼                               ▼
+             ┌───────────────────────────┐      ┌───────────────────────────┐
+             │ ECS Fargate: dirigible-   │      │ ECS Fargate: dirigible-   │
+             │ runtime  (desired = 1,    │      │ authoring (IDE, DEVELOPER,│
+             │ stop-then-start deploys)  │      │ EFS workspace, own DB)    │
+             │ content baked into image  │      └───────────────────────────┘
+             │ publish disabled          │
+             └────┬──────────┬───────────┘
+     ═══ isolated ▼ subnets ═╪══════════════════════════════════════════════════
+             ┌───────────────────────────┐      ┌───────────────────────────┐
+             │ RDS PostgreSQL, Multi-AZ  │      │ S3: documents/CMS         │
+             │  SystemDB (platform)      │      │  keys <tenantId>/…        │
+             │  DefaultDB:               │      │  SSE-KMS, versioning      │
+             │   default schema          │      └───────────────────────────┘
+             │   TENANT1, TENANT2, …     │
+             │   (schema + DB user each) │      Secrets Manager · CloudWatch
+             └───────────────────────────┘      VPC endpoints (S3/ECR/Logs/…)
+
+             ┌───────────────────────────────────────────────────────────────┐
+             │ Amazon Cognito — ONE user pool                                │
+             │   app clients: tenant1, tenant2, …  (callback per subdomain)  │
+             │   groups: t:tenant1:manager, t:tenant2:viewer, …              │
+             │   resource servers per tenant (M2M scopes)                    │
+             │   pre-token-generation Lambda ──reads──▶ DynamoDB             │
+             │     clientId → tenant                    (clientId→tenant map)│
+             └───────────────────────────────────────────────────────────────┘
+```
+
+### Network, DNS, TLS, edge
+
+- One VPC, two AZs. Public subnets: ALB only. Private: Fargate tasks. Isolated (no route out): RDS.
+- **Route 53 wildcard alias** `*.app.com` → ALB, one **ACM wildcard certificate**. Tenant onboarding touches no DNS.
+- **AWS WAF** on the ALB: managed common rules, per-IP rate limiting, and a block on `/actuator/**` and `/spring-admin/**` from non-admin CIDRs.
+- **No CloudFront.** Tenant resolution reads the `Host` header; CloudFront rewrites it to the origin by default. Add it later only for static-asset offload, with an origin request policy forwarding the viewer `Host`.
+- ALB specifics: stickiness on (heap-bound HTTP sessions, WebSockets), idle timeout above the app's long-request ceiling, health check target **`/services/core/healthcheck`** — the actuator readiness probe flips UP before the first synchronization pass, while `HealthCheckFilter` still 302-redirects everything to `/index-busy.html`. Pointing the ALB at actuator readiness routes live traffic to a busy instance.
+
+### Compute
+
+`dirigible-runtime` (Fargate, ARM64 — the CI images are multi-arch):
+
+| Setting | Value | Why |
+| --- | --- | --- |
+| desiredCount / deploy | `1`, `minimumHealthyPercent=0`, `maximumPercent=100` | §2.2 |
+| Size | 2 vCPU / 8 GiB to start; measure | GraalJS is interpreted → CPU-hungry |
+| JVM | `JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError` | Image ships no heap flags (defaults to 25 % of task memory) |
+| Ports | 8080 only, security group ALB→task | ttyd 9000 / debug 8081 / SFTP 8022 unmapped **and** disabled by env (§8) |
+| Health grace | ALB `healthCheckGracePeriodSeconds` ≈ 600 | Boot includes classpath expansion + a full sync pass |
+| Shutdown | `server.shutdown=graceful` via env; stopTimeout > deregistration delay | Not set anywhere in the shipped config |
+| Logs | stdout → awslogs (JSON) | The three file appenders don't rotate — never rely on them |
+| Ephemeral storage | ≥ 30 GiB | fat-jar lib extraction, multipart tmp, Graal caches |
+
+`dirigible-authoring` (optional but recommended): desired 1, internal ALB, WAF/SG IP allow-list, EFS for workspaces, its own small RDS. This is the only place the IDE, ttyd and the DEVELOPER role exist.
+
+### Database
+
+**RDS PostgreSQL, Multi-AZ**, `db.r6g.large` class to start. Two logical databases matching Dirigible's two datasources:
+
+- `SystemDB` — platform schema (Liquibase-managed, cluster-safe). Own credentials.
+- `DefaultDB` — application data; default tenant in the connecting user's default schema, every other tenant in its own schema owned by its own DB user, created by the provisioner. **Verify before go-live that the connecting credential can `CREATE ROLE` / `CREATE SCHEMA` on RDS** — on RDS the master user can; a least-privilege role cannot, and provisioning fails silently into the retry loop.
+
+Plain provisioned RDS rather than Aurora Serverless v2: the load profile of one unit with a bounded tenant count is steady, and a fixed Multi-AZ instance is simpler and cheaper than a serverless floor. Revisit if tenant load proves spiky.
+
+With the pool fix (§6, fix 1: max 5 / minIdle 0 per tenant datasource), 100 tenants peak below ~500 connections with near-zero idle — comfortable for the class (~1,700 `max_connections`). **Without the fix this architecture does not hold at 100 tenants.** Alarm on `DatabaseConnections` ÷ `max_connections` (§9).
+
+### Storage
+
+- **Documents/CMS → S3**: `DIRIGIBLE_CMS_PROVIDER=cms-provider-s3`, `DIRIGIBLE_S3_BUCKET`, task-role auth (leave the static key env vars unset so the default credentials chain is used). Tenant isolation comes from `TenantPathResolver`'s key prefix. SSE-KMS, versioning, lifecycle rules.
+- **Registry → the image.** Bake published projects as a jar layer under `META-INF/dirigible/**`; `ClasspathExpander` writes them into the registry at boot. Set `DIRIGIBLE_PUBLISH_DISABLED=true`. The runtime task then needs **no persistent volume at all**: task replacement rebuilds identical state. Do not put the registry on EFS (WatchService + Lucene + thousands of small files).
+
+---
+
+## 4. Identity — one pool, per-tenant app clients, roles as prefixed groups
+
+### 4.1 Why Cognito (and not Keycloak on ECS)
+
+Keycloak's realm–client–role model fits this problem naturally, but it is a second stateful, always-on service to run, patch, back up and upgrade — on an architecture already constrained to careful single-writer operations, adding another one is real cost. Cognito is managed, priced per MAU, and its two relevant primitives (pool-wide SSO session, pre-token-generation trigger) cover the requirement. That the fork ships a cognito Spring profile (the groups→authorities mapper, the per-tenant login entry point) lowers integration effort further, but the decision stands on managed-vs-operated alone. Cognito on the **Essentials** tier (required for pre-token-generation trigger V2_0).
+
+### 4.2 One app client for all tenants, or one per tenant? — the decision
+
+Both are workable at this scale; this is the one identity decision that deserves a real trade-off analysis rather than inheritance from either the platform's shipped machinery or AWS blog patterns.
+
+**Option A — one shared app client.**
+The app side is genuinely simple: **one** Spring client registration whose redirect uses the standard `{baseUrl}` template (`{baseUrl}/login/oauth2/code/cognito` — Spring resolves it against the request host; the shipped config pins `${DIRIGIBLE_HOST}` instead, a one-line change), one client secret, no host→registration resolution at all. Onboarding a tenant = add `https://<sub>.app.com/login/oauth2/code/cognito` to the client's callback list + create the tenant's groups. But:
+
+- **Hard ceiling at ~100 tenants:** Cognito allows **100 callback URLs per app client, no wildcards** — the ceiling lands exactly on this unit's design capacity, and the only escape is per-tenant clients, i.e. a migration at the design point.
+- **The token cannot be tenant-scoped.** The pre-token Lambda's only reliable tenant signal in managed-login flows is `callerContext.clientId` (`clientMetadata` is not passed on hosted-UI/`InitiateAuth` flows). With one client, every token must carry **all** the user's `t:*:*` groups, and the application filters by the host-resolved tenant at login. Denial of non-members happens only app-side; the IdP happily issues tokens for tenants the user doesn't belong to.
+- **A stolen bearer token is valid on every tenant the victim belongs to** — the membership check passes wherever they are a member. There is no audience binding to assert.
+- **Per-tenant federation is not expressible** — which external IdPs a client offers is per-app-client configuration.
+- One leaked client secret affects all tenants.
+
+**Option B — one confidential app client per tenant** (name = subdomain, callback `https://<sub>.app.com/login/oauth2/code/<sub>`, sign-out `https://<sub>.app.com`).
+
+- **The token is tenant-scoped at issuance:** the Lambda keys on `clientId`, emits only that tenant's roles into `cognito:groups`, and stamps `dirigible:tenant` — least privilege in the token itself, an audience binding the app can assert (§6, fix 2), and a stolen token that is useless on every other tenant.
+- **Deny at the IdP:** a non-member never receives a token at all.
+- No callback ceiling (one URL per client; 1,000 clients/pool default, raisable to 10,000); per-tenant enterprise federation later is a per-client setting; a leaked secret is one tenant's problem.
+- **The honest cost:** N clients and N secrets to create and rotate (onboarding automation), a clientId→tenant map for the Lambda, and — since this proposal does not assume the shipped registration module — a fork-built **host-keyed `ClientRegistrationRepository`** that resolves the request's subdomain to that tenant's client id + secret (§6, fix 7). That is a real component, not free.
+
+**Recommendation: Option B, one app client per tenant.** The shared client's 100-callback limit coincides with the unit's target capacity, and the tokens it produces are strictly weaker — multi-tenant bearer tokens with app-side-only denial. Option B buys issuance-time least privilege, IdP-side denial and federation headroom for the price of one well-understood component plus onboarding automation that has to exist anyway. Choose Option A only for a small, fixed tenant fleet (≲ 20) where operational minimalism outweighs headroom — and note that the groups model, claims contract and login flows are identical in both options, so a later A→B migration is contained (create clients, extend the Lambda, add the resolver), but it *is* a migration.
+
+### 4.3 The topology
+
+- **One user pool.** This is what satisfies requirement 4: one identity (email sign-in) per person, one password, one MFA enrolment. Cognito's managed-login session cookie is shared across all app clients in a pool (~1 h), so signing into a second tenant is **silent** — no credential prompt.
+- **One confidential app client per tenant** (§4.2). Each tenant's client id + secret live in Secrets Manager and are resolved per request host by the fork's registration resolver (§6, fix 7) — that is what makes `https://<sub>.app.com/login/<sub>` reach the right client.
+- **One Cognito resource server per tenant** (identifier = subdomain, custom scopes = role names) for machine-to-machine access, plus an M2M app client per tenant that needs it.
+
+### 4.4 Membership and roles: prefixed Cognito groups
+
+Roles live in Cognito as groups named **`t:<subdomain>:<roleName>`** — e.g. `t:tenant1:ADMINISTRATOR`, `t:tenant2:employee-manager`. Membership in a tenant *is* holding at least one of its groups. No separate membership database: the IdP is the single source of truth, administered with plain Cognito APIs/console.
+
+Arithmetic at target scale: 100 tenants × ~5 roles = ~500 groups (pool limit 10,000). The **non-adjustable 100-groups-per-user** limit caps one person at ~100 tenant-role pairs — a non-issue for a person in a handful of tenants; flagged as a growth watchpoint (§11).
+
+The `custom:tenant` user attribute that the shipped `CognitoTenantFilter` reads is **retired** — a user-global comma-separated attribute is a second source of truth that drifts, and it carries no per-tenant roles.
+
+### 4.5 The pre-token-generation Lambda (V2_0) — the per-tenant lens
+
+Configured on the pool; runs on every token issuance (including refresh):
+
+1. Map `event.callerContext.clientId` → tenant subdomain. The map is a two-column DynamoDB table written at onboarding (clientId → subdomain), cached in the Lambda.
+2. Take the user's groups, keep those with prefix `t:<subdomain>:`, strip the prefix.
+3. **Not a member (no matching group)?** Throw — Cognito fails the sign-in and never issues a token. Deny at the IdP; Dirigible never sees the session.
+4. **Member:** emit `groupsToOverride = [roles-here]` (replaces `cognito:groups` in **both** ID and access tokens) and add the claim **`dirigible:tenant = <subdomain>`** to both tokens.
+
+The resulting claims contract:
+
+| Claim | Tokens | Meaning |
+| --- | --- | --- |
+| `sub` | both | Global identity of the person (immutable; the Lambda cannot alter it) |
+| `cognito:groups` | both | The caller's roles **in this token's tenant only** — must equal Dirigible role names (`.roles` artefacts + the built-ins) exactly |
+| `dirigible:tenant` | both | The tenant this token was minted for; Dirigible asserts it equals the host-resolved tenant (§6, fix 2) |
+| `scope` (M2M) | access | `<subdomain>/<role>`; the shipped converter takes the segment after the last `/` |
+
+Because the token is tenant-scoped at issuance, the shipped `cognito:groups` → authorities mapper is **correct per tenant with zero changes**. And because `JSESSIONID` is host-scoped, each subdomain gets its own Spring session holding its own authority snapshot — the "authorities are snapshotted at login" behaviour becomes per-tenant automatically.
+
+### 4.6 Flows
+
+**Login:** `https://tenant1.app.com/` → unauthenticated → `/login/tenant1` (validated against provisioned subdomains) → `/oauth2/authorization/tenant1` → Cognito managed login (client `tenant1`) → Lambda: member, `cognito:groups=[manager]`, `dirigible:tenant=tenant1` → callback → session for `tenant1.app.com` with `ROLE_manager`.
+
+**Cross-tenant hop (requirement 4):** same browser opens `https://tenant2.app.com/` → no session for this host → `/login/tenant2` → Cognito: pool-wide session cookie still valid ⇒ **no credential prompt** → Lambda mints through client `tenant2`: `cognito:groups=[viewer]` → independent session for `tenant2.app.com` with `ROLE_viewer`. Same credentials, different roles, one interactive sign-in.
+
+**Logout:** clear the local session, redirect to Cognito `/logout` with the **current tenant's** client id and `logout_uri=https://<sub>.app.com` (fork fix 5 — the shipped handler uses the single default client and host). Honest caveat: Cognito logout ends the pool-wide managed-login session (all tenants' SSO), while live Dirigible sessions on other subdomains survive until they expire — keep the session timeout ≤ 30 min.
+
+**M2M:** client-credentials against the tenant's M2M client, scopes from the tenant's resource server (`tenant1/data-reader` → `ROLE_data-reader` via the shipped converter). The hardened membership filter (fix 2) asserts the token's tenant against the host, closing today's bypass where Bearer requests skip the check entirely.
+
+**Role-change propagation is refresh-bound:** the Lambda also fires on token refresh, so a group change lands within one access-token lifetime (set 60 min) plus the Dirigible session. An immediate revoke = remove groups + `AdminUserGlobalSignOut` + invalidate the Dirigible session (an explicit "eject" runbook, not an assumption).
+
+---
+
+## 5. Isolation summary
+
+| Layer | Mechanism | Status |
+| --- | --- | --- |
+| HTTP request → tenant | Host/`x-forwarded-host` subdomain, 404 on unknown | Ships today |
+| Application data | Schema + dedicated DB user per tenant | Ships today (provisioner) |
+| Documents | S3 key prefix per tenant | Ships today (`TenantPathResolver`) |
+| Jobs / messaging / BPM | Name-prefixing / Flowable tenantId | Ships today |
+| Identity | One identity per person (pool), membership = prefixed groups | Cognito config |
+| Authorization | Tenant-scoped token (`cognito:groups` filtered per client) | Lambda + fix 2/3 |
+| Token replay across tenants | `dirigible:tenant` claim == host tenant asserted per request | **Fork fix 2 — required** |
+| Platform tables | Shared SystemDB — not partitioned | Accepted; mitigations in §8 |
+| Registry / published code | Shared across tenants by design | Accepted: one application, all tenants run the same code |
+
+---
+
+## 6. Fork changes (minimal set)
+
+The design deliberately needs **no change** to tenant resolution, datasource routing, provisioning, the synchronizer replay, or the authorities mapper. What it needs:
+
+### Must fix before production
+
+1. **Make Hikari pool sizing configurable** — `components/data/data-sources/.../manager/DataSourceInitializer.java:155-159`. The hardcoded `setMaximumPoolSize(20)` / `setMinimumIdle(10)` run after the properties constructor and override any env setting. Add `DirigibleConfig` keys (defaults preserving today's values); production sets max 5 / minIdle 0 / `idleTimeout≈120s` per tenant datasource. *This is the change that makes 100 tenants fit on one RDS instance.*
+2. **Tenant assertion for all principal types** — `components/security/security-cognito/.../CognitoTenantFilter.java`. Replace the `custom:tenant` attribute check with: for `OAuth2AuthenticationToken` **and** `JwtAuthenticationToken`, require token claim `dirigible:tenant == currentTenant.subdomain` (M2M fallback: a `scope` whose resource-server prefix equals the subdomain); 403 otherwise. Closes two real holes: M2M/Bearer requests currently skip the membership check entirely (the filter guards on `instanceof OAuth2AuthenticationToken`), and nothing today prevents a token minted for tenant1 being used on tenant2.
+3. **Enable method security under the cognito profile** — `@EnableMethodSecurity(jsr250Enabled = true)` exists only on `BasicSecurityConfig` (conditional on `basic.enabled=true`) and, in default-off form, on the Keycloak config. Read literally, every `@RolesAllowed` in `components/` is **inert** under the cognito profile. *Hypothesis — verify first* with an integration test (cognito profile, token without the required group, expect 403), then add the annotation to `CognitoSecurityConfiguration`.
+4. **Deterministic filter ordering in the cognito chain** — `CognitoSecurityConfiguration` never adds `TenantContextInitFilter` (Basic/Keycloak/Snowflake configs all do); it and `CognitoTenantFilter` run only via Boot's servlet auto-registration, unordered relative to authentication. Add both explicitly to the chain, membership filter after tenant-context filter.
+5. **Per-tenant logout** — `CognitoLogoutSuccessHandler` hardcodes the default client id and `DIRIGIBLE_HOST`. Resolve the current tenant's registration and build `logout_uri` from the request host.
+6. **Tenant cache sizing** — `TenantExtractor.java:44` caps the cache at 100 entries, our exact target count; at 100+ it thrashes and every miss hits the DB. Make it configurable, default 1,000.
+7. **Host-keyed OAuth client-registration resolver** — a `ClientRegistrationRepository` that resolves the request's tenant subdomain to that tenant's client id + secret, reading from AWS Secrets Manager (secret per tenant, cached with a short TTL) or the tenant registry. This is the app-side component the per-tenant-client decision (§4.2) pays for. Specified fresh: the shipped `security-client-registration` module is **not** a design input — whether the implementation reworks it or replaces it is decided at coding time against production criteria (no plaintext secret reads, no process-global mutable statics, tenant-linked rows).
+
+### Worth doing soon after
+
+8. **Fail-fast guards:** refuse to boot a production-profile task with `DIRIGIBLE_TRIAL_ENABLED=true` (it grants every role to every principal, tenant-blind) or with publishing enabled.
+9. **Provisioning idempotency + `FAILED` status** — `DefaultDataSourceProvisioning` re-runs whole on failure and mints a new DB user/schema each retry. Check-before-create makes the 60 s retry loop safe; a `FAILED` status makes stuck tenants observable.
+10. **Close the cross-tenant admin surface** — `TenantEndpoint`/`UsersEndpoint` `getAll()` are not tenant-scoped (any tenant's ADMINISTRATOR can enumerate everything). Under cognito the users endpoint is unused — gate both on `basic.enabled` or a platform-operator role. Interim mitigation is operational: never grant `ADMINISTRATOR`/`OPERATOR` groups to tenant users.
+11. **Dockerfile hygiene:** non-root user; keep heap flags in env.
+
+---
+
+## 7. Tenant onboarding (automation runbook)
+
+Idempotent script or Step Functions; order matters (the Lambda must be able to map the client before anyone signs in). No DNS or TLS step — wildcard covers it.
+
+```
+ 1. Cognito: create resource server "<sub>" (scopes = role catalog)      [idempotent]
+ 2. Cognito: create confidential app client "<sub>"
+       callback https://<sub>.app.com/login/oauth2/code/<sub>
+       (+ optional M2M client with the tenant's scopes)
+ 3. DynamoDB: put clientId → "<sub>"                                     [Lambda's map]
+ 4. Secrets Manager: put dirigible/tenants/<sub>/oauth = { clientId, clientSecret }
+       — the fork's host-keyed registration resolver (fix 7) reads it per request
+ 5. Dirigible: POST /services/core/security/tenants { name, subdomain }  → INITIAL
+ 6. Poll tenant status until PROVISIONED
+       (set DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS=60;
+        alarm if INITIAL > 15 min — there is no FAILED state, and each retry
+        can orphan a DB user/schema until fork fix 9 lands)
+ 7. Cognito: create groups t:<sub>:<role>; create/invite the tenant-admin user
+       and add them to t:<sub>:<their-role>
+       — MANDATORY: the platform creates no user for a new tenant
+       — the tenant-admin role is a business role, NOT Dirigible ADMINISTRATOR
+ 8. Smoke test: GET https://<sub>.app.com/login/<sub> → 302 to Cognito
+```
+
+Adding a person to another tenant later = add them to that tenant's groups. Nothing else.
+
+**Offboarding** (no platform de-provisioning exists): disable the app client → delete the tenant's groups → delete the client registration (tenant now unreachable and un-login-able) → `pg_dump -n <TENANT_SCHEMA>` + S3 prefix copy to archive → manual `DROP SCHEMA … CASCADE` / `DROP USER`, datasource-row and tenant-row cleanup per runbook → restart the task (the tenant's pool and cache entries have no external eviction path).
+
+---
+
+## 8. Security hardening checklist
+
+Shipped defaults that must be closed, and the closing move:
+
+| Risk (default) | Action |
+| --- | --- |
+| ttyd shell, port 9000, **no auth** (`DIRIGIBLE_TERMINAL_ENABLED=true`) | `DIRIGIBLE_TERMINAL_ENABLED=false`; port unmapped |
+| Graalium debugger, port 8081 (`DIRIGIBLE_GRAALIUM_ENABLE_DEBUG=true` shipped) | `DIRIGIBLE_GRAALIUM_ENABLE_DEBUG=false`; port unmapped |
+| SFTP, port 8022, admin/admin | disabled/unmapped; SG exposes 8080 only |
+| Actuator `management.endpoints.web.exposure.include=*` | `include=health`; WAF blocks `/actuator/**` from non-admin CIDRs |
+| `DIRIGIBLE_TRIAL_ENABLED` grants all roles | `false` + fail-fast guard (fix 8) |
+| Default basic admin/admin | cognito profile sets `basic.enabled=false`; leave `DIRIGIBLE_BASIC_*` unset |
+| DEVELOPER role = in-JVM code execution | runtime-only: no `t:*:DEVELOPER` groups; `DIRIGIBLE_PUBLISH_DISABLED=true`; content baked in; authoring on the internal instance |
+| Cross-tenant token/session replay | fork fix 2 (`dirigible:tenant` assertion) |
+| Cross-tenant admin enumeration | fix 10 + never grant ADMINISTRATOR to tenant users |
+| Tenant DB passwords stored in SystemDB (`DIRIGIBLE_DATA_SOURCES`) | accept + encrypt at rest; restrict SystemDB credentials; treat SystemDB compromise as full-unit compromise |
+| CSRF disabled, frame options disabled | compensate at the edge (WAF, `SameSite=Lax`, short sessions); re-enabling CSRF needs UI compatibility testing (hypothesis §12) |
+| Root container, writable FS | non-root user (fix 11); minimal task role (S3 prefix, KMS, Logs — nothing else) |
+| Secrets | Secrets Manager → ECS `secrets` for DB creds + Cognito client secrets; nothing in plain env |
+| Mode flags | `SPRING_PROFILES_ACTIVE=cognito`, `DIRIGIBLE_MULTI_TENANT_MODE=true`, `DIRIGIBLE_MULTI_TENANT_MODE_COGNITO_SINGLE_USER_POOL=true` |
+
+---
+
+## 9. Operations
+
+**Deploy.** New image (content baked in) → stop-then-start ECS deployment with circuit breaker + rollback. Planned downtime ≈ boot + first sync pass; deploy in a quiet window, optionally with an ALB fixed-response maintenance rule. Never run two versions concurrently (§2.2).
+
+**Backup / restore.** RDS automated backups + PITR, **plus a nightly per-tenant `pg_dump -n <SCHEMA>` to S3** — that is the practical per-tenant restore path (restore a snapshot to a side instance and extract one schema is the slow fallback). S3 CMS bucket versioned. Cognito has no native backup: a nightly Lambda exports users/groups/clients to S3. Rehearse the single-tenant restore before a customer asks for it.
+
+**Observability.** JSON logs to CloudWatch with the built-in tenant id in every line → per-tenant Logs Insights queries and error-rate metric filters are one-liners. `engine-open-telemetry` + ADOT sidecar for traces/metrics (JVM, per-tenant Hikari pools, Quartz). ALB access logs → Athena for per-Host traffic. **Alarms:** `DatabaseConnections`/`max_connections` > 70 %, tenant INITIAL > 15 min, health check failing > 5 min, task restart, p95 latency, heap after GC.
+
+**Cost ballpark** (monthly, eu-central-1, on-demand): Fargate runtime ≈ $95 · RDS `db.r6g.large` Multi-AZ + 100 GB ≈ $450 · ALB ≈ $30 · NAT ≈ $40 · WAF ≈ $20 · Cognito Essentials ≈ $0–50 at modest MAU · S3/Secrets/CloudWatch/Route 53 ≈ $40 → **≈ $700/month**, + ~$150 for the authoring instance if always on (schedule it to business hours).
+
+---
+
+## 10. Where this agrees / differs with `docs/aws-multitenancy-research`
+
+Designed independently, the two efforts **converge** on: one Cognito pool + one app client per tenant; a pre-token-generation Lambda minting tenant-scoped tokens; a `dirigible:tenant` claim asserted against the host tenant; the M2M bypass and `@RolesAllowed`-inert-under-cognito findings; single-writer ⇒ one task + stop-then-start; S3 for CMS; registry baked into the image; the runtime/authoring split as a security boundary; `/services/core/healthcheck` as the ALB target; RDS Proxy rejected for `SET search_path` pinning. That convergence is strong evidence both designs sit on the platform's real constraints.
+
+**Differences (deliberate):**
+
+| Topic | This proposal | Research branch | Why differ |
+| --- | --- | --- | --- |
+| Where roles live | **Prefixed Cognito groups** (`t:<sub>:<role>`); Lambda filters by prefix | DynamoDB membership store; Lambda reads it; groups synthesized | One fewer authoritative store and admin surface at ≤100 tenants; accepts the 100-groups-per-user ceiling they designed around. Migrating to their model later is only a Lambda + data change — the token contract is identical |
+| Client-registration plumbing | **Fork-built host-keyed `ClientRegistrationRepository`** reading Secrets Manager; per-tenant clients re-derived from first principles (§4.2) | Reuses the shipped `security-client-registration` module (`POST /services/security/client-registrations`) | Their own review flags that module as defective (process-global static map, plaintext secret reads, no tenant column). This proposal removes it as a design input entirely; the client topology must stand without it — and does |
+| Database | RDS PostgreSQL Multi-AZ (provisioned) | Aurora Serverless v2 | One right-sized unit with steady load; provisioned is simpler and cheaper than a serverless floor |
+| Pool sizing | **Fork fix** making Hikari sizing configurable | Size the DB around the hardcoded pools | Their as-is doc was written under a no-code-changes constraint; with the fork allowed, fixing the root cause is strictly better |
+| Scope | One unit + short growth note | Multi-cell control plane, tenant→cell registry, lifecycle automation | Right-sizing per the actual ask; their cell model remains the correct end-state at larger scale |
+
+---
+
+## 11. How it grows
+
+Past what one unit sustains (connection budget, CPU, or blast-radius tolerance):
+
+- **Add a second unit** = one more {ECS service + RDS instance + ALB}. Tenants are pinned to a unit.
+- **DNS changes shape once:** wildcard-to-one-ALB becomes a per-tenant Route 53 alias created at onboarding, pointing at the tenant's unit. (Keep the wildcard as a catch-all to a "no such tenant" page.)
+- **What stays shared:** the Cognito user pool (identity, SSO and per-tenant roles are unit-agnostic), the pre-token Lambda + client map, the image pipeline, WAF rules, the wildcard certificate.
+- **Watchpoints on the way:** the 100-groups-per-user Cognito hard limit (a person in ~30+ tenants — that is the trigger to move the membership graph to a store, per the research branch's model); per-unit connection budget; and only if a *single tenant* outgrows a unit does the deep fork surgery (external broker, non-local repository) become worth discussing.
+
+---
+
+## 12. Hypotheses to verify before go-live
+
+Flagged, not asserted:
+
+1. **`@RolesAllowed` inert under the cognito profile** — annotation absence is confirmed by inspection; behaviour needs the integration test in fix 3 before relying on (or adding) method security.
+2. **`groupsToOverride` → `cognito:groups` as seen by `userAuthoritiesMapper`** — the mapper reads the OIDC principal's attributes (ID token / userinfo); confirm with one real pool that the overridden groups arrive there, before building onboarding automation.
+3. **RDS master credential can execute the provisioner's `CREATE USER` / `CREATE SCHEMA … AUTHORIZATION`** — provision one throwaway tenant end-to-end on RDS first.
+4. **CSRF re-enablement compatibility** with the shipped UI (§8).
+5. **Boot + first-sync duration at ~100 provisioned tenants** — drives the deploy window and the ALB health-check grace period.
+6. **Federated-IdP SSO behaviour** (if a tenant later brings its own IdP): the pool-wide session-cookie SSO statement is worded for local users; test the cross-tenant hop for federated users before promising it.

--- a/AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md
+++ b/AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md
@@ -4,6 +4,32 @@
 **Date:** 2026-07-29
 **Companion:** [`AWS_DEPLOYMENT_PROPOSAL.md`](AWS_DEPLOYMENT_PROPOSAL.md) — the subdomain-per-tenant variant of the same one-unit deployment. Everything below the identity layer (compute, database, storage, hardening, operations) is inherited from it unchanged; this document specifies only what the changed requirements alter, and §8 weighs the two models honestly.
 
+**Contents**
+
+- [0. The changed requirements, and what they force](#0-the-changed-requirements-and-what-they-force)
+- [1. Topology — what changes on AWS (almost nothing)](#1-topology--what-changes-on-aws-almost-nothing)
+- [2. Identity — one client, multi-tenant tokens, roles filtered at pick time](#2-identity--one-client-multi-tenant-tokens-roles-filtered-at-pick-time)
+  - [2.1 Why one app client is now the right answer](#21-why-one-app-client-is-now-the-right-answer)
+  - [2.2 The token contract](#22-the-token-contract)
+  - [2.3 Optional pre-token Lambda](#23-optional-pre-token-lambda)
+- [3. The tenant-picker mechanism (the heart of the fork change)](#3-the-tenant-picker-mechanism-the-heart-of-the-fork-change)
+  - [3.1 Session model](#31-session-model)
+  - [3.2 Request → tenant resolution (replacing `TenantExtractor`)](#32-request--tenant-resolution-replacing-tenantextractor)
+  - [3.3 Login and switch, end to end](#33-login-and-switch-end-to-end)
+  - [3.4 The one behavioural cost to state up front](#34-the-one-behavioural-cost-to-state-up-front)
+  - [3.5 Security notes specific to this model](#35-security-notes-specific-to-this-model)
+- [4. Fork changes](#4-fork-changes)
+- [5. Machine-to-machine access](#5-machine-to-machine-access)
+- [6. Tenant onboarding (simpler than the subdomain runbook)](#6-tenant-onboarding-simpler-than-the-subdomain-runbook)
+- [7. Login & switch — sequence (for the visualization)](#7-login--switch--sequence-for-the-visualization)
+- [8. Honest comparison with the subdomain model — and one rejected alternative](#8-honest-comparison-with-the-subdomain-model--and-one-rejected-alternative)
+- [9. Hypotheses to verify before go-live](#9-hypotheses-to-verify-before-go-live)
+- [10. Horizontal scaling — will this design run on more than one instance?](#10-horizontal-scaling--will-this-design-run-on-more-than-one-instance)
+  - [10.1 What happens if you raise `desiredCount` today](#101-what-happens-if-you-raise-desiredcount-today)
+  - [10.2 Enabling true replicas — the layer-by-layer bill](#102-enabling-true-replicas--the-layer-by-layer-bill)
+  - [10.3 Scaling out by units under a single host — the picker-specific catch](#103-scaling-out-by-units-under-a-single-host--the-picker-specific-catch)
+  - [10.4 Recommended posture](#104-recommended-posture)
+
 ---
 
 ## 0. The changed requirements, and what they force

--- a/AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md
+++ b/AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md
@@ -53,7 +53,7 @@ What does **not** change: `TenantContext` is a clean thread-local SPI (`componen
 | No tenant selected | Redirect to the **tenant picker page** (auto-select when the user has exactly one membership); never fall through to the default tenant | Silent default-tenant fallback would read/write the wrong tenant's data |
 | Identity | One Cognito user pool | Same-credentials requirement |
 | OAuth app clients | **ONE confidential app client** (single callback `https://app.example.com/login/oauth2/code/cognito`) | One host = one callback; the per-tenant-client rationale from the subdomain proposal (per-tenant callbacks, tenant signal at mint time) evaporates — see §2 |
-| Membership & roles | Cognito groups `t:<tenantId>:<role>` — same model as the subdomain proposal | One source of truth in the IdP; the full set arrives in the token and is filtered app-side per pick |
+| Membership & roles | Cognito groups `t:<tenantId>:<role>` — same model as the subdomain proposal; **no tenant user attribute** (membership is derived from the group pattern, §2.2) | One source of truth in the IdP; the full set arrives in the token and is filtered app-side per pick |
 | Pre-token Lambda | **Not required** (optional refinement, §2.3) | With one client there is no per-tenant token to mint; prefixed groups pass through as-is — Cognito **Lite** plan may suffice |
 | Roles at runtime | Authorities **rebuilt on every tenant switch** from the session's membership snapshot; one active tenant per browser session | §3 — the load-bearing fork mechanism |
 | Everything below identity | Inherited unchanged from `AWS_DEPLOYMENT_PROPOSAL.md` | ECS Fargate desiredCount=1, RDS Multi-AZ schema-per-tenant, S3 CMS, baked-in content, hardening, ops |
@@ -120,6 +120,13 @@ So: **one confidential app client**, the shipped static registration, standard `
 | `email` | Sign-in / display identity | `user-name-attribute` |
 | `cognito:groups` | **All** memberships as prefixed groups: `["t:acme:manager", "t:acme:ADMINISTRATOR", "t:globex:viewer"]` | Parsed **once at login** into a membership map `{acme: [manager, ADMINISTRATOR], globex: [viewer]}` held on the principal; **no authorities are granted from it directly** |
 | `scope` (M2M only) | `<tenantId>/<role>` per-tenant scopes | membership + roles for client-credentials callers |
+
+**There is no tenant user attribute.** The shipped `CognitoTenantFilter` reads a `custom:tenant` attribute (a user-global comma-separated list); this design retires it entirely, like the subdomain proposal. A user's tenants are **derived from the group pattern**: membership in a tenant *is* holding at least one `t:<tenant>:*` group. The picker lists exactly the tenants present in the parsed membership map, the switch endpoint's membership check is a key lookup in that same map, and the roles granted after a pick are that key's values — one claim (`cognito:groups`) feeds all three, so there is no second source of truth to drift out of sync.
+
+Two consequences of deriving membership purely from the pattern:
+
+- **Administration is a single operation surface.** Add someone to a tenant = add a group; change their roles = change groups; remove them = delete their `t:<tenant>:*` groups. Nothing else to update anywhere.
+- **A "member with zero roles" state does not exist** — removing someone's last `t:<tenant>:*` group removes the membership itself (the tenant disappears from their picker at the next login/switch). If "belongs, but no permissions yet" is ever needed, adopt a conventional marker role (e.g. `t:<tenant>:member`) that the mapper treats as membership-only.
 
 The 100-groups-per-user Cognito hard limit applies to the *person's total* tenant-role pairs — same watchpoint as the subdomain design, unchanged.
 

--- a/AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md
+++ b/AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md
@@ -232,6 +232,7 @@ Actors: Browser · Dirigible (app.example.com) · Cognito (one pool, one client)
 | DNS/TLS | Wildcard cert + wildcard DNS | One record, one plain cert |
 | Fork surface (identity layer) | Small — per-host sessions do the heavy lifting | **Larger** — S1–S6: resolver, neutral mapper, switch endpoint, picker UI, M2M header, tab guard |
 | Per-tenant enterprise federation later | Per-app-client setting, clean | Needs home-realm discovery (an email-domain → IdP hint step at login) — doable, not free |
+| Scale-out routing to more units | Per-tenant DNS records — clean | The edge cannot see the tenant (it lives in the session); needs a routing cookie + CloudFront Function, or a gateway tier — §10.3 |
 | Tenant onboarding | Cognito client + secret + registration per tenant | Groups only — the simplest onboarding of any variant |
 
 **Rejected alternative — path-based tenancy (`/t/{tenant}/…`).** It would restore per-request tenant signal (fixing concurrent tabs and deep links) while keeping one host. Rejected because Dirigible's URL space is absolute-path-native everywhere — `/services/**`, `/public/**`, `/webjars/**`, WebSocket endpoints, generated UI assets, OAuth callback paths — so a tenant path prefix means either a rewriting reverse-proxy layer with cookie-path juggling or invasive URL surgery across the platform and every generated application. That is an order of magnitude more fork than S1–S6 for a UX refinement the picker requirement doesn't demand. Revisit only if concurrent multi-tenant tabs become a hard requirement.
@@ -247,3 +248,56 @@ Inherited from the companion (still valid here): `@RolesAllowed` inert under the
 3. **Group-claim size:** a user with the maximum realistic memberships fits the ID-token/JWT header limits comfortably (arithmetic says yes; verify with a real pool).
 4. **Cognito Lite vs Essentials:** confirm the no-Lambda baseline works on Lite pricing for your MAU; the Lambda upgrade path forces Essentials.
 5. **Session semantics under the shipped UI:** the full-reload-on-switch leaves no stale per-tenant state in shell/iframe caches (exercise the deepest generated app view before and after a switch).
+
+---
+
+## 10. Horizontal scaling — will this design run on more than one instance?
+
+**Short answer: not today, and that is a platform property, not a picker property.** The same single-writer constraints that pin the subdomain model to `desiredCount=1` (companion §2.2) pin this one. The picker's session mechanism adds exactly **one** extra requirement for the day replicas become possible — an external session store — and that requirement has a standard, well-understood answer. This section separates the three questions people conflate: what happens if you just raise the count, what enabling true replicas would take, and how this model scales *out* by units.
+
+### 10.1 What happens if you raise `desiredCount` today
+
+The second task **blocks at boot**: the embedded ActiveMQ broker uses a JDBC locker on SystemDB and `broker.start()` waits until it holds the exclusive lock, so the new task's Spring context never finishes refreshing and it never passes the health check. The failure mode is a stuck deployment, not split traffic — no request ever reaches a second instance, so the in-heap session is never silently wrong. This is inconvenient but *safe*: the platform protects its own constraint by construction.
+
+### 10.2 Enabling true replicas — the layer-by-layer bill
+
+What each layer needs before two runtime tasks can serve one unit's traffic. Items 1–5 are platform blockers shared by both models; item 6 is the only picker-specific one.
+
+| # | Layer | Multi-instance today? | What enabling it takes |
+| --- | --- | --- | --- |
+| 1 | **Embedded ActiveMQ** (`vm://localhost` hardcoded, JDBC lock, `MessagingConfig.java`) | ✗ — blocks the second boot | Replace with an external broker (Amazon MQ for ActiveMQ) or refactor `.listener` processing onto SQS/SNS. Fork change to `engine-listeners`; the connector URL is a constant, there is no configuration path |
+| 2 | **Synchronizer model** — artefact checksums/state are *shared* in SystemDB, but the side effects (Camel routes, JMS listeners, Quartz registrations, compiled client Java) are *per-JVM* | ✗ — the second node sees checksums already current and **never materializes its own runtime state** | Per-node reconciliation: node-scoped sync state, or an unconditional full replay at boot regardless of stored checksums. A real `core-initializers` engine rework — this is the deepest item on the list |
+| 3 | **Repository + Lucene** (`LocalRepository`, local filesystem) | ✓ for **runtime-only** tasks — baked-in content is expanded identically into each task's ephemeral disk at boot; nothing shared is written (`DIRIGIBLE_PUBLISH_DISABLED=true`) | Nothing, for runtime replicas. The **authoring** instance can never be replicated (workspaces, git, Lucene are stateful and local) — it stays at 1 |
+| 4 | **Boot-time DDL races** — Quartz `initialize-schema=always` drops/recreates `QRTZ_*`, `JobsInitializer` unschedule/reschedule, Flowable schema update, check-then-insert initializers | ✗ — concurrent boots corrupt shared state | Switch Quartz schema init to `never` (manage it once via migration), make the initializers concurrency-safe or serialize instance boots (one-at-a-time rolling) |
+| 5 | **Per-JVM caches with no invalidation channel** — tenant lookup cache, tenant-config cache, `.access` ACL cache | ✗ — a write on node A is invisible on node B until TTL (or forever) | Short TTLs everywhere as the cheap fix; a Redis pub/sub invalidation bus as the proper one |
+| 6 | **HTTP session (picker-specific)** — `activeTenant` + the rebuilt `SecurityContext` live in the Tomcat heap | ✗ — a `JSESSIONID` is only valid on the instance that minted it | **`spring-session` + ElastiCache Redis** (or JDBC). The tenant-picker design survives *unchanged*: the tenant stays session state, the switch endpoint keeps its validate-store-rebuild atomicity — only where the session physically lives moves. Implementation caveat: the principal and membership map must serialize cleanly into the store. ALB stickiness is a stopgap only — failover or a deploy wipes the stuck-to instance's sessions |
+
+Two cross-cutting consequences of any replication:
+
+- **Connection budget multiplies per instance.** Pools are per *(instance, tenant)*, so N replicas ≈ N× the idle and peak connections. The configurable-pool-sizing fork fix (companion §6, fix 1) goes from important to non-negotiable, and the RDS class must be re-sized for the product.
+- **WebSockets and other instance-local endpoints** (terminal, LSP, debug — authoring concerns mostly, but also `data/transfer`) bind to one JVM; replicated runtimes need ALB stickiness for those paths regardless of the session store.
+
+**Verdict:** items 1, 2 and 4 are substantial fork surgery in the engine layer. They are only worth paying for when a *single unit's single task* can no longer be scaled vertically (bigger Fargate task) or the SLO genuinely requires intra-unit HA. Until then, the sanctioned growth path is **more units**, not more replicas — which leads to the picker-specific catch below.
+
+### 10.3 Scaling out by units under a single host — the picker-specific catch
+
+A "unit" is {ECS service + RDS + ALB}, tenants pinned to a unit. Under subdomains, routing tenants to units is trivial — a per-tenant DNS record pointing at the right ALB. Under a single host **the edge has nothing to route on**: the tenant lives in a server-side session the ALB cannot see, and ALB listener rules cannot match on cookies at all. Worse, one user may belong to tenants pinned to *different* units, and their one session cannot span units.
+
+Options, in order of preference:
+
+1. **Routing cookie + CloudFront Function.** The switch endpoint sets a `unit=<n>` cookie (routing metadata only — never an authorization input; membership is still enforced server-side). A CloudFront Function in front selects the origin (unit ALB) from that cookie. Cross-unit switches bounce through a small redirect step that re-establishes a session on the target unit (a fresh OIDC round-trip — silent, the Cognito session is pool-wide). Workable, adds one edge component.
+2. **A thin gateway/router tier** in front of the units that terminates the session and proxies by tenant. Clean model, but it *is* a new stateful service — the thing this architecture has avoided everywhere else.
+3. **Placement constraint:** "all of a user's tenants live on the same unit." Avoids cross-unit sessions entirely but collapses the moment memberships grow organically across units — acceptable only as a temporary rule while unit count is 2–3.
+
+If none of these appeals, the pragmatic hybrid is to reintroduce hostnames **for routing only** (e.g. `unit2.app.example.com` hosting the same single-host application) — invisible to the tenancy model, which stays session-based.
+
+### 10.4 Recommended posture
+
+| Phase | Shape | What to do |
+| --- | --- | --- |
+| Now | One unit, one task | The design as specified. Nothing session-related to change |
+| Early optional win | One task + external sessions | Add `spring-session` + Redis ahead of need: sessions survive deploys/restarts, so users stop being logged out by every release. Cheap, independent of replication |
+| Unit growth | 2–5 units | §10.3 option 1 (routing cookie + CloudFront Function); revisit the subdomain hybrid if edge complexity grows |
+| True replicas | N tasks per unit | Pay the §10.2 bill: external broker, per-node sync replay, boot-race fixes, cache invalidation — then the picker mechanism scales with the session store unchanged |
+
+**Bottom line:** the tenant-picker approach is not what stands between this deployment and horizontal scaling — the platform's single-writer engine layer is, identically in both models. When (if) those blockers are paid down, the picker's session-scoped tenancy scales horizontally with one standard addition, `spring-session` on Redis, and no change to its security model.

--- a/AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md
+++ b/AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md
@@ -1,0 +1,249 @@
+# Multitenant Dirigible on AWS — Single Host with an In-App Tenant Picker
+
+**Status:** architecture proposal. Nothing here is deployed or implemented.
+**Date:** 2026-07-29
+**Companion:** [`AWS_DEPLOYMENT_PROPOSAL.md`](AWS_DEPLOYMENT_PROPOSAL.md) — the subdomain-per-tenant variant of the same one-unit deployment. Everything below the identity layer (compute, database, storage, hardening, operations) is inherited from it unchanged; this document specifies only what the changed requirements alter, and §8 weighs the two models honestly.
+
+---
+
+## 0. The changed requirements, and what they force
+
+| Requirement | Architectural consequence |
+| --- | --- |
+| Same credentials in every tenant the user belongs to, different roles in each | One identity store (one Cognito user pool) — unchanged |
+| The user logs in **once**, then picks/changes the current tenant **in the UI** | The tenant is chosen *after* authentication and can change *without* re-authentication ⇒ the token cannot be tenant-scoped at issuance; roles for **all** memberships must be available to the session, filtered when the tenant is picked |
+| **No dedicated subdomain per tenant** | The `Host` header carries no tenant signal ⇒ Dirigible's host-based `TenantExtractor` model is unusable and must be replaced in the fork ⇒ the active tenant becomes **server-side session state** |
+
+The third point is the deep one. Today the platform is *host-native multitenant*: `TenantExtractor` regex-matches the subdomain, and — crucially — the per-host `JSESSIONID` gives every tenant its own session and its own login-time authority snapshot for free. Removing subdomains removes both, so the fork must supply (a) a new per-request tenant source and (b) a way to change the session's authorities when the picker changes the tenant.
+
+What does **not** change: `TenantContext` is a clean thread-local SPI (`components/core/core-base/.../tenant/TenantContext.java`), and everything tenant-aware — datasource-name routing, per-tenant synchronizer replay, CMS path prefixing, Quartz/JMS naming, Flowable — consumes it, not the HTTP host. Replace the *resolver* that feeds the context and the entire isolation machinery keeps working untouched.
+
+### Decisions at a glance
+
+| Concern | Decision | Why |
+| --- | --- | --- |
+| Application host | One host, e.g. `app.example.com` — single Route 53 record, single ACM cert (no wildcard) | Requirement |
+| Active-tenant carrier | **HTTP session attribute**, set by a picker endpoint; `X-Dirigible-Tenant` header for API/M2M callers | The only carrier that works for browser top-level navigation; header where clients can set headers |
+| No tenant selected | Redirect to the **tenant picker page** (auto-select when the user has exactly one membership); never fall through to the default tenant | Silent default-tenant fallback would read/write the wrong tenant's data |
+| Identity | One Cognito user pool | Same-credentials requirement |
+| OAuth app clients | **ONE confidential app client** (single callback `https://app.example.com/login/oauth2/code/cognito`) | One host = one callback; the per-tenant-client rationale from the subdomain proposal (per-tenant callbacks, tenant signal at mint time) evaporates — see §2 |
+| Membership & roles | Cognito groups `t:<tenantId>:<role>` — same model as the subdomain proposal | One source of truth in the IdP; the full set arrives in the token and is filtered app-side per pick |
+| Pre-token Lambda | **Not required** (optional refinement, §2.3) | With one client there is no per-tenant token to mint; prefixed groups pass through as-is — Cognito **Lite** plan may suffice |
+| Roles at runtime | Authorities **rebuilt on every tenant switch** from the session's membership snapshot; one active tenant per browser session | §3 — the load-bearing fork mechanism |
+| Everything below identity | Inherited unchanged from `AWS_DEPLOYMENT_PROPOSAL.md` | ECS Fargate desiredCount=1, RDS Multi-AZ schema-per-tenant, S3 CMS, baked-in content, hardening, ops |
+
+---
+
+## 1. Topology — what changes on AWS (almost nothing)
+
+```
+                Route 53   app.example.com ──alias──┐        auth.example.com (Cognito managed login)
+                                                    │
+        ┌───────────────────────────────────────────▼────────────────────────────┐
+        │  AWS WAF  →  ALB (HTTPS, ACM app.example.com)                          │
+        │  health check: /services/core/healthcheck                              │
+        └───────────────────────────────┬────────────────────────────────────────┘
+                                        │  session cookie + activeTenant (server-side)
+        ════ private / isolated ════════▼══════════════════════════════════════════
+        ┌───────────────────────────┐       ┌────────────────────────────────────┐
+        │ ECS Fargate               │       │ RDS PostgreSQL Multi-AZ            │
+        │ dirigible-runtime         │──────▶│  SystemDB · DefaultDB              │
+        │ desiredCount = 1          │       │  (schema + DB user per tenant)     │
+        │ stop-then-start deploys   │       └────────────────────────────────────┘
+        │ content baked in          │       ┌────────────────────────────────────┐
+        └────────────┬──────────────┘──────▶│ S3 CMS  ·  Secrets Mgr · CloudWatch│
+                     │ OIDC (ONE app client)└────────────────────────────────────┘
+        ┌────────────▼───────────────────────────────────────────────────────────┐
+        │ Amazon Cognito — one user pool (Lite plan may suffice)                 │
+        │   ONE app client "dirigible" — callback app.example.com/login/…        │
+        │   groups: t:acme:manager · t:acme:ADMINISTRATOR · t:globex:viewer · …  │
+        │   [optional] pre-token Lambda — claim compaction / store-backed roles  │
+        └─────────────────────────────────────────────────────────────────────────┘
+```
+
+Deltas from the subdomain proposal, all simplifications:
+
+- **DNS/TLS:** one A/alias record, one plain certificate. No wildcard anything.
+- **Cognito:** one app client, one secret, one callback. No per-tenant clients, no clientId→tenant DynamoDB map, and no pre-token Lambda in the baseline — which means the **Lite** feature plan may be enough (verify; the subdomain design required Essentials for trigger V2_0).
+- **Dropped fork components:** the host-keyed `ClientRegistrationRepository` (fix 7 there) is unnecessary — the shipped single static registration in `application-cognito.properties` is exactly right, with its `redirect-uri` pointed at the one host. The per-tenant logout fix is unnecessary — the shipped single-client `CognitoLogoutSuccessHandler` is correct as-is. `CognitoLoginController`'s `/login/{subdomain}` entry point goes unused.
+- Unchanged and still binding: the single-writer compute constraint, the Hikari pool-sizing fix, the schema-per-tenant provisioning flow, S3 CMS, all of the hardening checklist, backup/observability/cost (§9 of the companion — subtract the wildcard cert and the Lambda; the numbers barely move).
+
+---
+
+## 2. Identity — one client, multi-tenant tokens, roles filtered at pick time
+
+### 2.1 Why one app client is now the right answer
+
+The subdomain proposal argued hard for one client per tenant (its §4.2). Every leg of that argument depended on per-tenant hosts, and each one falls with them:
+
+| Per-tenant-client argument (subdomain model) | Under a single host |
+| --- | --- |
+| Per-tenant callback URLs (100-URL cap, no wildcards) | There is exactly **one** callback URL — the cap is irrelevant |
+| The app client is the Lambda's tenant signal, enabling tenant-scoped tokens | The user picks the tenant **after** the token is minted and switches without re-auth — no issuance-time scoping is possible in principle, client topology can't buy it back |
+| Deny non-members at the IdP | Membership denial moves app-side by necessity (the IdP can't know which tenant the user will pick) |
+| Per-tenant IdP federation (per-client setting) | Lost either way on one host — federation selection would need a home-realm-discovery step, not client topology (§8) |
+| Per-tenant secret blast radius | One host, one app — one secret is the natural shape |
+
+So: **one confidential app client**, the shipped static registration, standard `authorization_code` flow. Per-tenant **M2M** app clients remain available if needed (client-credentials has no callbacks and each M2M client can carry its tenant in its scopes) — see §5.
+
+### 2.2 The token contract
+
+| Claim | Content | Consumed by |
+| --- | --- | --- |
+| `sub` | Global identity of the person | identity key |
+| `email` | Sign-in / display identity | `user-name-attribute` |
+| `cognito:groups` | **All** memberships as prefixed groups: `["t:acme:manager", "t:acme:ADMINISTRATOR", "t:globex:viewer"]` | Parsed **once at login** into a membership map `{acme: [manager, ADMINISTRATOR], globex: [viewer]}` held on the principal; **no authorities are granted from it directly** |
+| `scope` (M2M only) | `<tenantId>/<role>` per-tenant scopes | membership + roles for client-credentials callers |
+
+The 100-groups-per-user Cognito hard limit applies to the *person's total* tenant-role pairs — same watchpoint as the subdomain design, unchanged.
+
+### 2.3 Optional pre-token Lambda
+
+The baseline needs none — prefixed groups flow through untouched. Add a V2_0 Lambda later only for: compacting a large group list into a JSON claim, sourcing roles from an external membership store (the research branch's DynamoDB model), or filtering what enters the token. It is an evolution, not a prerequisite — and adding it is what moves the pool from Lite to Essentials.
+
+---
+
+## 3. The tenant-picker mechanism (the heart of the fork change)
+
+### 3.1 Session model
+
+- After OIDC login the session holds an authenticated principal with the **membership map** and **zero tenant roles**. `activeTenant` is unset.
+- A request with no `activeTenant` is redirected to the **picker page** (static assets and the picker/auth endpoints excepted). A user with exactly one membership is auto-selected. **No request ever silently runs against the default tenant** — with host-resolution gone, the shipped fallback-to-default behaviour becomes a data-integrity bug and must be removed for authenticated traffic.
+- `POST /services/core/security/tenants/current { "tenant": "acme" }`:
+  1. Validate `acme` is in the principal's membership map — 403 otherwise.
+  2. Validate the tenant row exists and is `PROVISIONED` — 409 otherwise.
+  3. Store `activeTenant = acme` in the session.
+  4. **Rebuild the authorities**: replace the session's `Authentication` with one carrying the same principal and exactly `ROLE_<r>` for the map's `acme` roles (the mapper seam already exists: `CognitoSecurityConfiguration.userAuthoritiesMapper()`).
+  5. The UI performs a **full reload** — every iframe, cached list and open perspective re-renders under the new tenant.
+- `GET /services/core/security/tenants/mine` returns the membership map (+ display names) — the data source for the picker page and the shell dropdown.
+
+### 3.2 Request → tenant resolution (replacing `TenantExtractor`)
+
+A new resolver feeds the existing `TenantContextInitFilter`/`TenantContext`, in order:
+
+1. **Session attribute** `activeTenant` — the browser path.
+2. **`X-Dirigible-Tenant` header** — API and M2M callers (validated against the caller's memberships / M2M scopes; 400 when absent, 403 when not a member).
+3. Neither ⇒ no tenant context: UI requests go to the picker; service requests are rejected.
+
+Everything downstream — `TenantDataSourceNameManager`'s `<tenantId>_DefaultDB` routing, CMS prefixing, job/queue naming, the per-tenant synchronizer replay, `executeForEachTenant` — is untouched: it consumes `TenantContext`, not the host.
+
+### 3.3 Login and switch, end to end
+
+```
+1  GET https://app.example.com/              → no session
+2  → /oauth2/authorization/cognito (single registration) → Cognito managed login
+3  token: cognito:groups = [t:acme:manager, t:globex:viewer]
+4  fork mapper: membership map on principal, NO roles yet → tenant picker page
+5  user picks Acme → POST /services/core/security/tenants/current
+      member? yes → session activeTenant=acme, authorities=[ROLE_manager] → reload
+6  every request now runs in TenantContext(acme) → ACME schema, ACME documents, …
+7  shell dropdown: "Globex" → same endpoint → authorities=[ROLE_viewer] → reload
+      no re-authentication, different roles            ← the requirement
+8  a user who belongs to no tenant: empty map → "no tenants" page, zero authorities
+```
+
+### 3.4 The one behavioural cost to state up front
+
+**One browser session has one active tenant at a time.** Two tabs share the `JSESSIONID`; switching the tenant in tab A silently switches tab B's context on its next request. The subdomain model gave concurrent multi-tenant tabs for free (per-host cookies); this model **cannot**, short of moving the tenant into every URL or header of the UI. Mitigations, in increasing cost:
+
+- The shell shows the active tenant persistently (name + colour chip) and the switch reloads the whole UI — stale tabs re-render on next interaction. *(baseline)*
+- A session-version cookie checked by the shell; a mismatch banner — "tenant changed in another tab" — forces reload before further writes. *(recommended)*
+- True concurrent tabs require per-request tenancy in the URL (path prefix `/t/{tenant}/…`), examined and rejected in §8.
+
+Every write API already runs server-side under the session's `activeTenant`, so the failure mode is a *confusing read* or a *write to the tenant the user actually switched to* — never a write crossing a tenant the user doesn't belong to. State it in the UX anyway.
+
+### 3.5 Security notes specific to this model
+
+- **The switch endpoint is state-changing: it must be CSRF-protected.** The platform disables CSRF globally (`BasicSecurityConfig`); at minimum enforce `SameSite=Lax` on the session cookie, require the custom `X-Requested-With` header on the switch call, and prefer re-enabling CSRF for this endpoint. A forced tenant switch is not privilege escalation (memberships are still enforced) but is an integrity nuisance.
+- **Rotate the session id on switch** (`changeSessionId()`) — cheap fixation hygiene when authority sets change.
+- Membership/role changes take effect at the **next login** in the baseline (the map is snapshotted from the login-time token). Optional freshness: the switch endpoint re-queries Cognito's `userInfo` with the stored access token and rebuilds the map — then a role change lands at the next *switch*, not the next login. The immediate-eject runbook (global sign-out + session invalidation) is unchanged.
+- A stolen bearer/refresh token now represents **all** the victim's tenants (no audience binding exists to assert) — inherent to the picker requirement, not to a topology choice. Compensate with short access-token lifetime (60 min), refresh-token rotation, and WAF rate rules.
+
+---
+
+## 4. Fork changes
+
+**Carried over unchanged from the subdomain proposal (§6 there):** configurable Hikari pool sizing *(must fix — capacity)*, `@EnableMethodSecurity(jsr250Enabled=true)` under the cognito profile *(must fix — verify-then-enable)*, trial-flag fail-fast, provisioning idempotency + `FAILED` status, gating the cross-tenant admin endpoints, non-root Dockerfile.
+
+**Dropped (no longer needed):** host-keyed `ClientRegistrationRepository`; per-tenant logout handler; tenant-cache sizing (no per-request subdomain lookups — resolution is a session read); `CognitoTenantFilter`'s host-vs-claim assertion in its subdomain form.
+
+**New — the single-host mechanism:**
+
+| # | Change | Where | Note |
+| --- | --- | --- | --- |
+| S1 | **Session/header tenant resolver** replacing host extraction; no-default-fallback for authenticated traffic; picker redirect | `core-tenants` (`TenantExtractor`, `TenantContextInitFilter`) | The resolver is the only thing that changes — `TenantContext` consumers are untouched |
+| S2 | **Membership-map principal + neutral login mapper** — parse `t:<t>:<r>` groups into a map; grant no authorities at login | `security-cognito` (`userAuthoritiesMapper()`) | The seam exists at `CognitoSecurityConfiguration.java:127` |
+| S3 | **Picker endpoints + authority rebuild on switch** — `GET …/tenants/mine`, `POST …/tenants/current` (validate membership + PROVISIONED, swap `Authentication`, rotate session id) | new, `core-tenants` | The heart of the feature; CSRF-protect (§3.5) |
+| S4 | **Tenant picker UI** — initial picker page + persistent shell dropdown with the active-tenant chip; full reload on switch | Harmonia application shell (`resources-application`) + platform shell | Data-driven from `…/tenants/mine` |
+| S5 | **M2M tenancy** — `X-Dirigible-Tenant` header resolved for `JwtAuthenticationToken` callers, asserted against per-tenant scopes | `security-cognito` filter + `ScopeRoleJwtAuthoritiesConverter` surroundings | Closes the same M2M gap the subdomain proposal's fix 2 closed, in header form |
+| S6 | **Stale-tab guard** — session-version cookie + shell banner | shell JS | §3.4, recommended tier |
+
+This is **more fork surface than the subdomain model** (which got per-tenant sessions and login-time scoping free from per-host cookies). That is the engineering price of the picker requirement, and it should be named in any comparison — see §8.
+
+---
+
+## 5. Machine-to-machine access
+
+One per-tenant M2M app client (client-credentials) with per-tenant resource-server scopes (`<tenantId>/<role>`), exactly as in the subdomain proposal — M2M has no callback constraints, so nothing changes on the Cognito side. The caller sends `X-Dirigible-Tenant: <tenantId>`; the fork asserts the header's tenant matches the token's scope prefix (S5). A single shared M2M client is possible but reintroduces "one secret, all tenants" for machines — keep M2M per-tenant.
+
+---
+
+## 6. Tenant onboarding (simpler than the subdomain runbook)
+
+```
+1. Dirigible: POST /services/core/security/tenants { name, subdomain }   → INITIAL
+      (subdomain remains a stored, unique tenant identifier — it just no
+       longer appears in any URL; it is the value the picker and the
+       X-Dirigible-Tenant header use)
+2. Wait for PROVISIONED  (provisioning interval 60 s; alarm INITIAL > 15 min)
+3. Cognito: create groups t:<tenantId>:<role>; add/invite the first users
+      — MANDATORY: the platform creates no user for a new tenant
+4. [only if the tenant needs API access] Cognito: resource server + M2M client
+5. Smoke test: log in as the invited user → tenant appears in the picker →
+      switch → correct roles
+```
+
+No DNS, no certificate, no app client, no callback registration, no secret distribution per tenant. Onboarding shrinks to *provision the schema + create the groups*. Offboarding likewise loses the Cognito-client steps; delete the tenant's groups (users lose it from their picker at next login/switch) and follow the companion's data-cleanup runbook.
+
+---
+
+## 7. Login & switch — sequence (for the visualization)
+
+Actors: Browser · Dirigible (app.example.com) · Cognito (one pool, one client).
+
+1. `GET /` — no session → redirect to `/oauth2/authorization/cognito`.
+2. Cognito managed login: credentials + MFA (one client, one callback).
+3. Callback: token with `cognito:groups = [t:acme:manager, t:globex:viewer]` → fork mapper builds the membership map, grants **no** roles → **tenant picker** (Acme · Globex).
+4. Pick **Acme** → `POST /services/core/security/tenants/current` → validate → session `activeTenant=acme`, authorities `[ROLE_manager]`, session id rotated → full reload → all requests run in `TenantContext(acme)` → `ACME` schema.
+5. Later, shell dropdown → **Globex** → same endpoint → authorities `[ROLE_viewer]` → reload. **No re-authentication; different roles.**
+6. Non-member tenant never appears in the picker, and a forged switch call 403s server-side.
+
+---
+
+## 8. Honest comparison with the subdomain model — and one rejected alternative
+
+| Dimension | Subdomains (`AWS_DEPLOYMENT_PROPOSAL.md`) | Single host + picker (this doc) |
+| --- | --- | --- |
+| Login UX | One sign-in per tenant hop (silent after the first) | **One sign-in, in-app switching** — the stated requirement |
+| Concurrent tabs in different tenants | **Yes** — per-host sessions | No — one active tenant per browser session (§3.4) |
+| Token scoping | Tenant-scoped at issuance; audience binding; IdP-side denial | Multi-tenant token; app-side denial only; stolen token spans the victim's tenants |
+| Deep links / bookmarks | Carry the tenant in the host | Tenant-less; land in whatever tenant is active |
+| Cognito surface | N app clients + Lambda + client map + Essentials plan | **One client, no Lambda, Lite plan may suffice** |
+| DNS/TLS | Wildcard cert + wildcard DNS | One record, one plain cert |
+| Fork surface (identity layer) | Small — per-host sessions do the heavy lifting | **Larger** — S1–S6: resolver, neutral mapper, switch endpoint, picker UI, M2M header, tab guard |
+| Per-tenant enterprise federation later | Per-app-client setting, clean | Needs home-realm discovery (an email-domain → IdP hint step at login) — doable, not free |
+| Tenant onboarding | Cognito client + secret + registration per tenant | Groups only — the simplest onboarding of any variant |
+
+**Rejected alternative — path-based tenancy (`/t/{tenant}/…`).** It would restore per-request tenant signal (fixing concurrent tabs and deep links) while keeping one host. Rejected because Dirigible's URL space is absolute-path-native everywhere — `/services/**`, `/public/**`, `/webjars/**`, WebSocket endpoints, generated UI assets, OAuth callback paths — so a tenant path prefix means either a rewriting reverse-proxy layer with cookie-path juggling or invasive URL surgery across the platform and every generated application. That is an order of magnitude more fork than S1–S6 for a UX refinement the picker requirement doesn't demand. Revisit only if concurrent multi-tenant tabs become a hard requirement.
+
+---
+
+## 9. Hypotheses to verify before go-live
+
+Inherited from the companion (still valid here): `@RolesAllowed` inert under the cognito profile; RDS master credential can run the provisioner's DDL; boot + first-sync duration at ~100 tenants; CSRF re-enablement compatibility. New to this model:
+
+1. **Authority rebuild on a live session** — replacing the `Authentication` in the security context + session propagates to subsequent requests in this Spring Security version (integration test: login → pick A → assert `ROLE_manager` → switch B → assert `ROLE_viewer` and *not* `ROLE_manager`).
+2. **No residual host-based fallback:** with the resolver replaced, verify no code path still consults `TenantExtractor`'s regex or falls back to the default tenant for authenticated traffic (grep + an IT hitting the app with no tenant selected).
+3. **Group-claim size:** a user with the maximum realistic memberships fits the ID-token/JWT header limits comfortably (arithmetic says yes; verify with a real pool).
+4. **Cognito Lite vs Essentials:** confirm the no-Lambda baseline works on Lite pricing for your MAU; the Lambda upgrade path forces Essentials.
+5. **Session semantics under the shipped UI:** the full-reload-on-switch leaves no stale per-tenant state in shell/iframe caches (exercise the deepest generated app view before and after a switch).

--- a/AWS_TENANCY_MODELS_COMPARISON.md
+++ b/AWS_TENANCY_MODELS_COMPARISON.md
@@ -1,0 +1,133 @@
+# Tenant by Subdomain vs Single Host with a Tenant Picker — Comparison
+
+**Status:** decision aid. Compares the two proposed tenancy models for multitenant Dirigible on AWS.
+**Date:** 2026-07-29
+**Companions:**
+- [`AWS_DEPLOYMENT_PROPOSAL.md`](AWS_DEPLOYMENT_PROPOSAL.md) — the full **subdomain** proposal (`tenant1.app.com`, `tenant2.app.com`, …).
+- [`AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md`](AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md) — the full **single-host + picker** proposal (one host, tenant chosen and switched in the UI).
+
+Both documents contain the detailed designs; this one exists to put the trade-offs side by side and support the decision.
+
+**Contents**
+
+- [1. The two models in one paragraph each](#1-the-two-models-in-one-paragraph-each)
+- [2. What is identical in both](#2-what-is-identical-in-both)
+- [3. Side-by-side comparison](#3-side-by-side-comparison)
+- [4. Subdomain model — pros and cons](#4-subdomain-model--pros-and-cons)
+- [5. Single host + picker — pros and cons](#5-single-host--picker--pros-and-cons)
+- [6. Decision guidance](#6-decision-guidance)
+- [7. The hybrid worth knowing about](#7-the-hybrid-worth-knowing-about)
+- [8. Switching models later](#8-switching-models-later)
+
+---
+
+## 1. The two models in one paragraph each
+
+**Subdomain:** every tenant has its own hostname (`acme.app.com`). The `Host` header *is* the tenant signal — Dirigible's shipped `TenantExtractor` resolves it per request, and per-host session cookies give every tenant an independent login session for free. Identity: one Cognito pool, **one app client per tenant**; a pre-token Lambda mints **tenant-scoped tokens** (only that tenant's roles + a `dirigible:tenant` audience claim). Moving to another tenant = opening its hostname; the pool-wide SSO cookie makes it silent.
+
+**Single host + picker:** all tenants share one hostname (`app.com`). The host carries no tenant signal, so the **active tenant is server-side session state**: the user logs in once, the token carries their **entire membership graph** (as `t:<tenant>:<role>` groups), and a picker endpoint validates the choice, stores it in the session and **rebuilds the session's authorities** to that tenant's roles. Identity: one Cognito pool, **one app client**, no Lambda required. Moving to another tenant = a dropdown action, no re-authentication, full UI reload.
+
+## 2. What is identical in both
+
+- **The requirement core:** one identity per person (one Cognito user pool), same credentials in every tenant, **different roles per tenant**.
+- **Membership model:** groups named `t:<tenant>:<role>`; no tenant user attribute; membership = holding ≥ 1 of the tenant's groups; the 100-groups-per-user limit as the growth watchpoint.
+- **Everything below the identity layer:** ECS Fargate single-writer runtime (`desiredCount=1`, stop-then-start deploys), RDS PostgreSQL Multi-AZ with schema-per-tenant provisioning, S3 CMS with tenant-prefixed keys, content baked into the image, the hardening checklist, backup/observability/cost.
+- **Horizontal-scaling blockers** (picker proposal §10.2, items 1–5): embedded ActiveMQ lock, per-node synchronizer replay, boot DDL races, per-JVM caches — the platform pins both models to one task per unit equally.
+- **Shared fork fixes:** configurable Hikari pool sizing, method security under the cognito profile, trial-flag fail-fast, provisioning idempotency, admin-endpoint gating.
+
+The decision is therefore **purely an identity/UX-layer decision** — infrastructure and data isolation do not move either way.
+
+## 3. Side-by-side comparison
+
+| Dimension | Subdomain per tenant | Single host + picker |
+| --- | --- | --- |
+| **Login UX** | Sign in per tenant host (silent after the first — pool-wide SSO cookie) | **One sign-in, switch in-app** — no second OIDC round-trip visible to the user |
+| **Tenant switching** | Navigate to the other hostname | Dropdown in the shell; authorities rebuilt server-side; full UI reload |
+| **Concurrent tabs in different tenants** | **Yes** — per-host cookies = independent sessions | **No** — one active tenant per browser session; a switch in one tab affects all tabs (stale-tab guard mitigates) |
+| **Deep links / bookmarks** | Carry the tenant in the URL | Tenant-less — open in whatever tenant is currently active |
+| **URL legibility / support** | The URL tells the user (and your support engineer, and the ALB access log) which tenant — useful in tickets, logs, screenshots | The tenant is invisible outside the session — support needs the user to say which tenant, edge logs can't attribute traffic per tenant |
+| **Token scoping** | **Tenant-scoped at issuance** — token holds only that tenant's roles + `dirigible:tenant` audience claim | Multi-tenant token — the user's whole membership graph in every token |
+| **Stolen-token blast radius** | One tenant (audience binding asserted per request) | **All** of the victim's tenants (no audience binding possible) |
+| **Non-member denial** | **At the IdP** — the Lambda refuses to mint the token | App-side only — the picker/switch endpoint 403s |
+| **Cognito surface** | N app clients + N secrets + pre-token Lambda + DynamoDB clientId→tenant map; **Essentials** plan (trigger V2_0) | **One app client, one secret, no Lambda, no map; Lite plan may suffice** |
+| **DNS / TLS** | Wildcard DNS record + wildcard ACM certificate | One record, one plain certificate |
+| **Tenant onboarding** | Cognito client + secret + Dirigible registration + groups | **Groups only** (plus the schema provisioning both need) |
+| **Fork surface (identity layer)** | Small — per-host cookies do the heavy lifting; 7 targeted fixes | **Larger** — S1–S6: session/header tenant resolver, neutral login mapper, switch endpoint + authority rebuild, picker UI, header M2M tenancy, stale-tab guard |
+| **Per-tenant branding before login** | Possible — the host identifies the tenant on the login/landing page | Not possible — the tenant is unknown until after login + pick |
+| **Per-tenant enterprise federation (tenant brings own IdP)** | Clean — IdP enablement is a per-app-client setting | Needs home-realm discovery (email-domain → IdP hint at login) — doable, not free |
+| **Per-tenant vanity/custom domains later** (`app.acme.com`) | Natural extension (CNAME + cert + one more callback) | Contradicts the model — would reintroduce host awareness |
+| **Per-tenant edge controls** (WAF rate rules, blocking one tenant at the ALB) | By host — easy | Impossible at the edge; only app-side |
+| **Scale-out to more units** | Per-tenant DNS records — clean | Edge can't see the tenant → routing cookie + CloudFront Function, gateway tier, or placement constraint (picker §10.3) |
+| **Horizontal replicas someday** | Platform blockers (shared); sessions per host are already store-friendly | Same platform blockers **plus** externalized sessions (spring-session + Redis) — after which the design carries over unchanged |
+| **M2M** | Per-tenant M2M client; tenant asserted from the token's audience/scopes | Per-tenant M2M client; tenant carried in `X-Dirigible-Tenant` header, asserted against scopes |
+| **Logout semantics** | Per-tenant logout (fork fix); Cognito logout ends pool-wide SSO | Single-client logout — the shipped handler is correct as-is |
+| **CSRF exposure of tenancy** | None — the tenant can't be changed by a forged request (it's the host) | The switch endpoint is state-changing and needs CSRF protection |
+
+## 4. Subdomain model — pros and cons
+
+**Pros**
+
+1. **Strongest token security:** issuance-time least privilege, audience binding (`dirigible:tenant` == host asserted every request), IdP-side denial of non-members, stolen tokens useless outside their tenant.
+2. **Concurrent multi-tenant work** — independent sessions per host; two tabs, two tenants, no interference.
+3. **The URL carries the tenant** — bookmarkable deep links, legible support tickets, per-tenant edge logs/WAF rules, pre-login branding.
+4. **Small fork footprint** — the platform is host-tenant native; per-host cookies solve session scoping for free.
+5. **Clean growth**: per-tenant DNS routes tenants to units; vanity domains and per-tenant federation are natural extensions.
+
+**Cons**
+
+1. **Per-tenant Cognito machinery:** N app clients and secrets to create/rotate, a pre-token Lambda, a clientId→tenant map, Essentials-plan pricing — onboarding automation must manage all of it.
+2. **Tenant switching is navigation, not an in-app control** — silent thanks to SSO, but it is a new page load on a new host, and the "which tenants do I have?" list needs the `dirigible:tenants` claim or a directory page.
+3. **Wildcard DNS + wildcard certificate** to operate (modest, but real).
+4. A fork-built host-keyed `ClientRegistrationRepository` is required to resolve N registrations (the shipped module was ruled out as a design input).
+5. Does not satisfy a product requirement of "no per-tenant URLs" — if the product must present one address, this model is disqualified by definition.
+
+## 5. Single host + picker — pros and cons
+
+**Pros**
+
+1. **The requirement's UX:** log in once, switch tenants from a dropdown, no visible re-authentication — the closest to a "single product with workspaces" feel.
+2. **Radically simpler identity operations:** one app client, one secret, no Lambda, no client map; Cognito Lite may suffice; tenant onboarding = create groups.
+3. **Simplest edge:** one DNS record, one plain certificate; the shipped OAuth registration and logout handler work nearly as-is.
+4. **One URL for everyone** — simpler to communicate, no per-tenant links to manage in emails/docs.
+5. The session-scoped design survives future horizontal scaling unchanged once sessions are externalized (spring-session + Redis) — and that addition is a cheap early win anyway (sessions survive deploys).
+
+**Cons**
+
+1. **Weaker token posture:** every token carries the whole membership graph; no audience binding exists to assert; denial of non-members happens only app-side; a stolen token spans all the victim's tenants.
+2. **One active tenant per browser** — concurrent tabs in different tenants are structurally impossible; the stale-tab guard softens, never removes, the surprise.
+3. **Bigger fork surface in the security layer** (S1–S6), including replacing tenant resolution, rebuilding authorities on a live session, and CSRF-protecting the switch endpoint — more new security-critical code to get right.
+4. **The tenant is invisible outside the app:** no per-tenant edge rules, no per-tenant traffic attribution at the ALB, no pre-login branding, tenant-less deep links, and support must ask "which tenant were you in?".
+5. **Scale-out friction:** routing tenants to more units needs an extra edge mechanism (routing cookie + CloudFront Function or a gateway) because nothing in the request names the tenant.
+6. Per-tenant enterprise federation requires an additional home-realm-discovery step.
+
+## 6. Decision guidance
+
+Choose **subdomains** when:
+
+- security posture dominates — per-tenant token scoping, IdP-side denial and small blast radius are worth per-tenant client operations;
+- users (or admins/support) routinely work in **several tenants at once**;
+- tenants are organizations that may later want **their own IdP or their own domain**;
+- per-tenant edge behaviour matters (rate-limiting one tenant, blocking one tenant, per-tenant branding before login);
+- the operator prefers **less fork code** over less Cognito configuration.
+
+Choose the **single host + picker** when:
+
+- the product requirement is literally "one address, switch inside the app" (which disqualifies subdomains regardless of other merits);
+- users belong to many tenants and hop frequently — the dropdown beats host navigation;
+- identity-operations simplicity matters more than token scoping (small trusted tenant fleet, internal deployment, one organization with several workspaces);
+- nobody needs concurrent multi-tenant tabs, per-tenant URLs or per-tenant edge controls.
+
+A useful framing: **subdomains treat tenants as separate products sharing a platform; the picker treats tenants as workspaces inside one product.** B2B SaaS with organizational customers usually wants the former; an internal or single-organization deployment usually wants the latter.
+
+## 7. The hybrid worth knowing about
+
+The picker *UX* does not strictly require the single-host *architecture*. On the subdomain model, a "tenant switcher" dropdown can simply link to the other tenants' hostnames (the membership list is available via the `dirigible:tenants` claim): the hop is silent thanks to the pool-wide SSO cookie, and every subdomain-model advantage (scoped tokens, per-host sessions, concurrent tabs) is retained. What the hybrid does **not** deliver is the literal requirement "no dedicated subdomain per tenant" — URLs remain per-tenant. If the requirement is about switching *convenience*, the hybrid may be the best of both; if it is about the *address itself*, only the single-host model qualifies.
+
+## 8. Switching models later
+
+The two models share the group naming (`t:<tenant>:<role>`), the pool, and the user base, so a later migration changes plumbing, not data:
+
+- **Picker → subdomains:** add per-tenant app clients + the pre-token Lambda + per-tenant DNS; replace the session resolver with the (shipped) host extractor; the groups stay as they are. The main new work is the per-tenant client onboarding automation.
+- **Subdomains → picker:** collapse to one client, drop the Lambda, add S1–S6. The main new work is the session/security layer.
+
+Neither direction touches tenant schemas, provisioned data, or the membership graph — which is the strongest argument for the shared groups convention both proposals adopted.

--- a/AWS_TENANT_PICKER_HORIZONTAL_SCALING.md
+++ b/AWS_TENANT_PICKER_HORIZONTAL_SCALING.md
@@ -1,0 +1,266 @@
+# Horizontal Scaling for the Tenant-Picker Model — Spring Session on Redis
+
+**Status:** design note. Nothing here is implemented.
+**Date:** 2026-07-29
+**Scope:** how the single-host tenant-picker model behaves on more than one runtime instance, and what externalising the HTTP session into Redis does and does not buy.
+**Companion:** [`AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md`](AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md) — the picker design itself; its §10 is the summary this document expands. See also [`AWS_DEPLOYMENT_PROPOSAL.md`](AWS_DEPLOYMENT_PROPOSAL.md) (the subdomain variant) and [`AWS_TENANCY_MODELS_COMPARISON.md`](AWS_TENANCY_MODELS_COMPARISON.md).
+
+**Contents**
+
+- [1. The claim, stated precisely](#1-the-claim-stated-precisely)
+- [2. Why the picker model is instance-bound today](#2-why-the-picker-model-is-instance-bound-today)
+- [3. What is actually in the session](#3-what-is-actually-in-the-session)
+- [4. The mechanism: what Spring Session changes](#4-the-mechanism-what-spring-session-changes)
+- [5. Serialization — the one real design constraint](#5-serialization--the-one-real-design-constraint)
+- [6. AWS topology and configuration](#6-aws-topology-and-configuration)
+- [7. What changes in the picker flows](#7-what-changes-in-the-picker-flows)
+- [8. What Redis does not solve](#8-what-redis-does-not-solve)
+- [9. Alternative: Spring Session on JDBC](#9-alternative-spring-session-on-jdbc)
+- [10. Rollout](#10-rollout)
+- [11. Operations and failure modes](#11-operations-and-failure-modes)
+- [12. Verification](#12-verification)
+
+---
+
+## 1. The claim, stated precisely
+
+> **Externalising the session makes the tenant-picker design horizontally scalable — and on its own it does not make the platform horizontally scalable.**
+
+Both halves matter.
+
+The picker model keeps the active tenant and the caller's rebuilt authorities in the HTTP session (fork change S3). That is the one part of the design that is *inherently* instance-bound, and it is the only picker-specific blocker to running more than one runtime task. Spring Session on Redis removes it completely, and the picker design survives unchanged: the switch endpoint keeps its validate → store → rebuild-authorities semantics, and only *where the session physically lives* moves.
+
+The platform, however, carries five further blockers that have nothing to do with the picker (§8). Until those are paid down, a second instance still cannot boot. **So this change is not the thing that unlocks scale-out — it is the thing that keeps the picker design from becoming the blocker once the others are cleared.**
+
+It is worth doing anyway, immediately, at one instance: it makes sessions survive deploys and task replacement, so users stop being logged out by every release. That benefit is independent of everything else in this document.
+
+---
+
+## 2. Why the picker model is instance-bound today
+
+Under the cognito profile the session policy is `SessionCreationPolicy.ALWAYS` (`CognitoSecurityConfiguration.java:86`), so every authenticated request has a session. That session lives in the Tomcat heap of whichever task created it — there is no `spring-session` on the classpath anywhere in the repository.
+
+With one task that is invisible. With two:
+
+```
+   ┌── request A ──▶ Task 1   session {activeTenant=acme, authorities=[ROLE_manager]}  ✔
+   │
+ALB┤
+   │
+   └── request B ──▶ Task 2   same cookie, no such session in this heap                ✘
+                              → unauthenticated → bounced to login → picker again
+```
+
+The user's requests land on whichever task the load balancer picks, so roughly half of them find no session. **ALB stickiness is a stopgap, not a fix**: it papers over the problem while both tasks are healthy, and loses every session pinned to a task the moment that task is replaced — which is exactly what a deploy, a scale-in event, or an AZ failure does.
+
+Note also that `build/application/src/main/resources/application.properties` already sets `spring.session.timeout=8h` (twice — lines 15 and 18, a duplicate worth tidying). That property is **inert today** because Spring Session is not on the classpath; it becomes live the moment the dependency is added, and an 8-hour session TTL is a deliberate sizing decision (§6), not a default to inherit unexamined.
+
+---
+
+## 3. What is actually in the session
+
+Before moving a session into a shared store, you must know precisely what has to survive the trip. For this codebase the surface is small and — importantly — **bounded by code, not by convention**:
+
+| Attribute | Type | Written by | Serialization risk |
+| --- | --- | --- | --- |
+| `SPRING_SECURITY_CONTEXT` | `SecurityContext` → `Authentication` → the principal (membership map) + granted authorities | Spring Security, rebuilt by the switch endpoint | **The only one that needs design care** (§5) |
+| `activeTenant` | `String` | The fork's switch endpoint (S3) | none |
+| `invocation.count` | `Integer` | `HttpSessionFacade.getSession()` — incremented on **every** access | none, but see write amplification below |
+| user-code attributes | **`String` only** | user JS/TS via `HttpSessionFacade` | none |
+
+The last row is the load-bearing finding. Dirigible exposes the HTTP session to user code through `components/api/api-http/.../HttpSessionFacade.java`, which at first glance looks like an open door for arbitrary objects. It is not — the setter is:
+
+```java
+public static final void setAttribute(String arg0, String arg1)
+```
+
+**String keys, String values.** User code cannot put a non-serializable object into the session, so no amount of user JS/TS can break the shared store. That converts session externalisation from "audit every project ever written on this platform" into "get one principal class right."
+
+**One caveat from the same class:** `HttpSessionFacade.getSession()` calls `request.getSession(true)` and increments `invocation.count` on *every* invocation. So any JS/TS API call that touches the session dirties it, and under Spring Session a dirtied session is written back to the store. Session-heavy user code therefore produces one store write per request — a strong argument for Redis over a relational store (§9).
+
+---
+
+## 4. The mechanism: what Spring Session changes
+
+Spring Session does not ask the application to change how it uses `HttpSession`. It installs a `SessionRepositoryFilter` very early in the chain that swaps the container's session implementation for one backed by Redis. Everything downstream — Spring Security's `SecurityContextRepository`, the fork's `activeTenant` attribute, `HttpSessionFacade` — keeps calling the same servlet API.
+
+```
+request  ─▶ SessionRepositoryFilter ─── read by session id ──▶ Redis
+                     │                                           │
+                     │  HttpSession now backed by the store      │
+                     ▼                                           │
+            Security filters  (SecurityContext read from the session attribute)
+                     ▼
+            TenantContextInitFilter  →  reads activeTenant  →  TenantContext(acme)
+                     ▼
+            controller / JS engine   (may touch HttpSessionFacade)
+                     ▼
+            SessionRepositoryFilter ─── write back at end of request ──▶ Redis
+```
+
+Two consequences to plan for rather than discover:
+
+- **The cookie name changes.** Spring Session issues its own `SESSION` cookie (a base64-encoded session id) instead of `JSESSIONID`. Anything asserting on `JSESSIONID` — integration tests, the stale-tab guard (S6), operational runbooks, any reverse-proxy rule — must be updated. The name is configurable if keeping `JSESSIONID` is worth more than convention.
+- **Write timing is a knob.** `spring.session.redis.flush-mode` defaults to `ON_SAVE` (write once, at end of request); `IMMEDIATE` writes as soon as an attribute changes. `save-mode` defaults to `ON_SET_ATTRIBUTE` (only changed attributes). These two settings are exactly the lever for the propagation window in §7.
+
+**A bonus worth taking:** using `RedisIndexedSessionRepository` (rather than the simpler default repository) maintains a principal-name index, which makes `findByIndexNameAndIndexValue` able to enumerate and delete *all* sessions for one user. That turns the "eject a user immediately" step — listed as a manual runbook item in both identity proposals — into an implementable operation: revoke membership, call Cognito global sign-out, and delete that user's sessions from the store in one go. Indexed mode costs extra Redis keys and needs keyspace notifications enabled for expiry events.
+
+---
+
+## 5. Serialization — the one real design constraint
+
+By default Spring Session serialises attributes with **JDK serialization**, so everything reachable from a session attribute must be `Serializable`. Given §3, that reduces to one object: the `Authentication` and its principal.
+
+**The design rule for the fork:** the membership-map principal introduced by change S2 must be a plain, self-contained value object from day one —
+
+- fields limited to the identity key (the Cognito `sub`, a `String`), a display name, and the membership map (`Map<String, List<String>>` of tenant → role names);
+- no references to Spring beans, JPA entities, repositories, `EntityManager`, or anything holding a database handle;
+- an explicit `serialVersionUID`;
+- immutable, with defensive copies of the map.
+
+This is cheap if designed in and expensive if retrofitted, which is the reason to write it down before S2 is implemented rather than after.
+
+**Rolling deploys and class evolution.** If the principal class changes shape between releases, sessions written by the old version fail to deserialize in the new one. Two honest mitigations: keep the class strictly backward-compatible (add fields, never remove or retype, keep the `serialVersionUID`), or accept that a deploy flushes the session store. The second is entirely reasonable here — the platform already deploys stop-then-start (§8), so a release is already a brief outage, and flushing sessions merely returns to today's behaviour where every deploy logs everyone out.
+
+**JSON serialization — verify before choosing it.** The usual alternative to JDK serialization is a JSON serializer, which is version-tolerant and human-readable in the store. Spring Security ships Jackson mix-ins for its own types to make this work. **This fork is on Spring Boot 4.1.0, where the web layer uses Jackson 3 (`tools.jackson`) rather than Jackson 2 (`com.fasterxml`)** — the same split that has already bitten this codebase in controllers. Whether Spring Security's session mix-ins are available for the Jackson version in play is a compatibility question to answer by experiment, not assumption (§12). JDK serialization has no such dependency and is the safe default for a first implementation.
+
+---
+
+## 6. AWS topology and configuration
+
+**Amazon ElastiCache**, in the private subnets, reachable only from the runtime tasks' security group:
+
+```
+        ┌──────────────── ECS service: dirigible-runtime ────────────────┐
+        │   task 1              task 2              task N              │
+        └──────┬───────────────────┬───────────────────┬────────────────┘
+               │  read at start of request / write at end (TLS, AUTH)
+               └───────────────────┴───────────────────┘
+                                   ▼
+                    ┌────────────────────────────────┐
+                    │ ElastiCache (Redis / Valkey)   │
+                    │ primary + replica, Multi-AZ    │
+                    │ automatic failover             │
+                    │ TLS in transit · encrypted     │
+                    │ at rest · AUTH token in        │
+                    │ Secrets Manager                │
+                    │ maxmemory-policy: noeviction   │
+                    └────────────────────────────────┘
+```
+
+**Sizing.** A session here is small — a principal with ~30 memberships, an active-tenant string, a counter and a few user strings is on the order of a few kilobytes. Ten thousand concurrent sessions is therefore tens of megabytes, so the smallest node class with a replica is ample; this is a latency and availability purchase, not a capacity one. Note the 8-hour timeout inherited from `application.properties` (§2) is what sets the working-set size — sessions linger for eight hours after last use, so the store holds far more than the concurrently active count.
+
+**The setting that matters most.** `maxmemory-policy` must **not** be `allkeys-lru`. Under memory pressure that silently evicts live sessions and logs users out at random, with no error anywhere. Use `noeviction` (writes fail loudly, which is a page-able signal) or `volatile-lru` combined with TTLs, and size the node so it never gets there. **Alarm on `Evictions > 0`** — in a session store the correct value is always zero.
+
+**Configuration sketch** (verify property names against the Spring Boot 4.1 / Spring Session versions actually resolved — §12):
+
+```properties
+spring.session.store-type=redis
+spring.session.timeout=8h
+spring.session.redis.namespace=dirigible:session
+spring.session.redis.flush-mode=on_save
+spring.session.redis.repository-type=indexed      # enables per-user session lookup (§4)
+
+spring.data.redis.host=${DIRIGIBLE_SESSION_REDIS_HOST}
+spring.data.redis.port=6379
+spring.data.redis.ssl.enabled=true
+spring.data.redis.password=${DIRIGIBLE_SESSION_REDIS_AUTH}   # from Secrets Manager
+```
+
+with `org.springframework.session:spring-session-data-redis` and `spring-boot-starter-data-redis` on the classpath. Per this repo's conventions the two environment variables belong in `DirigibleConfig`, not read ad hoc.
+
+---
+
+## 7. What changes in the picker flows
+
+**Unchanged:** everything about the design's semantics. The picker page, `GET …/tenants/mine`, and the switch endpoint's validate → store `activeTenant` → rebuild authorities → rotate session id sequence all behave identically; `changeSessionId()` is supported by Spring Session. The tenant resolver (S1) still reads `activeTenant` from the session — it neither knows nor cares that the session is now in Redis. Membership is still enforced server-side on every switch.
+
+**One new behaviour: a propagation window.** With `flush-mode=on_save`, the session is written back when the request completes. If a user switches tenant on instance 1 while another of their requests is already in flight on instance 2, that in-flight request finishes under the *previous* tenant and authorities.
+
+This is bounded and benign, but should be stated rather than discovered:
+
+- the window is the duration of one overlapping request;
+- the stale request runs with authorities the user legitimately held moments earlier, in a tenant they are a member of — it is never an escalation, and never a cross-tenant leak to a tenant they don't belong to;
+- the switch is followed by a full UI reload, so the browser is not issuing much concurrently;
+- `flush-mode=immediate` narrows the window at the cost of an extra write per mutation.
+
+The **stale-tab guard** (S6) is unaffected in design and becomes more useful: with a shared store, the session-version value is visible to every instance.
+
+---
+
+## 8. What Redis does not solve
+
+Externalising the session clears exactly one of six items. The other five are platform-level and identical for the subdomain model:
+
+| # | Blocker | Still blocking after Redis? |
+| --- | --- | --- |
+| 1 | Embedded ActiveMQ on hardcoded `vm://localhost` with a JDBC lock on SystemDB — the second task blocks at broker start and never becomes healthy | **Yes** — replace with Amazon MQ or move `.listener` work to SQS/SNS |
+| 2 | Synchronizer effects are per-JVM while artefact checksums are shared — the second node sees "already current" and never materialises its own runtime state | **Yes** — needs per-node reconciliation or an unconditional boot replay |
+| 3 | Boot-time DDL races (Quartz `initialize-schema=always` drops/recreates `QRTZ_*`, check-then-insert initializers) | **Yes** — schema init to `never`, initializers made concurrency-safe |
+| 4 | Per-JVM caches with no invalidation channel (tenant lookup, tenant config, `.access` ACL) | **Yes** — though Redis pub/sub is then the obvious invalidation bus |
+| 5 | Local filesystem repository + Lucene | **No** — already fine for *runtime-only* tasks with baked-in content; the authoring instance stays at one forever |
+| 6 | **HTTP session in the Tomcat heap** | **No — this is what Redis fixes** |
+
+Three further consequences of running N > 1 that Redis does not address:
+
+- **WebSocket endpoints stay instance-bound.** Terminal, LSP, debug and data-transfer handlers attach to processes in one JVM; those paths still need stickiness regardless of where sessions live.
+- **Connection pools multiply.** Pools are per *(instance, tenant)*, so N replicas is N× the idle and peak database connections — the configurable-pool-sizing fork fix moves from important to mandatory, and the database class must be re-sized for the product.
+- **Unit routing is untouched.** The single-host model's inability to route tenants to different units from the edge (the picker proposal's §10.3) is a separate problem with separate answers.
+
+**And Redis becomes a dependency in the authentication path.** If the store is unavailable, sessions cannot be read and every user appears logged out. Multi-AZ with automatic failover keeps that to a brief blip, but the failure mode must be an explicit decision — fail closed (users re-authenticate; correct and simple) rather than silently degrading to a tenant-less or default-tenant state, which would be a data-integrity bug of exactly the kind the picker design removes elsewhere.
+
+---
+
+## 9. Alternative: Spring Session on JDBC
+
+`spring-session-jdbc` stores sessions in `SPRING_SESSION` / `SPRING_SESSION_ATTRIBUTES` tables in a database you already run. It deserves a fair hearing because it adds **no new infrastructure**: the deployment already has RDS PostgreSQL Multi-AZ, already backs it up, already secures and monitors it.
+
+| | Redis (ElastiCache) | JDBC (existing RDS) |
+| --- | --- | --- |
+| New infrastructure | one managed cache cluster | **none** |
+| Latency per request | sub-millisecond | a database round trip |
+| Load added | isolated from application queries | lands on the instance already sized for per-tenant pools |
+| Backup / HA | separate concern | inherits the RDS story |
+| Per-user session lookup | `RedisIndexedSessionRepository` | SQL query — trivial |
+| Expiry | native TTL | a cleanup job deletes expired rows |
+
+**Recommendation: Redis**, and the deciding factor is specific to this codebase rather than generic preference. `HttpSessionFacade` dirties the session on *every* access (§3), so session-touching user code produces a store write per request. Sending that traffic to the same RDS instance that already carries every tenant's application queries — on a deployment whose documented capacity ceiling is database connections — is the wrong place to put it. Redis absorbs that pattern at a fraction of the cost and keeps the database sized for what it is for.
+
+If a hard constraint forbids a new service, JDBC is a legitimate choice at this scale; measure the added query rate first, and revisit if session writes become visible in database load.
+
+---
+
+## 10. Rollout
+
+The phases are independent, and the first delivers value on its own:
+
+**Phase 1 — adopt at one instance (do this early).** Add the dependency and configuration; nothing else changes. Sessions immediately survive task replacement and deploys, so users stop being logged out by every release. This is a real quality-of-life improvement with no dependency on any of the five platform blockers, and it de-risks the rest by proving serialization in production at N = 1.
+
+**Phase 2 — prove it.** Confirm the principal round-trips, measure the store write rate under real user code, size the node against the 8-hour timeout, alarm on evictions.
+
+**Phase 3 — only then, N > 1.** Pay down blockers 1–4 (§8). Raise the replica count last, with stickiness retained on WebSocket paths and the database re-sized for multiplied pools.
+
+Attempting Phase 3 before Phase 2 is how a session store becomes an incident; attempting it before blockers 1–4 simply does not work, because the second task never boots.
+
+---
+
+## 11. Operations and failure modes
+
+- **Store unavailable** → treat as fail-closed: users re-authenticate. Never fall back to a default tenant.
+- **Failover** → a short window of failed reads; the client retries or re-authenticates. Multi-AZ with automatic failover is not optional for a store in the authentication path.
+- **TTL alignment** → `spring.session.timeout`, the session cookie `max-age`, and the store's own expiry must agree, or sessions die in one layer while another still advertises them. Note the existing duplicate `spring.session.timeout=8h` (§2) and decide the value deliberately.
+- **Security** → TLS in transit, encryption at rest, AUTH token or Redis RBAC held in Secrets Manager, no public accessibility, security group limited to the task role's group. The store holds live authenticated sessions: compromise of it is compromise of every signed-in user.
+- **Monitoring** → `Evictions` (must be zero), memory usage against `maxmemory`, replication lag, connection count, command latency, and the application-side session read/write rate.
+
+---
+
+## 12. Verification
+
+1. **Two instances, one store.** Run two application instances locally against one Redis, sign in through instance 1, force the next request to instance 2, and confirm the session, the active tenant and the authorities are all intact.
+2. **Kill test.** Mid-session, stop the instance that created the session; confirm the user continues uninterrupted on the survivor.
+3. **Switch across instances.** Pick tenant A on instance 1, then switch to tenant B via instance 2, and assert the authorities are B's only — the same assertion the picker proposal already lists for the single-instance case.
+4. **Serialization round-trip.** A test that writes the principal to the store and reads it back on a fresh context, plus a deliberate class-shape change to observe the failure mode you will get during a rolling deploy.
+5. **The Jackson question** (§5): determine whether JSON session serialization is available and supported for the Jackson version resolved under Spring Boot 4.1.0, or whether JDK serialization is the only practical option. Decide before writing the principal class.
+6. **Property names.** Confirm `spring.session.*` and `spring.data.redis.*` keys against the exact Spring Boot 4.1 and Spring Session versions the build resolves — these have been renamed across versions.
+7. **Cookie rename fallout.** Grep the repository and the integration suite for `JSESSIONID` before switching, and decide whether to keep the name.
+8. **Eviction policy.** Verify `maxmemory-policy` on the actual parameter group, not in the console description — this is the setting that fails silently.


### PR DESCRIPTION
## Summary

Documentation only — two sibling architecture proposals for deploying a multitenant Dirigible application on AWS, both right-sized to **one production unit (~50–100 tenants)** and designed **independently** of the `docs/aws-multitenancy-research` branch (each records where it agrees/differs).

### 1. `AWS_DEPLOYMENT_PROPOSAL.md` — subdomain per tenant

- **Compute:** ECS Fargate, `desiredCount=1`, stop-then-start deploys. The runtime is single-writer by construction (embedded ActiveMQ `vm://` broker holding a JDBC lock on SystemDB, node-local synchronizer effects, `LocalRepository`) — the availability consequence (~99.5% SLO) is stated honestly instead of worked around.
- **Data:** RDS PostgreSQL Multi-AZ with the shipped schema-per-tenant provisioning; documents on S3 (`engine-cms-s3`); content baked into the image with publishing disabled; optional internal authoring instance as the In-System-Programming security boundary.
- **Identity:** ONE Cognito user pool (one identity = same credentials in every tenant) and **one confidential app client per tenant** — decided on merit in §4.2 against the single-shared-client alternative (100-callback hard ceiling at the design capacity, no tenant signal for the pre-token Lambda, multi-tenant bearer tokens with app-side-only denial). The shipped `security-client-registration` module is explicitly **not** a design input.
- **Cross-tenant login:** membership and roles as prefixed Cognito groups (`t:<subdomain>:<role>`); a pre-token-generation Lambda scopes every token to its tenant (`cognito:groups` = roles-here-only + a `dirigible:tenant` audience claim). One interactive sign-in, silent SSO into other tenants, different roles in each.
- **Fork changes:** seven must-fix items with file:line anchors, plus four follow-ups; onboarding/offboarding runbooks, hardening checklist, operations, cost ballpark (~$700/month), how-it-grows, and six pre-go-live hypotheses flagged rather than asserted.

### 2. `AWS_SINGLE_HOST_TENANT_PICKER_PROPOSAL.md` — no subdomains, in-app tenant picker

The variant for changed requirements: **one host, one login, and the user changes the current tenant from a picker in the UI**, holding different roles in each. Everything below the identity layer is inherited from proposal 1 unchanged.

- Dropping subdomains removes the `Host` header as the tenant signal, and the picker means the tenant is chosen *after* login and changes *without* re-auth — so the **active tenant becomes server-side session state**, and the default-tenant fallback is removed for authenticated traffic (no selection → picker page, never silent default).
- The token carries the **full membership graph** as prefixed groups, parsed at login into a membership map with zero authorities; `POST /services/core/security/tenants/current` validates membership, **rebuilds the session's authorities to the picked tenant's roles**, rotates the session id and reloads the UI. Switching tenants is the same call — no re-authentication.
- **Cognito simplifies radically:** ONE app client (shipped static registration nearly as-is), no pre-token Lambda (Lite plan may suffice), no clientId→tenant map; onboarding shrinks to provision-the-schema + create-the-groups.
- **Honest costs stated:** one browser session = one active tenant (concurrent multi-tenant tabs — free under subdomains — are impossible here), multi-tenant tokens with no audience binding, tenant-less deep links, and a *larger* fork surface (S1–S6: session/header resolver, neutral login mapper, switch endpoint, picker UI, header-based M2M tenancy, stale-tab guard). Path-based tenancy (`/t/<tenant>/…`) is analysed and rejected.
- §8 is a side-by-side trade-off table between the two models; §9 lists the model-specific go-live hypotheses (e.g. authority rebuild on a live session).
- **§10 answers horizontal scaling head-on:** raising `desiredCount` today just blocks the second task at boot (ActiveMQ JDBC lock — safe, never split traffic); the layer-by-layer bill for true replicas (external broker, per-node synchronizer replay, boot-race fixes, cache invalidation — shared by both models; plus `spring-session` + Redis as the only picker-specific item, after which the design survives unchanged); and the picker-specific unit-routing catch (the edge can't see a session-resident tenant → routing cookie + CloudFront Function). Proposal 1's §11 cross-references it.

### 3. `AWS_TENANCY_MODELS_COMPARISON.md` — the decision aid

Puts the two models side by side: what is identical in both (groups-only membership, everything below the identity layer, the horizontal-scaling blockers), a 19-row comparison table, explicit pros/cons per model, decision guidance ("subdomains treat tenants as separate products sharing a platform; the picker treats tenants as workspaces inside one product"), the hybrid option (a picker-style dropdown on top of subdomains), and the migration story between the models (the shared `t:<tenant>:<role>` group convention means switching changes plumbing, never data).

### 4. `AWS_COGNITO_TENANT_ROLES_LIMITS.md` — the storage-limits analysis

Standalone; **changes none of the three documents above** (its §9 records what it would imply for them). Prompted by the real scale — a user in 20–30 tenants, each tenant defining ~10 roles — it shows that the prefixed-group model the other documents specify does not survive those numbers: **"Groups to which each user can belong: 100 — not adjustable"** allows at most ~3 held roles per tenant at 30 tenants, and the stated worst case needs 300. Covers the defined-vs-held distinction (pool quota 10,000 vs per-user 100), every applicable quota with its adjustability, the arithmetic (group grid, ~9 KB claims carried in both tokens, the non-adjustable 25 RPS account-wide write quota, reverse queries, propagation delay), six options with the wall each hits, and the recommendation: Cognito for identity, an external store for the tenant ↔ user ↔ roles graph.

### 5. `AWS_TENANT_PICKER_HORIZONTAL_SCALING.md` — the session layer, in depth

Expands §10 of the picker proposal into a dedicated design note with diagrams. The claim in two halves: externalising the HTTP session makes the **picker design** horizontally scalable (it removes the only picker-specific blocker, and the design survives unchanged — only *where the session lives* moves), and on its own it does **not** make the platform scalable, because five further blockers are platform-level and identical for the subdomain model. Worth adopting at one instance regardless: sessions then survive deploys.

Three repository-verified facts shape the recommendation: `HttpSessionFacade.setAttribute(String, String)` means user code can only put Strings in the session, so the serialization surface reduces to one principal class rather than an audit of every project; the same class dirties the session on **every** access, producing a store write per request — the codebase-specific reason to prefer Redis over `spring-session-jdbc` (which is still presented fairly as the no-new-infrastructure option); and `spring.session.timeout=8h` is already in `application.properties`, inert today, live the moment the dependency lands. Also covers the tenant-switch propagation window, the indexed repository making "eject a user immediately" implementable, the `SESSION`-vs-`JSESSIONID` cookie rename, ElastiCache topology, a three-phase rollout, and the `maxmemory-policy` setting that fails silently. Two items are flagged for experiment rather than asserted — notably whether JSON session serialization is viable under Spring Boot 4.1.0's Jackson 3 web layer.

## Test plan

- [ ] Documentation-only change — no code, no configuration, no CI-relevant files touched
- [ ] Markdown renders correctly on GitHub (tables, diagrams, section anchors) in both documents
- [ ] Cross-references resolve: file:line anchors spot-checked against current sources (`DataSourceInitializer.java:155-159`, `TenantExtractor.java:44`, `security-cognito` classes, `TenantContext.java`); the two documents' links to each other work

🤖 Generated with [Claude Code](https://claude.com/claude-code)




