### PR TITLE
feat(runtime): drop-in /modules classpath directory in the container image (#6592)

### DIFF
--- a/build/application/Dockerfile
+++ b/build/application/Dockerfile
@@ -26,7 +26,16 @@ RUN npm i -g esbuild \
 
 
 COPY target/dirigible-application-*-executable.jar dirigible.jar
-ENTRYPOINT ["java", "--add-opens", "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED", "--add-opens", "java.base/java.nio=ALL-UNNAMED", "-jar", "/dirigible.jar"]
+
+# Drop-in directory for AOT compiled module jars (a jar carrying the module's compiled classes, its
+# META-INF/dirigible/<project>/.compiled marker and its registry payload). A downstream image COPYs
+# such jars here, or they are mounted at run time - the platform jar is consumed verbatim. Empty or
+# missing /modules is a no-op. Set LOADER_PATH to use other locations (comma-separated).
+RUN mkdir -p /modules
+
+# PropertiesLauncher (instead of the default JarLauncher) is what makes -Dloader.path work; it reads
+# the Start-Class from /dirigible.jar's manifest, so the application boots exactly as with -jar.
+ENTRYPOINT ["java", "--add-opens", "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED", "--add-opens", "java.base/java.nio=ALL-UNNAMED", "-cp", "/dirigible.jar", "-Dloader.path=/modules", "org.springframework.boot.loader.launch.PropertiesLauncher"]
 
 # 8080 for the spring boot application,
 # 8081 for graalium debug port

--- a/components/engine/engine-java/CLAUDE.md
+++ b/components/engine/engine-java/CLAUDE.md
@@ -25,7 +25,42 @@ component shapes. Read this before changing anything under `engine-java`, `data-
   consumers. So when a consumer runs, every bean is already built and injected.
 - Platform classpath for `javac` comes from `ClassPathIndex` — it extracts `BOOT-INF/lib/*.jar` once
   to disk; **never** introspect nested fat-jar entries in-process (closes pooled `NestedJarFile`
-  handles → cascading `NoClassDefFoundError`).
+  handles → cascading `NoClassDefFoundError`). It also appends the drop-in module jars (next section).
+
+## AOT compiled modules + the `/modules` drop-in directory
+
+A module can ship **already compiled** instead of as registry sources — no runtime `javac` at all
+(PR [#6400](https://github.com/eclipse-dirigible/dirigible/pull/6400)). Such a module jar carries:
+
+- its compiled classes (`gen.*` / `custom.*` packages),
+- a marker at `META-INF/dirigible/<project>/.compiled` — a UTF-8 list of the module's top-level class
+  binary names, one per line (`#` comments allowed),
+- the module's declarative registry payload under the same `META-INF/dirigible/<project>/` folder.
+
+On `ApplicationReadyEvent`, `CompiledModuleClassProvider` scans `classpath*:META-INF/dirigible/*/.compiled`,
+`Class.forName`s every listed class through the **application** classloader and installs them via
+`JavaLoader.installCompiledModules(...)` — the same install path a registry rebuild uses, so the standard
+consumers register the controllers / entities / handlers (`Registered [N] class(es) from AOT compiled
+module(s) on the classpath`). The installed generation is the **union** of the registry-compiled and the
+classpath-compiled sub-generations: a later registry rebuild does not unload compiled modules. In
+parallel, the existing `ClasspathExpander` lays the payload into `registry/public/<project>/`, so one jar
+delivers both halves of the module.
+
+**Getting such a jar onto the classpath of the shipped image (issue [#6592](https://github.com/eclipse-dirigible/dirigible/issues/6592)):**
+`build/application/Dockerfile` launches through Spring Boot's **`PropertiesLauncher`** with
+`-Dloader.path=/modules` (instead of `JarLauncher` via `-jar`), and creates an empty `/modules`. A
+downstream image `COPY`s module jars there, or they are volume-mounted at run time — **the platform jar
+is consumed verbatim**; never explode the fat jar to add jars to `BOOT-INF/lib`.
+
+- **Empty or missing `/modules` is a no-op** — `PropertiesLauncher` reads `Start-Class` from the jar's
+  manifest, so boot is identical to `java -jar` (verified: same startup lines, same startup time).
+- `loader.path` entries are **prepended** to `BOOT-INF/classes` + `BOOT-INF/lib`, so in principle a
+  drop-in jar could shadow a platform class. In practice it cannot happen by accident: module packages
+  are `gen.*` / `custom.*`, which the platform does not use.
+- **`LOADER_PATH`** (env var, comma-separated) is the override for non-default locations — Spring Boot
+  honors it natively, so there is no `DIRIGIBLE_*` property for this.
+- `ClassPathIndex` appends the same `loader.path` / `LOADER_PATH` jars to the **compile** classpath, so
+  registry sources can still be compiled against a drop-in module's classes.
 
 ## The bean container (`ComponentContainer`, `engine-java`)
 

--- a/components/engine/engine-java/README.md
+++ b/components/engine/engine-java/README.md
@@ -125,6 +125,36 @@ The engine sidesteps this by cracking the outer fat jar with the standard
 `javac`'s `--class-path` via `setLocationFromPaths(CLASS_PATH, ...)`. The extraction is
 cleaned up on shutdown via `DisposableBean#destroy()`.
 
+### AOT compiled modules and the `/modules` drop-in directory
+
+A module can also ship **already compiled**, with no runtime `javac` at all. Such a module jar carries
+its compiled classes (packages `gen.*` / `custom.*`), a marker at
+`META-INF/dirigible/<project>/.compiled` listing the module's top-level class binary names (one per
+line, `#` comments allowed), and the module's declarative registry payload under the same
+`META-INF/dirigible/<project>/` folder.
+
+On `ApplicationReadyEvent`, `CompiledModuleClassProvider` scans the classpath for those markers, loads
+each listed class through the application classloader and installs them via
+`JavaLoader.installCompiledModules(...)` — the same install path a registry rebuild uses, so the standard
+consumers register the module's controllers, entities and handlers (`Registered [N] class(es) from AOT
+compiled module(s) on the classpath`). `ClasspathExpander` lays the payload into
+`registry/public/<project>/` in parallel, so a single jar delivers both halves of the module.
+
+The runtime image (`build/application/Dockerfile`) makes such jars deployable without touching the
+platform artifact: it launches through Spring Boot's `PropertiesLauncher` with `-Dloader.path=/modules`
+and ships an empty `/modules` directory. Drop module jars in — by `COPY` in a downstream image, or by
+mounting a volume — and they are on the application classpath; there is no need to explode the fat jar.
+
+- Empty or missing `/modules` is a **no-op**: `PropertiesLauncher` reads `Start-Class` from the jar's
+  manifest, so the boot sequence and startup time match a plain `java -jar` launch.
+- `loader.path` entries precede the fat jar's own `BOOT-INF/classes` + `BOOT-INF/lib`, so a drop-in jar
+  could in principle shadow a platform class — in practice it cannot happen by accident, because module
+  packages are `gen.*` / `custom.*`, which the platform does not use.
+- **`LOADER_PATH`** (comma-separated, honored natively by `PropertiesLauncher`) overrides the location;
+  no Dirigible configuration property is involved.
+- `ClassPathIndex` appends the same entries to the compile classpath, so registry sources can be
+  compiled against a drop-in module's classes.
+
 ### Hot reload + classloader hygiene
 
 Each source unit gets a **fresh** `BytecodeClassLoader`. On update, the registry's `put` atomically

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/ClassPathIndex.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/ClassPathIndex.java
@@ -60,6 +60,12 @@ import org.springframework.stereotype.Component;
  * For development / test runs the application is launched from a plain {@link URLClassLoader}, not
  * a fat jar. In that case we simply collect the loader's URLs — they're already on disk and no
  * extraction is needed.
+ *
+ * <p>
+ * Either way the entries of {@code loader.path} / {@code LOADER_PATH} are appended — the runtime
+ * image's drop-in directory for AOT compiled module jars (see
+ * {@code build/application/Dockerfile}). Those jars are on the application classpath, so client
+ * sources must be able to compile against them.
  */
 @Component
 public class ClassPathIndex {
@@ -95,6 +101,12 @@ public class ClassPathIndex {
     }
 
     private static List<Path> build() {
+        List<Path> entries = new ArrayList<>(buildPlatformEntries());
+        entries.addAll(loaderPathEntries(rawLoaderPath()));
+        return Collections.unmodifiableList(entries);
+    }
+
+    private static List<Path> buildPlatformEntries() {
         Path anchor = locateAnchorOnDisk();
         if (anchor != null && anchor.toString()
                                     .endsWith(".jar")
@@ -102,6 +114,55 @@ public class ClassPathIndex {
             return extractFatJar(anchor);
         }
         return collectFromUrlClassLoader();
+    }
+
+    /**
+     * The drop-in modules location as Spring Boot's {@code PropertiesLauncher} sees it: the
+     * {@code loader.path} system property the runtime image sets, or the {@code LOADER_PATH}
+     * environment variable that overrides it. Absent under a plain {@code java -jar} launch.
+     */
+    private static String rawLoaderPath() {
+        String property = System.getProperty("loader.path");
+        return property != null ? property : System.getenv("LOADER_PATH");
+    }
+
+    /**
+     * Resolve a {@code loader.path} value - a comma-separated list of directories and/or jars already
+     * on the application classpath - to on-disk {@code javac} entries, so client sources can compile
+     * against the classes an AOT compiled module drops in. A directory contributes its {@code *.jar}
+     * files (in a stable order); a jar contributes itself; anything that does not exist is skipped.
+     * Package-visible for testing.
+     */
+    static List<Path> loaderPathEntries(String rawLoaderPath) {
+        if (rawLoaderPath == null || rawLoaderPath.isBlank()) {
+            return List.of();
+        }
+        List<Path> entries = new ArrayList<>();
+        for (String segment : rawLoaderPath.split(",")) {
+            String trimmed = segment.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            Path path = Path.of(trimmed);
+            if (Files.isDirectory(path)) {
+                entries.addAll(jarsIn(path));
+            } else if (Files.isRegularFile(path) && trimmed.endsWith(".jar")) {
+                entries.add(path);
+            }
+        }
+        return entries;
+    }
+
+    private static List<Path> jarsIn(Path directory) {
+        try (var stream = Files.list(directory)) {
+            return stream.filter(p -> p.toString()
+                                       .endsWith(".jar"))
+                         .sorted()
+                         .toList();
+        } catch (IOException e) {
+            LOGGER.warn("Could not list the drop-in modules directory [{}]: {}", directory, e.getMessage(), e);
+            return List.of();
+        }
     }
 
     private static Path locateAnchorOnDisk() {

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/runtime/ClassPathIndexTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/runtime/ClassPathIndexTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.java.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Resolution of the runtime image's drop-in modules location ({@code loader.path} /
+ * {@code LOADER_PATH}) to {@code javac} classpath entries.
+ */
+class ClassPathIndexTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void a_directory_contributes_its_jars_in_a_stable_order() throws IOException {
+        Path modules = Files.createDirectory(tempDir.resolve("modules"));
+        Path second = Files.createFile(modules.resolve("b-module.jar"));
+        Path first = Files.createFile(modules.resolve("a-module.jar"));
+        Files.createFile(modules.resolve("notes.txt"));
+
+        assertEquals(List.of(first, second), ClassPathIndex.loaderPathEntries(modules.toString()));
+    }
+
+    @Test
+    void a_jar_contributes_itself_and_missing_segments_are_skipped() throws IOException {
+        Path jar = Files.createFile(tempDir.resolve("module.jar"));
+
+        List<Path> entries = ClassPathIndex.loaderPathEntries(jar + " , " + tempDir.resolve("absent") + ",");
+
+        assertEquals(List.of(jar), entries);
+    }
+
+    @Test
+    void an_empty_or_missing_loader_path_contributes_nothing() throws IOException {
+        Files.createDirectory(tempDir.resolve("empty"));
+
+        assertTrue(ClassPathIndex.loaderPathEntries(null)
+                                 .isEmpty());
+        assertTrue(ClassPathIndex.loaderPathEntries("   ")
+                                 .isEmpty());
+        assertTrue(ClassPathIndex.loaderPathEntries(tempDir.resolve("empty")
+                                                           .toString())
+                                 .isEmpty());
+    }
+
+}


### PR DESCRIPTION
Closes #6592.

#6400 added classpath loading of AOT compiled modules (`CompiledModuleClassProvider` → `JavaLoader.installCompiledModules`, no runtime `javac`), but there was no supported way to get such a module jar onto the classpath of the **shipped image**: the entrypoint used Spring Boot's `JarLauncher` (`java -jar`), which has no mechanism for external jars. Verifying #6400 required exploding the fat jar and copying the module into `BOOT-INF/lib`, i.e. mutating the published artifact.

## What changes

- **`build/application/Dockerfile`** — launch through `PropertiesLauncher` with `-Dloader.path=/modules`, and ship an empty `/modules` directory. A downstream image `COPY`s AOT module jars there, or they are volume-mounted at run time; the platform jar is consumed verbatim. `--add-opens` flags unchanged. `LOADER_PATH` (comma-separated, honored natively by the launcher) is the override for other locations — no new Dirigible configuration property.
- **`ClassPathIndex`** — appends the same `loader.path` / `LOADER_PATH` jars to the `javac` classpath, so registry `.java` sources can still be compiled against a drop-in module's classes. (They could be, back when the module jar was hand-copied into `BOOT-INF/lib`; without this the drop-in route would silently lose that.) A directory contributes its `*.jar` files in a stable order, a jar contributes itself, missing segments are skipped.
- **Docs** — a section in `components/engine/engine-java/README.md` and in the module's guide (`CLAUDE.md`) covering what goes into `/modules`, the `LOADER_PATH` override and the relationship to #6400, plus a comment in the Dockerfile.

The derived OpenTelemetry images (`open-telemetry/dirigible/*/Dockerfile`) inherit the entrypoint and only replace `/dirigible.jar` at the same path, so they need no change.

## Verification

Built the image locally and ran it both ways. Module jar under test: a `gen.aotdemo.AotDemoController` class, its `META-INF/dirigible/aot-demo/.compiled` marker and a registry payload file.

**Empty `/modules` is a strict no-op** — compared against a `java -jar` (JarLauncher) baseline of the same jar:

| | JarLauncher baseline | PropertiesLauncher, empty `/modules` |
|---|---|---|
| Startup | `Started DirigibleApplication in 18.27 seconds` | `19.20 seconds` (in-container; 20.7s in the first local run) |
| Compile classpath | `1051` entries | `1051` entries |
| AOT registration line | none | none |
| `/actuator/health/readiness` | 200 | 200 |

A normalised diff of the two boot logs (timestamps/thread ids/numbers stripped) shows only concurrent-init ordering noise — no structural difference. `PropertiesLauncher` reads `Start-Class` from the jar manifest, so the application boots exactly as with `-jar`.

**Module jar in `/modules`** (`-v .../modules:/modules:ro`):

```
ClassPathIndex          - Materialised compile-time classpath: [1052] entries        # 1051 + the drop-in jar
ControllerRouter        - Registered controller [aot-demo::gen.aotdemo.AotDemoController] (1 routes)
CompiledModuleClassProvider - Registered [1] class(es) from AOT compiled module(s) on the classpath

$ ls /target/dirigible/repository/root/registry/public/aot-demo
.compiled  marker.json                                                              # payload expanded

$ curl -u admin:admin .../services/java/aot-demo/gen/aotdemo/AotDemoController/ping
pong from the aot-demo drop-in module                                               # 200
```

No `javac` activity for the module — the only log mention is the controller registration.

**Classpath order** (requirement 2 of the issue): confirmed against the shipped `PropertiesLauncher` bytecode — `getClassPathUrls()` adds the `loader.path` paths first, then `getClassPathUrlsForRoot()` (`BOOT-INF/classes` + `BOOT-INF/lib`). So a drop-in jar *can* shadow a platform class in principle, but not by accident: module packages are `gen.*` / `custom.*`, which the platform does not use. Stated explicitly in the docs.

**Tests:** `ClassPathIndexTest` covers the `loader.path` resolution (directory → its jars in stable order, jar → itself, blank/missing/empty → nothing). engine-java 72/72 green; formatter and `-P release` javadoc clean on the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
