### PR TITLE
fix(harmonia): document item dialog honors readOnly / calculated flags on personal & partner surfaces (#6552)

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
@@ -314,7 +314,7 @@
           <template x-for="col in itemColumns()" :key="col.name">
             <div x-h-field :class="col.kind === 'text' ? 'col-span-2' : ''">
               <label x-h-label x-text="T(col.tkey, col.label)"></label>
-              <template x-if="col.lookup">
+              <template x-if="!col.readonly && col.lookup">
                 <div x-h-select data-filter="contains">
                   <input x-h-select-input x-model="draft[col.name]" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select {{name}}...', { name: T(col.tkey, col.label) })" />
                   <div x-h-select-content>
@@ -325,14 +325,19 @@
                   </div>
                 </div>
               </template>
-              <template x-if="!col.lookup && col.number">
+              <template x-if="!col.readonly && !col.lookup && col.number">
                 <div x-h-input-number><input type="number" step="any" x-model.number="draft[col.name]" /></div>
               </template>
-              <template x-if="!col.lookup && col.date">
+              <template x-if="!col.readonly && !col.lookup && col.date">
                 <div x-h-date-picker><input type="text" /><button x-h-date-picker-trigger aria-label="Choose date"></button><div x-h-date-picker-popup x-model="draft[col.name]"></div></div>
               </template>
-              <template x-if="!col.lookup && !col.date && !col.number">
+              <template x-if="!col.readonly && !col.lookup && !col.date && !col.number">
                 <input x-h-input type="text" x-model="draft[col.name]" :pattern="col.pattern" />
+              </template>
+              <!-- A read-only column (calculated / intent readOnly) is a VALUE, not a control: the
+                   server recomputes it on save, so rendering an input only faked editability. -->
+              <template x-if="col.readonly">
+                <div class="text-sm py-2 text-secondary-foreground" x-text="displayItem(draft, col)"></div>
               </template>
             </div>
           </template>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
@@ -189,7 +189,7 @@
           <template x-for="col in itemColumns()" :key="col.name">
             <div x-h-field :class="col.kind === 'text' ? 'col-span-2' : ''">
               <label x-h-label x-text="T(col.tkey, col.label)"></label>
-              <template x-if="col.lookup">
+              <template x-if="!col.readonly && col.lookup">
                 <div x-h-select data-filter="contains">
                   <input x-h-select-input x-model="draft[col.name]" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select {{name}}...', { name: T(col.tkey, col.label) })" />
                   <div x-h-select-content>
@@ -200,14 +200,19 @@
                   </div>
                 </div>
               </template>
-              <template x-if="!col.lookup && col.number">
+              <template x-if="!col.readonly && !col.lookup && col.number">
                 <div x-h-input-number><input type="number" step="any" x-model.number="draft[col.name]" /></div>
               </template>
-              <template x-if="!col.lookup && col.date">
+              <template x-if="!col.readonly && !col.lookup && col.date">
                 <div x-h-date-picker><input type="text" /><button x-h-date-picker-trigger aria-label="Choose date"></button><div x-h-date-picker-popup x-model="draft[col.name]"></div></div>
               </template>
-              <template x-if="!col.lookup && !col.date && !col.number">
+              <template x-if="!col.readonly && !col.lookup && !col.date && !col.number">
                 <input x-h-input type="text" x-model="draft[col.name]" :pattern="col.pattern" />
+              </template>
+              <!-- A read-only column (calculated / intent readOnly) is a VALUE, not a control: the
+                   server recomputes it on save, so rendering an input only faked editability. -->
+              <template x-if="col.readonly">
+                <div class="text-sm py-2 text-secondary-foreground" x-text="displayItem(draft, col)"></div>
               </template>
             </div>
           </template>


### PR DESCRIPTION
Closes #6552.

### Problem
The metadata-driven document **item create/edit dialog** rendered `readOnly` and calculated columns as editable inputs on the generated **personal** (`my-*`) and **partner** (`partner-*`) document surfaces. A user-entered value in such a field was then silently clobbered by the server-side recompute — confusing and lossy.

### Fix
The main document view (`ui/perspective/document/document-view.html.template`) already gates these fields on `col.readonly`. This brings the two personal-surface copies in line:

- `ui/my/my-document-view.html.template`
- `ui/partner/partner-document-view.html.template`

Both already reuse the same `editColumns` metadata from `detail-register.js.template`, which carries a `readonly` flag (`isCalculatedProperty || isReadOnlyProperty`) — the dialogs just weren't consuming it. Now:

- each editable branch (lookup / number / date / text) guards on `!col.readonly`, and
- read-only columns render **display-only** via the existing `displayItem(draft, col)` helper (resolves FK labels, formats dates/numbers, em dash when empty).

No save-path change is needed: a create draft starts empty so derived columns are omitted on create, and the server stays authoritative on edit.

### Scope / notes
- Surgical: I did **not** port the main view's live-recalc machinery (`harmoniaCalcEval` + watchers) into these deliberately-leaner surfaces — the issue accepts display-only and the server recomputes on save.
- Template-only change (Velocity + Alpine markup); no Java affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)