### PR TITLE
fix(security): enforce endpoint role guards on every authentication profile

### DIFF
--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/http/access/MethodSecurityConfig.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/http/access/MethodSecurityConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.http.access;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+
+/**
+ * Enables the JSR-250 method security the platform's endpoints rely on.
+ * <p>
+ * The URL rules in {@link HttpSecurityURIConfigurator} guard only a few path prefixes; every other
+ * endpoint under {@code /services/**} is merely authenticated there and carries its own
+ * {@code jakarta.annotation.security.RolesAllowed} annotation instead. Those annotations are
+ * enforced ONLY when JSR-250 method security is switched on, so this declaration must be
+ * unconditional: it previously lived on the basic-authentication configuration, which every
+ * single-sign-on profile ({@code keycloak}, {@code cognito}, {@code github}, {@code snowflake})
+ * disables via {@code basic.enabled=false} - silently turning every {@code @RolesAllowed} on the
+ * platform into a no-op and leaving administrative surfaces (SQL execution, data sources, users,
+ * tenants, configurations) open to any authenticated user.
+ * <p>
+ * Keep it here, unconditional and profile-independent, so a newly added authentication profile
+ * cannot reintroduce that gap. {@code prePostEnabled} / {@code securedEnabled} stay off: the
+ * platform authorizes exclusively with {@code @RolesAllowed}.
+ */
+@Configuration
+@EnableMethodSecurity(securedEnabled = false, jsr250Enabled = true, prePostEnabled = false)
+class MethodSecurityConfig {
+}

--- a/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/http/access/MethodSecurityConfigTest.java
+++ b/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/http/access/MethodSecurityConfigTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.http.access;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+
+/**
+ * Guards the platform-wide authorization invariant.
+ * <p>
+ * Most endpoints authorize with {@code @RolesAllowed}, which Spring enforces only when JSR-250
+ * method security is enabled. That switch used to live on the basic-authentication configuration,
+ * which every single-sign-on profile disables - so under Keycloak / Cognito / GitHub / Snowflake
+ * every {@code @RolesAllowed} silently became a no-op and administrative endpoints were open to any
+ * authenticated user. These tests fail if that shape ever returns.
+ */
+class MethodSecurityConfigTest {
+
+    @Test
+    void jsr250IsEnabledSoRolesAllowedIsEnforced() {
+        EnableMethodSecurity annotation = MethodSecurityConfig.class.getAnnotation(EnableMethodSecurity.class);
+
+        assertTrue(annotation != null, "MethodSecurityConfig must carry @EnableMethodSecurity");
+        assertTrue(annotation.jsr250Enabled(), "jsr250Enabled must be true - every @RolesAllowed on the platform depends on it");
+    }
+
+    @Test
+    void theConfigurationIsUnconditionalSoNoAuthenticationProfileCanDisableIt() {
+        assertNull(MethodSecurityConfig.class.getAnnotation(Profile.class),
+                "method security must not be bound to an authentication profile");
+        assertNull(MethodSecurityConfig.class.getAnnotation(ConditionalOnProperty.class),
+                "method security must not be conditional - a disabled condition silently unguards every @RolesAllowed endpoint");
+    }
+
+    /**
+     * A second declaration would reintroduce the gap from the other side: Spring reads the switches
+     * from the annotated class, so an authentication configuration carrying its own (attribute-less,
+     * hence JSR-250-less) {@code @EnableMethodSecurity} is exactly how the defect shipped.
+     *
+     * @throws IOException when the source tree cannot be read
+     */
+    @Test
+    void methodSecurityIsDeclaredExactlyOnceInTheSourceTree() throws IOException {
+        Path sourceRoot = repositoryRoot();
+        if (sourceRoot == null) {
+            return; // not running from a source checkout - nothing to scan
+        }
+        List<Path> declarations = new ArrayList<>();
+        for (String module : new String[] {"components", "modules", "build"}) {
+            Path moduleRoot = sourceRoot.resolve(module);
+            if (!Files.isDirectory(moduleRoot)) {
+                continue;
+            }
+            try (Stream<Path> files = Files.walk(moduleRoot)) {
+                files.filter(Files::isRegularFile)
+                     .filter(path -> path.toString()
+                                         .endsWith(".java"))
+                     .filter(path -> !path.toString()
+                                          .contains("/target/"))
+                     .filter(path -> !path.toString()
+                                          .contains("/src/test/"))
+                     .filter(MethodSecurityConfigTest::declaresMethodSecurity)
+                     .forEach(declarations::add);
+            }
+        }
+        assertEquals(1, declarations.size(),
+                "@EnableMethodSecurity must be declared exactly once (in MethodSecurityConfig); found: " + declarations);
+    }
+
+    private static boolean declaresMethodSecurity(Path path) {
+        try {
+            return Files.readString(path, StandardCharsets.UTF_8)
+                        .contains("@EnableMethodSecurity");
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /** The checkout root, located by walking up from the module directory; null when not found. */
+    private static Path repositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                           .toAbsolutePath();
+        while (current != null) {
+            if (Files.isDirectory(current.resolve("components")) && Files.isRegularFile(current.resolve("pom.xml"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        return null;
+    }
+}

--- a/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/http/access/MethodSecurityConfigTest.java
+++ b/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/http/access/MethodSecurityConfigTest.java
@@ -76,10 +76,14 @@ class MethodSecurityConfigTest {
                 files.filter(Files::isRegularFile)
                      .filter(path -> path.toString()
                                          .endsWith(".java"))
-                     .filter(path -> !path.toString()
-                                          .contains("/target/"))
-                     .filter(path -> !path.toString()
-                                          .contains("/src/test/"))
+                     // Normalize separators before matching: on Windows path.toString() uses '\', so a
+                     // hardcoded "/target/" / "/src/test/" never matched and the scan counted the test's
+                     // OWN source (which carries the @EnableMethodSecurity token) - 2 found, not 1.
+                     .filter(path -> {
+                         String normalized = path.toString()
+                                                 .replace('\\', '/');
+                         return !normalized.contains("/target/") && !normalized.contains("/src/test/");
+                     })
                      .filter(MethodSecurityConfigTest::declaresMethodSecurity)
                      .forEach(declarations::add);
             }

--- a/components/core/core-extensions/src/main/java/org/eclipse/dirigible/components/extensions/endpoint/ExtensionEndpoint.java
+++ b/components/core/core-extensions/src/main/java/org/eclipse/dirigible/components/extensions/endpoint/ExtensionEndpoint.java
@@ -26,12 +26,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.annotation.security.RolesAllowed;
 
 /**
  * The Class ExtensionEndpoint.
  */
 @RestController
 @RequestMapping(BaseEndpoint.PREFIX_ENDPOINT_CORE + "extensions")
+@RolesAllowed({"ADMINISTRATOR", "DEVELOPER", "OPERATOR"})
 public class ExtensionEndpoint extends BaseEndpoint {
 
     /** The extension service. */

--- a/components/core/core-extensions/src/main/java/org/eclipse/dirigible/components/extensions/endpoint/ExtensionPointEndpoint.java
+++ b/components/core/core-extensions/src/main/java/org/eclipse/dirigible/components/extensions/endpoint/ExtensionPointEndpoint.java
@@ -27,12 +27,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.annotation.security.RolesAllowed;
 
 /**
  * The Class ExtensionPointEndpoint.
  */
 @RestController
 @RequestMapping(BaseEndpoint.PREFIX_ENDPOINT_CORE + "extensionpoints")
+@RolesAllowed({"ADMINISTRATOR", "DEVELOPER", "OPERATOR"})
 public class ExtensionPointEndpoint extends BaseEndpoint {
 
     /** The extension point service. */

--- a/components/core/core-extensions/src/test/java/org/eclipse/dirigible/components/extensions/endpoint/ExtensionPointEndpointTest.java
+++ b/components/core/core-extensions/src/test/java/org/eclipse/dirigible/components/extensions/endpoint/ExtensionPointEndpointTest.java
@@ -45,7 +45,7 @@ import jakarta.persistence.EntityManager;
 /**
  * The Class ExtensionPointEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"DEVELOPER"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/components/core/core-registry/src/test/java/org/eclipse/dirigible/components/registry/endpoint/RegistryEndpointTest.java
+++ b/components/core/core-registry/src/test/java/org/eclipse/dirigible/components/registry/endpoint/RegistryEndpointTest.java
@@ -33,7 +33,7 @@ import org.springframework.web.context.WebApplicationContext;
 /**
  * The Class RegistryEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"ADMINISTRATOR"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/security/BasicSecurityConfig.java
+++ b/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/security/BasicSecurityConfig.java
@@ -19,7 +19,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.Customizer;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -33,7 +32,6 @@ import org.springframework.web.cors.CorsConfigurationSource;
 @Configuration
 @EnableWebSecurity
 @ConditionalOnProperty(name = "basic.enabled", havingValue = "true")
-@EnableMethodSecurity(securedEnabled = false, jsr250Enabled = true, prePostEnabled = false)
 public class BasicSecurityConfig {
 
     /**

--- a/components/core/core-tracing/src/test/java/org/eclipse/dirigible/components/tracing/TaskStateEndpointTest.java
+++ b/components/core/core-tracing/src/test/java/org/eclipse/dirigible/components/tracing/TaskStateEndpointTest.java
@@ -45,7 +45,7 @@ import jakarta.persistence.EntityManager;
 /**
  * The Class TaskStateEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"ADMINISTRATOR"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/components/data/data-export/src/test/java/org/eclipse/dirigible/components/data/export/endpoint/DataAsyncExportEndpointTest.java
+++ b/components/data/data-export/src/test/java/org/eclipse/dirigible/components/data/export/endpoint/DataAsyncExportEndpointTest.java
@@ -44,7 +44,7 @@ import org.springframework.web.context.WebApplicationContext;
 /**
  * The Class DataExportEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"ADMINISTRATOR"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/components/data/data-export/src/test/java/org/eclipse/dirigible/components/data/export/endpoint/DataExportEndpointTest.java
+++ b/components/data/data-export/src/test/java/org/eclipse/dirigible/components/data/export/endpoint/DataExportEndpointTest.java
@@ -42,7 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * The Class DataExportEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"ADMINISTRATOR"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/components/data/data-management/src/test/java/org/eclipse/dirigible/components/data/management/endpoint/DatabaseMetadataEndpointTest.java
+++ b/components/data/data-management/src/test/java/org/eclipse/dirigible/components/data/management/endpoint/DatabaseMetadataEndpointTest.java
@@ -37,7 +37,7 @@ import java.util.Base64;
 /**
  * The Class DatabaseMetadataEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"ADMINISTRATOR"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/components/data/data-sources/src/test/java/org/eclipse/dirigible/components/data/sources/endpoint/DataSourceEndpointTest.java
+++ b/components/data/data-sources/src/test/java/org/eclipse/dirigible/components/data/sources/endpoint/DataSourceEndpointTest.java
@@ -45,7 +45,7 @@ import org.springframework.web.context.WebApplicationContext;
 /**
  * The Class DataSourceEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"ADMINISTRATOR"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/endpoint/BpmInboxEndpoint.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/endpoint/BpmInboxEndpoint.java
@@ -106,6 +106,10 @@ public class BpmInboxEndpoint extends BaseEndpoint {
 
     @GetMapping(value = "/tasks/{taskId}/variables")
     public ResponseEntity<?> getTaskVariables(@PathVariable("taskId") String taskId) {
+        // A task's variables carry its business payload (the record id and the locators a task form
+        // resolves), so reading them is gated exactly like acting on the task - the inbox is scoped
+        // to the tasks the caller is assigned to or a candidate for, never addressable by bare id.
+        verifyCurrentUserHasPermissionForTask(taskId);
         try {
             Map<String, Object> variables = bpmService.getTaskVariables(taskId);
             TaskVariablesDTO taskVariables = new TaskVariablesDTO(variables);

--- a/components/engine/engine-cms/src/main/java/org/eclipse/dirigible/components/engine/cms/endpoint/CmsEndpoint.java
+++ b/components/engine/engine-cms/src/main/java/org/eclipse/dirigible/components/engine/cms/endpoint/CmsEndpoint.java
@@ -18,6 +18,7 @@ import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.commons.config.ResourcesCache;
 import org.eclipse.dirigible.commons.config.ResourcesCache.Cache;
 import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
+import org.eclipse.dirigible.components.base.http.roles.Roles;
 import org.eclipse.dirigible.components.engine.cms.CmisDocument;
 import org.eclipse.dirigible.components.engine.cms.CmisObject;
 import org.eclipse.dirigible.components.engine.cms.CmisSessionFactory;
@@ -40,9 +41,13 @@ import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * The Class CmsEndpoint.
+ * <p>
+ * Secured path only. The CMS holds tenant BUSINESS content - record attachments, generated document
+ * snapshots and the database export dumps - so it must never be served from the unauthenticated
+ * {@code /public/**} space, where a known or guessable path is readable with no credentials at all.
  */
 @RestController
-@RequestMapping({BaseEndpoint.PREFIX_ENDPOINT_SECURED + "cms", BaseEndpoint.PREFIX_ENDPOINT_PUBLIC + "cms"})
+@RequestMapping(BaseEndpoint.PREFIX_ENDPOINT_SECURED + "cms")
 public class CmsEndpoint extends BaseEndpoint {
 
     /** The Constant logger. */
@@ -50,6 +55,12 @@ public class CmsEndpoint extends BaseEndpoint {
 
     /** The Constant INDEX_HTML. */
     private static final String INDEX_HTML = "index.html";
+
+    /**
+     * The CMS folder the asynchronous database export writes its dumps into. Mirrors
+     * {@code DataAsyncExportService.EXPORTS_FOLDER_NAME}, which this module cannot depend on.
+     */
+    private static final String EXPORTS_FOLDER_NAME = "__EXPORTS";
 
     /** The cms service. */
     private final CmsService cmsService;
@@ -83,8 +94,10 @@ public class CmsEndpoint extends BaseEndpoint {
         if (path.trim()
                 .isEmpty()) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Listing of web folders is forbidden.");
-        } else if (path.trim()
-                       .endsWith("/")) {
+        }
+        assertExportsAccess(path);
+        if (path.trim()
+                .endsWith("/")) {
             return getDocumentByPath(path + INDEX_HTML);
         }
         ResponseEntity resourceResponse = getDocumentByPath(path);
@@ -93,6 +106,28 @@ public class CmsEndpoint extends BaseEndpoint {
                             .add("X-Frame-Options", "Deny");
         }
         return resourceResponse;
+    }
+
+    /**
+     * A database export dump is readable only by the roles entitled to produce one. Attachments and
+     * document snapshots stay readable by any authenticated user - the applications that own them
+     * govern their own access - but a full schema dump is an administrative artefact and must not be
+     * reachable just because its file name is known.
+     *
+     * @param path the requested CMS path
+     */
+    private void assertExportsAccess(String path) {
+        String normalized = path.trim();
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        if (!normalized.equals(EXPORTS_FOLDER_NAME) && !normalized.startsWith(EXPORTS_FOLDER_NAME + "/")) {
+            return; // the folder itself or anything under it - not merely a name starting with it
+        }
+        if (!request.isUserInRole(Roles.ADMINISTRATOR.getRoleName()) && !request.isUserInRole(Roles.OPERATOR.getRoleName())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access to the database exports requires the "
+                    + Roles.ADMINISTRATOR.getRoleName() + " or " + Roles.OPERATOR.getRoleName() + " role.");
+        }
     }
 
     /**

--- a/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/endpoint/JobEndpointTest.java
+++ b/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/endpoint/JobEndpointTest.java
@@ -49,7 +49,7 @@ import org.springframework.web.context.WebApplicationContext;
 /**
  * The Class JobEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"ADMINISTRATOR"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/endpoint/ListenerEndpointTest.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/endpoint/ListenerEndpointTest.java
@@ -41,7 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * The Class ListenerEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"ADMINISTRATOR"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/components/engine/engine-openapi/src/test/java/org/eclipse/dirigible/components/openapi/endpoint/OpenAPIEndpointTest.java
+++ b/components/engine/engine-openapi/src/test/java/org/eclipse/dirigible/components/openapi/endpoint/OpenAPIEndpointTest.java
@@ -45,7 +45,7 @@ import org.springframework.web.context.WebApplicationContext;
 /**
  * The Class OpenAPIEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"ADMINISTRATOR"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {OpenAPIRepository.class, RepositoryConfig.class})
 @AutoConfigureMockMvc

--- a/components/engine/engine-security/src/test/java/org/eclipse/dirigible/components/security/endpoint/AccessEndpointTest.java
+++ b/components/engine/engine-security/src/test/java/org/eclipse/dirigible/components/security/endpoint/AccessEndpointTest.java
@@ -38,7 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * The Class AccessEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"ADMINISTRATOR"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {AccessRepository.class})
 @AutoConfigureMockMvc

--- a/components/engine/engine-security/src/test/java/org/eclipse/dirigible/components/security/endpoint/RoleEndpointTest.java
+++ b/components/engine/engine-security/src/test/java/org/eclipse/dirigible/components/security/endpoint/RoleEndpointTest.java
@@ -37,7 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * The Class RoleEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"ADMINISTRATOR"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {RoleRepository.class})
 @AutoConfigureMockMvc

--- a/components/engine/engine-web/src/main/java/org/eclipse/dirigible/components/engine/web/endpoint/ExposeEndpoint.java
+++ b/components/engine/engine-web/src/main/java/org/eclipse/dirigible/components/engine/web/endpoint/ExposeEndpoint.java
@@ -22,11 +22,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.annotation.security.RolesAllowed;
+
 /**
  * The Class ExposeEndpoint.
  */
 @RestController
 @RequestMapping(BaseEndpoint.PREFIX_ENDPOINT_SECURED + "exposes")
+@RolesAllowed({"ADMINISTRATOR", "DEVELOPER", "OPERATOR"})
 public class ExposeEndpoint extends BaseEndpoint {
 
     /**

--- a/components/ide/ide-problems/src/test/java/org/eclipse/dirigible/components/ide/problems/endpoint/ProblemsEndpointTest.java
+++ b/components/ide/ide-problems/src/test/java/org/eclipse/dirigible/components/ide/problems/endpoint/ProblemsEndpointTest.java
@@ -35,7 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * The Class ProblemsEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"ADMINISTRATOR"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/components/ide/ide-workspace/src/test/java/org/eclipse/dirigible/components/ide/workspace/endpoint/WorkspaceEndpointTest.java
+++ b/components/ide/ide-workspace/src/test/java/org/eclipse/dirigible/components/ide/workspace/endpoint/WorkspaceEndpointTest.java
@@ -47,7 +47,7 @@ import org.springframework.web.context.WebApplicationContext;
 /**
  * The Class WorkspaceEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"ADMINISTRATOR"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)

--- a/components/ide/ide-workspace/src/test/java/org/eclipse/dirigible/components/ide/workspace/endpoint/WorkspaceFindEndpointTest.java
+++ b/components/ide/ide-workspace/src/test/java/org/eclipse/dirigible/components/ide/workspace/endpoint/WorkspaceFindEndpointTest.java
@@ -36,7 +36,7 @@ import org.springframework.web.context.WebApplicationContext;
 /**
  * The Class WorkspaceFindEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"ADMINISTRATOR"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)

--- a/components/ide/ide-workspace/src/test/java/org/eclipse/dirigible/components/ide/workspace/endpoint/WorkspaceSearchEndpointTest.java
+++ b/components/ide/ide-workspace/src/test/java/org/eclipse/dirigible/components/ide/workspace/endpoint/WorkspaceSearchEndpointTest.java
@@ -36,7 +36,7 @@ import org.springframework.web.context.WebApplicationContext;
 /**
  * The Class WorkspaceSearchEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"ADMINISTRATOR"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)

--- a/components/ide/ide-workspace/src/test/java/org/eclipse/dirigible/components/ide/workspace/endpoint/WorkspacesEndpointTest.java
+++ b/components/ide/ide-workspace/src/test/java/org/eclipse/dirigible/components/ide/workspace/endpoint/WorkspacesEndpointTest.java
@@ -43,7 +43,7 @@ import org.springframework.web.context.WebApplicationContext;
 /**
  * The Class WorkspacesEndpointTest.
  */
-@WithMockUser
+@WithMockUser(roles = {"ADMINISTRATOR"})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)

--- a/components/resources/platform-core/src/main/resources/META-INF/dirigible/platform-core/ui/platform/shell.js
+++ b/components/resources/platform-core/src/main/resources/META-INF/dirigible/platform-core/ui/platform/shell.js
@@ -99,7 +99,7 @@ if (window !== top) {
           const dialogHub = new DialogHub();
           const exportsHub = new ExportsHub();
           const DB_EXPORT_SERVICE_URL = "/services/data/export-async/";
-          scope.EXPORT_BASE_URL = "/public/cms/__EXPORTS/";
+          scope.EXPORT_BASE_URL = "/services/cms/__EXPORTS/";
           scope.ExportStatus = {
             TRIGGRED: "TRIGGRED",
             FINISHED: "FINISHED",

--- a/components/security/security-keycloak/src/main/java/org/eclipse/dirigible/components/security/keycloak/KeycloakSecurityConfiguration.java
+++ b/components/security/security-keycloak/src/main/java/org/eclipse/dirigible/components/security/keycloak/KeycloakSecurityConfiguration.java
@@ -28,7 +28,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.Customizer;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -50,7 +49,6 @@ import org.springframework.security.web.access.intercept.AuthorizationFilter;
 @Profile("keycloak")
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity
 public class KeycloakSecurityConfiguration {
 
     /** The Constant LOGGER. */

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/EndpointAuthorizationIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/EndpointAuthorizationIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.not;
+
+import org.eclipse.dirigible.components.base.http.roles.Roles;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.eclipse.dirigible.tests.framework.security.SecurityUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * End-to-end proof that the {@code @RolesAllowed} annotations guarding the platform's endpoints are
+ * actually ENFORCED, not merely present.
+ * <p>
+ * Only a few path prefixes carry role rules in the central URL configuration; every other endpoint
+ * under {@code /services/**} is authenticated there and relies on its own {@code @RolesAllowed},
+ * which Spring honours only while JSR-250 method security is switched on. When that switch was
+ * bound to the basic-authentication configuration, every single-sign-on profile turned it off and
+ * the annotations silently stopped guarding anything - the administrative surfaces below were open
+ * to any authenticated user, with no error anywhere. This test locks the enforcement in place.
+ */
+class EndpointAuthorizationIT extends IntegrationTest {
+
+    private static final String PLAIN_USER = "endpoint-authz-it-user";
+    private static final String ADMIN_USER = "endpoint-authz-it-admin";
+    private static final String PASSWORD = "endpoint-authz-it-password";
+
+    /** Administrative surfaces that must never answer a role-less but authenticated caller. */
+    private static final String[] PRIVILEGED_ENDPOINTS = { //
+            "/services/data/metadata/", // database metadata (the Database perspective)
+            "/services/data/sources", // data source definitions - carry credentials
+            "/services/core/configurations", // configuration values
+            "/services/security/tenants", // tenant administration
+            "/services/core/extensions"}; // extension inventory
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @Autowired
+    private SecurityUtil securityUtil;
+
+    @Test
+    void privileged_endpoints_reject_an_authenticated_user_without_a_platform_role() {
+        securityUtil.createUserInDefaultTenant(PLAIN_USER, PASSWORD);
+
+        for (String endpoint : PRIVILEGED_ENDPOINTS) {
+            restAssuredExecutor.execute(() -> given().when()
+                                                     .get(endpoint)
+                                                     .then()
+                                                     .statusCode(403),
+                    PLAIN_USER, PASSWORD);
+        }
+    }
+
+    @Test
+    void privileged_endpoints_admit_an_administrator() {
+        securityUtil.createUserInDefaultTenant(ADMIN_USER, PASSWORD, Roles.RoleNames.ADMINISTRATOR);
+
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get("/services/core/configurations")
+                                                 .then()
+                                                 .statusCode(200),
+                ADMIN_USER, PASSWORD);
+    }
+
+    /**
+     * The database export dumps live in the CMS. They were reachable anonymously through the public CMS
+     * mapping; now the CMS is served only from the secured path, and the exports folder inside it
+     * additionally requires the roles that may produce an export.
+     */
+    @Test
+    void database_exports_are_not_readable_without_an_administrative_role() {
+        securityUtil.createUserInDefaultTenant(PLAIN_USER, PASSWORD);
+
+        // the anonymous CMS mapping is gone entirely, so the path resolves to no handler at all
+        given().when()
+               .get("/public/cms/__EXPORTS/dump.zip")
+               .then()
+               .statusCode(404);
+
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get("/services/cms/__EXPORTS/dump.zip")
+                                                 .then()
+                                                 .statusCode(403),
+                PLAIN_USER, PASSWORD);
+
+        // ... and the roles that MAY read an export still get past the guard (the export download in
+        // the IDE shell must keep working - this request only fails later, on the missing document)
+        securityUtil.createUserInDefaultTenant(ADMIN_USER, PASSWORD, Roles.RoleNames.ADMINISTRATOR);
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get("/services/cms/__EXPORTS/dump.zip")
+                                                 .then()
+                                                 .statusCode(not(403)),
+                ADMIN_USER, PASSWORD);
+    }
+
+    /**
+     * A task's variables carry its business payload, so reading them is scoped to the caller's own
+     * inbox exactly like acting on the task - a bare task id must not address them.
+     */
+    @Test
+    void task_variables_are_not_readable_for_a_foreign_task() {
+        securityUtil.createUserInDefaultTenant(PLAIN_USER, PASSWORD);
+
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get("/services/inbox/tasks/1234567890/variables")
+                                                 .then()
+                                                 .statusCode(403),
+                PLAIN_USER, PASSWORD);
+    }
+}


### PR DESCRIPTION
## Problem

`HttpSecurityURIConfigurator` carries role rules for only a few path prefixes - DEVELOPER for `/services/ide/**` and `/services/bpm/**`, OPERATOR for `/actuator`/`/spring-admin`, DEVELOPER|ADMINISTRATOR|OPERATOR for `/services/native-apps/**`. **Every other endpoint under `/services/**` is merely `.authenticated()` there** and relies on its own `@RolesAllowed`, which Spring enforces only while JSR-250 method security is switched on.

That switch lived on `BasicSecurityConfig`, which is `@ConditionalOnProperty(name = "basic.enabled", havingValue = "true")`. Every single-sign-on profile ships `basic.enabled=false` (`application-keycloak/cognito/snowflake.properties`, `application-github.properties`), so the configuration never loaded. What remained: `KeycloakSecurityConfiguration` had a bare `@EnableMethodSecurity` (**`jsr250Enabled` defaults to `false`**), and the cognito / oauth2 / snowflake configurations had none at all.

Consequence under any SSO deployment: every `@RolesAllowed` on the platform was a silent no-op, leaving only the URL rules - so any authenticated user could reach `/services/data/**` (SQL execution, data source definitions, import/export) and `/services/core/**` + `/services/security/**` (configurations, users, tenants, roles/access, repository, registry). Nothing failed loudly; the annotations read as protection.

Three narrower gaps found in the same sweep of all 73 endpoint classes:

- `GET /services/inbox/tasks/{taskId}/variables` had no permission check, while `POST /services/inbox/tasks/{id}` did - so any authenticated user could read any task's variables (its business payload and the entity locators a generated task form resolves) by bare id.
- `CmsEndpoint` mapped both `/services/cms` **and** `/public/cms`, and `/public/**` is `permitAll` - so tenant business content (record attachments, generated document snapshots) and, notably, the asynchronous **database export dumps** under `__EXPORTS` were readable with no credentials; the IDE shell downloaded them from `/public/cms/__EXPORTS/`.
- The extension inventory (`/services/core/extensions`, `/services/core/extensionpoints`) and `/services/exposes` had no guard, though their only consumer is the IDE.

## Fix

- **`MethodSecurityConfig`** (new, `core-base` `http/access/`) declares `@EnableMethodSecurity(securedEnabled = false, jsr250Enabled = true, prePostEnabled = false)` **unconditionally**, and the declaration is removed from `BasicSecurityConfig` and `KeycloakSecurityConfiguration` so exactly one exists. `prePost`/`secured` stay off - the platform authorizes exclusively with `@RolesAllowed` (no `@PreAuthorize`/`@Secured` exists in the tree).
- **`BpmInboxEndpoint`**: `verifyCurrentUserHasPermissionForTask` on the variables read. The generated task form calls it as the task's assignee/candidate, so the legitimate flow is unchanged. (`GET /instance/{id}/tasks` was checked and needed nothing - `prepareQuery(type)` already scopes it to the caller.)
- **`CmsEndpoint`**: the `/public/cms` mapping is removed, and the `__EXPORTS` folder requires ADMINISTRATOR/OPERATOR - the roles that may produce an export. `platform-core` `shell.js` downloads from `/services/cms/__EXPORTS/`. The rest of the CMS stays readable by any authenticated user, since applications legitimately serve their own attachments from it.
- **`ExtensionEndpoint` / `ExtensionPointEndpoint` / `ExposeEndpoint`**: `@RolesAllowed({"ADMINISTRATOR", "DEVELOPER", "OPERATOR"})`.

## Verification

- **`MethodSecurityConfigTest`** (unit, core-base) asserts JSR-250 is enabled, the configuration is unconditional (no `@Profile` / `@ConditionalOnProperty`), and `@EnableMethodSecurity` is declared **exactly once in the source tree**. This is the test that catches the regression: the integration tests run under the basic profile, where the annotations always worked, so no IT could have caught the original defect.
- **`EndpointAuthorizationIT`** (4 tests) - a role-less authenticated user gets 403 on `/services/data/metadata/`, `/services/data/sources`, `/services/core/configurations`, `/services/security/tenants` and `/services/core/extensions`; an ADMINISTRATOR gets 200; the anonymous CMS path is gone (404) while `__EXPORTS` is 403 for a plain user and still reachable for an ADMINISTRATOR (so the IDE export download keeps working); a foreign task's variables are 403.
- `mvn formatter:validate` clean; `-P release` javadoc clean; unit tests green on every touched module (`ExtensionPointEndpointTest` now uses `@WithMockUser(roles = {"DEVELOPER"})` since its endpoint is guarded); `IntentEmissionCoverageIT` re-run green as the targeted regression for the inbox / task-form flow.

## Note for maintainers

The first item changes authorization behaviour for existing SSO deployments: endpoints that were reachable by any authenticated user now require ADMINISTRATOR / DEVELOPER / OPERATOR as their annotations always intended. Deployments that unknowingly relied on the missing enforcement will see 403s until the corresponding roles are assigned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
