### PR TITLE
feat(intent): generates computed item lines - expression-valued cells on create-from (#6555)

### DIFF
--- a/components/engine/engine-intent/README.md
+++ b/components/engine/engine-intent/README.md
@@ -338,6 +338,21 @@ generates:
     sourceStatus: 3                   # optional completion hook: the SOURCE's EntityStatus after creation
 ```
 
+`items:` has two mutually-exclusive shapes. As an OBJECT (above) it MIRRORS each source child row
+1:1. As a LIST (below, #6555) it builds COMPUTED synthetic lines whose cells are expressions over the
+SOURCE record - the target's line-items child is resolved automatically:
+
+```yaml
+    items:                            # computed synthetic lines over the SOURCE record
+      - name: "Services for {period}"   # string: {field} interpolation (or a source-field copy / literal)
+        quantity: 1                     # numeric: a Calc arithmetic expression (PascalCase source idents)
+        price: BillableAmount           #   rounded to the target field's scale (a literal is trivial)
+        when: "BillableAmount != 0"     # optional guard: `<SourceField> ==|!= <number>` (Calc, null-safe)
+```
+
+A numeric cell is `Calc.eval(...)` (like posting item amounts); a to-one relation cell copies the raw
+source FK (#6533 parity); a string cell interpolates / copies / literals.
+
 Adds a button on the source view; the clone saves through the target's repository so numbering,
 status init and calculated fields fire. `sourceStatus:` flips the SOURCE to the given EntityStatus
 seed id once the target exists (proforma -> INVOICED) - a system write: no `-updated` re-fire, but

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -687,7 +687,12 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                                                                                  .isBlank()
                     && items.getTo() != null && !items.getTo()
                                                       .isBlank();
+            List<Map<String, String>> lineRows = g.getItemLines();
+            // Computed-line form (issue #6555). Mutually exclusive with the mirror form - the parser
+            // rejects declaring both; here the mirror wins defensively if both slipped through.
+            boolean hasItemLines = !hasItems && lineRows != null && !lineRows.isEmpty();
             e.put("hasItems", hasItems);
+            e.put("hasItemLines", hasItemLines);
             if (hasItems) {
                 e.put("fromItemEntity", items.getFrom());
                 e.put("toItemEntity", items.getTo());
@@ -709,6 +714,43 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                 CrossModelSupport.TargetInfo itemTarget = uses == null ? null : CrossModelSupport.resolve(context, uses, items.getTo());
                 e.put("itemFieldAssignments", childAssignments(items.getMap(), items.getDefaults(), "srcItem",
                         temporalKinds(crossModel ? null : byName.get(items.getTo()), itemTarget)));
+                e.put("itemLines", new ArrayList<>());
+            } else if (hasItemLines) {
+                // The synthetic lines write into the TARGET document's composition line-items child,
+                // resolved automatically (never named in the intent): same-model from this model,
+                // cross-model from the owner .model. Its perspective == the header target's (a document
+                // renders its items there), so toJavaPerspective/toGenFolder/toPk carry over unchanged;
+                // only the item ENTITY name and its per-cell field TYPES are new. Cells are expressions
+                // over the loaded `source` master (Calc arithmetic / {} string interpolation / FK copy),
+                // the postings item-cell conventions applied to a create-from.
+                String itemEntityName;
+                Map<String, CellMeta> itemMetas;
+                if (crossModel) {
+                    CrossModelSupport.ItemsChildInfo child = CrossModelSupport.resolveItemsChild(context, uses, g.getTo());
+                    if (!child.resolved()) {
+                        throw new org.eclipse.dirigible.components.intent.parser.IntentValidationException(
+                                List.of("generates [" + g.getName() + "] declares computed item lines but the cross-model target ["
+                                        + g.getTo() + "] (model [" + g.getUses() + "]) has no composition line-items child"));
+                    }
+                    itemEntityName = child.childEntity();
+                    itemMetas = crossModelCellMetas(child);
+                } else {
+                    EntityIntent itemEntity = compositionChild(byName.get(g.getTo()), byName);
+                    if (itemEntity == null) {
+                        throw new org.eclipse.dirigible.components.intent.parser.IntentValidationException(
+                                List.of("generates [" + g.getName() + "] declares computed item lines but the target [" + g.getTo()
+                                        + "] has no composition line-items child"));
+                    }
+                    itemEntityName = itemEntity.getName();
+                    itemMetas = localCellMetas(itemEntity);
+                }
+                e.put("fromItemEntity", "");
+                e.put("toItemEntity", itemEntityName);
+                e.put("fromItemPerspective", "");
+                e.put("srcFkProperty", "");
+                e.put("toFkProperty", IntentNaming.pascalCase(g.getTo()));
+                e.put("itemFieldAssignments", new ArrayList<>());
+                e.put("itemLines", computedItemLines(lineRows, itemMetas, sourceProperties(source)));
             } else {
                 e.put("fromItemEntity", "");
                 e.put("toItemEntity", "");
@@ -716,6 +758,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                 e.put("srcFkProperty", "");
                 e.put("toFkProperty", "");
                 e.put("itemFieldAssignments", new ArrayList<>());
+                e.put("itemLines", new ArrayList<>());
             }
             out.add(e);
         }
@@ -1595,6 +1638,288 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             list.add(assignment(entry.getKey(), expression));
         }
         return list;
+    }
+
+    /**
+     * The rendering-relevant type of a target line-items cell: its logical {@code kind} ({@code string}
+     * / {@code decimal} / {@code double} / {@code integer} / {@code long} / {@code boolean} /
+     * {@code date} / {@code timestamp} / {@code month} / {@code week} / {@code unknown}), the decimal
+     * {@code scale} (for the {@code Calc} rounding of a numeric cell) and whether the cell is a to-one
+     * {@code relation} (a foreign-key copy, not an arithmetic value).
+     */
+    private record CellMeta(String kind, int scale, boolean relation) {
+    }
+
+    /**
+     * The cell metas of a SAME-model target items child, read from its intent fields / to-one
+     * relations.
+     */
+    private static Map<String, CellMeta> localCellMetas(EntityIntent itemEntity) {
+        Map<String, CellMeta> metas = new LinkedHashMap<>();
+        if (itemEntity.getRelations() != null) {
+            for (RelationIntent relation : itemEntity.getRelations()) {
+                boolean toOne = "manyToOne".equals(relation.getKind()) || "oneToOne".equals(relation.getKind());
+                if (toOne && relation.getName() != null) {
+                    metas.put(IntentNaming.pascalCase(relation.getName()), new CellMeta("relation", 0, true));
+                }
+            }
+        }
+        if (itemEntity.getFields() != null) {
+            for (FieldIntent field : itemEntity.getFields()) {
+                if (field.getName() == null || field.getType() == null) {
+                    continue;
+                }
+                int scale = field.getScale() != null ? field.getScale() : 2;
+                metas.put(IntentNaming.pascalCase(field.getName()), new CellMeta(kindOfIntentType(field.getType()), scale, false));
+            }
+        }
+        return metas;
+    }
+
+    /** The cell metas of a CROSS-model target items child, read from the owner {@code .model}. */
+    private static Map<String, CellMeta> crossModelCellMetas(CrossModelSupport.ItemsChildInfo child) {
+        Map<String, CellMeta> metas = new LinkedHashMap<>();
+        for (Map.Entry<String, String> property : child.propertyTypes()
+                                                       .entrySet()) {
+            String name = property.getKey(); // owner .model property names are already PascalCase
+            if (child.relationProperties()
+                     .contains(name)) {
+                metas.put(name, new CellMeta("relation", 0, true));
+                continue;
+            }
+            String widget = child.propertyWidgets()
+                                 .get(name);
+            String kind;
+            if ("MONTH".equals(widget)) {
+                kind = "month";
+            } else if ("WEEK".equals(widget)) {
+                kind = "week";
+            } else {
+                kind = kindOfJdbcType(property.getValue());
+            }
+            int scale = child.propertyScales()
+                             .getOrDefault(name, 2);
+            metas.put(name, new CellMeta(kind, scale, false));
+        }
+        return metas;
+    }
+
+    /** Logical cell kind for an intent field type (same-model target). */
+    private static String kindOfIntentType(String type) {
+        return switch (type.toLowerCase(java.util.Locale.ROOT)) {
+            case "string", "text", "uuid" -> "string";
+            case "integer", "int" -> "integer";
+            case "long" -> "long";
+            case "decimal" -> "decimal";
+            case "double" -> "double";
+            case "boolean" -> "boolean";
+            case "date" -> "date";
+            case "timestamp" -> "timestamp";
+            case "month" -> "month";
+            case "week" -> "week";
+            default -> "unknown";
+        };
+    }
+
+    /**
+     * Logical cell kind for a JDBC {@code dataType} (cross-model target, read from the owner .model).
+     */
+    private static String kindOfJdbcType(String dataType) {
+        return switch (dataType == null ? "" : dataType.toUpperCase(java.util.Locale.ROOT)) {
+            case "VARCHAR", "CHAR", "CLOB", "LONGVARCHAR", "NVARCHAR" -> "string";
+            case "DECIMAL", "NUMERIC" -> "decimal";
+            case "DOUBLE", "REAL", "FLOAT" -> "double";
+            case "INTEGER", "SMALLINT", "TINYINT" -> "integer";
+            case "BIGINT" -> "long";
+            case "BOOLEAN", "BIT" -> "boolean";
+            case "DATE" -> "date";
+            case "TIMESTAMP", "TIME" -> "timestamp";
+            default -> "unknown";
+        };
+    }
+
+    /**
+     * PascalCase names of the source entity's fields + to-one relations (drives string-cell
+     * copy/interpolation).
+     */
+    private static java.util.Set<String> sourceProperties(EntityIntent source) {
+        java.util.Set<String> names = new java.util.LinkedHashSet<>();
+        if (source == null) {
+            return names;
+        }
+        if (source.getFields() != null) {
+            for (FieldIntent field : source.getFields()) {
+                if (field.getName() != null) {
+                    names.add(IntentNaming.pascalCase(field.getName()));
+                }
+            }
+        }
+        if (source.getRelations() != null) {
+            for (RelationIntent relation : source.getRelations()) {
+                if (relation.getName() != null) {
+                    names.add(IntentNaming.pascalCase(relation.getName()));
+                }
+            }
+        }
+        return names;
+    }
+
+    /**
+     * Render the computed line-items ({@code itemLines}, issue #6555): one entry per synthetic line,
+     * each {@code {guard, assigns:[{targetProp, expr}]}} - the same pre-rendered shape a posting item
+     * row uses, so the template stays logic-free. Every {@code expr} runs over the loaded
+     * {@code source} master. A {@code when} cell becomes the row guard.
+     */
+    private static List<Map<String, Object>> computedItemLines(List<Map<String, String>> rows, Map<String, CellMeta> metas,
+            java.util.Set<String> sourceProps) {
+        List<Map<String, Object>> out = new ArrayList<>();
+        if (rows == null) {
+            return out;
+        }
+        for (Map<String, String> row : rows) {
+            Map<String, Object> rendered = new LinkedHashMap<>();
+            List<Map<String, Object>> assigns = new ArrayList<>();
+            String guard = "";
+            for (Map.Entry<String, String> cell : row.entrySet()) {
+                String value = cell.getValue() == null ? ""
+                        : cell.getValue()
+                              .trim();
+                if ("when".equalsIgnoreCase(cell.getKey())) {
+                    guard = computedGuard(value);
+                    continue;
+                }
+                CellMeta meta = metas.get(IntentNaming.pascalCase(cell.getKey()));
+                assigns.add(assignment(cell.getKey(), computedCellExpression(value, meta, sourceProps)));
+            }
+            rendered.put("guard", guard);
+            rendered.put("assigns", assigns);
+            out.add(rendered);
+        }
+        return out;
+    }
+
+    /**
+     * A single computed-line cell as a Java expression over {@code source}: a to-one relation copies
+     * the source foreign key ({@code source.<Prop>}, issue #6533 parity); a numeric field is a
+     * {@code Calc} arithmetic expression rounded to its scale (integer/long narrowed off the
+     * {@code BigDecimal}); a string field is a {@code {field}}-interpolated concatenation, a bare
+     * source-property copy, or a quoted literal; a {@code month}/{@code week}/date/boolean field takes
+     * {@code now} / a literal.
+     */
+    private static String computedCellExpression(String value, CellMeta meta, java.util.Set<String> sourceProps) {
+        String v = value == null ? "" : value.trim();
+        if (meta != null && meta.relation()) {
+            return "source." + IntentNaming.pascalCase(v);
+        }
+        String kind = meta == null ? "unknown" : meta.kind();
+        int scale = meta == null ? 2 : meta.scale();
+        switch (kind) {
+            case "decimal":
+                return calcExpression(v, scale);
+            case "double":
+                return calcExpression(v, scale) + ".doubleValue()";
+            case "integer":
+                return calcExpression(v, 0) + ".intValue()";
+            case "long":
+                return calcExpression(v, 0) + ".longValue()";
+            case "boolean":
+            case "date":
+            case "timestamp":
+            case "month":
+            case "week": {
+                // A bare source property copies it (e.g. a date carried over from the source); otherwise
+                // `now` / a literal in the field's own shape (month -> YYYY-MM, week -> YYYY-Www, else
+                // LocalDate / boolean / quoted string).
+                String copy = bareSourceCopy(v, sourceProps);
+                String temporalKind = "month".equals(kind) || "week".equals(kind) ? kind : null;
+                return copy != null ? copy : literalExpression(v, temporalKind);
+            }
+            case "string":
+                return stringCellExpression(v, sourceProps);
+            default:
+                // unknown: only when a cross-model item child is unresolved (null-context unit tests);
+                // best effort - an arithmetic-looking value is numeric, otherwise a string.
+                return v.matches("[\\w.]*[-+*/()][\\w.+\\-*/() ]*") ? calcExpression(v, scale) : stringCellExpression(v, sourceProps);
+        }
+    }
+
+    /**
+     * {@code Calc.eval("<expr>", source, <scale>)} - the calculated-field / posting-amount convention.
+     */
+    private static String calcExpression(String expr, int scale) {
+        return "Calc.eval(\"" + expr.replace("\\", "\\\\")
+                                    .replace("\"", "\\\"")
+                + "\", source, " + scale + ")";
+    }
+
+    /**
+     * A string cell: {@code {field}} placeholders become a Java concatenation over {@code source}; a
+     * bare identifier that IS a source property copies it ({@code source.<Prop>}); anything else is a
+     * quoted literal (so a plain caption like {@code "Consulting services"} is NOT read as a field).
+     */
+    private static String stringCellExpression(String v, java.util.Set<String> sourceProps) {
+        if (v.contains("{")) {
+            StringBuilder expr = new StringBuilder();
+            java.util.regex.Matcher m = java.util.regex.Pattern.compile("\\{(\\w+)\\}")
+                                                               .matcher(v);
+            int last = 0;
+            while (m.find()) {
+                if (m.start() > last) {
+                    appendConcat(expr, '"' + v.substring(last, m.start())
+                                              .replace("\"", "\\\"")
+                            + '"');
+                }
+                appendConcat(expr, "String.valueOf(source." + IntentNaming.pascalCase(m.group(1)) + ")");
+                last = m.end();
+            }
+            if (last < v.length()) {
+                appendConcat(expr, '"' + v.substring(last)
+                                          .replace("\"", "\\\"")
+                        + '"');
+            }
+            return expr.length() == 0 ? "\"\"" : expr.toString();
+        }
+        String copy = bareSourceCopy(v, sourceProps);
+        if (copy != null) {
+            return copy;
+        }
+        return "\"" + v.replace("\\", "\\\\")
+                       .replace("\"", "\\\"")
+                       .replace("\n", "\\n")
+                       .replace("\r", "\\r")
+                + "\"";
+    }
+
+    /**
+     * {@code source.<Prop>} when {@code v} is a bare identifier naming a source property, else null.
+     */
+    private static String bareSourceCopy(String v, java.util.Set<String> sourceProps) {
+        if (v.matches("[A-Za-z_]\\w*") && sourceProps.contains(IntentNaming.pascalCase(v))) {
+            return "source." + IntentNaming.pascalCase(v);
+        }
+        return null;
+    }
+
+    private static void appendConcat(StringBuilder expr, String term) {
+        if (expr.length() > 0) {
+            expr.append(" + ");
+        }
+        expr.append(term);
+    }
+
+    /**
+     * A computed-line {@code when} guard as a null-safe {@code Calc} comparison over {@code source} -
+     * the postings item-row guard convention ({@code <field> ==|!= <n>}); an unparseable guard yields
+     * no guard (the line is always created).
+     */
+    private static String computedGuard(String value) {
+        java.util.regex.Matcher guard = java.util.regex.Pattern.compile("\\s*(\\w+)\\s*([!=]=)\\s*(\\d+(?:\\.\\d+)?)\\s*")
+                                                               .matcher(value);
+        if (guard.matches()) {
+            return "Calc.eval(\"" + IntentNaming.pascalCase(guard.group(1)) + "\", source, 6).compareTo(new java.math.BigDecimal(\""
+                    + guard.group(3) + "\")) " + ("==".equals(guard.group(2)) ? "==" : "!=") + " 0";
+        }
+        return "";
     }
 
     /**

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/CrossModelSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/CrossModelSupport.java
@@ -118,6 +118,135 @@ public final class CrossModelSupport {
     }
 
     /**
+     * Everything a {@code generates} computed-line
+     * ({@link org.eclipse.dirigible.components.intent.model.GeneratesIntent#getItemLines()}) needs to
+     * type its cells against a cross-model target's line-items child: the child entity name and the
+     * perspective it lives under (== the master's, a document renders its items there), plus each
+     * property's JDBC type / decimal scale and which properties are to-one relations. Types drive the
+     * per-cell rendering (numeric {@code Calc} vs {@code {}} string interpolation vs foreign-key copy)
+     * exactly as the local {@code FieldIntent} does for a same-model target.
+     *
+     * @param resolved whether the owner model was found, parsed AND contained a composition child of
+     *        the master (false → nothing resolved; the caller treats the target as having no items
+     *        child)
+     */
+    public record ItemsChildInfo(boolean resolved, String childEntity, String perspectiveName, Map<String, String> propertyTypes,
+            Map<String, Integer> propertyScales, java.util.Set<String> relationProperties, Map<String, String> propertyWidgets) {
+    }
+
+    /**
+     * Resolve the composition line-items child of a cross-model {@code generates} target master (e.g.
+     * {@code SalesInvoiceItem} for {@code SalesInvoice}). Order-independent and read from the same two
+     * sources as {@link #resolve} (workspace {@code .model}, else the published registry copy); fails
+     * loudly the same way when neither is present so a computed-line create-from never silently drops
+     * its lines. A resolved model that simply has no composition child of the master returns an
+     * <b>unresolved</b> {@link ItemsChildInfo} (not an error) - the caller reports "no items child".
+     */
+    public static ItemsChildInfo resolveItemsChild(IntentGenerationContext context, UsesIntent uses, String masterEntity) {
+        if (context == null || context.getRepository() == null || context.getProjectRoot() == null) {
+            return new ItemsChildInfo(false, null, masterEntity, java.util.Map.of(), java.util.Map.of(), java.util.Set.of(),
+                    java.util.Map.of()); // no repository (unit test)
+        }
+        String alias = uses.getModel();
+        String project = uses.resolveProject();
+        IRepository repository = context.getRepository();
+        String workspacePath = siblingModelPath(context.getProjectRoot(), project, alias);
+        ItemsChildInfo fromWorkspace = readItemsChild(repository, workspacePath, masterEntity);
+        if (fromWorkspace != null) {
+            return fromWorkspace;
+        }
+        String registryPath = IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + project + "/" + alias + ".model";
+        ItemsChildInfo fromRegistry = readItemsChild(repository, registryPath, masterEntity);
+        if (fromRegistry != null) {
+            return fromRegistry;
+        }
+        throw new IntentValidationException(List.of("Cross-model generates target [" + masterEntity + "] (model alias [" + alias
+                + "], project [" + project + "]) cannot be resolved for computed item lines: no model found in the workspace ["
+                + workspacePath + "] or the registry [" + registryPath + "]. Generate the [" + alias
+                + "] model first, or install/publish its prebuilt module so its .model is in the registry."));
+    }
+
+    /**
+     * Read the target master's composition line-items child from a {@code .model} resource, or
+     * {@code null} when the resource is absent / unparseable (so the caller tries the next source). A
+     * resource that parses but has no composition child of the master returns a resolved-but-empty
+     * {@link ItemsChildInfo} so the caller stops looking and reports "no items child".
+     */
+    @SuppressWarnings("unchecked")
+    private static ItemsChildInfo readItemsChild(IRepository repository, String modelPath, String masterEntity) {
+        if (modelPath == null) {
+            return null;
+        }
+        IResource resource = repository.getResource(modelPath);
+        if (!resource.exists()) {
+            return null;
+        }
+        try {
+            String content = new String(resource.getContent(), StandardCharsets.UTF_8);
+            Map<String, Object> root = GSON.fromJson(content, Map.class);
+            Map<String, Object> body = (Map<String, Object>) root.get("model");
+            List<Map<String, Object>> entities = body == null ? null : (List<Map<String, Object>>) body.get("entities");
+            if (entities == null) {
+                return null;
+            }
+            for (Map<String, Object> entity : entities) {
+                List<Map<String, Object>> properties = (List<Map<String, Object>>) entity.get("properties");
+                if (properties == null) {
+                    continue;
+                }
+                boolean isChild = false;
+                for (Map<String, Object> p : properties) {
+                    if ("COMPOSITION".equals(String.valueOf(p.get("relationshipType")))
+                            && masterEntity.equals(String.valueOf(p.get("relationshipEntityName")))) {
+                        isChild = true;
+                        break;
+                    }
+                }
+                if (!isChild) {
+                    continue;
+                }
+                String childEntity = str(entity.get("name"), null);
+                String perspective = str(entity.get("perspectiveName"), masterEntity);
+                Map<String, String> propertyTypes = new java.util.LinkedHashMap<>();
+                Map<String, Integer> propertyScales = new java.util.LinkedHashMap<>();
+                java.util.Set<String> relationProperties = new java.util.LinkedHashSet<>();
+                Map<String, String> propertyWidgets = new java.util.LinkedHashMap<>();
+                for (Map<String, Object> p : properties) {
+                    String propertyName = str(p.get("name"), null);
+                    if (propertyName == null) {
+                        continue;
+                    }
+                    propertyTypes.put(propertyName, str(p.get("dataType"), "VARCHAR"));
+                    Object scale = p.get("dataScale");
+                    if (scale != null) {
+                        try {
+                            propertyScales.put(propertyName, (int) Double.parseDouble(String.valueOf(scale)));
+                        } catch (NumberFormatException ignore) {
+                            // a non-numeric scale is meaningless - leave it unscaled (default applies)
+                        }
+                    }
+                    String relationshipType = str(p.get("relationshipType"), null);
+                    if (relationshipType != null && !"null".equals(relationshipType)) {
+                        relationProperties.add(propertyName);
+                    }
+                    String widget = str(p.get("widgetType"), null);
+                    if (widget != null) {
+                        propertyWidgets.put(propertyName, widget);
+                    }
+                }
+                return new ItemsChildInfo(true, childEntity, perspective, propertyTypes, propertyScales, relationProperties,
+                        propertyWidgets);
+            }
+            // The model resolved but declares no composition child of the master - stop looking here.
+            return new ItemsChildInfo(false, null, masterEntity, java.util.Map.of(), java.util.Map.of(), java.util.Set.of(),
+                    java.util.Map.of());
+        } catch (RuntimeException e) {
+            LOGGER.warn("Failed to read owner model [{}] for cross-model items child of [{}]", modelPath, masterEntity, e);
+        }
+        return null;
+    }
+
+    /**
      * Read the cross-model target entity's facts from a {@code .model} resource, or {@code null} when
      * the resource is absent, unparseable, or does not contain the target entity (so the caller can try
      * the next source).

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/GeneratesIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/GeneratesIntent.java
@@ -10,6 +10,7 @@
 package org.eclipse.dirigible.components.intent.model;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -34,7 +35,19 @@ import java.util.Map;
  * Mapping is split into two disjoint maps so the source-copy vs constant intent is unambiguous:
  * {@link #map} copies a source property onto a target property; {@link #defaults} sets a target
  * property to {@code now} (the current date) or a literal (string / integer / decimal / boolean).
- * {@link #items} optionally mirrors the composition child rows the same way.
+ *
+ * <p>
+ * The composition line-items of the target are filled by exactly one of two mutually-exclusive
+ * shapes:
+ * <ul>
+ * <li>{@link #items} (an OBJECT) - the <b>mirror</b> form: for each source item row a target item
+ * row is created and its cells copied ({@code map}) / defaulted ({@code defaults}); and</li>
+ * <li>{@link #itemLines} (a LIST) - the <b>computed</b> form (issue #6555): a fixed set of
+ * synthetic target lines whose cells are EXPRESSIONS over the SOURCE record - numeric arithmetic
+ * evaluated through {@code Calc} (as calculated fields / posting item amounts are), {@code {field}}
+ * string interpolation, a source foreign-key copy, or a {@code now}/literal. This expresses the
+ * "one line for the period's rolled-up total" invoice a create-from could not build before.</li>
+ * </ul>
  */
 public class GeneratesIntent {
 
@@ -87,9 +100,21 @@ public class GeneratesIntent {
     private Map<String, String> defaults = new LinkedHashMap<>();
 
     /**
-     * Optional composition child mapping (the source document's items -> the target document's items).
+     * Optional composition child mapping (the source document's items -> the target document's items) -
+     * the MIRROR form. Mutually exclusive with {@link #itemLines}.
      */
     private GeneratesItemsIntent items;
+
+    /**
+     * Optional computed line-items (issue #6555) - the COMPUTED form. Each element is one synthetic
+     * target line: a cell key names a field or to-one relation of the target document's line-items
+     * child, and its value is an expression over the SOURCE record (a numeric {@code Calc} arithmetic
+     * expression, a {@code {field}}-interpolated string, a source foreign-key copy, or a
+     * {@code now}/literal); an optional {@code when} cell guards the whole line. Mutually exclusive
+     * with {@link #items}. The parser moves a list-valued {@code items:} here so the two shapes stay
+     * typed.
+     */
+    private List<Map<String, String>> itemLines;
 
     /**
      * Scheduled generation only: child blocks generated under the created target - one child per
@@ -200,6 +225,14 @@ public class GeneratesIntent {
 
     public void setItems(GeneratesItemsIntent items) {
         this.items = items;
+    }
+
+    public List<Map<String, String>> getItemLines() {
+        return itemLines;
+    }
+
+    public void setItemLines(List<Map<String, String>> itemLines) {
+        this.itemLines = itemLines;
     }
 
     public java.util.List<GenerateChildIntent> getChildren() {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -141,6 +141,7 @@ public final class IntentParser {
             return new IntentModel();
         }
         rejectRemovedNumberKeys(tree);
+        moveGeneratesItemLines(tree);
         String json = GSON.toJson(tree);
         IntentModel model;
         try {
@@ -752,7 +753,8 @@ public final class IntentParser {
                     + "] (add a uses: alias if the target lives in another model)");
         }
         validateMapSource(source, g.getMap(), "schedule [" + name + "]", "generate map", issues);
-        if (g.getItems() != null) {
+        if (g.getItems() != null || (g.getItemLines() != null && !g.getItemLines()
+                                                                   .isEmpty())) {
             issues.add("schedule [" + name + "] generate declares items - item cloning is not supported for a scheduled generation;"
                     + " use an on-demand generates action for document-to-document cloning");
         }
@@ -2303,6 +2305,47 @@ public final class IntentParser {
      * @param tree the SnakeYAML-loaded raw tree
      * @throws IntentValidationException naming every removed key found, with the migration target
      */
+    /**
+     * A {@code generates[].items} may be EITHER an object (the mirror form ->
+     * {@link GeneratesItemsIntent}) or a LIST of computed line rows (issue #6555 ->
+     * {@code GeneratesIntent.itemLines}). Gson maps a field by its static type, so a list-valued
+     * {@code items:} would fail the typed mapping against the object-typed {@code items} field. Rehome
+     * a list-valued {@code items:} to the {@code itemLines} key on the raw tree, BEFORE the typed
+     * mapping, so the two shapes stay in distinct typed fields. A mapping-valued {@code items:} is left
+     * untouched.
+     *
+     * @param tree the SnakeYAML-loaded raw tree
+     */
+    private static void moveGeneratesItemLines(Object tree) {
+        if (!(tree instanceof Map<?, ?> root)) {
+            return;
+        }
+        if (root.get("generates") instanceof List<?> generates) {
+            for (Object generateNode : generates) {
+                rehomeItemLines(generateNode);
+            }
+        }
+        // A schedule's generate rejects items entirely (validated below); rehome a list-valued items:
+        // here too, so the invalid combination surfaces as that clear message rather than a Gson crash.
+        if (root.get("schedules") instanceof List<?> schedules) {
+            for (Object scheduleNode : schedules) {
+                if (scheduleNode instanceof Map<?, ?> schedule) {
+                    rehomeItemLines(schedule.get("generate"));
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void rehomeItemLines(Object generateNode) {
+        if (!(generateNode instanceof Map<?, ?> generate) || !(generate.get("items") instanceof List<?> itemLines)) {
+            return;
+        }
+        Map<Object, Object> mutable = (Map<Object, Object>) generate;
+        mutable.put("itemLines", itemLines);
+        mutable.remove("items");
+    }
+
     private static void rejectRemovedNumberKeys(Object tree) {
         if (!(tree instanceof Map<?, ?> root)) {
             return;
@@ -3701,6 +3744,106 @@ public final class IntentParser {
                     issues.add("generates [" + name + "] items has no to entity");
                 }
                 validateMapSource(itemSource, items.getMap(), "generates [" + name + "]", "items map", issues);
+            }
+            validateGeneratesItemLines(g, name, source, byName, crossModel, issues);
+        }
+    }
+
+    /**
+     * Validate the computed line-items form ({@code itemLines}, issue #6555): a fixed set of synthetic
+     * target lines whose cells are expressions over the SOURCE record. The two item forms are mutually
+     * exclusive. For a SAME-model target the cell keys must be fields / to-one relations of the target
+     * document's composition line-items child (resolved automatically, never named), a to-one relation
+     * cell copies a bare source relation, a {@code {field}} placeholder / bare-identifier string cell
+     * references a real source property, and a {@code when} guard has the {@code <field> ==|!= <n>}
+     * shape. A CROSS-model target's items child lives in the owner model (not loaded here), so only the
+     * always-checkable shapes are validated - the cell keys are checked at generation, the same
+     * deferral the mirror form's cross-model {@code map} uses.
+     */
+    private static void validateGeneratesItemLines(GeneratesIntent g, String name, EntityIntent source, Map<String, EntityIntent> byName,
+            boolean crossModel, List<String> issues) {
+        List<Map<String, String>> itemLines = g.getItemLines();
+        if (itemLines == null || itemLines.isEmpty()) {
+            return;
+        }
+        String subject = "generates [" + name + "]";
+        if (g.getItems() != null) {
+            issues.add(subject + " declares both an items mapping (object) and computed item lines (list) - use exactly one");
+        }
+        EntityIntent itemsChild = null;
+        if (!crossModel && g.getTo() != null && byName.get(g.getTo()) != null) {
+            itemsChild = compositionChildOf(byName.get(g.getTo()), byName);
+            if (itemsChild == null) {
+                issues.add(
+                        subject + " declares computed item lines but the target [" + g.getTo() + "] has no composition line-items child");
+            }
+        }
+        Set<String> sourceProperties = new HashSet<>();
+        if (source != null) {
+            if (source.getFields() != null) {
+                for (FieldIntent field : source.getFields()) {
+                    if (field.getName() != null) {
+                        sourceProperties.add(field.getName()
+                                                  .toLowerCase(Locale.ROOT));
+                    }
+                }
+            }
+            if (source.getRelations() != null) {
+                for (RelationIntent relation : source.getRelations()) {
+                    if (relation.getName() != null) {
+                        sourceProperties.add(relation.getName()
+                                                     .toLowerCase(Locale.ROOT));
+                    }
+                }
+            }
+        }
+        for (Map<String, String> row : itemLines) {
+            boolean hasCell = false;
+            for (Map.Entry<String, String> cell : row.entrySet()) {
+                String key = cell.getKey();
+                String value = cell.getValue() == null ? ""
+                        : cell.getValue()
+                              .trim();
+                if ("when".equalsIgnoreCase(key)) {
+                    if (!value.matches("\\s*\\w+\\s*[!=]=\\s*\\d+(\\.\\d+)?\\s*")) {
+                        issues.add(subject + " item line when [" + value + "] must be `<SourceField> ==|!= <number>`");
+                    }
+                    continue;
+                }
+                hasCell = true;
+                if (itemsChild != null && !hasPropertyIgnoreCase(itemsChild, key)) {
+                    issues.add(subject + " item line cell [" + key + "] is not a field or to-one relation of the target items child ["
+                            + itemsChild.getName() + "]");
+                    continue;
+                }
+                if (itemsChild != null && toOneRelationByName(itemsChild, key) != null) {
+                    // A to-one relation cell copies a bare source foreign key (issue #6533 parity) - it
+                    // cannot be arithmetic-evaluated. Its value must name a to-one relation of the source.
+                    if (!value.matches("\\w+")) {
+                        issues.add(subject + " item line cell [" + key + "] is a to-one relation - its value must copy a source to-one"
+                                + " relation (a bare source relation name), not an expression [" + value + "]");
+                    } else if (source != null && toOneRelationByName(source, value) == null) {
+                        issues.add(subject + " item line cell [" + key + "] copies [" + value + "] which is not a to-one relation of the"
+                                + " source entity [" + source.getName() + "]");
+                    }
+                } else if (source != null) {
+                    // A string {field} placeholder / bare-identifier copy must reference a real source
+                    // property; a numeric Calc expression's identifiers are validated at runtime (a null
+                    // field reads as 0, the calculated-field contract), so only the string refs are checked.
+                    java.util.regex.Matcher placeholders = java.util.regex.Pattern.compile("\\{(\\w+)\\}")
+                                                                                  .matcher(value);
+                    while (placeholders.find()) {
+                        if (!sourceProperties.contains(placeholders.group(1)
+                                                                   .toLowerCase(Locale.ROOT))) {
+                            issues.add(subject + " item line cell [" + key + "] interpolates {" + placeholders.group(1)
+                                    + "} which is not a property of the source entity ["
+                                    + (source.getName() == null ? g.getFrom() : source.getName()) + "]");
+                        }
+                    }
+                }
+            }
+            if (!hasCell) {
+                issues.add(subject + " has a computed item line with no cells");
             }
         }
     }

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -1013,8 +1013,8 @@ generates:
     defaults:                      # target property <- now | literal (string / integer / decimal / boolean)
       InvoiceDate: now
       Note: "Generated from timesheet"
-    items:                         # optional: clone the source document's composition items too
-      from: ProjectTimesheetItem
+    items:                         # optional MIRROR form (an OBJECT): clone each source item row
+      from: ProjectTimesheetItem   #   1:1 into a target item row (map = copy, defaults = now/literal)
       to: SalesInvoiceItem
       map:
         Description: Description
@@ -1022,6 +1022,32 @@ generates:
     sourceStatus: 3                # optional completion hook: the SOURCE's EntityStatus seed id
                                    # after the target is created (e.g. proforma -> INVOICED)
 ```
+
+**Computed line-items (the `items:` LIST form).** When the target's lines are not a 1:1 mirror of a
+source child but must be **computed** from the source record (e.g. one invoice line carrying a
+period's rolled-up total), give `items:` a **list** of synthetic rows instead of the object above.
+The target's line-items child is resolved automatically (never named). Each cell value is an
+expression over the SOURCE record - the same conventions as calculated fields and posting item
+amounts:
+
+```yaml
+    items:                         # LIST form => computed synthetic lines over the SOURCE record
+      - name: "Services for {period}"   # string cell: {field} interpolates a source property
+        quantity: 1                     # numeric cell: a Calc arithmetic expression over the source,
+        price: BillableAmount           #   rounded to the target field's scale (a literal is trivial)
+        when: "BillableAmount != 0"     # optional guard: `<SourceField> ==|!= <number>` (Calc, null-safe)
+```
+
+- A **numeric** target field (decimal/double/integer/long) takes a `Calc` arithmetic expression -
+  identifiers are **PascalCase** source field names (`BillableAmount`, `Hours * Rate`), exactly as
+  posting item amounts are authored; a null field reads as 0.
+- A **string** field takes `{field}` interpolation of source properties, a bare source-property name
+  (a copy), or a plain quoted literal (a caption is not mistaken for a field).
+- A **to-one relation** cell copies the raw source foreign key (a bare source relation name) - the
+  counterparty/dimension the line carries; it is never arithmetic-evaluated.
+- A `when` cell guards the whole line (the line is created only when the guard holds).
+- The two forms are **mutually exclusive** - a `generates` uses either the object mirror or the list.
+  The list form is not available on a scheduled generate.
 
 **Rules:** unique `name`; `from` must be a declared entity in this model; `to` must be a declared
 entity (add a `uses:` alias when the target lives in another model); `forEntity` must be a declared

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueGeneratesTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueGeneratesTest.java
@@ -275,4 +275,135 @@ class GlueGeneratesTest {
         // The decimal `quantity` default renders as BigDecimal (a bare `1` would not compile).
         assertTrue(itemFields.contains(Map.of("targetProp", "Quantity", "expr", "new java.math.BigDecimal(\"1\")")));
     }
+
+    /**
+     * The computed line-items form (issue #6555): a list-valued {@code items:} builds a fixed set of
+     * synthetic target lines whose cells are expressions over the SOURCE master - a numeric cell runs
+     * through {@code Calc} rounded to the target field's scale (a bare literal is a trivial
+     * expression), a {@code {field}} string cell interpolates the source, a to-one relation copies the
+     * source FK, and a {@code when} cell becomes a null-safe {@code Calc} row guard. The target items
+     * child is resolved automatically (never named). No source item repository is iterated - the mirror
+     * keys stay empty.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    void computedItemLinesRenderExpressionsOverTheSource() {
+        IntentModel model = IntentParser.parse("""
+                name: sales
+                entities:
+                  - name: Timesheet
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: number, type: string, documentTitle: true }
+                      - { name: period, type: month }
+                      - { name: billableAmount, type: decimal, precision: 18, scale: 2 }
+                    relations:
+                      - { name: Customer, kind: manyToOne, to: Customer }
+                      - { name: Product, kind: manyToOne, to: Product }
+                  - name: Invoice
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: number, type: string, documentTitle: true }
+                      - { name: date, type: date }
+                    relations:
+                      - { name: Customer, kind: manyToOne, to: Customer }
+                  - name: InvoiceItem
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                      - { name: quantity, type: decimal, precision: 18, scale: 3 }
+                      - { name: price, type: decimal, precision: 18, scale: 2 }
+                    relations:
+                      - { name: Invoice, kind: manyToOne, to: Invoice, composition: true, required: true }
+                      - { name: Product, kind: manyToOne, to: Product }
+                  - name: Customer
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: Product
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                generates:
+                  - name: invoice-from-timesheet
+                    from: Timesheet
+                    to: Invoice
+                    forEntity: Timesheet
+                    map:
+                      Customer: Customer
+                    defaults:
+                      Date: now
+                    items:
+                      - name: "Services for {period}"
+                        quantity: 1
+                        price: BillableAmount
+                        Product: Product
+                        when: "BillableAmount != 0"
+                """);
+        Map<String, Object> g = GlueIntentGenerator.buildGeneratesForTest(model)
+                                                   .get(0);
+
+        assertEquals(false, g.get("hasItems"));
+        assertEquals(true, g.get("hasItemLines"));
+        // The target items child + its master FK are resolved automatically - the intent never names them.
+        assertEquals("InvoiceItem", g.get("toItemEntity"));
+        assertEquals("Invoice", g.get("toFkProperty"));
+        // The mirror-form keys stay empty (no source item repository is iterated).
+        assertEquals("", g.get("fromItemEntity"));
+        assertTrue(((List<?>) g.get("itemFieldAssignments")).isEmpty());
+
+        List<Map<String, Object>> lines = (List<Map<String, Object>>) g.get("itemLines");
+        assertEquals(1, lines.size());
+        Map<String, Object> row = lines.get(0);
+        // The `when` cell becomes a null-safe Calc row guard (the postings guard convention).
+        assertEquals("Calc.eval(\"BillableAmount\", source, 6).compareTo(new java.math.BigDecimal(\"0\")) != 0", row.get("guard"));
+
+        List<Map<String, Object>> assigns = (List<Map<String, Object>>) row.get("assigns");
+        // String cell: {period} interpolates the source master (a month field is a plain String).
+        assertTrue(assigns.contains(Map.of("targetProp", "Name", "expr", "\"Services for \" + String.valueOf(source.Period)")));
+        // Numeric cells run through Calc rounded to the TARGET field's scale (quantity 3, price 2).
+        assertTrue(assigns.contains(Map.of("targetProp", "Quantity", "expr", "Calc.eval(\"1\", source, 3)")));
+        assertTrue(assigns.contains(Map.of("targetProp", "Price", "expr", "Calc.eval(\"BillableAmount\", source, 2)")));
+        // A to-one relation cell copies the raw source foreign key (issue #6533 parity), not a Calc value.
+        assertTrue(assigns.contains(Map.of("targetProp", "Product", "expr", "source.Product")));
+    }
+
+    /**
+     * A string cell that is neither a {@code {}} template nor a source property is a plain literal (a
+     * caption is not mistaken for a field), and a {@code double} target narrows the {@code Calc}
+     * result.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    void computedItemLineStringLiteralAndDoubleNarrowing() {
+        IntentModel model = IntentParser.parse("""
+                name: sales
+                entities:
+                  - name: Timesheet
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: hours, type: decimal, precision: 18, scale: 2 }
+                  - name: Invoice
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: InvoiceItem
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                      - { name: factor, type: double }
+                    relations:
+                      - { name: Invoice, kind: manyToOne, to: Invoice, composition: true, required: true }
+                generates:
+                  - name: invoice-from-timesheet
+                    from: Timesheet
+                    to: Invoice
+                    items:
+                      - name: "Consulting services"
+                        factor: "Hours * 2"
+                """);
+        Map<String, Object> g = GlueIntentGenerator.buildGeneratesForTest(model)
+                                                   .get(0);
+        List<Map<String, Object>> assigns = (List<Map<String, Object>>) ((List<Map<String, Object>>) g.get("itemLines")).get(0)
+                                                                                                                        .get("assigns");
+        assertTrue(assigns.contains(Map.of("targetProp", "Name", "expr", "\"Consulting services\"")));
+        assertTrue(assigns.contains(Map.of("targetProp", "Factor", "expr", "Calc.eval(\"Hours * 2\", source, 2).doubleValue()")));
+    }
 }

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/GeneratesIntentTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/GeneratesIntentTest.java
@@ -209,6 +209,164 @@ class GeneratesIntentTest {
     }
 
     @Test
+    void parsesComputedItemLinesAsAList() {
+        // A list-valued `items:` is the computed form (issue #6555): it lands in itemLines, NOT items.
+        IntentModel model = IntentParser.parse("""
+                name: sales
+                entities:
+                  - name: Quote
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: total, type: decimal }
+                  - name: Order
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: OrderItem
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                      - { name: price, type: decimal }
+                    relations:
+                      - { name: Order, kind: manyToOne, to: Order, composition: true, required: true }
+                generates:
+                  - name: order-from-quote
+                    from: Quote
+                    to: Order
+                    items:
+                      - { name: "Total for the period", price: Total }
+                """);
+        GeneratesIntent g = model.getGenerates()
+                                 .get(0);
+        assertEquals(null, g.getItems());
+        assertEquals(1, g.getItemLines()
+                         .size());
+        assertEquals("Total", g.getItemLines()
+                               .get(0)
+                               .get("price"));
+    }
+
+    @Test
+    void rejectsComputedItemLineCellNotOnTheTargetItemsChild() {
+        String yaml = """
+                name: sales
+                entities:
+                  - name: Quote
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: total, type: decimal }
+                  - name: Order
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: OrderItem
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: price, type: decimal }
+                    relations:
+                      - { name: Order, kind: manyToOne, to: Order, composition: true, required: true }
+                generates:
+                  - name: order-from-quote
+                    from: Quote
+                    to: Order
+                    items:
+                      - { nope: 1 }
+                """;
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("item line cell [nope] is not a field or to-one relation")),
+                "got: " + ex.getIssues());
+    }
+
+    @Test
+    void rejectsComputedItemLineWhenTargetHasNoItemsChild() {
+        String yaml = """
+                name: sales
+                entities:
+                  - name: Quote
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: Order
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                generates:
+                  - name: order-from-quote
+                    from: Quote
+                    to: Order
+                    items:
+                      - { anything: 1 }
+                """;
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("has no composition line-items child")),
+                "got: " + ex.getIssues());
+    }
+
+    @Test
+    void rejectsComputedItemLineBadWhenGuard() {
+        String yaml = """
+                name: sales
+                entities:
+                  - name: Quote
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: total, type: decimal }
+                  - name: Order
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: OrderItem
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: price, type: decimal }
+                    relations:
+                      - { name: Order, kind: manyToOne, to: Order, composition: true, required: true }
+                generates:
+                  - name: order-from-quote
+                    from: Quote
+                    to: Order
+                    items:
+                      - { price: Total, when: "Total > 0" }
+                """;
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("item line when") && i.contains("==|!=")),
+                "got: " + ex.getIssues());
+    }
+
+    @Test
+    void rejectsComputedItemLineUnknownInterpolationSource() {
+        String yaml = """
+                name: sales
+                entities:
+                  - name: Quote
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: total, type: decimal }
+                  - name: Order
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: OrderItem
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                    relations:
+                      - { name: Order, kind: manyToOne, to: Order, composition: true, required: true }
+                generates:
+                  - name: order-from-quote
+                    from: Quote
+                    to: Order
+                    items:
+                      - { name: "Line {missing}" }
+                """;
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("interpolates {missing}")),
+                "got: " + ex.getIssues());
+    }
+
+    @Test
     void rejectsOneHopRelationFieldMapping() {
         String yaml = """
                 name: sales

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Generate.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Generate.java.template
@@ -6,6 +6,9 @@ import org.eclipse.dirigible.sdk.component.Component;
 import org.eclipse.dirigible.sdk.http.Controller;
 import org.eclipse.dirigible.sdk.http.Post;
 import org.eclipse.dirigible.sdk.utils.Json;
+#if($hasItemLines)
+import org.eclipse.dirigible.sdk.utils.Calc;
+#end
 
 /**
  * Create-from ${name}: builds a new ${toEntity} from an existing ${fromEntity} (loaded by the id in
@@ -55,6 +58,26 @@ public class ${className}Generate {
             item.${toFkProperty} = saved.${toPk};
             new gen.${toGenFolder}.data.${toJavaPerspective}.${toItemEntity}Repository().save(item);
         }
+#end
+#if($hasItemLines)
+        // Computed line-items (intent `items:` list form - issue #6555): a fixed set of synthetic lines
+        // whose cells are expressions over the loaded `source` master (Calc arithmetic / {} string
+        // interpolation / source foreign-key copy), each optionally guarded by a `when` condition. Saved
+        // through the target item repository so the target document's own line logic fires.
+#foreach($row in $itemLines)
+#if($row.guard != "")
+        if (${row.guard})
+#end
+        {
+            gen.${toGenFolder}.data.${toJavaPerspective}.${toItemEntity}Entity item =
+                    new gen.${toGenFolder}.data.${toJavaPerspective}.${toItemEntity}Entity();
+#foreach($a in $row.assigns)
+            item.${a.targetProp} = ${a.expr};
+#end
+            item.${toFkProperty} = saved.${toPk};
+            new gen.${toGenFolder}.data.${toJavaPerspective}.${toItemEntity}Repository().save(item);
+        }
+#end
 #end
 #if($sourceStatusValue != "")
         // Completion hook (intent `sourceStatus:`): the source document reaches its post-generation

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -1099,6 +1099,10 @@ export function generateFiles(model, parameters, templateSources) {
                                 toPk: g.toPk,
                                 fieldAssignments: g.fieldAssignments,
                                 hasItems: g.hasItems,
+                                // Computed line-items form (issue #6555): synthetic lines whose cells are
+                                // pre-rendered expressions over the source master; passed through untouched.
+                                hasItemLines: g.hasItemLines,
+                                itemLines: g.itemLines,
                                 fromItemEntity: g.fromItemEntity,
                                 toItemEntity: g.toItemEntity,
                                 // The source item's own package (a non-composition primary source item

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -315,9 +315,18 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 function: DocumentItem
                 fields:
                   - { name: id,     type: integer, primaryKey: true, generated: true }
+                  - { name: note,   type: string }
                   - { name: amount, type: decimal }
                 relations:
                   - { name: Voucher, kind: manyToOne, to: Voucher, composition: true, required: true }
+
+              # Source of the computed create-from below (#6555): a Voucher is generated from a Slip
+              # with ONE synthetic line whose cells are expressions over the Slip (not a 1:1 mirror).
+              - name: Slip
+                fields:
+                  - { name: id,    type: integer, primaryKey: true, generated: true }
+                  - { name: label, type: string }
+                  - { name: total, type: decimal, precision: 18, scale: 2 }
 
               # documentItemsLayout: chat - the document master's line-items child renders as a
               # conversation thread (x-h-chat bubbles + a composer) instead of the editable table;
@@ -665,6 +674,22 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 items:
                   - { debit: "Amount" }
                   - { credit: "Amount" }
+
+            # Computed create-from item lines (#6555): the list form of generates.items builds a fixed
+            # synthetic line from EXPRESSIONS over the source Slip - a Calc amount, a {} interpolated
+            # string, and a when guard - instead of mirroring a source child 1:1. The target items child
+            # (VoucherLine) is resolved automatically. Enforcement lives in the generated Generate.java.
+            generates:
+              - name: voucher-from-slip
+                from: Slip
+                to: Voucher
+                defaults:
+                  refNumber: "AUTO"
+                  date: now
+                items:
+                  - note: "Slip {label}"
+                    amount: "Total * 2"
+                    when: "Total != 0"
 
             seeds:
               - name: people
@@ -1369,6 +1394,23 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 "the admin perspective must declare the ADMIN kind and group");
         assertTrue(contentOf("gen/emission/perspectives/admin/perspective.extension").contains("application-admin-perspectives"),
                 "the admin perspective must register on the admin extension point (never the application/my/partner ones)");
+
+        // generates computed item lines (#6555): the create-from controller builds ONE synthetic
+        // VoucherLine whose cells are expressions over the loaded `source` Slip - a Calc amount rounded
+        // to the target field's scale, a {} interpolated string, and a null-safe Calc `when` guard -
+        // then re-points it at the saved Voucher through the target repository. The Calc import proves
+        // the numeric-expression path is wired.
+        String generate = contentOf("gen/events/emission/VoucherFromSlipGenerate.java");
+        assertTrue(generate.contains("import org.eclipse.dirigible.sdk.utils.Calc;"),
+                "a computed item line must import Calc for its numeric expressions");
+        assertTrue(generate.contains("Calc.eval(\"Total * 2\", source, 2)"),
+                "a numeric item-line cell must emit a Calc expression over the source, rounded to the target scale");
+        assertTrue(generate.contains("\"Slip \" + String.valueOf(source.Label)"),
+                "a {field} string item-line cell must emit source interpolation");
+        assertTrue(generate.contains("Calc.eval(\"Total\", source, 6).compareTo(new java.math.BigDecimal(\"0\")) != 0"),
+                "an item-line when cell must emit a null-safe Calc row guard");
+        assertTrue(generate.contains("VoucherLineEntity item") && generate.contains("item.Voucher = saved.Id;"),
+                "the computed line must write into the auto-resolved target items child and re-point it at the saved master");
     }
 
     /** Layer 2 (the outermost): the published app enforces the features over REST. */
@@ -1443,6 +1485,54 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                                                  .post(API + "/voucher/VoucherController")
                                                  .then()
                                                  .statusCode(400));
+
+        // generates computed item lines (#6555) at the outermost layer: create a Slip, fire the
+        // create-from, and assert the Voucher was born with ONE computed line - amount = Total * 2
+        // (Calc arithmetic over the source), note = "Slip <label>" ({} interpolation). This is the
+        // capability that did not exist before: a create-from that builds a COMPUTED line, not a
+        // 1:1 clone of a source child.
+        AtomicInteger slipId = new AtomicInteger();
+        restAssuredExecutor.execute(() -> slipId.set(given().contentType("application/json")
+                                                            .body("{\"Label\":\"March\",\"Total\":21}")
+                                                            .when()
+                                                            .post(API + "/slip/SlipController")
+                                                            .then()
+                                                            .statusCode(200)
+                                                            .extract()
+                                                            .path("Id")));
+        AtomicInteger generatedVoucherId = new AtomicInteger();
+        // The generated create-from controller returns Json.stringify(saved) as a String, which the SDK
+        // serves as text/plain - so parse the body as JSON explicitly rather than RestAssured's
+        // content-type-driven .path() (which only maps a JSON/XML response).
+        restAssuredExecutor.execute(() -> {
+            String voucher = given().contentType("application/json")
+                                    .body("{\"id\":" + slipId.get() + "}")
+                                    .when()
+                                    .post("/services/java/" + PROJECT + "/gen/events/emission/VoucherFromSlipGenerate/run")
+                                    .then()
+                                    .statusCode(200)
+                                    .extract()
+                                    .asString();
+            generatedVoucherId.set(io.restassured.path.json.JsonPath.from(voucher)
+                                                                    .getInt("Id"));
+        });
+        restAssuredExecutor.execute(() -> {
+            int voucherId = generatedVoucherId.get();
+            String matching = "findAll { it.Voucher == " + voucherId + " }";
+            io.restassured.path.json.JsonPath lines = given().when()
+                                                             .get(API + "/voucher/VoucherLineController")
+                                                             .then()
+                                                             .statusCode(200)
+                                                             .extract()
+                                                             .jsonPath();
+            assertEquals(1, lines.getList(matching)
+                                 .size(),
+                    "the computed create-from must produce exactly one synthetic line");
+            // amount = Total(21) * 2, computed by Calc over the source (not a copied literal).
+            assertEquals(42.0f, lines.getFloat(matching + ".Amount[0]"), 0.001f);
+            // note = "Slip " + the source's label, via {} interpolation.
+            assertEquals("Slip March", lines.getString(matching + ".Note[0]"));
+        });
 
         // #6336 pattern: a malformed e-mail must be rejected by the generated controller, and a
         // well-formed one accepted - the regex authored in the intent is what actually runs.


### PR DESCRIPTION
Closes #6555.

### Problem
`generates.items` could only clone **literal** item fields from the source document's items (the *mirror* form). A create-from could not emit a **computed** line — e.g. generating an invoice from an aggregated source (a period's approved work) whose single line carries the source's rolled-up total — so the flow stopped one step short of the business document.

### What this adds — the *computed* form
`items:` may now be a **LIST** of synthetic target lines whose cells are expressions over the loaded **SOURCE** master, reusing the calculated-field / posting-item conventions:

```yaml
generates:
  to: SalesInvoice
  items:
    - { name: "Services for {Period}", quantity: 1, price: "BillableAmount" }
```

Per-cell rendering is driven by the **target line-item** property's type:
- **numeric field** → a `Calc` arithmetic expression over `source`, rounded to the field's scale (integer/long narrowed off the `BigDecimal`) — the calculated-field / posting-amount convention;
- **string field** → `{field}` interpolation, a bare source-property copy, or a quoted literal (a plain caption is *not* read as a field);
- **to-one relation** → copies a source foreign key (issue #6533 parity);
- **`when` cell** (`<SourceField> ==|!= <n>`) → guards the whole line.

### Design notes
- **Target items child resolved automatically** (never named in the intent): same-model from this model; cross-model from the owner `.model` (`CrossModelSupport.resolveItemsChild`), failing loudly when unresolvable so a computed-line create-from never silently drops its lines.
- **Two item shapes are mutually exclusive.** Gson maps a field by its static type, so the parser rehomes a list-valued `items:` into a distinct typed `itemLines` field *before* the typed mapping, and rejects declaring both an object and a list.
- **Validation split** parse-time (cell keys against the target items child, `{field}`/bare-identifier refs against the source, `when` shape) vs generation-time (a cross-model target's cell keys defer to generation — the same deferral the mirror form's cross-model `map` uses).
- Emitted into the create-from controller (`Generate.java.template`) as guarded synthetic lines saved through the **target** item repository, so the target document's own line logic (numbering, calculated fields, rollups) fires.

### Tests
- `GeneratesIntentTest` (parser: list-form parsing, mutual exclusion, cell/guard validation) and `GlueGeneratesTest` (generator: Calc/string/FK/guard cell rendering) — **19 unit tests, green**.
- `IntentEmissionCoverageIT` extended for the computed-line emission.

Verified locally: unit tests green, `formatter:validate` clean, `javadoc` (release profile) BUILD SUCCESS with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)