### PR TITLE
feat(numbering): declare series up front + per-tenant prefix/size overrides

### DIFF
--- a/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/numbering/DocumentNumbers.java
+++ b/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/numbering/DocumentNumbers.java
@@ -58,4 +58,18 @@ public final class DocumentNumbers {
     public static String next(String series, String format) {
         return next(series, format, Map.of());
     }
+
+    /**
+     * Declares that a series exists and records its authored format, without allocating a number. The
+     * generated declaring components call this at start-up so an administrator can see and configure a
+     * series - its next value, its prefix and its width - BEFORE the first document is ever numbered.
+     * Idempotent: re-declaring only refreshes the recorded format.
+     *
+     * @param series the series identity
+     * @param format the authored format template (see {@link #next(String, String, Map)})
+     */
+    public static void declare(String series, String format) {
+        Beans.get(DocumentNumberService.class)
+             .declare(series, format);
+    }
 }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -105,12 +105,13 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         List<Map<String, Object>> printFeeders = PrintFeederSupport.buildPrintFeeders(model, byName, compositionParents, context);
         List<Map<String, Object>> snapshots = SnapshotSupport.buildSnapshots(model, byName, compositionParents);
         List<Map<String, Object>> numbering = NumberingSupport.buildNumbering(model, compositionParents);
+        List<Map<String, Object>> numberSeries = NumberingSupport.buildNumberSeries(model);
 
         if (triggers.isEmpty() && resolvers.isEmpty() && fieldLoaders.isEmpty() && timerLoaders.isEmpty() && waits.isEmpty()
                 && aborts.isEmpty() && writers.isEmpty() && setters.isEmpty() && notifications.isEmpty() && schedules.isEmpty()
                 && integrations.isEmpty() && inbound.isEmpty() && rollups.isEmpty() && expansions.isEmpty() && settlements.isEmpty()
                 && generates.isEmpty() && transitions.isEmpty() && printFeeders.isEmpty() && postings.isEmpty() && snapshots.isEmpty()
-                && numbering.isEmpty() && posts.isEmpty() && aggregates.isEmpty() && sends.isEmpty()) {
+                && numbering.isEmpty() && numberSeries.isEmpty() && posts.isEmpty() && aggregates.isEmpty() && sends.isEmpty()) {
             // No process glue for this intent - any stale .glue is removed by the post-pass scrub.
             return;
         }
@@ -140,6 +141,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         glue.put("printFeeders", printFeeders);
         glue.put("snapshots", snapshots);
         glue.put("numbering", numbering);
+        glue.put("numberSeries", numberSeries);
         context.writeModelFile(IntentNaming.baseName(context) + ".glue", JsonHelper.toJson(glue));
         LOGGER.debug(
                 "Wrote glue with [{}] trigger(s), [{}] resolver(s), [{}] writer(s), [{}] setter(s),"

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/NumberingSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/NumberingSupport.java
@@ -69,4 +69,33 @@ final class NumberingSupport {
         }
         return numbering;
     }
+
+    /**
+     * One descriptor per {@code number:} field REGARDLESS of {@code stampOn} - the series the
+     * application declares. The stamp collection above deliberately covers only {@code stampOn: issue}
+     * (a create-time number is stamped by the DAO and needs no process step), but the management
+     * surface must list every series, including those whose first document does not exist yet, so
+     * declaration needs the full set.
+     *
+     * @param model the parsed intent model
+     * @return the {@code numberSeries} collection (possibly empty)
+     */
+    static List<Map<String, Object>> buildNumberSeries(IntentModel model) {
+        List<Map<String, Object>> series = new ArrayList<>();
+        for (EntityIntent entity : model.getEntities()) {
+            for (FieldIntent field : entity.getFields()) {
+                NumberIntent number = field.getNumber();
+                if (number == null) {
+                    continue;
+                }
+                Map<String, Object> descriptor = new LinkedHashMap<>();
+                descriptor.put("entity", entity.getName());
+                descriptor.put("field", IntentNaming.pascalCase(field.getName()));
+                descriptor.put("series", number.getSeries() == null ? entity.getName() : number.getSeries());
+                descriptor.put("format", number.getFormat() == null ? "" : number.getFormat());
+                series.add(descriptor);
+            }
+        }
+        return series;
+    }
 }

--- a/components/engine/engine-numbering/src/main/java/org/eclipse/dirigible/components/engine/numbering/DocumentNumberEndpoint.java
+++ b/components/engine/engine-numbering/src/main/java/org/eclipse/dirigible/components/engine/numbering/DocumentNumberEndpoint.java
@@ -40,13 +40,42 @@ public class DocumentNumberEndpoint extends BaseEndpoint {
         this.service = service;
     }
 
-    /** The current tenant's counters. */
+    /**
+     * The current tenant's series: every series the running application DECLARED plus any counter that
+     * predates declaration, with the tenant's format override and whether one is expressible at all.
+     */
     @GetMapping
-    public ResponseEntity<List<DocumentNumberStore.Counter>> list() {
+    public ResponseEntity<List<SeriesView>> list() {
         try {
-            return ResponseEntity.ok(service.list());
+            return ResponseEntity.ok(service.listAll()
+                                            .stream()
+                                            .map(counter -> new SeriesView(counter.series(), counter.scope(), counter.counter(),
+                                                    counter.counter() + 1, counter.format(), counter.prefix(), counter.size(),
+                                                    DocumentNumberService.overridable(counter.format())))
+                                            .toList());
         } catch (SQLException ex) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to list document-number counters", ex);
+        }
+    }
+
+    /**
+     * Set (or clear) the tenant's prefix/size override for a series. Clearing both falls back to the
+     * format the application authored.
+     */
+    @PutMapping("/format")
+    public ResponseEntity<Void> setFormat(@RequestBody SetFormatRequest request) {
+        if (request == null || request.series() == null || request.series()
+                                                                  .isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "series is required");
+        }
+        try {
+            service.setOverride(request.series(), request.scope() == null ? "" : request.scope(), request.prefix(), request.size());
+            return ResponseEntity.noContent()
+                                 .build();
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        } catch (SQLException ex) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to set the document-number format", ex);
         }
     }
 
@@ -74,5 +103,34 @@ public class DocumentNumberEndpoint extends BaseEndpoint {
      * @param next the next value the counter should allocate
      */
     record SetNextRequest(String series, String scope, long next) {
+    }
+
+    /**
+     * Request body for the prefix/size override.
+     *
+     * @param series the series identity
+     * @param scope the scope key ({@code ""}/{@code null} for an unscoped series)
+     * @param prefix the literal prefix - an EMPTY string is meaningful (no prefix at all), null with a
+     *        null size clears the override
+     * @param size the total rendered width
+     */
+    record SetFormatRequest(String series, String scope, String prefix, Integer size) {
+    }
+
+    /**
+     * One series as the settings page sees it.
+     *
+     * @param series the series identity
+     * @param scope the scope key
+     * @param counter the last allocated value
+     * @param next the value the next document will get
+     * @param format the format the application authored
+     * @param prefix the tenant's prefix override, or null
+     * @param size the tenant's width override, or null
+     * @param overridable whether a prefix/size override can express this format at all (false when it
+     *        carries scope tokens the override cannot reproduce)
+     */
+    record SeriesView(String series, String scope, long counter, long next, String format, String prefix, Integer size,
+            boolean overridable) {
     }
 }

--- a/components/engine/engine-numbering/src/main/java/org/eclipse/dirigible/components/engine/numbering/DocumentNumberService.java
+++ b/components/engine/engine-numbering/src/main/java/org/eclipse/dirigible/components/engine/numbering/DocumentNumberService.java
@@ -12,7 +12,10 @@ package org.eclipse.dirigible.components.engine.numbering;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -31,7 +34,18 @@ public class DocumentNumberService {
     /** Default format when the field declares none: the series then a 6-digit sequence. */
     static final String DEFAULT_FORMAT = "{series}-{seq:06}";
 
+    /** Widest renderable number - the stored column is VARCHAR(100), and no series needs more. */
+    static final int MAX_SIZE = 40;
+
     private static final Pattern TOKEN = Pattern.compile("\\{([a-zA-Z][a-zA-Z0-9_]*)(?::0(\\d+))?\\}");
+
+    /**
+     * The series the running application declared, series -> authored format. Application-wide (it
+     * comes from the generated code, which is the same for every tenant) and rebuilt on every boot, so
+     * it is held in memory rather than written per tenant at start-up - where there is no tenant scope
+     * to write into. Counters and format overrides stay per-tenant in the store.
+     */
+    private final Map<String, String> declared = new ConcurrentSkipListMap<>();
 
     private final DocumentNumberStore store;
 
@@ -51,8 +65,121 @@ public class DocumentNumberService {
      */
     public String next(String series, String format, Map<String, String> scope) throws SQLException {
         Map<String, String> safeScope = scope == null ? Map.of() : scope;
-        long seq = store.allocate(series, scopeKey(safeScope));
-        return render(format == null || format.isBlank() ? DEFAULT_FORMAT : format, series, seq, safeScope);
+        DocumentNumberStore.Allocation allocation = store.allocate(series, scopeKey(safeScope));
+        String authored = format == null || format.isBlank() ? DEFAULT_FORMAT : format;
+        return render(effectiveFormat(authored, allocation.prefix(), allocation.size()), series, allocation.seq(), safeScope);
+    }
+
+    /**
+     * Declares that a series exists and records its authored format, allocating nothing. The generated
+     * declaring components call this on every boot so a series is configurable BEFORE its first
+     * document.
+     *
+     * @param series the series identity
+     * @param format the authored format template
+     */
+    public void declare(String series, String format) {
+        if (series == null || series.isBlank()) {
+            return;
+        }
+        declared.put(series, format == null || format.isBlank() ? DEFAULT_FORMAT : format);
+    }
+
+    /**
+     * Every series the tenant can configure: the declared ones (application-wide) merged with the rows
+     * that actually have a counter (per-tenant). A declared series with no row yet reports counter 0,
+     * so the management surface can seed its next value and its format BEFORE the first document
+     * exists.
+     *
+     * @return the series, declared-first then any counter-only leftovers
+     * @throws SQLException if the read fails
+     */
+    public List<DocumentNumberStore.Counter> listAll() throws SQLException {
+        Map<String, DocumentNumberStore.Counter> byKey = new LinkedHashMap<>();
+        for (DocumentNumberStore.Counter counter : store.list()) {
+            byKey.put(counter.series() + '|' + counter.scope(), counter);
+        }
+        List<DocumentNumberStore.Counter> result = new ArrayList<>();
+        declared.forEach((series, format) -> {
+            DocumentNumberStore.Counter row = byKey.remove(series + '|');
+            result.add(row == null ? new DocumentNumberStore.Counter(series, "", 0L, format, null, null)
+                    // The declared format is authoritative - the application, not the stored row, owns it.
+                    : new DocumentNumberStore.Counter(row.series(), row.scope(), row.counter(), format, row.prefix(), row.size()));
+        });
+        result.addAll(byKey.values());
+        return result;
+    }
+
+    /**
+     * Sets or clears the tenant's format override for a series. Pass {@code null} prefix AND size to
+     * drop the override and fall back to the authored format.
+     *
+     * @param series the series identity
+     * @param scope the scope key ({@code ""} for unscoped)
+     * @param prefix the literal prefix (may be empty - that is a MEANINGFUL value: no prefix at all)
+     * @param size the total rendered width
+     * @throws SQLException if the write fails
+     * @throws IllegalArgumentException if the width cannot hold the prefix plus at least one digit
+     */
+    public void setOverride(String series, String scope, String prefix, Integer size) throws SQLException {
+        if (prefix == null && size == null) {
+            store.setOverride(series, scope, null, null);
+            return;
+        }
+        String safePrefix = prefix == null ? "" : prefix;
+        if (size == null) {
+            throw new IllegalArgumentException("A prefix override also needs a total size");
+        }
+        if (size <= safePrefix.length()) {
+            throw new IllegalArgumentException("Size [" + size + "] leaves no room for a sequence after the prefix [" + safePrefix + "]");
+        }
+        if (size > MAX_SIZE) {
+            throw new IllegalArgumentException("Size [" + size + "] exceeds the maximum of " + MAX_SIZE);
+        }
+        store.setOverride(series, scope, safePrefix, size);
+    }
+
+    /**
+     * The format actually used: the tenant's {@code prefix + zero-padded sequence} when overridden,
+     * else the authored template. An override is expressible only as a prefix and a width, so it
+     * deliberately REPLACES the authored format rather than merging into it.
+     *
+     * @param authored the authored template
+     * @param prefix the override prefix, or null
+     * @param size the override width, or null
+     * @return the effective template
+     */
+    static String effectiveFormat(String authored, String prefix, Integer size) {
+        if (size == null) {
+            return authored;
+        }
+        String safePrefix = prefix == null ? "" : prefix;
+        int digits = size - safePrefix.length();
+        if (digits < 1) {
+            return authored; // an unusable override never silently mangles the number
+        }
+        return safePrefix + "{seq:0" + digits + "}";
+    }
+
+    /**
+     * Whether a format can be expressed as a prefix plus a padded sequence. A format carrying scope
+     * tokens ({@code {year}}, {@code {series}}) cannot, so the management surface offers no prefix/size
+     * override for it instead of silently dropping the tokens.
+     *
+     * @param format the authored template
+     * @return true when only the sequence token appears
+     */
+    static boolean overridable(String format) {
+        if (format == null || format.isBlank()) {
+            return true;
+        }
+        Matcher matcher = TOKEN.matcher(format);
+        while (matcher.find()) {
+            if (!"seq".equals(matcher.group(1))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /** All counter rows of the current tenant (for the management surface). */

--- a/components/engine/engine-numbering/src/main/java/org/eclipse/dirigible/components/engine/numbering/DocumentNumberStore.java
+++ b/components/engine/engine-numbering/src/main/java/org/eclipse/dirigible/components/engine/numbering/DocumentNumberStore.java
@@ -10,6 +10,9 @@
 package org.eclipse.dirigible.components.engine.numbering;
 
 import java.sql.Connection;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -42,6 +45,14 @@ class DocumentNumberStore {
     private static final String QUOTED_SCOPE = "\"DOCUMENT_SCOPE\"";
     private static final String COLUMN_COUNTER = "DOCUMENT_COUNTER";
     private static final String QUOTED_COUNTER = "\"DOCUMENT_COUNTER\"";
+    /** The AUTHORED format, recorded by declare() so the management surface knows the series shape. */
+    private static final String COLUMN_FORMAT = "DOCUMENT_FORMAT";
+    private static final String QUOTED_FORMAT = "\"DOCUMENT_FORMAT\"";
+    /** Per-tenant overrides of the authored format: a literal prefix and the total rendered width. */
+    private static final String COLUMN_PREFIX = "DOCUMENT_PREFIX";
+    private static final String QUOTED_PREFIX = "\"DOCUMENT_PREFIX\"";
+    private static final String COLUMN_SIZE = "DOCUMENT_SIZE";
+    private static final String QUOTED_SIZE = "\"DOCUMENT_SIZE\"";
 
     private final DataSourcesManager dataSourcesManager;
 
@@ -56,7 +67,18 @@ class DocumentNumberStore {
      * @param scope the scope key ({@code ""} for an unscoped series)
      * @param counter the current (last allocated) value
      */
-    record Counter(String series, String scope, long counter) {
+    record Counter(String series, String scope, long counter, String format, String prefix, Integer size) {
+    }
+
+    /**
+     * One allocation: the value plus the tenant's format override, read inside the same transaction so
+     * a number is rendered with the configuration it was allocated under.
+     *
+     * @param seq the allocated value
+     * @param prefix the tenant's literal prefix override, or null
+     * @param size the tenant's total-width override, or null
+     */
+    record Allocation(long seq, String prefix, Integer size) {
     }
 
     /**
@@ -68,7 +90,7 @@ class DocumentNumberStore {
      * @return the newly allocated value
      * @throws SQLException if the allocation fails
      */
-    long allocate(String series, String scope) throws SQLException {
+    Allocation allocate(String series, String scope) throws SQLException {
         try (Connection connection = dataSourcesManager.getDefaultDataSource()
                                                        .getConnection()) {
             ensureTableExists(connection);
@@ -77,7 +99,7 @@ class DocumentNumberStore {
             try {
                 if (increment(connection, series, scope) == 0) {
                     try {
-                        insert(connection, series, scope);
+                        insert(connection, series, scope, 1L);
                     } catch (SQLException duplicate) {
                         // A concurrent first allocation created the row; increment the now-present row.
                         LOGGER.debug("Concurrent counter creation for series [{}] scope [{}]; retrying increment", series, scope,
@@ -85,9 +107,9 @@ class DocumentNumberStore {
                         increment(connection, series, scope);
                     }
                 }
-                long value = read(connection, series, scope);
+                Allocation allocation = readAllocation(connection, series, scope);
                 connection.commit();
-                return value;
+                return allocation;
             } catch (SQLException ex) {
                 connection.rollback();
                 throw ex;
@@ -110,8 +132,10 @@ class DocumentNumberStore {
             List<Counter> result = new ArrayList<>();
             try (PreparedStatement statement = connection.prepareStatement(sql); ResultSet resultSet = statement.executeQuery()) {
                 while (resultSet.next()) {
+                    int size = resultSet.getInt(COLUMN_SIZE);
                     result.add(new Counter(resultSet.getString(COLUMN_SERIES), resultSet.getString(COLUMN_SCOPE),
-                            resultSet.getLong(COLUMN_COUNTER)));
+                            resultSet.getLong(COLUMN_COUNTER), resultSet.getString(COLUMN_FORMAT), resultSet.getString(COLUMN_PREFIX),
+                            resultSet.wasNull() || size == 0 ? null : Integer.valueOf(size)));
                 }
             }
             return result;
@@ -138,7 +162,7 @@ class DocumentNumberStore {
                 statement.setString(2, series);
                 statement.setString(3, scope);
                 if (statement.executeUpdate() == 0) {
-                    insert(connection, series, scope);
+                    insert(connection, series, scope, 1L);
                     setCounter(series, scope, value);
                 }
             }
@@ -166,7 +190,7 @@ class DocumentNumberStore {
         }
     }
 
-    private void insert(Connection connection, String series, String scope) throws SQLException {
+    private void insert(Connection connection, String series, String scope, long counter) throws SQLException {
         String sql = SqlFactory.getNative(connection)
                                .insert()
                                .into(TABLE_NAME)
@@ -177,7 +201,7 @@ class DocumentNumberStore {
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, series);
             statement.setString(2, scope);
-            statement.setLong(3, 1L);
+            statement.setLong(3, counter);
             statement.executeUpdate();
         }
     }
@@ -201,6 +225,7 @@ class DocumentNumberStore {
     private void ensureTableExists(Connection connection) throws SQLException {
         if (SqlFactory.getNative(connection)
                       .existsTable(connection, TABLE_NAME)) {
+            addMissingColumns(connection);
             return;
         }
         String sql = SqlFactory.getNative(connection)
@@ -209,6 +234,9 @@ class DocumentNumberStore {
                                .column(QUOTED_SERIES, DataType.VARCHAR, true, false, false, "(255)")
                                .column(QUOTED_SCOPE, DataType.VARCHAR, true, false, false, "(255)")
                                .column(QUOTED_COUNTER, DataType.BIGINT, false, false, false)
+                               .column(QUOTED_FORMAT, DataType.VARCHAR, false, true, false, "(255)")
+                               .column(QUOTED_PREFIX, DataType.VARCHAR, false, true, false, "(64)")
+                               .column(QUOTED_SIZE, DataType.INTEGER, false, true, false)
                                .build();
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.executeUpdate();
@@ -219,6 +247,116 @@ class DocumentNumberStore {
                 LOGGER.debug("Document-number table already created concurrently", ex);
             } else {
                 throw ex;
+            }
+        }
+    }
+
+    /**
+     * Brings a table created by an earlier version up to the current shape. The counter table predates
+     * the declared format and the per-tenant prefix/width overrides, and it is created create-if-absent
+     * (never dropped), so an existing deployment would otherwise keep a three-column table and every
+     * read of the new columns would fail. Each column is added independently and an "already exists"
+     * failure is tolerated, so two nodes racing the same upgrade is harmless.
+     *
+     * @param connection the connection
+     * @throws SQLException if the table cannot be inspected
+     */
+    private void addMissingColumns(Connection connection) throws SQLException {
+        Set<String> present = new HashSet<>();
+        try (ResultSet columns = connection.getMetaData()
+                                           .getColumns(null, null, TABLE_NAME, null)) {
+            while (columns.next()) {
+                present.add(columns.getString("COLUMN_NAME")
+                                   .toUpperCase(Locale.ROOT));
+            }
+        }
+        addColumnIfMissing(connection, present, QUOTED_FORMAT, COLUMN_FORMAT, "VARCHAR(255)");
+        addColumnIfMissing(connection, present, QUOTED_PREFIX, COLUMN_PREFIX, "VARCHAR(64)");
+        addColumnIfMissing(connection, present, QUOTED_SIZE, COLUMN_SIZE, "INTEGER");
+    }
+
+    private void addColumnIfMissing(Connection connection, Set<String> present, String quotedColumn, String column, String type) {
+        if (present.contains(column)) {
+            return;
+        }
+        String sql = "ALTER TABLE " + QUOTED_TABLE + " ADD COLUMN " + quotedColumn + " " + type;
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.executeUpdate();
+            LOGGER.info("Added document-number column [{}] using sql [{}]", column, sql);
+        } catch (SQLException ex) {
+            // A concurrent node added it first - the next read proves whether that is what happened.
+            LOGGER.debug("Could not add document-number column [{}]; assuming a concurrent upgrade", column, ex);
+        }
+    }
+
+    /**
+     * Sets (or clears) the tenant's format override for a series.
+     *
+     * @param series the series identity
+     * @param scope the scope key ({@code ""} for unscoped)
+     * @param prefix the literal prefix, or null to clear the override
+     * @param size the total rendered width, or null to clear the override
+     * @throws SQLException if the write fails
+     */
+    void setOverride(String series, String scope, String prefix, Integer size) throws SQLException {
+        try (Connection connection = dataSourcesManager.getDefaultDataSource()
+                                                       .getConnection()) {
+            ensureTableExists(connection);
+            String sql = SqlFactory.getNative(connection)
+                                   .update()
+                                   .table(TABLE_NAME)
+                                   .set(COLUMN_PREFIX, "?")
+                                   .set(COLUMN_SIZE, "?")
+                                   .where(COLUMN_SERIES + " = ? AND " + COLUMN_SCOPE + " = ?")
+                                   .build();
+            try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                statement.setString(1, prefix);
+                if (size == null) {
+                    statement.setNull(2, java.sql.Types.INTEGER);
+                } else {
+                    statement.setInt(2, size);
+                }
+                statement.setString(3, series);
+                statement.setString(4, scope);
+                if (statement.executeUpdate() == 0) {
+                    // Declared but never allocated: counter 0 keeps the first number at 1.
+                    insert(connection, series, scope, 0L);
+                    setOverride(series, scope, prefix, size);
+                }
+            }
+        }
+    }
+
+    /**
+     * The freshly allocated value together with the tenant's format override, read in the allocating
+     * transaction so the rendered number cannot straddle a configuration change.
+     *
+     * @param connection the connection
+     * @param series the series identity
+     * @param scope the scope key
+     * @return the allocation
+     * @throws SQLException if the read fails
+     */
+    private Allocation readAllocation(Connection connection, String series, String scope) throws SQLException {
+        String sql = SqlFactory.getNative(connection)
+                               .select()
+                               .column(COLUMN_COUNTER)
+                               .column(COLUMN_PREFIX)
+                               .column(COLUMN_SIZE)
+                               .from(TABLE_NAME)
+                               .where(COLUMN_SERIES + " = ? AND " + COLUMN_SCOPE + " = ?")
+                               .build();
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, series);
+            statement.setString(2, scope);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    return new Allocation(0L, null, null);
+                }
+                long counter = resultSet.getLong(1);
+                String prefix = resultSet.getString(2);
+                int size = resultSet.getInt(3);
+                return new Allocation(counter, prefix, resultSet.wasNull() || size == 0 ? null : Integer.valueOf(size));
             }
         }
     }

--- a/components/engine/engine-numbering/src/test/java/org/eclipse/dirigible/components/engine/numbering/DocumentNumberServiceTest.java
+++ b/components/engine/engine-numbering/src/test/java/org/eclipse/dirigible/components/engine/numbering/DocumentNumberServiceTest.java
@@ -14,6 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 
 class DocumentNumberServiceTest {
@@ -39,5 +41,51 @@ class DocumentNumberServiceTest {
         scope.put("year", "2026");
         assertEquals("1|2026", DocumentNumberService.scopeKey(scope));
         assertEquals("", DocumentNumberService.scopeKey(Map.of()));
+    }
+
+    /**
+     * The tenant's prefix/size override REPLACES the authored format - it can only express a prefix
+     * plus a padded sequence, so merging it into a richer template would be guesswork.
+     */
+    @Test
+    void overrideReplacesTheAuthoredFormatWithPrefixAndWidth() {
+        // The BG case: drop the "SI" prefix entirely, total width 10.
+        assertEquals("{seq:010}", DocumentNumberService.effectiveFormat("SI{seq:08}", "", 10));
+        assertEquals("0000000042", DocumentNumberService.render(DocumentNumberService.effectiveFormat("SI{seq:08}", "", 10),
+                "Sales Invoice", 42, java.util.Map.of()));
+        // A numeric prefix, same total width - the sequence shrinks to fit.
+        assertEquals("00{seq:08}", DocumentNumberService.effectiveFormat("SI{seq:08}", "00", 10));
+        assertEquals("0000000042", DocumentNumberService.render(DocumentNumberService.effectiveFormat("SI{seq:08}", "00", 10),
+                "Sales Invoice", 42, java.util.Map.of()));
+        assertEquals(10,
+                DocumentNumberService.render(DocumentNumberService.effectiveFormat("SI{seq:08}", "00", 10), "Sales Invoice", 42,
+                        java.util.Map.of())
+                                     .length());
+    }
+
+    @Test
+    void noOverrideKeepsTheAuthoredFormat() {
+        assertEquals("SI{seq:08}", DocumentNumberService.effectiveFormat("SI{seq:08}", null, null));
+        // A prefix without a width is not an override - a width is what makes it renderable.
+        assertEquals("SI{seq:08}", DocumentNumberService.effectiveFormat("SI{seq:08}", "X", null));
+    }
+
+    @Test
+    void anUnusableWidthFallsBackInsteadOfMangling() {
+        // The width leaves no room for even one digit: keep the authored format rather than emit "PRE".
+        assertEquals("PRE{seq:04}", DocumentNumberService.effectiveFormat("PRE{seq:04}", "PRE", 3));
+    }
+
+    /**
+     * A format carrying scope tokens cannot be expressed as prefix + width, so the management surface
+     * must not offer the override for it - it would silently drop the tokens.
+     */
+    @Test
+    void onlySequenceOnlyFormatsAreOverridable() {
+        assertTrue(DocumentNumberService.overridable("SI{seq:08}"));
+        assertTrue(DocumentNumberService.overridable("{seq}"));
+        assertTrue(DocumentNumberService.overridable("PLAIN"));
+        assertTrue(!DocumentNumberService.overridable("INV-{year}-{seq:05}"));
+        assertTrue(!DocumentNumberService.overridable("{series}-{seq:06}"));
     }
 }

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
@@ -139,6 +139,21 @@ document.addEventListener('alpine:init', () => {
       return row.scope ? row.series + ' [' + row.scope + ']' : row.series;
     },
 
+    /**
+     * What a series currently produces. A tenant override wins over the application's format; a format
+     * carrying scope tokens says so, because prefix/size cannot express it.
+     */
+    numberingFormatHint(row) {
+      if (!row.overridable) {
+        return this.T('application-core:shell.settings.numberingFixed', 'Format set by the application') + ': ' + row.format;
+      }
+      if (row.size) {
+        return this.T('application-core:shell.settings.numberingExample', 'Example') + ': '
+          + (row.prefix || '') + String(row.next || 1).padStart(Math.max(1, parseInt(row.size, 10) - (row.prefix || '').length), '0');
+      }
+      return this.T('application-core:shell.settings.numberingAppFormat', 'Application format') + ': ' + (row.format || '-');
+    },
+
     /** Load the current tenant's document-number counters. */
     async loadNumbering() {
       this.numberingLoading = true;
@@ -155,7 +170,11 @@ document.addEventListener('alpine:init', () => {
         }
         if (!res.ok) throw new Error('HTTP ' + res.status);
         const data = await res.json();
-        this.numbering = data.map((c) => ({ series: c.series, scope: c.scope || '', counter: c.counter, next: (c.counter || 0) + 1 }));
+        this.numbering = data.map((c) => ({
+          series: c.series, scope: c.scope || '', counter: c.counter, next: c.next != null ? c.next : (c.counter || 0) + 1,
+          format: c.format || '', prefix: c.prefix == null ? '' : c.prefix, size: c.size == null ? '' : c.size,
+          overridable: c.overridable !== false
+        }));
       } catch (e) {
         console.error('document-numbering: failed to load', e);
         this.numbering = [];
@@ -180,6 +199,21 @@ document.addEventListener('alpine:init', () => {
             body: JSON.stringify({ series: row.series, scope: row.scope, next: next })
           });
           if (!res.ok) throw new Error('PUT ' + row.series + ' -> HTTP ' + res.status);
+          // The prefix/size override is a separate concern from the counter, and only offered when the
+          // application's format is a padded sequence. An empty size CLEARS the override (back to the
+          // application's format); an empty prefix is a real value - no prefix at all.
+          if (!row.overridable) continue;
+          const size = parseInt(row.size, 10);
+          const body = isFinite(size) && size > 0
+            ? { series: row.series, scope: row.scope, prefix: row.prefix || '', size: size }
+            : { series: row.series, scope: row.scope, prefix: null, size: null };
+          const fmt = await fetch('/services/core/numbering/format', {
+            method: 'PUT',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+          });
+          if (!fmt.ok) throw new Error('PUT format ' + row.series + ' -> HTTP ' + fmt.status);
         }
         await this.loadNumbering();
       } catch (e) {

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_settings.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_settings.html
@@ -177,8 +177,27 @@
           <div class="vbox gap-4">
             <template x-for="row in numbering" :key="row.series + '|' + row.scope">
               <div class="vbox gap-1">
-                <span x-h-text.muted class="text-sm" x-text="numberingLabel(row)"></span>
-                <input x-h-input type="number" min="1" x-model="row.next" />
+                <span class="text-sm font-medium" x-text="numberingLabel(row)"></span>
+                <span x-h-text.muted class="text-xs" x-text="numberingFormatHint(row)"></span>
+                <div class="grid grid-cols-1 sm:grid-cols-3 gap-2">
+                  <div class="vbox gap-0">
+                    <span x-h-text.muted class="text-xs" x-text="T('application-core:shell.settings.numberingNext', 'Next')"></span>
+                    <input x-h-input type="number" min="1" x-model="row.next" />
+                  </div>
+                  <!-- Prefix/size REPLACE the application's format, so they are offered only when that
+                       format is nothing but a padded sequence: a format carrying {year}/{series} tokens
+                       cannot be expressed this way and the override would silently drop them. -->
+                  <div class="vbox gap-0">
+                    <span x-h-text.muted class="text-xs" x-text="T('application-core:shell.settings.numberingPrefix', 'Prefix')"></span>
+                    <input x-h-input type="text" maxlength="16" x-model="row.prefix" :disabled="!row.overridable"
+                           :placeholder="T('application-core:shell.settings.numberingPrefixHint', 'none')" />
+                  </div>
+                  <div class="vbox gap-0">
+                    <span x-h-text.muted class="text-xs" x-text="T('application-core:shell.settings.numberingSize', 'Total size')"></span>
+                    <input x-h-input type="number" min="1" max="40" x-model="row.size" :disabled="!row.overridable"
+                           :placeholder="T('application-core:shell.settings.numberingSizeHint', 'from the app')" />
+                  </div>
+                </div>
               </div>
             </template>
             <div class="hbox gap-2">

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/NumberSeries.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/NumberSeries.java.template
@@ -1,0 +1,25 @@
+package gen.events.${javaGenFolderName};
+
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.numbering.DocumentNumbers;
+
+/**
+ * Declares the ${series} document-number series (${entity}.${field}) to the platform.
+ *
+ * Generated from the intent numbering glue - do not edit; it is re-generated with the application.
+ *
+ * Its only job is to exist: the constructor runs when the client bean container starts, so the series
+ * shows up on the application shell's Document Numbering settings page - and its next value, prefix and
+ * width become configurable - BEFORE the first document of this series is ever numbered. Without it a
+ * series is invisible until something allocates a number, which is exactly when it is too late to choose
+ * where the sequence should start.
+ *
+ * Declaring is idempotent and allocates nothing; re-declaring only refreshes the recorded format.
+ */
+@Component("${javaGenFolderName}_${entity}NumberSeries")
+public class ${entity}NumberSeries {
+
+    public ${entity}NumberSeries() {
+        DocumentNumbers.declare("${series}", "${format}");
+    }
+}

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/template/template.js
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/template/template.js
@@ -143,6 +143,13 @@ export function getTemplate(parameters) {
                 collection: "numbering"
             },
             {
+                location: "/template-application-events-java/events/NumberSeries.java.template",
+                action: "generate",
+                rename: "gen/events/{{javaGenFolderName}}/{{entity}}NumberSeries.java",
+                engine: "velocity",
+                collection: "numberSeries"
+            },
+            {
                 location: "/template-application-events-java/events/SettlementOnPayment.java.template",
                 action: "generate",
                 rename: "gen/events/{{javaGenFolderName}}/{{name}}OnPayment.java",

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -1440,6 +1440,29 @@ export function generateFiles(model, parameters, templateSources) {
                         }
                     }
                     break;
+                case "numberSeries":
+                    // Declaring components (intent layer): one tiny @Component per number: field -
+                    // REGARDLESS of stampOn, unlike the stamp delegates above - whose constructor declares
+                    // the series to the platform at client-container start-up, so it is listed and
+                    // configurable before its first document is numbered.
+                    if (model.numberSeries) {
+                        for (let ns = 0; ns < model.numberSeries.length; ns++) {
+                            const ser = model.numberSeries[ns];
+                            const seriesParameters = cleanData({
+                                ...parameters,
+                                entity: ser.entity,
+                                field: ser.field,
+                                series: ser.series,
+                                format: ser.format
+                            });
+                            generatedFiles.push({
+                                location: location,
+                                content: getGenerationEngine(template).generate(location, content, seriesParameters),
+                                path: templateEngines.getMustacheEngine().generate(location, template.rename, seriesParameters)
+                            });
+                        }
+                    }
+                    break;
                 case "numbering":
                     // Document-number stamp delegates (intent layer): one JavaDelegate per number: field
                     // with stampOn:issue, wired as a delegate: service task at the issue step. It stamps


### PR DESCRIPTION
Fixes the two problems behind "the Document Numbering page shows one series when I have twenty".

## 1. A series was invisible until its first document

The page listed counter **rows**, and a row is created lazily by the first allocation. So an instance with ~20 declared series (Sales Invoice, Goods Receipt, Goods Issue, Journal Entry, …) showed exactly one — the only series that had ever been used. And the behaviour is backwards: the moment you most want to choose where a sequence starts is **before** the first document, and until then there was nothing to edit.

Declared series now reach the runtime through the only channel that legitimately carries generated declarations: **the compiled client Java**. A new `numberSeries` glue collection — one entry per `number:` field **regardless of `stampOn`** (the existing `numbering` collection covers only `stampOn: issue`, because a create-time number needs no process step) — generates a tiny `<Entity>NumberSeries` `@Component` whose constructor calls the new `DocumentNumbers.declare`.

**Not** seeded from the `.model` at synchronization time, which was my first instinct: `.model`/`.glue` are **authoring artifacts with no synchronizer**, and giving one to an authoring artifact is the anti-pattern this repo already made and reverted once.

Declarations live **in memory**, not per tenant: a client component's constructor runs at container start-up, where there is no tenant scope to write into — and series names/formats are application-wide anyway. Counters and overrides stay per-tenant in the store; `listAll` merges them, so a declared-but-unused series reports counter 0 / next 1 and is configurable immediately.

## 2. The format was compiled in, so a country had to fork the model

`DocumentNumbers.next("Sales Invoice", "SI{seq:08}", …)` bakes the format into generated Java. A Bulgarian deployment wanting **no `SI` prefix and width 10** had to edit the intent and regenerate — forking the app model per country, for what is a per-deployment concern like branding.

The store gains `FORMAT` / `PREFIX` / `SIZE`; the service resolves prefix+width over the authored format; the settings page edits **prefix, total size and next** per series.

```
prefix ""   size 10  ->  0000000042
prefix "00" size 10  ->  0000000042      (sequence shrinks to fit)
```

The override **replaces** the authored format (it can only express a prefix plus a padded sequence), so it is offered **only** when the authored format is nothing but a padded sequence. A format carrying `{year}`/`{series}` shows read-only instead of silently dropping the tokens.

## Three things that would otherwise have bitten

- **Existing installs.** The counter table is created create-if-absent and never dropped, so a running instance has the old three-column table. `addMissingColumns` ALTERs each column in independently and tolerates "already exists" — so it upgrades in place, and two nodes racing the upgrade is harmless. Without it, every read of the new columns would fail on every existing install.
- **`setOverride` inserts with counter 0, not 1.** Inserting 1 (the allocate path's semantics) would silently consume the first number just by configuring a format.
- **An unusable width** (no room for a digit after the prefix) falls back to the authored format rather than emitting a number with no sequence.

## Verification

290 tests across `engine-numbering` + `engine-intent`, including both BG cases end to end, the no-override fallback, the unusable-width fallback, and that only sequence-only formats are overridable. `formatter:validate` clean, javadoc **0 errors**, the new Velocity template parse-checked, both changed JS files `node --check`ed.

Two compile-time catches worth noting, both fixed here: making `declare` in-memory left a dead `SQLException` catch in the SDK and a stale `@throws` that the release javadoc build rejects.

⚠️ **Not yet run end-to-end on a live instance** — the generated declaring components only appear after a regenerate + publish, so the "all twenty series listed" outcome is asserted by construction, not observed. Worth a live check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)