### PR TITLE
feat(intent): conditional posting rule column - rule(by:, cases:, default:)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -30,6 +30,7 @@ import org.eclipse.dirigible.components.intent.model.InboundIntent;
 import org.eclipse.dirigible.components.intent.model.IntegrationIntent;
 import org.eclipse.dirigible.components.intent.model.IntentModel;
 import org.eclipse.dirigible.components.intent.model.NotificationIntent;
+import org.eclipse.dirigible.components.intent.model.PostingRuleSelector;
 import org.eclipse.dirigible.components.intent.model.ProcessIntent;
 import org.eclipse.dirigible.components.intent.model.RelationIntent;
 import org.eclipse.dirigible.components.intent.model.ExpansionIntent;
@@ -1324,6 +1325,11 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                                                                       .get("entity") != null;
             e.put("hasRule", hasRule);
             java.util.Set<String> usedRuleColumns = new java.util.LinkedHashSet<>();
+            // Conditional rule(by:...) cells (#6534): the selected column is a RUNTIME choice, so it
+            // cannot join the static usedRuleColumns null-skip (that would skip whenever ANY case column
+            // is null). Each collected expression is instead null-checked as a whole after the rule row
+            // is resolved - an unmatched/undetermined account skips the posting fail-soft.
+            List<String> conditionalRuleGuards = new ArrayList<>();
             if (hasRule) {
                 String ruleEntityName = String.valueOf(effective.getRule()
                                                                 .get("entity"));
@@ -1370,11 +1376,19 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                         }
                         continue;
                     }
-                    java.util.regex.Matcher ruleRef = java.util.regex.Pattern.compile("rule\\((\\w+)\\)")
-                                                                             .matcher(value);
                     Map<String, Object> assign = new LinkedHashMap<>();
                     assign.put("targetProp", IntentNaming.pascalCase(cell.getKey()));
-                    if (ruleRef.matches()) {
+                    java.util.Optional<PostingRuleSelector> ruleSelector = PostingRuleSelector.parse(value);
+                    java.util.regex.Matcher ruleRef = java.util.regex.Pattern.compile("rule\\((\\w+)\\)")
+                                                                             .matcher(value);
+                    if (ruleSelector.isPresent()) {
+                        // Conditional rule column (#6534): a null-safe classifier ternary that reads the
+                        // rule row's column chosen by the source's `by` value. Not a static usedRuleColumn
+                        // (the choice is per-row at runtime); its resolved value is null-guarded below.
+                        String ternary = conditionalRuleExpression(ruleSelector.get());
+                        conditionalRuleGuards.add(ternary);
+                        assign.put("expr", ternary);
+                    } else if (ruleRef.matches()) {
                         String column = IntentNaming.pascalCase(ruleRef.group(1));
                         usedRuleColumns.add(column);
                         assign.put("expr", "ruleRow." + column);
@@ -1402,6 +1416,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             }
             e.put("itemRows", itemRows);
             e.put("usedRuleColumns", new ArrayList<>(usedRuleColumns));
+            e.put("conditionalRuleGuards", conditionalRuleGuards);
             out.add(e);
         }
         return out;
@@ -1448,6 +1463,29 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
      * A posting header assignment: a bare source property name copies it; a value containing
      * {@code {prop}} placeholders becomes a Java string concatenation; anything else is a literal.
      */
+    /**
+     * The Java expression for a conditional {@code rule(by: ..., cases: ..., default: ...)} account
+     * reference (#6534): a null-safe classifier ternary that reads the resolved {@code ruleRow}'s
+     * column chosen by the source's {@code by} value. The classifier is read through the SDK
+     * {@code Calc} evaluator (null-safe, the same reader the {@code when} guard uses), each case key
+     * compared as a {@code BigDecimal}; an unmatched value falls to the {@code default} column, or to
+     * {@code null} (which the generated handler null-guards → the posting skips to the unposted
+     * worklist).
+     */
+    private static String conditionalRuleExpression(PostingRuleSelector selector) {
+        String classifier = IntentNaming.pascalCase(selector.by());
+        String expr = selector.defaultColumn() != null ? "ruleRow." + IntentNaming.pascalCase(selector.defaultColumn()) : "null";
+        List<Map.Entry<String, String>> entries = new ArrayList<>(selector.cases()
+                                                                          .entrySet());
+        for (int i = entries.size() - 1; i >= 0; i--) {
+            Map.Entry<String, String> caseEntry = entries.get(i);
+            String condition =
+                    "Calc.eval(\"" + classifier + "\", source, 6).compareTo(new java.math.BigDecimal(\"" + caseEntry.getKey() + "\")) == 0";
+            expr = condition + " ? ruleRow." + IntentNaming.pascalCase(caseEntry.getValue()) + " : " + expr;
+        }
+        return "(" + expr + ")";
+    }
+
     private static Map<String, Object> postingAssignment(String targetProperty, String value) {
         Map<String, Object> a = new LinkedHashMap<>();
         a.put("targetProp", IntentNaming.pascalCase(targetProperty));

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/PostingRuleSelector.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/PostingRuleSelector.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.model;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The conditional form of a posting item's {@code rule(...)} account reference: the rule-row column
+ * is chosen at runtime by a classifier field of the source, e.g.
+ *
+ * <pre>
+ * account: "rule(by: PaymentMethod, cases: { 1: BankAccount, 2: CashAccount }, default: SuspenseAccount)"
+ * </pre>
+ *
+ * reads the resolved rule row's {@code BankAccount} column when the source's {@code PaymentMethod}
+ * classifier is {@code 1}, {@code CashAccount} when {@code 2}, else {@code SuspenseAccount} (or,
+ * with no {@code default}, nothing - which skips the posting to the unposted worklist). It mirrors
+ * the classifier-with-cases shape the conditional {@code dependsOn} {@code valueFrom} already uses
+ * ({@code by} / {@code cases} / {@code default}) and extends the plain {@code rule(<column>)} idiom
+ * without changing the string-valued item-cell shape - so a single item row replaces the
+ * {@code when:}-gated row pair that used to be the only way to vary the account column by a source
+ * value.
+ *
+ * @param by the classifier: a field or to-one relation name of the source (read null-safe as a
+ *        number)
+ * @param cases the classifier value (a seed id / number, as authored) to rule-row column mapping,
+ *        in authoring order
+ * @param defaultColumn the rule-row column used when no case matches, or {@code null} for none
+ */
+public record PostingRuleSelector(String by, Map<String, String> cases, String defaultColumn) {
+
+    /**
+     * Matches {@code rule(by: <field>, cases: { <k>: <col>, ... }, default: <col> )} with an optional
+     * {@code default}. The cases body is captured raw (it never contains a nested brace) and split
+     * downstream. The whole value must be this form - a plain {@code rule(<column>)} does not match.
+     */
+    private static final Pattern PATTERN = Pattern.compile(
+            "\\s*rule\\(\\s*by:\\s*(\\w+)\\s*,\\s*cases:\\s*\\{\\s*([^}]*?)\\s*\\}\\s*(?:,\\s*default:\\s*(\\w+)\\s*)?\\)\\s*");
+
+    /**
+     * Parse the conditional {@code rule(by: ..., cases: ..., default: ...)} form.
+     *
+     * @param value the authored item-cell value (typically a quoted scalar, since it carries colons and
+     *        braces)
+     * @return the parsed selector, or {@link Optional#empty()} when {@code value} is not the
+     *         conditional form (a plain {@code rule(<column>)}, an expression, or a source-relation
+     *         copy)
+     */
+    public static Optional<PostingRuleSelector> parse(String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        Matcher matcher = PATTERN.matcher(value);
+        if (!matcher.matches()) {
+            return Optional.empty();
+        }
+        Map<String, String> cases = new LinkedHashMap<>();
+        for (String part : matcher.group(2)
+                                  .split(",")) {
+            if (part.isBlank()) {
+                continue;
+            }
+            int colon = part.indexOf(':');
+            if (colon < 0) {
+                // A malformed case (no `key: column`) - keep the raw fragment as a key with an empty
+                // column so the parser can report it precisely rather than silently dropping it.
+                cases.put(part.trim(), "");
+                continue;
+            }
+            cases.put(part.substring(0, colon)
+                          .trim(),
+                    part.substring(colon + 1)
+                        .trim());
+        }
+        return Optional.of(new PostingRuleSelector(matcher.group(1), cases, matcher.group(3)));
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/PostingRuleSelector.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/PostingRuleSelector.java
@@ -42,11 +42,19 @@ public record PostingRuleSelector(String by, Map<String, String> cases, String d
 
     /**
      * Matches {@code rule(by: <field>, cases: { <k>: <col>, ... }, default: <col> )} with an optional
-     * {@code default}. The cases body is captured raw (it never contains a nested brace) and split
-     * downstream. The whole value must be this form - a plain {@code rule(<column>)} does not match.
+     * {@code default}. The cases body is captured raw (it never contains a nested brace) and split +
+     * trimmed downstream. The whole value must be this form - a plain {@code rule(<column>)} does not
+     * match.
+     * <p>
+     * The cases body is captured with a single greedy {@code [^}]*} - NOT {@code \s*([^}]*?)\s*} - on
+     * purpose: {@code \s} is a subset of {@code [^}]}, so wrapping the body in
+     * {@code \s*}...{@code \s*} makes the space runs ambiguous between three quantifiers and backtracks
+     * catastrophically on a crafted {@code cases:{ } with many spaces and no closing brace (a ReDoS -
+     * CodeQL flagged it). Edge whitespace is harmless here because every split fragment is trimmed in
+     * {@link #parse}.
      */
-    private static final Pattern PATTERN = Pattern.compile(
-            "\\s*rule\\(\\s*by:\\s*(\\w+)\\s*,\\s*cases:\\s*\\{\\s*([^}]*?)\\s*\\}\\s*(?:,\\s*default:\\s*(\\w+)\\s*)?\\)\\s*");
+    private static final Pattern PATTERN =
+            Pattern.compile("\\s*rule\\(\\s*by:\\s*(\\w+)\\s*,\\s*cases:\\s*\\{([^}]*)\\}\\s*(?:,\\s*default:\\s*(\\w+)\\s*)?\\)\\s*");
 
     /**
      * Parse the conditional {@code rule(by: ..., cases: ..., default: ...)} form.

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -37,6 +37,7 @@ import org.eclipse.dirigible.components.intent.model.IntentModel;
 import org.eclipse.dirigible.components.intent.model.LabelExpression;
 import org.eclipse.dirigible.components.intent.model.NotificationIntent;
 import org.eclipse.dirigible.components.intent.model.ProcessIntent;
+import org.eclipse.dirigible.components.intent.model.PostingRuleSelector;
 import org.eclipse.dirigible.components.intent.model.RelationIntent;
 import org.eclipse.dirigible.components.intent.model.SlotsIntent;
 import org.eclipse.dirigible.components.intent.model.ReportIntent;
@@ -2192,6 +2193,31 @@ public final class IntentParser {
         return false;
     }
 
+    /**
+     * Whether a posting {@code rule(<column>)} reference names a field or a relation of the rule entity
+     * (authored lower-camel matched case-insensitively against the PascalCase property).
+     */
+    private static boolean isRuleColumn(EntityIntent ruleEntity, String column) {
+        if (column == null || column.isBlank()) {
+            return false;
+        }
+        if (ruleEntity.getFields() != null) {
+            for (FieldIntent field : ruleEntity.getFields()) {
+                if (column.equalsIgnoreCase(field.getName())) {
+                    return true;
+                }
+            }
+        }
+        if (ruleEntity.getRelations() != null) {
+            for (RelationIntent relation : ruleEntity.getRelations()) {
+                if (column.equalsIgnoreCase(relation.getName())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     /** The entity's composition child (the first entity declaring a composition to-one back to it). */
     private static EntityIntent compositionChildOf(EntityIntent entity, java.util.Map<String, EntityIntent> byName) {
         for (EntityIntent candidate : byName.values()) {
@@ -3508,36 +3534,56 @@ public final class IntentParser {
                     if (!hasPropertyIgnoreCase(itemsEntity, key)) {
                         issues.add(subject + " item [" + key + "] is not a field or to-one relation of [" + itemsEntity.getName() + "]");
                     }
+                    // Conditional rule column (#6534): the rule-row column is chosen by a source
+                    // classifier - `rule(by: <field>, cases: { <id>: <column>, ... }, default: <column>? )`.
+                    // The by/cases selector already branches the account, so it replaces the when:-gated
+                    // row pair; a when: on the same row is redundant and rejected.
+                    java.util.Optional<PostingRuleSelector> selector = PostingRuleSelector.parse(value);
+                    if (selector.isPresent()) {
+                        PostingRuleSelector sel = selector.get();
+                        if (ruleEntity == null) {
+                            issues.add(subject + " item [" + key + "] references rule(by: ...) but the posting declares no rule");
+                        }
+                        if (row.containsKey("when")) {
+                            issues.add(subject + " item [" + key + "] combines a conditional rule(by: ...) with a when: guard"
+                                    + " - the by/cases selector already branches the account; drop the when:");
+                        }
+                        if (sel.cases()
+                               .isEmpty()) {
+                            issues.add(subject + " item [" + key + "] rule(by: ...) declares no cases");
+                        }
+                        // `by` reads the source at runtime (Calc, as a number); deep-check it only for a
+                        // LOCAL source - a cross-model source is resolved at generation time.
+                        if (postingSource != null && !hasPropertyIgnoreCase(postingSource, sel.by())) {
+                            issues.add(subject + " rule(by: " + sel.by() + ") is not a field or to-one relation of the source ["
+                                    + postingSource.getName() + "]");
+                        }
+                        for (java.util.Map.Entry<String, String> caseEntry : sel.cases()
+                                                                                .entrySet()) {
+                            if (!caseEntry.getKey()
+                                          .matches("-?\\d+(\\.\\d+)?")) {
+                                issues.add(subject + " rule(by: ...) case key [" + caseEntry.getKey()
+                                        + "] must be a number (the classifier's seed id)");
+                            }
+                            if (ruleEntity != null && !isRuleColumn(ruleEntity, caseEntry.getValue())) {
+                                issues.add(subject + " rule(by: ...) case column [" + caseEntry.getValue()
+                                        + "] is not a field or to-one relation of [" + ruleEntity.getName() + "]");
+                            }
+                        }
+                        if (sel.defaultColumn() != null && ruleEntity != null && !isRuleColumn(ruleEntity, sel.defaultColumn())) {
+                            issues.add(subject + " rule(by: ...) default column [" + sel.defaultColumn()
+                                    + "] is not a field or to-one relation of [" + ruleEntity.getName() + "]");
+                        }
+                        continue;
+                    }
                     java.util.regex.Matcher ruleRef = java.util.regex.Pattern.compile("\\s*rule\\((\\w+)\\)\\s*")
                                                                              .matcher(value);
                     if (ruleRef.matches()) {
                         if (ruleEntity == null) {
                             issues.add(subject + " item [" + key + "] references rule(...) but the posting declares no rule");
-                        } else {
-                            String column = ruleRef.group(1);
-                            // Authored lower-camel matches a PascalCase relation (rule(receivableAccount)
-                            // -> ReceivableAccount) - compare case-insensitively.
-                            boolean known = false;
-                            if (ruleEntity.getFields() != null) {
-                                for (FieldIntent f : ruleEntity.getFields()) {
-                                    if (column.equalsIgnoreCase(f.getName())) {
-                                        known = true;
-                                        break;
-                                    }
-                                }
-                            }
-                            if (!known && ruleEntity.getRelations() != null) {
-                                for (RelationIntent r : ruleEntity.getRelations()) {
-                                    if (column.equalsIgnoreCase(r.getName())) {
-                                        known = true;
-                                        break;
-                                    }
-                                }
-                            }
-                            if (!known) {
-                                issues.add(subject + " rule(" + column + ") is not a field or to-one relation of [" + ruleEntity.getName()
-                                        + "]");
-                            }
+                        } else if (!isRuleColumn(ruleEntity, ruleRef.group(1))) {
+                            issues.add(subject + " rule(" + ruleRef.group(1) + ") is not a field or to-one relation of ["
+                                    + ruleEntity.getName() + "]");
                         }
                     } else if (toOneRelationByName(itemsEntity, key) != null) {
                         // Source-FK copy (issue #6533): a to-one relation item cell copies a source

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -283,7 +283,19 @@ composition is opt-in.
   references, arithmetic over the SOURCE's fields, or - for a to-one relation cell - a bare SOURCE
   relation name whose FK is copied onto the line; a row `when` is `<SourceField> ==|!= <number>`.
   A missing rule row or null referenced column SKIPS the posting (the unposted worklist = final-status
-  documents with no back-referencing target), never throws. All writes go through the generated
+  documents with no back-referencing target), never throws.
+  **Conditional rule column** - when the account must be chosen by a source value (a payment posts to
+  the bank account for a transfer, the cash account for cash), a single row selects the rule column by
+  a classifier instead of duplicating the row per case (the `by`/`cases`/`default` shape the
+  conditional `dependsOn` `valueFrom` uses). Quote it - it carries colons and braces:
+  ```yaml
+    items:
+      - { Account: "rule(by: Method, cases: { 1: BankAccount, 2: CashAccount }, default: SuspenseAccount)", debit: "Amount" }
+  ```
+  `by` is a source field/relation (compared as a number, like `when`); `cases` keys are the classifier's
+  seed ids, values are columns of the rule entity; `default` (optional) is the fallback column. No match
+  and no default - or a null selected column - skips the posting to the unposted worklist. A conditional
+  cell already branches the account, so it cannot also carry a row `when`. All writes go through the generated
   repositories, so numbering/status-init/`checks:` fire on the created document.
   **Reversal mode (red storno):** a posting with `reverses: <sibling posting name>` undoes the
   sibling's document when the source is voided/cancelled - pair it with a `transitions:` void:

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GluePostingsTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GluePostingsTest.java
@@ -118,6 +118,79 @@ class GluePostingsTest {
     }
 
     /**
+     * Conditional rule column (#6534): {@code rule(by: Method, cases: {...}, default: ...)} pre-renders
+     * a null-safe classifier ternary over the rule row's columns - NOT static usedRuleColumns - and
+     * registers the whole expression as a null guard so an undetermined account skips the posting.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    void conditionalRuleColumnEmitsAClassifierTernaryAndAGuard() {
+        String yaml =
+                """
+                        name: ledger
+                        entities:
+                          - name: Account
+                            fields:
+                              - { name: id, type: integer, primaryKey: true, generated: true }
+                              - { name: number, type: string }
+                          - name: PaymentMethodType
+                            kind: setting
+                            fields:
+                              - { name: id, type: integer, primaryKey: true, generated: true }
+                              - { name: name, type: string }
+                          - name: PostingRule
+                            kind: setting
+                            fields:
+                              - { name: id, type: integer, primaryKey: true, generated: true }
+                              - { name: documentType, type: string }
+                            relations:
+                              - { name: BankAccount, kind: manyToOne, to: Account }
+                              - { name: CashAccount, kind: manyToOne, to: Account }
+                              - { name: SuspenseAccount, kind: manyToOne, to: Account }
+                          - name: Payment
+                            fields:
+                              - { name: id, type: integer, primaryKey: true, generated: true }
+                              - { name: amount, type: decimal, precision: 18, scale: 2 }
+                            relations:
+                              - { name: Method, kind: manyToOne, to: PaymentMethodType, required: true }
+                          - name: JournalEntry
+                            fields:
+                              - { name: id, type: integer, primaryKey: true, generated: true }
+                            relations:
+                              - { name: Payment, kind: manyToOne, to: Payment }
+                          - name: JournalEntryItem
+                            fields:
+                              - { name: id, type: integer, primaryKey: true, generated: true }
+                              - { name: debit, type: decimal, precision: 18, scale: 2 }
+                            relations:
+                              - { name: JournalEntry, kind: manyToOne, to: JournalEntry, composition: true, required: true }
+                              - { name: Account, kind: manyToOne, to: Account, required: true }
+                        postings:
+                          - name: paymentPosting
+                            event: { onCreate: Payment }
+                            creates: JournalEntry
+                            backReference: Payment
+                            rule: { entity: PostingRule, match: { documentType: "Payment" } }
+                            items:
+                              - { Account: "rule(by: Method, cases: { 1: BankAccount, 2: CashAccount }, default: SuspenseAccount)", debit: "Amount" }
+                        """;
+        Map<String, Object> p = GlueIntentGenerator.buildPostingsForTest(IntentParser.parse(yaml))
+                                                   .get(0);
+        String ternary = "(Calc.eval(\"Method\", source, 6).compareTo(new java.math.BigDecimal(\"1\")) == 0 ? ruleRow.BankAccount"
+                + " : Calc.eval(\"Method\", source, 6).compareTo(new java.math.BigDecimal(\"2\")) == 0 ? ruleRow.CashAccount"
+                + " : ruleRow.SuspenseAccount)";
+
+        List<Map<String, Object>> assigns = (List<Map<String, Object>>) ((List<Map<String, Object>>) p.get("itemRows")).get(0)
+                                                                                                                       .get("assigns");
+        assertTrue(assigns.stream()
+                          .anyMatch(a -> "Account".equals(a.get("targetProp")) && ternary.equals(a.get("expr"))),
+                "the Account cell must be the classifier ternary: " + assigns);
+        // the whole expression is a runtime null guard, NOT a static rule column
+        assertEquals(List.of(ternary), p.get("conditionalRuleGuards"));
+        assertEquals(List.of(), p.get("usedRuleColumns"));
+    }
+
+    /**
      * The onCreate trigger (#6421): a source with no status lifecycle - a booked payment - posts on its
      * INSERT. The glue flags the create event and carries no status guard.
      */

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/model/PostingRuleSelectorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/model/PostingRuleSelectorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+/** Parsing the conditional {@code rule(by:..., cases:..., default:...)} posting item-cell form. */
+class PostingRuleSelectorTest {
+
+    @Test
+    void parsesByCasesAndDefaultInAuthoringOrder() {
+        Optional<PostingRuleSelector> parsed =
+                PostingRuleSelector.parse("rule(by: PaymentMethod, cases: { 1: BankAccount, 2: CashAccount }, default: SuspenseAccount)");
+        assertTrue(parsed.isPresent());
+        PostingRuleSelector selector = parsed.get();
+        assertEquals("PaymentMethod", selector.by());
+        assertEquals("SuspenseAccount", selector.defaultColumn());
+        assertEquals(List.of("1", "2"), List.copyOf(selector.cases()
+                                                            .keySet()));
+        assertEquals("BankAccount", selector.cases()
+                                            .get("1"));
+        assertEquals("CashAccount", selector.cases()
+                                            .get("2"));
+    }
+
+    @Test
+    void defaultIsOptional() {
+        PostingRuleSelector selector = PostingRuleSelector.parse("rule(by: Method, cases: { 1: BankAccount })")
+                                                          .orElseThrow();
+        assertEquals(null, selector.defaultColumn());
+        assertEquals(1, selector.cases()
+                                .size());
+    }
+
+    @Test
+    void plainRuleAndExpressionsAreNotTheConditionalForm() {
+        assertFalse(PostingRuleSelector.parse("rule(receivableAccount)")
+                                       .isPresent());
+        assertFalse(PostingRuleSelector.parse("Net + Vat")
+                                       .isPresent());
+        assertFalse(PostingRuleSelector.parse(null)
+                                       .isPresent());
+    }
+}

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/model/PostingRuleSelectorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/model/PostingRuleSelectorTest.java
@@ -11,8 +11,10 @@ package org.eclipse.dirigible.components.intent.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
@@ -54,5 +56,17 @@ class PostingRuleSelectorTest {
                                        .isPresent());
         assertFalse(PostingRuleSelector.parse(null)
                                        .isPresent());
+    }
+
+    /**
+     * ReDoS guard (CodeQL): the cases-body match must be linear. The witness is a crafted prefix with a
+     * long run of spaces and no closing brace - the old {@code \s*([^}]*?)\s*\}} backtracked
+     * catastrophically on it; the current single greedy {@code [^}]*} returns effectively instantly.
+     */
+    @Test
+    void doesNotBacktrackCatastrophicallyOnAMaliciousCasesBody() {
+        String malicious = "rule(by:0,cases:{{" + " ".repeat(50_000);
+        assertTimeoutPreemptively(Duration.ofSeconds(2), () -> assertFalse(PostingRuleSelector.parse(malicious)
+                                                                                              .isPresent()));
     }
 }

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/IntentParserTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/IntentParserTest.java
@@ -794,6 +794,107 @@ class IntentParserTest {
                              .size());
     }
 
+    /**
+     * A payment posting whose account column is chosen by a source classifier - #6534. The single
+     * {@code items} row is supplied per test.
+     */
+    private static String conditionalRulePosting(String itemRow) {
+        return """
+                name: ledger
+                entities:
+                  - name: Account
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: number, type: string }
+                  - name: PaymentMethodType
+                    kind: setting
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                  - name: PostingRule
+                    kind: setting
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: documentType, type: string }
+                    relations:
+                      - { name: BankAccount, kind: manyToOne, to: Account }
+                      - { name: CashAccount, kind: manyToOne, to: Account }
+                      - { name: SuspenseAccount, kind: manyToOne, to: Account }
+                  - name: Payment
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: amount, type: decimal, precision: 18, scale: 2 }
+                    relations:
+                      - { name: Method, kind: manyToOne, to: PaymentMethodType, required: true }
+                  - name: JournalEntry
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                    relations:
+                      - { name: Payment, kind: manyToOne, to: Payment }
+                  - name: JournalEntryItem
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: debit, type: decimal, precision: 18, scale: 2 }
+                    relations:
+                      - { name: JournalEntry, kind: manyToOne, to: JournalEntry, composition: true, required: true }
+                      - { name: Account, kind: manyToOne, to: Account, required: true }
+                postings:
+                  - name: paymentPosting
+                    event: { onCreate: Payment }
+                    creates: JournalEntry
+                    backReference: Payment
+                    rule: { entity: PostingRule, match: { documentType: "Payment" } }
+                    items:
+                      - %s
+                """.formatted(itemRow);
+    }
+
+    @Test
+    void conditionalRuleColumnParses() {
+        IntentParser.parse(conditionalRulePosting(
+                "{ Account: \"rule(by: Method, cases: { 1: BankAccount, 2: CashAccount }, default: SuspenseAccount)\", debit: \"Amount\" }"));
+    }
+
+    @Test
+    void conditionalRuleUnknownCaseColumnIsRejected() {
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(
+                conditionalRulePosting("{ Account: \"rule(by: Method, cases: { 1: Nonsuch })\", debit: \"Amount\" }")));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("case column [Nonsuch] is not a field or to-one relation of [PostingRule]")),
+                "expected an unknown case-column issue, got: " + ex.getIssues());
+    }
+
+    @Test
+    void conditionalRuleWithAWhenGuardIsRejected() {
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(conditionalRulePosting(
+                "{ Account: \"rule(by: Method, cases: { 1: BankAccount })\", debit: \"Amount\", when: \"Amount == 0\" }")));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("combines a conditional rule(by: ...) with a when: guard")),
+                "expected a conditional+when issue, got: " + ex.getIssues());
+    }
+
+    @Test
+    void conditionalRuleNonNumericCaseKeyIsRejected() {
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(
+                conditionalRulePosting("{ Account: \"rule(by: Method, cases: { bank: BankAccount })\", debit: \"Amount\" }")));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("case key [bank] must be a number")),
+                "expected a non-numeric case-key issue, got: " + ex.getIssues());
+    }
+
+    @Test
+    void conditionalRuleUnknownClassifierIsRejected() {
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(
+                conditionalRulePosting("{ Account: \"rule(by: Nonsuch, cases: { 1: BankAccount })\", debit: \"Amount\" }")));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("rule(by: Nonsuch) is not a field or to-one relation of the source [Payment]")),
+                "expected an unknown-classifier issue, got: " + ex.getIssues());
+    }
+
     /** The event declares exactly one trigger - onTransition XOR onCreate. */
     @Test
     void postingEventDeclaresExactlyOneTrigger() {

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Posting.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Posting.java.template
@@ -79,6 +79,11 @@ public class ${className}Posting implements MessageHandler {
             return; // incomplete determination -> unposted worklist
         }
 #end
+#foreach($guard in $conditionalRuleGuards)
+        if (${guard} == null) {
+            return; // conditional rule(by: ...) selected no account (unmatched or null) -> unposted worklist
+        }
+#end
 #end
         // Idempotent + resumable posting (cloud-native: no cross-step transaction). The back-reference
         // identifies an existing post: a fresh source posts a new target + items; a redelivery of a

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -1395,6 +1395,10 @@ export function generateFiles(model, parameters, templateSources) {
                                 ruleMatchProperty: po.ruleMatchProperty,
                                 ruleMatchValueJava: po.ruleMatchValueJava,
                                 usedRuleColumns: po.usedRuleColumns,
+                                // Conditional rule(by:...) selectors (#6534): whole-expression null
+                                // guards, checked after the rule row resolves (the selected column is a
+                                // runtime choice, so it cannot be a static usedRuleColumn).
+                                conditionalRuleGuards: po.conditionalRuleGuards,
                                 headerAssignments: po.headerAssignments,
                                 itemRows: po.itemRows
                             };

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -1700,6 +1700,79 @@ class IntentEngineIT extends IntegrationTest {
     }
 
     @Test
+    void conditional_rule_column_emits_a_classifier_ternary_and_a_runtime_guard() {
+        // #6534: the account column is chosen by a source classifier - rule(by: Method, cases: {...}) -
+        // so ONE item row replaces the when:-gated row pair. The generated handler reads the rule row's
+        // column selected at runtime and null-guards the whole selection (an undetermined account skips
+        // the posting fail-soft), instead of statically null-checking every case column.
+        String yaml =
+                """
+                        name: condposting
+                        entities:
+                          - name: Account
+                            fields:
+                              - { name: id, type: integer, primaryKey: true, generated: true }
+                              - { name: number, type: string }
+                          - name: PaymentMethodType
+                            kind: setting
+                            fields:
+                              - { name: id, type: integer, primaryKey: true, generated: true }
+                              - { name: name, type: string, required: true, length: 100 }
+                          - name: PostingRule
+                            kind: setting
+                            fields:
+                              - { name: id, type: integer, primaryKey: true, generated: true }
+                              - { name: documentType, type: string }
+                            relations:
+                              - { name: BankAccount, kind: manyToOne, to: Account }
+                              - { name: CashAccount, kind: manyToOne, to: Account }
+                              - { name: SuspenseAccount, kind: manyToOne, to: Account }
+                          - name: Payment
+                            fields:
+                              - { name: id, type: integer, primaryKey: true, generated: true }
+                              - { name: amount, type: decimal, precision: 18, scale: 2 }
+                            relations:
+                              - { name: Method, kind: manyToOne, to: PaymentMethodType, required: true }
+                          - name: Ledger
+                            fields:
+                              - { name: id, type: integer, primaryKey: true, generated: true }
+                              - { name: memo, type: string, length: 400 }
+                            relations:
+                              - { name: Payment, kind: manyToOne, to: Payment }
+                          - name: LedgerLine
+                            fields:
+                              - { name: id, type: integer, primaryKey: true, generated: true }
+                              - { name: debit, type: decimal, precision: 18, scale: 2 }
+                            relations:
+                              - { name: Ledger, kind: manyToOne, to: Ledger, composition: true, required: true }
+                              - { name: Account, kind: manyToOne, to: Account, required: true }
+                        postings:
+                          - name: paymentLedger
+                            event: { onCreate: Payment }
+                            creates: Ledger
+                            backReference: Payment
+                            rule: { entity: PostingRule, match: { documentType: "Payment" } }
+                            items:
+                              - { Account: "rule(by: Method, cases: { 1: BankAccount, 2: CashAccount }, default: SuspenseAccount)", debit: "Amount" }
+                        """;
+        writeIntent(yaml);
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .post(GENERATE_URL)
+                                                 .then()
+                                                 .statusCode(200));
+        generateFromModel("template-application-events-java/template/template.js", "condposting.glue");
+        String posting = contentOf("gen/events/condposting/PaymentLedgerPosting.java");
+        assertTrue(
+                posting.contains("Calc.eval(\"Method\", source, 6).compareTo(new java.math.BigDecimal(\"1\")) == 0 ? ruleRow.BankAccount"),
+                "the account is a classifier ternary over the rule row's columns");
+        assertTrue(posting.contains("ruleRow.CashAccount") && posting.contains("ruleRow.SuspenseAccount"),
+                "every case column + the default is reachable from the ternary");
+        assertTrue(posting.contains("selected no account"), "the whole selection is null-guarded at runtime (fail-soft skip)");
+        assertFalse(posting.contains("if (ruleRow.BankAccount == null)"),
+                "a conditional case column must NOT be a static usedRuleColumns skip");
+    }
+
+    @Test
     void generates_completion_hook_flips_the_source_via_targeted_update() {
         // A create-from with a sourceStatus completion hook: after the Invoice is created, the Proforma
         // flips to status 3 - via a TARGETED single-column write (updateProperty), never a full-row


### PR DESCRIPTION
Closes #6534.

## What

A posting item's account column may be chosen by a **source classifier** instead of duplicating the whole item row per case:

```yaml
items:
  - { Account: "rule(by: Method, cases: { 1: BankAccount, 2: CashAccount }, default: SuspenseAccount)", debit: "Amount" }
```

Reads the resolved rule row's `BankAccount` column when the source's `Method` is `1`, `CashAccount` when `2`, else `SuspenseAccount` (or, with no `default`, nothing → the posting skips to the unposted worklist).

## Why

The only way to vary the account column by a source value used to be a `when:`-gated **row pair**, duplicating the entire line per case — it works for two cases but duplicates every other cell and scales linearly. (The other conceptual alternative — a dynamic `rule.match` selecting a different *row* per value — was rejected: it forces a data-model reshape from "one rule row = a set of named accounts" to N partitioned rows, and is less consistent.) The column selector keeps the natural rule-row model and mirrors the `by`/`cases`/`default` classifier shape the conditional `dependsOn` `valueFrom` (#6358) already uses.

## How

- **`PostingRuleSelector`** (new model record) parses `rule(by: F, cases: { k: C, ... }, default: D? )` — shared by the parser and the generator. The plain `rule(<column>)` idiom is untouched; the item-cell shape stays string-valued (the conditional form is a quoted scalar, since it carries colons/braces).
- **Parser** — `by` is a source field/relation (deep-checked for a local source, deferred for a cross-model one, like the #6533 FK copy); `cases` keys are numeric ids and values (and `default`) are columns of the rule entity; a conditional cell cannot also carry a row `when:` (the selector already branches).
- **Generator** — emits a null-safe `Calc` classifier ternary over `ruleRow.<Col>` and collects the whole expression into a new `conditionalRuleGuards` list. The selected column is a **runtime** choice, so it is deliberately **not** a static `usedRuleColumns` null-check (that would skip whenever *any* case column is null — e.g. a cash-only rule row would drop a cash payment).
- **`Posting.java` template** — after the static `usedRuleColumns` skip, a per-guard `if ((<ternary>) == null) return;` fail-soft skip (unmatched/undetermined account → unposted worklist). `generateUtils.js` passes the list through.

## Tests

- **Unit** — `PostingRuleSelectorTest` (parse), `GluePostingsTest` (ternary + `conditionalRuleGuards` emitted, case columns absent from `usedRuleColumns`), `IntentParserTest` (unknown case column / non-numeric key / unknown classifier / `when`+conditional rejected). Full engine-intent suite green (321).
- **IT** — `IntentEngineIT` asserts the generated `Posting.java` carries the classifier ternary, every case column + default, the runtime null guard, and no static case-column skip.
- **Live** — generated a self-contained conditional-rule posting, published it, and confirmed the client-Java batch compiles (`[19] units, 0 failures`) — the `Calc` classifier on a to-one relation FK and the ternary/guard are valid.

## Docs

intentfile.org (vendor-neutral, open) + dirigible.io `/help/intent/` (merged), same effort.
