### PR TITLE
fix(cms): apply the per-path access grants to the raw content path too

### DIFF
--- a/components/engine/engine-cms/src/main/java/org/eclipse/dirigible/components/engine/cms/endpoint/CmsEndpoint.java
+++ b/components/engine/engine-cms/src/main/java/org/eclipse/dirigible/components/engine/cms/endpoint/CmsEndpoint.java
@@ -23,6 +23,7 @@ import org.eclipse.dirigible.components.engine.cms.CmisDocument;
 import org.eclipse.dirigible.components.engine.cms.CmisObject;
 import org.eclipse.dirigible.components.engine.cms.CmisSessionFactory;
 import org.eclipse.dirigible.components.engine.cms.ObjectType;
+import org.eclipse.dirigible.components.engine.cms.documents.DocumentAccessEvaluator;
 import org.eclipse.dirigible.components.engine.cms.service.CmsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,6 +66,9 @@ public class CmsEndpoint extends BaseEndpoint {
     /** The cms service. */
     private final CmsService cmsService;
 
+    /** Decides whether the caller may read the requested path. */
+    private final DocumentAccessEvaluator accessEvaluator;
+
     /** The Constant WEB_CACHE. */
     private static final Cache WEB_CACHE = ResourcesCache.getWebCache();
 
@@ -77,10 +81,11 @@ public class CmsEndpoint extends BaseEndpoint {
      * Instantiates a new cms endpoint.
      *
      * @param cmsService the cms service
+     * @param accessEvaluator the per-path access evaluator
      */
-    @Autowired
-    public CmsEndpoint(CmsService cmsService) {
+    public CmsEndpoint(CmsService cmsService, DocumentAccessEvaluator accessEvaluator) {
         this.cmsService = cmsService;
+        this.accessEvaluator = accessEvaluator;
     }
 
     /**
@@ -96,6 +101,7 @@ public class CmsEndpoint extends BaseEndpoint {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Listing of web folders is forbidden.");
         }
         assertExportsAccess(path);
+        assertReadable(path);
         if (path.trim()
                 .endsWith("/")) {
             return getDocumentByPath(path + INDEX_HTML);
@@ -109,10 +115,9 @@ public class CmsEndpoint extends BaseEndpoint {
     }
 
     /**
-     * A database export dump is readable only by the roles entitled to produce one. Attachments and
-     * document snapshots stay readable by any authenticated user - the applications that own them
-     * govern their own access - but a full schema dump is an administrative artefact and must not be
-     * reachable just because its file name is known.
+     * A database export dump is readable only by the roles entitled to produce one: a full schema dump
+     * is an administrative artefact and must not be reachable just because its file name is known. This
+     * is a blanket rule, independent of the per-path grants applied by {@link #assertReadable}.
      *
      * @param path the requested CMS path
      */
@@ -127,6 +132,21 @@ public class CmsEndpoint extends BaseEndpoint {
         if (!request.isUserInRole(Roles.ADMINISTRATOR.getRoleName()) && !request.isUserInRole(Roles.OPERATOR.getRoleName())) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access to the database exports requires the "
                     + Roles.ADMINISTRATOR.getRoleName() + " or " + Roles.OPERATOR.getRoleName() + " role.");
+        }
+    }
+
+    /**
+     * The per-path role grants apply here exactly as they do to the Documents API.
+     * <p>
+     * This endpoint reads the same tenant content by path, so without this check a grant restricting a
+     * folder would hide it from the Documents user interface while still serving every file under it to
+     * any authenticated caller who knows - or guesses - the path.
+     *
+     * @param path the requested CMS path
+     */
+    private void assertReadable(String path) {
+        if (!accessEvaluator.isReadable(path, request)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access to the requested path is not allowed.");
         }
     }
 

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/CmsAccessControlIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/CmsAccessControlIT.java
@@ -14,6 +14,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 
+import java.nio.charset.StandardCharsets;
+
 import org.eclipse.dirigible.components.base.http.roles.Roles;
 import org.eclipse.dirigible.tests.base.IntegrationTest;
 import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
@@ -38,8 +40,12 @@ class CmsAccessControlIT extends IntegrationTest {
     private static final String DOCUMENTS = "/services/documents";
     private static final String ACCESS = DOCUMENTS + "/access";
 
+    /** The raw content path - the same tenant content, served by file path. */
+    private static final String CMS = "/services/cms";
+
     private static final String FOLDER = "cms-access-it";
     private static final String FOLDER_PATH = "/" + FOLDER;
+    private static final String FILE_NAME = "secret.txt";
     private static final String GRANTED_ROLE = "cms-access-it-role";
 
     private static final String ADMIN = "cms-access-it-admin";
@@ -149,6 +155,41 @@ class CmsAccessControlIT extends IntegrationTest {
         }, PLAIN, PASSWORD);
     }
 
+    /**
+     * A grant must govern every way the content can be read, not only the Documents API. The raw
+     * content path serves the same tenant files by path, so if it ignored the grants, restricting a
+     * folder would hide it from the user interface while leaving every file under it downloadable by
+     * any authenticated caller who knows - or guesses - the path.
+     */
+    @Test
+    void a_read_grant_also_blocks_the_raw_cms_content_path() {
+        restAssuredExecutor.execute(() -> {
+            createFolder();
+            upload();
+        }, ADMIN, PASSWORD);
+
+        // open by default: both surfaces serve the file while no rule exists
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get(CMS + FOLDER_PATH + "/" + FILE_NAME)
+                                                 .then()
+                                                 .statusCode(200),
+                PLAIN, PASSWORD);
+
+        restAssuredExecutor.execute(() -> grant(FOLDER_PATH, "READ", GRANTED_ROLE), ADMIN, PASSWORD);
+
+        restAssuredExecutor.execute(() -> {
+            given().when()
+                   .get(DOCUMENTS + "/download?path=" + FOLDER_PATH + "/" + FILE_NAME)
+                   .then()
+                   .statusCode(403);
+
+            given().when()
+                   .get(CMS + FOLDER_PATH + "/" + FILE_NAME)
+                   .then()
+                   .statusCode(403);
+        }, PLAIN, PASSWORD);
+    }
+
     @Test
     void the_internal_folders_are_not_grantable() {
         restAssuredExecutor.execute(() -> given().contentType(ContentType.JSON)
@@ -165,6 +206,14 @@ class CmsAccessControlIT extends IntegrationTest {
                .body("{\"parentFolder\":\"/\",\"name\":\"" + FOLDER + "\"}")
                .when()
                .post(DOCUMENTS + "/folder");
+    }
+
+    private static void upload() {
+        given().multiPart("file", FILE_NAME, "secret".getBytes(StandardCharsets.UTF_8))
+               .when()
+               .post(DOCUMENTS + "?path=" + FOLDER_PATH)
+               .then()
+               .statusCode(200);
     }
 
     private static void grant(String path, String method, String role) {


### PR DESCRIPTION
Follow-up to #6566, which shipped the dynamic per-path CMS access control. That PR made the Documents API honour the grants; this closes the one read path that did not.

## The gap

`GET /services/cms/{*path}` serves the same tenant content **by file path** and consulted only the `__EXPORTS` role rule added in #6559. So a grant restricting a folder removed it from the Documents user interface while every file under it stayed downloadable by any authenticated caller who knew — or guessed — the path.

The old javadoc stated this as intended (*"Attachments and document snapshots stay readable by any authenticated user"*). That was defensible before there was a real, UI-exposed ACL; with #6566 merged it silently defeats the feature.

Reproduced against a running instance **before** the fix — a `READ` grant on `/AclProbe` for a role the caller does not hold:

| request | before | after |
|---|---|---|
| `GET /services/documents?path=/AclProbe` | 403 | 403 |
| `GET /services/documents/download?path=/AclProbe/probe.txt` | 403 | 403 |
| `GET /services/cms/AclProbe/probe.txt` | **200 — file contents** | **403** |

## The fix

`CmsEndpoint` consults the same `DocumentAccessEvaluator` the Documents API uses, so both surfaces share one decision and the escapes — no request context, anonymous mode, `DIRIGIBLE_CMS_ROLES_ENABLED=false` — apply uniformly. No new semantics, no new configuration.

Deliberately unchanged:

- The blanket `__EXPORTS` rule still runs **first**, so a dump stays administrator/operator-only regardless of grants.
- **No grants means open**, so an installation that never creates one behaves exactly as before — verified: the file is served through the raw path while the folder is open.
- Revoking restores access on the next request, as everywhere else.

## Verification

- `CmsAccessControlIT` gains `a_read_grant_also_blocks_the_raw_cms_content_path` — the file is served through the raw path while the folder is open, and 403 through **both** surfaces once the grant exists.
- ITs green: `CmsAccessControlIT` 5/5, `DocumentsApiIT` 3/3, and `EndpointAuthorizationIT` 4/4 — the last confirms #6559's exports guard is untouched.
- Live-verified end to end on a running instance (the table above), including revoke-restores and the exports rule.
- `mvn formatter:validate` clean; `-P release` javadoc clean on `engine-cms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)