### PR TITLE
feat(intent): postings item cell copies a source to-one FK (counterparty dimension) (#6533)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -1357,6 +1357,15 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                         String column = IntentNaming.pascalCase(ruleRef.group(1));
                         usedRuleColumns.add(column);
                         assign.put("expr", "ruleRow." + column);
+                    } else if (toOneRelation(itemsEntity, cell.getKey()) != null) {
+                        // Source-FK copy (issue #6533): the item cell's key is a to-one relation of the
+                        // items entity, so the value names a source relation whose FK id is copied
+                        // verbatim onto the line - the counterparty dimension (Customer/Supplier) that
+                        // makes an auto-posted line show up in the subledger balances. The raw Long FK is
+                        // copied (no re-resolution); a null source FK copies null (the line simply carries
+                        // no dimension). NOT negated under reversal: a red-storno line must carry the SAME
+                        // dimension as the original, or it would not net the counterparty's balance.
+                        assign.put("expr", "source." + IntentNaming.pascalCase(value));
                     } else {
                         FieldIntent target = fieldOf(itemsEntity, cell.getKey());
                         int scale = target != null && target.getScale() != null ? target.getScale() : 2;

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -3451,6 +3451,15 @@ public final class IntentParser {
                 issues.add(subject + " requires at least one items row");
                 continue;
             }
+            // The event source entity - resolvable here only for a LOCAL source; a cross-model source
+            // (event.model alias) is resolved at generation time via CrossModelSupport, so its relations
+            // cannot be deep-checked at parse time. The FK-copy item cell (issue #6533) is therefore
+            // shape-validated always, and target-entity-matched only when the source is local.
+            Object eventAlias = posting.getEvent() == null ? null
+                    : posting.getEvent()
+                             .get("model");
+            EntityIntent postingSource =
+                    eventAlias == null ? byName.get(String.valueOf(onTransition != null ? onTransition : onCreate)) : null;
             for (java.util.Map<String, String> row : posting.getItems()) {
                 for (java.util.Map.Entry<String, String> cell : row.entrySet()) {
                     String key = cell.getKey();
@@ -3493,6 +3502,28 @@ public final class IntentParser {
                             if (!known) {
                                 issues.add(subject + " rule(" + column + ") is not a field or to-one relation of [" + ruleEntity.getName()
                                         + "]");
+                            }
+                        }
+                    } else if (toOneRelationByName(itemsEntity, key) != null) {
+                        // Source-FK copy (issue #6533): a to-one relation item cell copies a source
+                        // to-one FK onto the line (the counterparty dimension). Its value must be a bare
+                        // source relation name, not a Calc expression - you cannot arithmetic-evaluate a
+                        // FK. When the source is local, the copied relation must exist on it and be
+                        // to-one to the SAME entity as the item relation.
+                        String rhs = value.trim();
+                        if (!rhs.matches("\\w+")) {
+                            issues.add(subject + " item [" + key + "] is a to-one relation - its value must copy a source"
+                                    + " to-one relation (a bare source relation name), not an expression [" + value + "]");
+                        } else if (postingSource != null) {
+                            RelationIntent itemRelation = toOneRelationByName(itemsEntity, key);
+                            RelationIntent sourceRelation = toOneRelationByName(postingSource, rhs);
+                            if (sourceRelation == null) {
+                                issues.add(subject + " item [" + key + "] copies [" + rhs + "] which is not a to-one relation of the"
+                                        + " source entity [" + postingSource.getName() + "]");
+                            } else if (!java.util.Objects.equals(itemRelation.getTo(), sourceRelation.getTo())
+                                    || !java.util.Objects.equals(itemRelation.getModel(), sourceRelation.getModel())) {
+                                issues.add(subject + " item [" + key + "] and its copied source [" + rhs + "] must be to-one to the same"
+                                        + " entity (item -> [" + itemRelation.getTo() + "], source -> [" + sourceRelation.getTo() + "])");
                             }
                         }
                     }

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -248,10 +248,15 @@ composition is opt-in.
       map: { entryDate: date, customer: Customer, reason: "Sales invoice {number}" }
       rule: { entity: PostingRule, match: { documentType: "Sales Invoice" } }
       items:
-        - { Account: rule(receivableAccount), debit: "Net + Vat" }
+        - { Account: rule(receivableAccount), debit: "Net + Vat", Customer: Customer }  # copy the source FK
         - { Account: rule(revenueAccount),    credit: "Net" }
         - { Account: rule(vatAccount),        credit: "Vat", when: "Vat != 0" }
   ```
+  A to-one relation item cell whose value is a bare SOURCE relation name copies that FK id onto the
+  line (`Customer: Customer` above, or a rename `Counterparty: Supplier`) - the counterparty
+  dimension that makes an auto-posted line appear in the subledger balances (by customer/supplier).
+  The item relation and the copied source relation must be to-one to the same entity; a null source
+  FK copies null.
   The trigger is `onTransition` (a status write; the `when` status guard is mandatory) or
   `onCreate` (the source's INSERT - the trigger for a source with no status lifecycle at all, e.g.
   a booked payment whose only event is being created; `when` stays optional there as a plain
@@ -275,7 +280,8 @@ composition is opt-in.
   generateNumber -> markIssued): "the transition is final" then also means "the document is
   complete"; `map` values are a source
   property (copy), a literal, or a `{sourceProperty}` template; item values are `rule(<column>)`
-  references or arithmetic over the SOURCE's fields; a row `when` is `<SourceField> ==|!= <number>`.
+  references, arithmetic over the SOURCE's fields, or - for a to-one relation cell - a bare SOURCE
+  relation name whose FK is copied onto the line; a row `when` is `<SourceField> ==|!= <number>`.
   A missing rule row or null referenced column SKIPS the posting (the unposted worklist = final-status
   documents with no back-referencing target), never throws. All writes go through the generated
   repositories, so numbering/status-init/`checks:` fire on the created document.
@@ -290,8 +296,9 @@ composition is opt-in.
   `creates`/`backReference`/`rule`/`map`/`items` are inherited from the sibling and must not be
   declared. Semantics: locate the ORIGINAL (back-reference = this source, storno link empty) - none
   -> skip fail-soft; create the negated copy (every item amount expression negated on the SAME
-  debit/credit side - never swapped) with the `storno` link stamped; idempotent (rows carrying the
-  link are the reversal's own; the sibling's guard symmetrically counts only rows without it). The
+  debit/credit side - never swapped; a copied source-FK dimension carries through UNCHANGED, so the
+  reversal nets the same counterparty's balance) with the `storno` link stamped; idempotent (rows
+  carrying the link are the reversal's own; the sibling's guard symmetrically counts only rows without it). The
   reversal lands as a normal new document (DRAFT status init, numbering, checks), dated by its own
   `map`-inherited header - corrections post into the open period.
 - `calculatedOnCreate` / `calculatedOnUpdate` - an expression the generated repository assigns to the

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GluePostingsTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GluePostingsTest.java
@@ -54,6 +54,7 @@ class GluePostingsTest {
                 relations:
                   - { name: JournalEntry, kind: manyToOne, to: JournalEntry, composition: true, required: true }
                   - { name: Account, kind: manyToOne, to: Account, required: true }
+                  - { name: Customer, kind: manyToOne, to: Customer, model: sales-invoices }
             postings:
               - name: salesInvoicePosting
                 event: { onTransition: SalesInvoice, model: sales-invoices, when: "Status == 3" }
@@ -62,7 +63,7 @@ class GluePostingsTest {
                 map: { entryDate: date, reason: "Sales invoice {number}" }
                 rule: { entity: PostingRule, match: { documentType: "Sales Invoice" } }
                 items:
-                  - { Account: rule(receivableAccount), debit: "Net + Vat" }
+                  - { Account: rule(receivableAccount), debit: "Net + Vat", Customer: Customer }
                   - { Account: rule(revenueAccount), credit: "Net" }
                   - { Account: rule(vatAccount), credit: "Vat", when: "Vat != 0" }
             """;
@@ -106,6 +107,10 @@ class GluePostingsTest {
         assertTrue(firstAssigns.stream()
                                .anyMatch(a -> "Debit".equals(a.get("targetProp"))
                                        && "Calc.eval(\"Net + Vat\", source, 2)".equals(a.get("expr"))));
+        // source-FK copy (#6533): a to-one relation item cell copies the source FK verbatim - no Calc.
+        assertTrue(firstAssigns.stream()
+                               .anyMatch(a -> "Customer".equals(a.get("targetProp")) && "source.Customer".equals(a.get("expr"))),
+                "a to-one relation item cell must pre-render as a source-FK copy");
         // the third row carries a null-safe Calc guard
         assertEquals("Calc.eval(\"Vat\", source, 6).compareTo(new java.math.BigDecimal(\"0\")) != 0", rows.get(2)
                                                                                                           .get("guard"));

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/PostingsSourceFkCopyIntentTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/PostingsSourceFkCopyIntentTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Parse + validation coverage for the postings source-FK-copy item cell (issue #6533): a to-one
+ * relation item cell copies a source to-one FK onto the generated line (the counterparty
+ * dimension). The source here is LOCAL, so the validator can deep-check the copied relation's
+ * target entity.
+ */
+class PostingsSourceFkCopyIntentTest {
+
+    // Doc.Party (source) and EntryLine.Party (item) are both to-one to Party - a valid copy. The
+    // trailing comments keep the two otherwise-identical relation lines individually replaceable.
+    private static final String VALID = """
+            name: ledger
+            entities:
+              - name: Party
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: Doc
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: amount, type: decimal }
+                relations:
+                  - { name: Status, kind: manyToOne, to: DocStatus, function: EntityStatus, init: 1 }
+                  - { name: Party, kind: manyToOne, to: Party }   # source dimension
+              - name: DocStatus
+                kind: setting
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: Entry
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: date, type: date }
+                relations:
+                  - { name: Doc, kind: manyToOne, to: Doc }
+              - name: EntryLine
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: debit, type: decimal }
+                  - { name: credit, type: decimal }
+                relations:
+                  - { name: Entry, kind: manyToOne, to: Entry, composition: true, required: true }
+                  - { name: Party, kind: manyToOne, to: Party }   # item dimension
+            postings:
+              - name: docPosting
+                event: { onTransition: Doc, when: "Status == 2" }
+                creates: Entry
+                backReference: Doc
+                map: { date: date }
+                items:
+                  - { debit: "Amount", Party: Party }
+                  - { credit: "Amount" }
+            """;
+
+    @Test
+    void parsesAValidSourceFkCopy() {
+        IntentModel model = IntentParser.parse(VALID);
+        assertEquals(1, model.getPostings()
+                             .size());
+        // The item row still carries the copy cell verbatim - the generator turns it into source.Party.
+        assertEquals("Party", model.getPostings()
+                                   .get(0)
+                                   .getItems()
+                                   .get(0)
+                                   .get("Party"));
+    }
+
+    @Test
+    void rejectsAnExpressionValuedRelationCell() {
+        // A to-one relation cell copies a FK - you cannot arithmetic-evaluate it.
+        String yaml = VALID.replace("Party: Party }", "Party: \"Amount + 1\" }");
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("item [Party]") && i.contains("not an expression")),
+                "got: " + ex.getIssues());
+    }
+
+    @Test
+    void rejectsAnUnknownSourceRelation() {
+        String yaml = VALID.replace("Party: Party }", "Party: Ghost }");
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("copies [Ghost] which is not a to-one relation of the source entity [Doc]")),
+                "got: " + ex.getIssues());
+    }
+
+    @Test
+    void rejectsATargetEntityMismatch() {
+        // Point the SOURCE relation at a different entity than the item relation - the copy would put a
+        // DocStatus FK into a Party column.
+        String yaml = VALID.replace("- { name: Party, kind: manyToOne, to: Party }   # source dimension",
+                "- { name: Party, kind: manyToOne, to: DocStatus }   # source dimension");
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("item [Party]") && i.contains("must be to-one to the same entity")),
+                "got: " + ex.getIssues());
+    }
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -146,6 +146,9 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                   - { name: amount, type: decimal }
                 relations:
                   - { name: Status, kind: manyToOne, to: EntryStatus, function: EntityStatus, init: 1 }
+                  # postings source-FK copy (#6533): this counterparty FK is copied onto the posted
+                  # line, so an auto-posted Entry line carries the subledger dimension.
+                  - { name: Party,  kind: manyToOne, to: Party }
 
               # postings onCreate source (#6421): a booked payment has NO status lifecycle -
               # its INSERT is the posting event.
@@ -154,6 +157,12 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                   - { name: id,     type: integer, primaryKey: true, generated: true }
                   - { name: date,   type: date, required: true }
                   - { name: amount, type: decimal }
+
+              # postings source-FK-copy counterparty (#6533): a plain nomenclature copied by FK id.
+              - name: Party
+                fields:
+                  - { name: id,   type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string, required: true, length: 100 }
 
               # first-class numbering, stampOn: create - the generated DAO allocates the real number
               # at insert from the tenant series that the module's AUTHORED .numbers artefact
@@ -187,6 +196,8 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 relations:
                   - { name: Entry, kind: manyToOne, to: Entry, composition: true, required: true }
                   - { name: Unit,  kind: manyToOne, to: Unit }
+                  # copied from Doc.Party by docPosting, and carried UNCHANGED onto the storno line (#6533).
+                  - { name: Party, kind: manyToOne, to: Party }
 
               # A master-detail (MANAGE_MASTER) entity carrying an EntityStatus: the master
               # layout must resolve the status FK to a label lookup and render it as a badge in
@@ -638,7 +649,8 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 backReference: Doc
                 map: { date: date }
                 items:
-                  - { debit: "Amount" }
+                  # Party: source-FK copy (#6533) - the debit line carries Doc.Party as its dimension.
+                  - { debit: "Amount", Party: Party }
                   - { credit: "Amount" }
               - name: docStorno
                 event: { onTransition: Doc, when: "Status == 3" }
@@ -665,6 +677,10 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 rows:
                   - { id: 1, note: mine,    rate: 50, Person: 1 }
                   - { id: 2, note: foreign, rate: 70, Person: 2 }
+              - name: parties
+                entity: Party
+                rows:
+                  - { id: 1, name: Acme }
               - name: entry-statuses
                 entity: EntryStatus
                 rows:
@@ -1270,6 +1286,13 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         String basePosting = contentOf("gen/events/emission/DocPostingPosting.java");
         assertTrue(basePosting.contains("candidate.Storno == null"), "the reversed posting's idempotency guard must exclude reversal rows");
         assertTrue(basePosting.contains("-Doc-transitioned"), "a status-triggered posting must bind the -transitioned topic");
+        // source-FK copy (#6533): a to-one relation item cell copies the source FK verbatim onto the
+        // line - no Calc, no negation, and it must carry through UNCHANGED onto the reversal line.
+        assertTrue(basePosting.contains("item.Party = source.Party;"),
+                "a to-one relation item cell must copy the source FK onto the posted line");
+        assertTrue(!basePosting.contains("Calc.eval(\"Party\""), "the FK copy must not go through Calc");
+        assertTrue(stornoPosting.contains("item.Party = source.Party;"),
+                "the reversal must carry the copied source FK dimension UNCHANGED (not negated)");
 
         // postings onCreate (#6421): a source with no status lifecycle posts on its INSERT - the
         // handler binds the source's bare create topic (creates publish unsuffixed) and carries no
@@ -1644,7 +1667,7 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         // postings: posting a Doc creates the balanced Entry (async handler - poll)...
         AtomicInteger doc = new AtomicInteger();
         restAssuredExecutor.execute(() -> doc.set(given().contentType("application/json")
-                                                         .body("{\"Date\":\"2026-01-17\",\"Amount\":250}")
+                                                         .body("{\"Date\":\"2026-01-17\",\"Amount\":250,\"Party\":1}")
                                                          .when()
                                                          .post(API + "/doc/DocController")
                                                          .then()
@@ -1667,6 +1690,16 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                                                                    .extract()
                                                                    .path("find { it.Doc == " + doc.get() + " && it.Storno == null }.Id")),
                 30);
+        // source-FK copy (#6533): the debit line copied Doc.Party as its dimension; the credit line
+        // (no Party cell) carries none.
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get(API + "/entry/EntryLineController")
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body("findAll { it.Entry == " + originalEntry.get() + " && it.Party == 1 }.size()",
+                                                         equalTo(1))
+                                                 .body("findAll { it.Entry == " + originalEntry.get() + " && it.Party == null }.size()",
+                                                         equalTo(1)));
         // ...and reverses: voiding the Doc creates the red storno - the SAME lines negated on the
         // SAME sides, linked to the original through the storno self-relation.
         restAssuredExecutor.execute(() -> given().contentType("application/json")
@@ -1693,7 +1726,11 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                                                  .body("findAll { it.Entry == " + reversalEntry.get()
                                                          + " && it.Debit != null && it.Debit < 0 }.size()", equalTo(1))
                                                  .body("findAll { it.Entry == " + reversalEntry.get()
-                                                         + " && it.Credit != null && it.Credit < 0 }.size()", equalTo(1)));
+                                                         + " && it.Credit != null && it.Credit < 0 }.size()", equalTo(1))
+                                                 // storno carry-through (#6533): the reversal's debit line
+                                                 // carries the SAME Party dimension, unnegated.
+                                                 .body("findAll { it.Entry == " + reversalEntry.get() + " && it.Party == 1 }.size()",
+                                                         equalTo(1)));
 
         // postings onCreate (#6421): a booked Payment has no status lifecycle - its INSERT posts
         // the balanced Entry (async handler - poll), back-referenced through Entry.Payment.


### PR DESCRIPTION
Closes #6533.

## Problem

A `postings:` item cell could be a `rule(<column>)` reference or a Calc arithmetic expression over
the source document, but it could not copy a **source to-one FK** onto the generated line. So an
auto-posted journal line carried no counterparty dimension (Customer / Supplier), and the subledger
family of reports (balances by customer, by supplier) saw only manually entered lines.

## Change

An item cell whose **key is a to-one relation** of the items entity now copies the named source
relation's FK verbatim onto the line:

```yaml
items:
  - { Account: rule(receivableAccount), debit: "Net + Vat", Customer: Customer }  # copy source FK
  - { Counterparty: Supplier }                                                    # rename allowed
```

Recognized structurally, no new sigil: `rule()` first, then a **relation-keyed cell -> `source.<Prop>`**,
otherwise the existing Calc path. The distinction is the cell KEY being a to-one relation, so scalar
cells (`debit`, `credit`) are unaffected.

- **Generator** (`GlueIntentGenerator`): a relation-keyed item cell pre-renders as `source.<Prop>`.
  NOT negated under reversal, so a red-storno line carries the SAME dimension and nets the same
  counterparty's balance.
- **Validator** (`IntentParser`): the value must be a bare source relation name (not an expression);
  for a LOCAL source it must be a to-one relation of the source, to-one to the same entity as the
  item relation. A cross-model source is resolved at generation. A null source FK copies null (the
  line simply carries no dimension), never an error.
- **Semantics**: the raw FK id is copied (no re-resolution).

## Tests

- `GluePostingsTest`: asserts the relation-keyed cell pre-renders `source.Customer` (no Calc).
- `PostingsSourceFkCopyIntentTest` (new): valid copy + three rejection paths (expression value,
  unknown source relation, target-entity mismatch).
- `IntentEmissionCoverageIT` (the PR smoke gate): the `postings:` fixture gains a `Party` counterparty
  copied by `docPosting`; **emission** asserts `item.Party = source.Party;` on both the base and the
  storno handler; **runtime** asserts the posted debit line carries the copied FK (credit line none)
  and the red-storno line carries it unchanged.

Guide (`intent-assistant-guide.md`) updated with the grammar, example, and storno carry-through note.
