### PR TITLE
perf(security): AccessVerifier matches without scanning every access definition (#111)

### DIFF
--- a/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/verifier/AccessVerifier.java
+++ b/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/verifier/AccessVerifier.java
@@ -10,10 +10,11 @@
 package org.eclipse.dirigible.components.security.verifier;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import org.eclipse.dirigible.components.base.synchronizer.SynchronizationWatcher;
 import org.eclipse.dirigible.components.security.domain.Access;
@@ -39,7 +40,14 @@ public class AccessVerifier {
     private static final Logger logger = LoggerFactory.getLogger(AccessVerifier.class);
 
     private final AntPathMatcher antPathMatcher;
-    private volatile Map<String, Map<String, List<Access>>> cache = Map.of();
+    /**
+     * Scope (lower-case) → HTTP method (upper-case, or {@code *}) → the access definitions for that
+     * bucket, pre-split into exact vs. Ant-pattern paths so the per-request match avoids scanning every
+     * definition. Rebuilt wholesale on {@link #refreshCache(boolean)} and published through this
+     * {@code volatile} reference; the {@link Bucket} it points at is never mutated after build, so
+     * concurrent readers are safe without locking.
+     */
+    private volatile Map<String, Map<String, Bucket>> cache = Map.of();
     private final AtomicBoolean modified;
 
     private final AccessService accessService;
@@ -59,6 +67,13 @@ public class AccessVerifier {
         refreshCache(false);
     }
 
+    /**
+     * Rebuild the access-definition cache from the current set (the scope+method index, each bucket
+     * split into exact vs. Ant-pattern paths) and swap it in atomically, so the matcher adapts to
+     * dynamically added, changed or removed {@code *.access} definitions.
+     *
+     * @param force rebuild even when nothing has been flagged as modified
+     */
     public void refreshCache(boolean force) {
         if (!force) {
             if (!this.isModified()) {
@@ -66,14 +81,67 @@ public class AccessVerifier {
             }
         }
         List<Access> all = accessService.getAll();
-        Map<String, Map<String, List<Access>>> newCache = all.stream()
-                                                             .collect(Collectors.groupingBy(a -> a.getScope()
-                                                                                                  .toLowerCase(),
-                                                                     Collectors.groupingBy(a -> a.getMethod()
-                                                                                                 .toUpperCase())));
+        // Group by scope + method, then pre-split each bucket into exact and Ant-pattern paths. Access
+        // definitions appear/change/disappear dynamically, so this is rebuilt from scratch on every
+        // (needed) refresh and swapped in atomically - the machinery adapts to the current set.
+        Map<String, Map<String, List<Access>>> byScopeMethod = new HashMap<>();
+        for (Access access : all) {
+            byScopeMethod.computeIfAbsent(access.getScope()
+                                                .toLowerCase(),
+                    scope -> new HashMap<>())
+                         .computeIfAbsent(access.getMethod()
+                                                .toUpperCase(),
+                                 method -> new ArrayList<>())
+                         .add(access);
+        }
+        Map<String, Map<String, Bucket>> newCache = new HashMap<>();
+        for (Map.Entry<String, Map<String, List<Access>>> scopeEntry : byScopeMethod.entrySet()) {
+            Map<String, Bucket> methodBuckets = new HashMap<>();
+            for (Map.Entry<String, List<Access>> methodEntry : scopeEntry.getValue()
+                                                                         .entrySet()) {
+                methodBuckets.put(methodEntry.getKey(), buildBucket(methodEntry.getValue()));
+            }
+            newCache.put(scopeEntry.getKey(), methodBuckets);
+        }
         this.cache = newCache;
         setModified(false);
         logger.debug("Access constraints reloaded");
+    }
+
+    /**
+     * Split a scope+method's access definitions into an exact-path index (matched by an O(1) lookup)
+     * and a list of genuine Ant patterns (matched by {@link AntPathMatcher}), the latter sorted by
+     * descending path length so the request-time scan can stop as soon as a candidate is shorter than
+     * the best match found so far.
+     *
+     * @param accesses the definitions of one scope+method bucket
+     * @return the pre-split bucket
+     */
+    private Bucket buildBucket(List<Access> accesses) {
+        Map<String, List<Access>> exact = new HashMap<>();
+        List<Access> patterns = new ArrayList<>();
+        for (Access access : accesses) {
+            if (antPathMatcher.isPattern(access.getPath())) {
+                patterns.add(access);
+            } else {
+                exact.computeIfAbsent(access.getPath(), path -> new ArrayList<>())
+                     .add(access);
+            }
+        }
+        patterns.sort(Comparator.comparingInt((Access access) -> access.getPath()
+                                                                       .length())
+                                .reversed());
+        return new Bucket(exact, patterns);
+    }
+
+    /**
+     * One scope+method's access definitions, pre-split so a request avoids matching every definition:
+     * an exact-path index for the common literal case, and the residual Ant patterns (longest first).
+     *
+     * @param exact literal path → its access definitions (an exact request-path lookup is O(1))
+     * @param patterns the Ant-pattern definitions, sorted by descending path length
+     */
+    private record Bucket(Map<String, List<Access>> exact, List<Access> patterns) {
     }
 
     @PostConstruct
@@ -113,58 +181,105 @@ public class AccessVerifier {
      */
     public List<Access> getMatchingSecurityAccesses(String scope, String path, String method) {
 
-        Map<String, Map<String, List<Access>>> localCache = this.cache;
-
-        Map<String, List<Access>> methodMap = localCache.get(scope.toLowerCase());
+        Map<String, Bucket> methodMap = this.cache.get(scope.toLowerCase());
 
         if (methodMap == null) {
             return List.of();
         }
 
-        List<Access> candidates = new ArrayList<>();
+        Bucket specificMethod = methodMap.get(method.toUpperCase());
+        Bucket wildcardMethod = methodMap.get("*");
 
-        List<Access> specificMethod = methodMap.get(method.toUpperCase());
-        List<Access> wildcardMethod = methodMap.get("*");
-
-        if (specificMethod != null) {
-            candidates.addAll(specificMethod);
-        }
-
-        if (wildcardMethod != null) {
-            candidates.addAll(wildcardMethod);
-        }
-
-        if (candidates.isEmpty()) {
+        if (specificMethod == null && wildcardMethod == null) {
             return List.of();
         }
 
-        Access currentSecurityAccess = null;
+        // The most specific match wins - the longest matching path string - with equal-length matches
+        // returned together (the caller then requires the user to hold a role from any of them).
         List<Access> result = new ArrayList<>();
+        int bestLength = -1;
 
-        for (Access securityAccess : candidates) {
+        // Exact paths first: a literal definition for this very path is a definite match, found by an
+        // O(1) lookup instead of running the Ant matcher over every definition. All exact hits share the
+        // request path's length; a longer Ant pattern (e.g. `/a/b/**` over `/a/b`) can still out-specify
+        // them, which the length comparison below preserves.
+        bestLength = collectExact(specificMethod, path, result, bestLength);
+        bestLength = collectExact(wildcardMethod, path, result, bestLength);
 
-            if (antPathMatcher.match(securityAccess.getPath(), path)) {
-                logger.debug("Path [{}] and HTTP method [{}] is secured by definition [{}]", path, method, securityAccess.getLocation());
-                if (currentSecurityAccess == null || securityAccess.getPath()
-                                                                   .length() > currentSecurityAccess.getPath()
-                                                                                                    .length()) {
-
-                    currentSecurityAccess = securityAccess;
-                    result.clear();
-                    result.add(securityAccess);
-                } else if (securityAccess.getPath()
-                                         .length() == currentSecurityAccess.getPath()
-                                                                           .length()) {
-                    result.add(securityAccess);
-                }
-            }
-        }
+        // Then the genuine Ant patterns (longest first): stop as soon as a candidate is shorter than the
+        // best match found - it can neither win nor tie.
+        bestLength = collectPatterns(specificMethod, path, method, result, bestLength);
+        collectPatterns(wildcardMethod, path, method, result, bestLength);
 
         if (result.isEmpty()) {
-            logger.trace("URI [{}] with HTTP method {}] is NOT secured", path, method);
+            logger.trace("URI [{}] with HTTP method [{}] is NOT secured", path, method);
         }
 
         return result;
+    }
+
+    /**
+     * Add a bucket's exact hit for {@code path} (if any) to {@code result}, keeping only the
+     * longest-path matches (an exact hit's length is the request path's length).
+     *
+     * @return the running best matched path length
+     */
+    private int collectExact(Bucket bucket, String path, List<Access> result, int bestLength) {
+        if (bucket == null) {
+            return bestLength;
+        }
+        List<Access> hits = bucket.exact()
+                                  .get(path);
+        if (hits == null) {
+            return bestLength;
+        }
+        for (Access securityAccess : hits) {
+            bestLength = keepLongest(result, securityAccess, path.length(), bestLength);
+        }
+        return bestLength;
+    }
+
+    /**
+     * Match a bucket's Ant patterns (pre-sorted by descending path length) against {@code path},
+     * keeping only the longest-path matches and breaking out as soon as a candidate cannot beat or tie
+     * the best.
+     *
+     * @return the running best matched path length
+     */
+    private int collectPatterns(Bucket bucket, String path, String method, List<Access> result, int bestLength) {
+        if (bucket == null) {
+            return bestLength;
+        }
+        for (Access securityAccess : bucket.patterns()) {
+            int length = securityAccess.getPath()
+                                       .length();
+            if (length < bestLength) {
+                break; // sorted descending - every remaining pattern is shorter, so none can win or tie
+            }
+            if (antPathMatcher.match(securityAccess.getPath(), path)) {
+                logger.debug("Path [{}] and HTTP method [{}] is secured by definition [{}]", path, method, securityAccess.getLocation());
+                bestLength = keepLongest(result, securityAccess, length, bestLength);
+            }
+        }
+        return bestLength;
+    }
+
+    /**
+     * Keep the most specific matches only: a strictly longer path replaces the collected set, an
+     * equal-length path joins it, a shorter one is ignored.
+     *
+     * @return the resulting best matched path length
+     */
+    private static int keepLongest(List<Access> result, Access securityAccess, int length, int bestLength) {
+        if (length > bestLength) {
+            result.clear();
+            result.add(securityAccess);
+            return length;
+        }
+        if (length == bestLength) {
+            result.add(securityAccess);
+        }
+        return bestLength;
     }
 
 }

--- a/components/engine/engine-security/src/test/java/org/eclipse/dirigible/components/security/verifier/AccessVerifierTest.java
+++ b/components/engine/engine-security/src/test/java/org/eclipse/dirigible/components/security/verifier/AccessVerifierTest.java
@@ -113,4 +113,59 @@ class AccessVerifierTest {
                                                 .next();
         assertThat(access.getRole()).isEqualTo("somerole");
     }
+
+    /** The most specific matching Ant pattern (the longest path string) wins over a shorter one. */
+    @Test
+    void mostSpecificAntPatternWins() {
+        securityAccessRepository.save(createSecurityAccess("/m/broad.access", "broad", "description", "HTTP", "/m/**", "GET", "broadRole"));
+        securityAccessRepository.save(
+                createSecurityAccess("/m/narrow.access", "narrow", "description", "HTTP", "/m/a/**", "GET", "narrowRole"));
+        securityAccessVerifier.refreshCache(true);
+
+        List<Access> matches = securityAccessVerifier.getMatchingSecurityAccesses("HTTP", "/m/a/b", "GET");
+        assertThat(matches).hasSize(1);
+        assertThat(matches.get(0)
+                          .getRole()).isEqualTo("narrowRole");
+    }
+
+    /** An exact definition is matched (via the O(1) index) and outranks a shorter Ant pattern. */
+    @Test
+    void exactMatchOutranksAShorterAntPattern() {
+        securityAccessRepository.save(
+                createSecurityAccess("/e/exact.access", "exact", "description", "HTTP", "/aa/bb/cc", "GET", "exactRole"));
+        securityAccessRepository.save(
+                createSecurityAccess("/e/pattern.access", "pattern", "description", "HTTP", "/aa/*/cc", "GET", "patternRole"));
+        securityAccessVerifier.refreshCache(true);
+
+        List<Access> matches = securityAccessVerifier.getMatchingSecurityAccesses("HTTP", "/aa/bb/cc", "GET");
+        assertThat(matches).hasSize(1);
+        assertThat(matches.get(0)
+                          .getRole()).isEqualTo("exactRole");
+    }
+
+    /** A longer Ant pattern still out-specifies an exact definition of the same path (longest wins). */
+    @Test
+    void longerAntPatternOutranksAnExactMatch() {
+        securityAccessRepository.save(
+                createSecurityAccess("/o/exact.access", "exact", "description", "HTTP", "/a/b/c", "GET", "exactRole"));
+        securityAccessRepository.save(
+                createSecurityAccess("/o/pattern.access", "pattern", "description", "HTTP", "/{seg}/b/c", "GET", "varRole"));
+        securityAccessVerifier.refreshCache(true);
+
+        List<Access> matches = securityAccessVerifier.getMatchingSecurityAccesses("HTTP", "/a/b/c", "GET");
+        assertThat(matches).hasSize(1);
+        assertThat(matches.get(0)
+                          .getRole()).isEqualTo("varRole");
+    }
+
+    /** The wildcard HTTP method bucket (*) contributes alongside the specific method. */
+    @Test
+    void wildcardMethodBucketIsIncluded() {
+        securityAccessRepository.save(
+                createSecurityAccess("/w/any.access", "any", "description", "HTTP", "/w/resource", "*", "anyMethodRole"));
+        securityAccessVerifier.refreshCache(true);
+
+        assertThat(securityAccessVerifier.getMatchingSecurityAccesses("HTTP", "/w/resource", "GET")).hasSize(1);
+        assertThat(securityAccessVerifier.getMatchingSecurityAccesses("HTTP", "/w/resource", "DELETE")).hasSize(1);
+    }
 }


### PR DESCRIPTION
Closes #111.

## Problem

`AccessVerifier.getMatchingSecurityAccesses(...)` runs on the `SecurityFilter` hot path for **every secured HTTP request**. It already narrows by a cached `scope → method` index (good), but then does a **linear scan calling `AntPathMatcher.match(pattern, path)` for every access definition** in that bucket — O(N) matcher calls per request, which is exactly the "many access definitions" cost the issue is about.

## Change

Pre-split each `(scope, method)` bucket **at cache-build time** into:
- an **exact-path index** (`Map<path, List<Access>>`) — the common literal case (`/services/js/proj/api/x.js`), matched by an **O(1) lookup** instead of the Ant matcher;
- the residual **Ant patterns**, sorted by **descending path length**.

At request time: the exact lookup, then match only the true patterns, **breaking out as soon as a candidate is shorter** than the best match found (it can neither win nor tie). With, say, 1000 exact + 5 wildcard definitions this goes from ~1000 `AntPathMatcher.match` calls to one hash lookup + 5.

## Semantics preserved

The "most specific wins — the **longest matching path string**, equal-length matches returned together" contract is unchanged. In particular a **longer Ant pattern still out-specifies an exact path** (e.g. `/{seg}/b/c` over `/a/b/c`): the exact hit is only *found* by the O(1) index — it still participates in the same length comparison against the pattern matches, so the exact path does **not** short-circuit the winner.

## Dynamic adaptation

Access files appear / change / disappear at runtime. The split is rebuilt **wholesale in `refreshCache(...)`** (fired by the existing `SynchronizationWatcher` change signal / scheduled refresh) and published through the `volatile` cache reference; the buckets are never mutated after build, so concurrent readers stay lock-free and always see a consistent set.

## Tests

`AccessVerifierTest` extended: most-specific-pattern-wins, exact-outranks-shorter-pattern, longer-pattern-outranks-exact, and the wildcard (`*`) method bucket — plus the existing exact-tie and Ant-pattern cases. 6/6 green.

_(Two unrelated `*EndpointTest` 403 failures in the module are pre-existing on `master` — the ongoing endpoint-authorization rework — and don't touch this class.)_
