### PR TITLE
feat(intent): parallel fork/join process step (kind: parallel) (#6556)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/ProcessParallelSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/ProcessParallelSupport.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.dirigible.components.intent.model.StepIntent;
+
+/**
+ * A {@code kind: parallel} process step - {@code args: { branches: [stepA, stepB], next: join }} -
+ * runs its declared branch steps concurrently and joins before {@code next}. It is emitted as a
+ * BPMN <b>parallel gateway pair</b>: a diverging {@code parallelGateway} (the fork step itself)
+ * fans an unconditioned flow to each branch, and a synthesized converging {@code parallelGateway}
+ * (id {@code <fork>Join}) waits for every branch before the single flow on to {@code next}.
+ *
+ * <p>
+ * The branch steps and the join gateway are <b>off the default linear chain</b> - like a decision's
+ * {@code then}/{@code else} targets - so the generator excludes them from the linear sequence and
+ * wires the fork/branch/join flows explicitly.
+ *
+ * <p>
+ * v1 scope: each branch is a <b>single</b> declared step that joins directly, and forks do not
+ * nest. Multi-step branch chains and nested parallels are a documented follow-up (see the module
+ * guide).
+ */
+public final class ProcessParallelSupport {
+
+    /** The id suffix of the synthesized converging join gateway. */
+    public static final String JOIN_SUFFIX = "Join";
+
+    private ProcessParallelSupport() {}
+
+    /**
+     * A parallel fork and its synthesized join.
+     *
+     * @param forkId the diverging {@code parallelGateway} id (the {@code parallel} step's name)
+     * @param branches the step names run concurrently between the fork and the join, in declared order
+     * @param next the step (or {@code end}) the join flows into, or {@code null} when unset
+     * @param joinId the synthesized converging {@code parallelGateway} id
+     */
+    public record Fork(String forkId, List<String> branches, String next, String joinId) {
+    }
+
+    /** The synthesized converging join gateway id for a fork step. */
+    public static String joinId(String forkId) {
+        return forkId + JOIN_SUFFIX;
+    }
+
+    /** The parallel forks declared across a step list, in declaration order. */
+    public static List<Fork> forks(List<StepIntent> steps) {
+        List<Fork> forks = new ArrayList<>();
+        for (StepIntent step : steps) {
+            if (!"parallel".equalsIgnoreCase(step.getKind()) || step.getName() == null) {
+                continue;
+            }
+            Map<String, Object> args = step.getArgs() == null ? Map.of() : step.getArgs();
+            List<String> branches = new ArrayList<>();
+            if (args.get("branches") instanceof List<?> list) {
+                for (Object branch : list) {
+                    if (branch != null) {
+                        branches.add(branch.toString());
+                    }
+                }
+            }
+            Object next = args.get("next");
+            String nextStep = next == null ? null
+                    : next.toString()
+                          .trim();
+            forks.add(new Fork(step.getName(), branches, nextStep == null || nextStep.isEmpty() ? null : nextStep, joinId(step.getName())));
+        }
+        return forks;
+    }
+
+    /** Every branch step name across the given forks (excluded from the linear chain). */
+    public static Set<String> branchNames(List<Fork> forks) {
+        Set<String> names = new LinkedHashSet<>();
+        for (Fork fork : forks) {
+            names.addAll(fork.branches());
+        }
+        return names;
+    }
+
+    /** Every synthesized join gateway id across the given forks (excluded from the linear chain). */
+    public static Set<String> joinIds(List<Fork> forks) {
+        Set<String> ids = new LinkedHashSet<>();
+        for (Fork fork : forks) {
+            ids.add(fork.joinId());
+        }
+        return ids;
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/bpmn/BpmnIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/bpmn/BpmnIntentGenerator.java
@@ -31,6 +31,7 @@ import org.eclipse.dirigible.components.intent.generator.ProcessFieldLoadSupport
 import org.eclipse.dirigible.components.intent.generator.ProcessResolverSupport;
 import org.eclipse.dirigible.components.intent.generator.ProcessResolverSupport.Resolver;
 import org.eclipse.dirigible.components.intent.generator.ProcessAbortSupport;
+import org.eclipse.dirigible.components.intent.generator.ProcessParallelSupport;
 import org.eclipse.dirigible.components.intent.generator.ProcessTimerSupport;
 import org.eclipse.dirigible.components.intent.generator.ProcessTimerSupport.TimerLoad;
 import org.eclipse.dirigible.components.intent.generator.ProcessWaitSupport;
@@ -315,8 +316,24 @@ public class BpmnIntentGenerator implements IntentTargetGenerator {
             }
             steps.removeIf(step -> abortThenName.equals(step.getName()));
         }
+        // parallel (fork/join): a `kind: parallel` step fans to its branch steps and joins before
+        // `next`. Synthesize the converging join gateway as a step (so it is emitted + laid out), and
+        // treat the branch steps + the join as OFF the linear chain (like decision branches) - the
+        // fork/branch/join flows are wired explicitly in buildSequenceFlows.
+        List<ProcessParallelSupport.Fork> forks = ProcessParallelSupport.forks(steps);
+        for (ProcessParallelSupport.Fork fork : forks) {
+            StepIntent join = new StepIntent();
+            join.setName(fork.joinId());
+            join.setKind("parallelJoin");
+            steps.add(join);
+        }
         List<String> effectiveSteps = buildEffectiveStepIds(steps);
-        List<SequenceFlow> flows = buildSequenceFlows(steps, effectiveSteps);
+        Set<String> parallelOffLinear = new HashSet<>(ProcessParallelSupport.branchNames(forks));
+        parallelOffLinear.addAll(ProcessParallelSupport.joinIds(forks));
+        List<String> linearSteps = effectiveSteps.stream()
+                                                 .filter(id -> !parallelOffLinear.contains(id))
+                                                 .collect(java.util.stream.Collectors.toList());
+        List<SequenceFlow> flows = buildSequenceFlows(steps, linearSteps, forks);
         // Boundary timers on user tasks (timeout: non-cancelling reminder; expire: cancelling,
         // date-field-driven). Their outgoing flow to `then` joins the sequence flows; the branch steps
         // are declared steps the author routes around with `next`, like decision branches.
@@ -693,6 +710,10 @@ public class BpmnIntentGenerator implements IntentTargetGenerator {
             case "wait":
                 appendWaitCatchEvent(sb, step, processName);
                 break;
+            case "parallel":
+            case "parallelJoin":
+                appendParallelGateway(sb, step);
+                break;
             case "end":
                 break;
             default:
@@ -909,6 +930,20 @@ public class BpmnIntentGenerator implements IntentTargetGenerator {
         sb.append("    </intermediateCatchEvent>\n");
     }
 
+    /**
+     * A {@code parallelGateway} - the diverging fork (a {@code parallel} step) or the synthesized
+     * converging join ({@code parallelJoin}). Unlike an exclusive gateway it carries no {@code default}
+     * flow: every outgoing branch fires, and every incoming branch must arrive before the join
+     * proceeds.
+     */
+    private static void appendParallelGateway(StringBuilder sb, StepIntent step) {
+        sb.append("    <parallelGateway id=\"")
+          .append(escapeXmlAttribute(step.getName()))
+          .append("\" name=\"")
+          .append(escapeXmlAttribute(IntentNaming.humanize(step.getName())))
+          .append("\"></parallelGateway>\n");
+    }
+
     private static void appendExclusiveGateway(StringBuilder sb, StepIntent step) {
         sb.append("    <exclusiveGateway id=\"")
           .append(escapeXmlAttribute(step.getName()))
@@ -933,11 +968,16 @@ public class BpmnIntentGenerator implements IntentTargetGenerator {
      * (e.g. {@code activate} and {@code reject} both flowing to {@code done}) without the first
      * silently falling through into the second.
      */
-    private static List<SequenceFlow> buildSequenceFlows(List<StepIntent> steps, List<String> effectiveIds) {
+    private static List<SequenceFlow> buildSequenceFlows(List<StepIntent> steps, List<String> effectiveIds,
+            List<ProcessParallelSupport.Fork> forks) {
         List<SequenceFlow> flows = new ArrayList<>();
         for (int i = 0; i < effectiveIds.size() - 1; i++) {
             String source = effectiveIds.get(i);
             String target = effectiveIds.get(i + 1);
+            // A parallel fork does not fall through linearly - it fans to its branches (wired below).
+            if ("parallel".equalsIgnoreCase(kindOf(source, steps))) {
+                continue;
+            }
             String flowId;
             StepIntent decision = decisionOf(source, steps);
             if (decision != null) {
@@ -968,7 +1008,25 @@ public class BpmnIntentGenerator implements IntentTargetGenerator {
             }
             flows.add(new SequenceFlow("flow_" + step.getName() + "_then", step.getName(), effectiveTarget(thenTarget, steps), condition));
         }
+        // parallel fork/join: the fork fans an unconditioned flow to each branch, each branch flows to
+        // the synthesized join, and the join flows once to `next` (or the end). All flows are
+        // unconditioned - every branch runs, and the join waits for all of them.
+        for (ProcessParallelSupport.Fork fork : forks) {
+            for (String branch : fork.branches()) {
+                String branchTarget = effectiveTarget(branch, steps);
+                flows.add(new SequenceFlow("flow_" + fork.forkId() + "_" + branch, fork.forkId(), branchTarget, null));
+                flows.add(new SequenceFlow("flow_" + branch + "_" + fork.joinId(), branchTarget, fork.joinId(), null));
+            }
+            String joinTarget = fork.next() == null ? END_ID : effectiveTarget(fork.next(), steps);
+            flows.add(new SequenceFlow("flow_" + fork.joinId() + "_" + joinTarget, fork.joinId(), joinTarget, null));
+        }
         return flows;
+    }
+
+    /** The kind of the step with the given id, or {@code null} when the id is not a declared step. */
+    private static String kindOf(String stepId, List<StepIntent> steps) {
+        StepIntent step = stepByName(stepId, steps);
+        return step == null ? null : step.getKind();
     }
 
     private static void writeSequenceFlows(StringBuilder sb, List<SequenceFlow> flows) {
@@ -1327,7 +1385,7 @@ public class BpmnIntentGenerator implements IntentTargetGenerator {
         }
         StepIntent step = stepByName(id, steps);
         String kind = step == null ? "userTask" : step.getKind();
-        if ("decision".equalsIgnoreCase(kind)) {
+        if ("decision".equalsIgnoreCase(kind) || "parallel".equalsIgnoreCase(kind) || "parallelJoin".equalsIgnoreCase(kind)) {
             return new int[] {40, 40};
         }
         if ("wait".equalsIgnoreCase(kind)) {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/StepIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/StepIntent.java
@@ -14,10 +14,11 @@ import java.util.Map;
 
 /**
  * Single step in a {@link ProcessIntent}. {@link #kind} is one of {@code userTask},
- * {@code serviceTask}, {@code decision}, {@code script}, {@code wait}, {@code end}. {@link #args}
- * carries kind-specific configuration ({@code assignee}, {@code form}, {@code if}, {@code then},
- * {@code call}, a wait's {@code onCreate}/{@code onUpdate}/{@code via}, a user task's
- * {@code timeout}/{@code expire} boundary timers); the process generator validates per kind.
+ * {@code serviceTask}, {@code decision}, {@code script}, {@code wait}, {@code parallel},
+ * {@code end}. {@link #args} carries kind-specific configuration ({@code assignee}, {@code form},
+ * {@code if}, {@code then}, {@code call}, a wait's {@code onCreate}/{@code onUpdate}/{@code via}, a
+ * user task's {@code timeout}/{@code expire} boundary timers, a parallel's
+ * {@code branches}/{@code next} fork/join); the process generator validates per kind.
  */
 public class StepIntent {
 

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -99,7 +99,7 @@ public final class IntentParser {
     private static final Set<String> FIELD_FUNCTIONS = Set.of("documenttitle");
     /** Implemented relation {@code function} values (lower-cased). */
     private static final Set<String> RELATION_FUNCTIONS = Set.of("entitystatus");
-    private static final Set<String> STEP_KINDS = Set.of("userTask", "serviceTask", "decision", "script", "wait", "end");
+    private static final Set<String> STEP_KINDS = Set.of("userTask", "serviceTask", "decision", "script", "wait", "parallel", "end");
     /** Entity lifecycle events a declarative-glue item (notification, reaction) can bind to. */
     private static final Set<String> EVENT_KINDS = Set.of("onCreate", "onUpdate", "onDelete");
     /** Notification delivery channels supported today. */
@@ -2739,6 +2739,7 @@ public final class IntentParser {
             validateWaitSteps(process, triggerEntity, byName, issues);
             validateUserTaskTimers(process, triggerEntity, byName, issues);
             validateAbortOn(process, triggerEntity, byName, issues);
+            validateParallelSteps(process, issues);
             validateTaskFormActions(process, model, issues);
         }
     }
@@ -2752,6 +2753,65 @@ public final class IntentParser {
      * needs no decision: it flows on linearly (typically to a status {@code setField} and the next user
      * task). Enforced so the author sees, at parse time, what the chosen actions actually do.
      */
+    /**
+     * A {@code kind: parallel} step forks over {@code args.branches} (declared steps run concurrently)
+     * and joins before {@code args.next}. v1 scope: at least two branches; each is a SINGLE declared
+     * task step that joins directly - no own {@code next}/{@code then}, no boundary timer, no nested
+     * parallel; {@code next} is a declared step or {@code end}. Multi-step branch chains and nested
+     * forks are a documented follow-up.
+     */
+    private static void validateParallelSteps(ProcessIntent process, List<String> issues) {
+        Map<String, StepIntent> byName = new HashMap<>();
+        for (StepIntent step : process.getSteps()) {
+            if (step.getName() != null) {
+                byName.put(step.getName(), step);
+            }
+        }
+        Set<String> usedBranches = new HashSet<>();
+        for (StepIntent step : process.getSteps()) {
+            if (!"parallel".equals(step.getKind())) {
+                continue;
+            }
+            String subject = "process [" + process.getName() + "] parallel [" + step.getName() + "]";
+            Map<String, Object> args = step.getArgs() == null ? Map.of() : step.getArgs();
+            List<?> branches = args.get("branches") instanceof List<?> list ? list : List.of();
+            if (branches.size() < 2) {
+                issues.add(subject + " needs a `branches` list of at least two step names");
+            }
+            Object next = args.get("next");
+            String nextStep = next == null ? null
+                    : next.toString()
+                          .trim();
+            if (nextStep == null || nextStep.isEmpty()) {
+                issues.add(subject + " needs a `next` step to join into");
+            } else if (!"end".equalsIgnoreCase(nextStep) && !byName.containsKey(nextStep)) {
+                issues.add(subject + " next [" + nextStep + "] is not a declared step or `end`");
+            }
+            for (Object branchRaw : branches) {
+                String branch = String.valueOf(branchRaw);
+                StepIntent branchStep = byName.get(branch);
+                if (branchStep == null) {
+                    issues.add(subject + " branch [" + branch + "] is not a declared step");
+                    continue;
+                }
+                if (!usedBranches.add(branch)) {
+                    issues.add(subject + " branch [" + branch + "] is a branch of more than one parallel");
+                }
+                String branchKind = branchStep.getKind() == null ? "userTask" : branchStep.getKind();
+                if (!"userTask".equals(branchKind) && !"serviceTask".equals(branchKind) && !"script".equals(branchKind)) {
+                    issues.add(subject + " branch [" + branch + "] must be a userTask/serviceTask/script step, not [" + branchKind
+                            + "] (nested parallels are not yet supported)");
+                }
+                Map<String, Object> branchArgs = branchStep.getArgs() == null ? Map.of() : branchStep.getArgs();
+                if (branchArgs.get("next") != null || branchArgs.get("then") != null || branchArgs.get("timeout") != null
+                        || branchArgs.get("expire") != null) {
+                    issues.add(subject + " branch [" + branch + "] declares next/then/timeout/expire - a v1 parallel branch is a single"
+                            + " step that joins directly (multi-step branch chains and boundary timers on a branch are not yet supported)");
+                }
+            }
+        }
+    }
+
     /** The entity a process trigger starts on (onCreate/onUpdate/onDelete target), or null. */
     private static String triggerEntityName(ProcessIntent process) {
         if (process.getTrigger() == null) {

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -690,11 +690,30 @@ processes:
       - { name: managerReview, kind: userTask, args: { assignee: manager, form: ApproveLoan } }
 ```
 
-**Rules:** step `kind` is one of `userTask` / `serviceTask` / `decision` / `script` / `wait` / `end`.
-A `decision` must have `if` + `then`; `else` is optional. `then` / `else` must name a declared step or
-the literal `end`. The `trigger` fires on exactly one lifecycle event of a declared entity -
-`onCreate`, `onUpdate` or `onDelete` - and may carry a `when` guard so the process starts only when the
-guard holds, e.g. `trigger: { onUpdate: Loan, when: "status == 'OVERDUE'" }`.
+**Rules:** step `kind` is one of `userTask` / `serviceTask` / `decision` / `script` / `wait` /
+`parallel` / `end`. A `decision` must have `if` + `then`; `else` is optional. `then` / `else` must name
+a declared step or the literal `end`. The `trigger` fires on exactly one lifecycle event of a declared
+entity - `onCreate`, `onUpdate` or `onDelete` - and may carry a `when` guard so the process starts only
+when the guard holds, e.g. `trigger: { onUpdate: Loan, when: "status == 'OVERDUE'" }`.
+
+**Parallel branches (`kind: parallel`).** When two steps should run **concurrently** and rejoin before
+the next step - e.g. a technical and a commercial review of the same order - use a `parallel` step. It
+lists its `branches` (declared steps run at the same time) and the `next` step to continue at once every
+branch is done; it emits a BPMN parallel-gateway fork/join.
+
+```yaml
+    steps:
+      - { name: reviews, kind: parallel, args: { branches: [techReview, commercialReview], next: consolidate } }
+      - { name: techReview,       kind: userTask, args: { assignee: engineer, form: ReviewOrder } }
+      - { name: commercialReview, kind: userTask, args: { assignee: sales,    form: ReviewOrder } }
+      - { name: consolidate,      kind: serviceTask, args: { setRelationField: Status, value: 2 } }
+      - { name: done, kind: end }
+```
+
+Rules: at least two `branches`, each a **single** declared task step (a `userTask` / `serviceTask` /
+`script`) that joins directly; `next` names a declared step or `end`. v1 does not support a branch that
+chains onward (its own `next`/`then`/boundary timer) or a branch that is itself `parallel` - multi-step
+branch chains and nested parallels are a planned follow-up.
 
 **Business key on the trigger.** By default a started process instance's BPM business key is the
 record's primary key (a bare number in the Processes admin view). Name a more readable trigger-entity

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/ProcessParallelSupportTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/ProcessParallelSupportTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.intent.generator.ProcessParallelSupport.Fork;
+import org.eclipse.dirigible.components.intent.model.StepIntent;
+import org.junit.jupiter.api.Test;
+
+/** Extracting parallel forks + the synthesized join id from a step list (#6556). */
+class ProcessParallelSupportTest {
+
+    private static StepIntent step(String name, String kind, Map<String, Object> args) {
+        StepIntent step = new StepIntent();
+        step.setName(name);
+        step.setKind(kind);
+        if (args != null) {
+            step.setArgs(args);
+        }
+        return step;
+    }
+
+    @Test
+    void extractsForkBranchesNextAndSynthesizedJoin() {
+        List<StepIntent> steps = List.of(
+                step("reviews", "parallel", Map.of("branches", List.of("techReview", "commercialReview"), "next", "consolidate")),
+                step("techReview", "userTask", null), step("commercialReview", "userTask", null), step("consolidate", "serviceTask", null));
+
+        List<Fork> forks = ProcessParallelSupport.forks(steps);
+        assertEquals(1, forks.size());
+        Fork fork = forks.get(0);
+        assertEquals("reviews", fork.forkId());
+        assertEquals(List.of("techReview", "commercialReview"), fork.branches());
+        assertEquals("consolidate", fork.next());
+        assertEquals("reviewsJoin", fork.joinId());
+
+        assertTrue(ProcessParallelSupport.branchNames(forks)
+                                         .containsAll(List.of("techReview", "commercialReview")));
+        assertTrue(ProcessParallelSupport.joinIds(forks)
+                                         .contains("reviewsJoin"));
+    }
+
+    @Test
+    void noParallelYieldsNoForks() {
+        assertTrue(ProcessParallelSupport.forks(List.of(step("confirm", "userTask", null), step("done", "end", null)))
+                                         .isEmpty());
+    }
+}

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/IntentParserTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/IntentParserTest.java
@@ -2077,4 +2077,92 @@ class IntentParserTest {
                      .anyMatch(i -> i.contains("declares both `format` and `pattern`")),
                 "expected a both-declared issue, got: " + ex.getIssues());
     }
+
+    /**
+     * A process with a parallel step (#6556), assembled by concatenation so each per-test {@code steps}
+     * fragment keeps exact six-space indentation - a multi-line value interpolated into a text block is
+     * not re-indented and breaks the YAML.
+     */
+    private static String parallelProcess(String steps) {
+        return "name: pp\n" //
+                + "entities:\n" //
+                + "  - name: OrderStatus\n" //
+                + "    function: Setting\n" //
+                + "    fields:\n" //
+                + "      - { name: id, type: integer, primaryKey: true, generated: true }\n" //
+                + "      - { name: name, type: string }\n" //
+                + "  - name: SalesOrder\n" //
+                + "    fields:\n" //
+                + "      - { name: id, type: integer, primaryKey: true, generated: true }\n" //
+                + "    relations:\n" //
+                + "      - { name: Status, kind: manyToOne, to: OrderStatus, function: EntityStatus, init: 1 }\n" //
+                + "processes:\n" //
+                + "  - name: Review\n" //
+                + "    trigger: { onCreate: SalesOrder }\n" //
+                + "    steps:\n" //
+                + steps //
+                + "forms:\n" //
+                + "  - { name: ReviewOrder, forEntity: SalesOrder, fields: [Status], actions: [approve] }\n";
+    }
+
+    private static final String P_FORK =
+            "      - { name: reviews, kind: parallel, args: { branches: [techReview, commercialReview], next: consolidate } }\n";
+    private static final String P_TECH = "      - { name: techReview, kind: userTask, args: { assignee: manager, form: ReviewOrder } }\n";
+    private static final String P_COMMERCIAL =
+            "      - { name: commercialReview, kind: userTask, args: { assignee: manager, form: ReviewOrder } }\n";
+    private static final String P_CONSOLIDATE =
+            "      - { name: consolidate, kind: serviceTask, args: { setRelationField: Status, value: 2 } }\n";
+
+    @Test
+    void parallelStepParses() {
+        IntentParser.parse(parallelProcess(P_FORK + P_TECH + P_COMMERCIAL + P_CONSOLIDATE + "      - { name: done, kind: end }\n"));
+    }
+
+    @Test
+    void parallelWithFewerThanTwoBranchesIsRejected() {
+        IntentValidationException ex = assertThrows(IntentValidationException.class,
+                () -> IntentParser.parse(
+                        parallelProcess("      - { name: reviews, kind: parallel, args: { branches: [techReview], next: consolidate } }\n"
+                                + P_TECH + P_CONSOLIDATE)));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("needs a `branches` list of at least two")),
+                "expected a too-few-branches issue, got: " + ex.getIssues());
+    }
+
+    @Test
+    void parallelUnknownBranchIsRejected() {
+        IntentValidationException ex = assertThrows(IntentValidationException.class,
+                () -> IntentParser.parse(parallelProcess(
+                        "      - { name: reviews, kind: parallel, args: { branches: [techReview, nope], next: consolidate } }\n" + P_TECH
+                                + P_CONSOLIDATE)));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("branch [nope] is not a declared step")),
+                "expected an unknown-branch issue, got: " + ex.getIssues());
+    }
+
+    @Test
+    void parallelBranchWithItsOwnNextIsRejected() {
+        // A branch that chains onward is the multi-step follow-up, not v1.
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(parallelProcess(
+                P_FORK + "      - { name: techReview, kind: userTask, args: { assignee: manager, form: ReviewOrder, next: consolidate } }\n"
+                        + P_COMMERCIAL + P_CONSOLIDATE)));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("branch [techReview] declares next/then/timeout/expire")),
+                "expected a multi-step-branch issue, got: " + ex.getIssues());
+    }
+
+    @Test
+    void parallelUnknownNextIsRejected() {
+        IntentValidationException ex = assertThrows(IntentValidationException.class,
+                () -> IntentParser.parse(parallelProcess(
+                        "      - { name: reviews, kind: parallel, args: { branches: [techReview, commercialReview], next: nowhere } }\n"
+                                + P_TECH + P_COMMERCIAL)));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("next [nowhere] is not a declared step or `end`")),
+                "expected an unknown-next issue, got: " + ex.getIssues());
+    }
 }

--- a/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/js/editor.js
+++ b/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/js/editor.js
@@ -469,7 +469,20 @@ editorView.controller('IntentEditorController', ($scope, $http, ViewParameters, 
                 // A wait parks the process on an entity event (a message catch event in the BPMN) - an
                 // ellipse like the terminals, but glue-rust so the event-driven resume stands out.
                 else if (step.kind === 'wait') byName[step.name] = graph.insertVertex(parent, null, step.name, 0, 0, 130, 44, shapeStyle('ellipse', COLOR.glue));
+                // A parallel fork is a gateway (diamond) that fans to its branches and joins before `next`.
+                else if (step.kind === 'parallel') byName[step.name] = graph.insertVertex(parent, null, step.name, 0, 0, 90, 60, shapeStyle('rhombus', COLOR.decision));
                 else byName[step.name] = graph.insertVertex(parent, null, step.name, 0, 0, 140, 44, nodeStyle(COLOR.entity));
+            }
+            // Parallel fork/join (mirrors BpmnIntentGenerator): the branch steps + a synthesized join
+            // gateway are OFF the linear chain; the fork wires fork -> branch -> join -> next.
+            const forks = steps.filter(s => s.kind === 'parallel').map(s => ({
+                id: s.name, branches: ((s.args || {}).branches) || [], next: (s.args || {}).next, joinId: s.name + 'Join'
+            }));
+            const branchNames = new Set();
+            const joinVertex = {};
+            for (const f of forks) {
+                (f.branches || []).forEach(b => branchNames.add(b));
+                joinVertex[f.joinId] = graph.insertVertex(parent, null, '', 0, 0, 50, 50, shapeStyle('rhombus', COLOR.decision));
             }
             const vertexFor = (name) => {
                 if (String(name).toLowerCase() === 'end') return end;
@@ -478,6 +491,7 @@ editorView.controller('IntentEditorController', ($scope, $http, ViewParameters, 
 
             const chain = [start];
             for (const step of steps) {
+                if (branchNames.has(step.name)) continue; // branches are off the linear chain
                 const v = String(step.kind).toLowerCase() === 'end' ? end : byName[step.name];
                 if (chain[chain.length - 1] !== v) chain.push(v);
             }
@@ -486,6 +500,17 @@ editorView.controller('IntentEditorController', ($scope, $http, ViewParameters, 
             for (let i = 0; i < chain.length - 1; i++) {
                 const source = chain[i];
                 let target = chain[i + 1];
+                // A parallel fork fans to its branches and joins before `next` - no linear fall-through.
+                const fork = forks.find(f => byName[f.id] === source);
+                if (fork) {
+                    const join = joinVertex[fork.joinId];
+                    for (const b of (fork.branches || [])) {
+                        graph.insertEdge(parent, null, '', source, vertexFor(b), edgeStyle(false));
+                        graph.insertEdge(parent, null, '', vertexFor(b), join, edgeStyle(false));
+                    }
+                    graph.insertEdge(parent, null, '', join, fork.next ? vertexFor(fork.next) : end, edgeStyle(false));
+                    continue;
+                }
                 const decision = steps.find(s => byName[s.name] === source && s.kind === 'decision');
                 if (decision) {
                     const args = decision.args || {};

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -912,6 +912,68 @@ class IntentEngineIT extends IntegrationTest {
     }
 
     @Test
+    void parallel_step_emits_a_fork_join_parallel_gateway_pair() {
+        // #6556: a `kind: parallel` step runs its branch steps concurrently and joins before `next`.
+        // Two reviews run at once; both must complete before consolidate. Emitted as a diverging
+        // parallelGateway (the fork) + a synthesized converging one (<fork>Join); the branch steps and
+        // the join are off the linear chain (the fork never falls through to consolidate directly).
+        String yaml = """
+                name: orders3
+                entities:
+                  - name: OrderStatus
+                    function: Setting
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                  - name: SalesOrder
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                    relations:
+                      - { name: Status, kind: manyToOne, to: OrderStatus, function: EntityStatus, init: 1 }
+                processes:
+                  - name: OrderReview
+                    trigger: { onCreate: SalesOrder }
+                    steps:
+                      - { name: reviews, kind: parallel, args: { branches: [techReview, commercialReview], next: consolidate } }
+                      - { name: techReview, kind: userTask, args: { assignee: manager, form: ReviewOrder } }
+                      - { name: commercialReview, kind: userTask, args: { assignee: manager, form: ReviewOrder } }
+                      - { name: consolidate, kind: serviceTask, args: { setRelationField: Status, value: 2 } }
+                      - { name: done, kind: end }
+                forms:
+                  - { name: ReviewOrder, forEntity: SalesOrder, fields: [Status], actions: [approve] }
+                seeds:
+                  - name: order-statuses
+                    entity: OrderStatus
+                    rows:
+                      - { id: 1, name: DRAFT }
+                      - { id: 2, name: REVIEWED }
+                """;
+        writeIntent(yaml);
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .post(GENERATE_URL)
+                                                 .then()
+                                                 .statusCode(200));
+
+        String bpmn = contentOf("OrderReview.bpmn");
+        assertTrue(bpmn.contains("<parallelGateway id=\"reviews\""), "the fork is a diverging parallelGateway");
+        assertTrue(bpmn.contains("<parallelGateway id=\"reviewsJoin\""), "a converging join parallelGateway is synthesized");
+        // The fork fans an unconditioned flow to each branch, each branch flows to the join, and the
+        // join flows once to `next`.
+        assertTrue(bpmn.contains("sourceRef=\"reviews\" targetRef=\"techReview\"")
+                && bpmn.contains("sourceRef=\"reviews\" targetRef=\"commercialReview\""), "the fork flows to both branches");
+        assertTrue(bpmn.contains("sourceRef=\"techReview\" targetRef=\"reviewsJoin\"")
+                && bpmn.contains("sourceRef=\"commercialReview\" targetRef=\"reviewsJoin\""), "both branches flow into the join");
+        assertTrue(bpmn.contains("sourceRef=\"reviewsJoin\" targetRef=\"consolidate\""), "the join flows on to `next`");
+        // The fork must NOT fall through the linear chain into the branches' successor.
+        assertFalse(bpmn.contains("sourceRef=\"reviews\" targetRef=\"consolidate\""),
+                "the fork must fan to branches, not fall through linearly to consolidate");
+        assertTrue(bpmn.contains("<userTask id=\"techReview\"") && bpmn.contains("<userTask id=\"commercialReview\""),
+                "the branch user tasks are emitted");
+        assertTrue(bpmn.contains("BPMNShape_reviewsJoin") && bpmn.contains("BPMNShape_reviews"),
+                "the fork and join gateways get DI shapes");
+    }
+
+    @Test
     void field_major_false_is_kept_off_the_list_via_widget_is_major() {
         // `major: false` on a field maps to the model's widgetIsMajor="false" so the entity list table
         // omits that column (the field is still shown in forms + the details pane). Default is true.


### PR DESCRIPTION
Closes #6556. Follow-up tracked in #6568.

## What

A `kind: parallel` process step runs its branch steps **concurrently** and joins before `next` — two independent approvals (technical + commercial review) run at once instead of being serialized:

```yaml
steps:
  - { name: reviews, kind: parallel, args: { branches: [techReview, commercialReview], next: consolidate } }
  - { name: techReview,       kind: userTask, args: { assignee: engineer, form: ReviewOrder } }
  - { name: commercialReview, kind: userTask, args: { assignee: sales,    form: ReviewOrder } }
  - { name: consolidate,      kind: serviceTask, args: { setRelationField: Status, value: 2 } }
  - { name: done, kind: end }
```

This is the last piece of the BPM event-support arc (waits/timers #6327/#6328, abort #6340).

## How

Emitted as a BPMN **parallelGateway pair**: the `parallel` step is a diverging gateway that fans an unconditioned flow to each branch; a **synthesized** converging gateway (`<fork>Join`) waits for every branch before the single flow to `next`. The branch steps + the join are **off the default linear chain** (exactly like decision `then`/`else` and `abortOn`'s cleanup): excluded from the linear sequence and wired `fork → branch → join → next` explicitly. The existing layered BPMN-DI layout already fans a gateway's branches into separate lanes, so **no new layout code** was needed. The editor's process diagram renders the fork/join pair too (auto-laid-out by mxHierarchicalLayout).

- New `ProcessParallelSupport` (fork extraction + synthesized join id), mirroring `ProcessAbortSupport`.
- `BpmnIntentGenerator`: synthesize the join step, emit `parallelGateway`s, exclude branches/join from the linear chain, wire the fork/branch/join flows, size the gateways in the DI.
- Parser `validateParallelSteps`: `>= 2` branches, each a single declared task step that joins directly, `next` a declared step or `end`.

## v1 scope + follow-up

Each branch is a **single** declared task step that joins directly, and forks do not nest — matching the issue's example. A branch that chains onward (its own `next`/`then`/boundary timer) or is itself `parallel` is **rejected at parse** with a clear message, and tracked as a follow-up in **#6568** (and the intentfile `Planned` list).

## Tests

- **Unit**: `ProcessParallelSupportTest` (fork extraction) + `IntentParserTest` (parses; too-few-branches / unknown-branch / branch-with-own-next / unknown-next rejected). Full engine-intent suite green (329).
- **IT**: `IntentEngineIT` asserts the generated `.bpmn` — the diverging + converging `parallelGateway`s, the `fork→branch`, `branch→join`, `join→next` flows, the branch user tasks, the DI shapes, and that the fork does **not** fall through linearly to `next`.
- **Live**: generated + published a parallel process — **Flowable deployed the BPMN** (`BpmnSynchronizer ... has been deployed`), no parse/deploy error, confirming the gateway pair is well-formed.

## Docs

intentfile.org (spec `processes.md` + `Planned`, open) and dirigible.io `/help/intent/` (merged), same effort.
