### PR TITLE
fix(templates): Harmonia form $http shim must carry the HTTP status (#6597)

### DIFF
--- a/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/form.js.template
+++ b/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/form.js.template
@@ -29,11 +29,15 @@
 
 // Self-contained fetch client (no window.App): every form URL is absolute (/services/...).
 const harmoniaHttp = {
-  async request(method, url, body) {
+  // Returns { data, status }. The status matters to the AngularJS $http shim below, whose callers
+  // branch on it (`if (response.status != 202)`), so it cannot be dropped on the success path.
+  async exchange(method, url, body) {
     const r = await fetch(url, {
       method,
       headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-      body: body != null ? JSON.stringify(body) : undefined,
+      // A string body is already serialized - AngularJS $http passes strings through untouched, and
+      // legacy .form code posts JSON.stringify(model). Re-encoding it would send a quoted string.
+      body: body == null ? undefined : (typeof body === 'string' ? body : JSON.stringify(body)),
       credentials: 'same-origin',
     });
     if (!r.ok) {
@@ -46,10 +50,14 @@ const harmoniaHttp = {
     }
     // A success can carry an empty body (204, or a 200 from an action endpoint such as task
     // complete) — don't call r.json() on it, that throws "Unexpected end of JSON input".
-    if (r.status === 204) return null;
+    if (r.status === 204) return { data: null, status: r.status };
     const text = await r.text();
-    if (!text) return null;
-    try { return JSON.parse(text); } catch (_) { return text; }
+    if (!text) return { data: null, status: r.status };
+    try { return { data: JSON.parse(text), status: r.status }; } catch (_) { return { data: text, status: r.status }; }
+  },
+  // The neutral ctx.http contract resolves the parsed body itself.
+  async request(method, url, body) {
+    return (await this.exchange(method, url, body)).data;
   },
   get(url)        { return this.request('GET', url, undefined); },
   post(url, body) { return this.request('POST', url, body); },
@@ -64,13 +72,16 @@ function formController(ctx) {
   // onto the neutral ctx, so AngularJS-authored forms run unchanged in this standalone runtime.
   const $scope = ctx;                 // $scope.model and $scope.onXClicked = fn land on ctx
   $scope.model = ctx.model;
-  const wrap = (p) => p.then((d) => ({ data: d }))
+  // AngularJS resolves $http with { data, status, statusText, ... } and legacy .form code branches
+  // on the status (`if (response.status != 202)`), so the success path must carry it too - not just
+  // the rejection path. ctx.http resolves the body alone, hence the exchange() call here.
+  const wrap = (p) => p.then((r) => ({ data: r.data, status: r.status }))
                        .catch((e) => { throw { data: { message: e && e.message }, status: e && e.httpStatus }; });
   const $http = {
-    get:    (url)       => wrap(ctx.http.get(url)),
-    post:   (url, data) => wrap(ctx.http.post(url, data)),
-    put:    (url, data) => wrap(ctx.http.put(url, data)),
-    delete: (url)       => wrap(ctx.http.delete(url)),
+    get:    (url)       => wrap(harmoniaHttp.exchange('GET', url, undefined)),
+    post:   (url, data) => wrap(harmoniaHttp.exchange('POST', url, data)),
+    put:    (url, data) => wrap(harmoniaHttp.exchange('PUT', url, data)),
+    delete: (url)       => wrap(harmoniaHttp.exchange('DELETE', url, undefined)),
   };
   function NotificationHub() {
     return { show: (o) => ctx.notify(((o && o.title) ? o.title + ': ' : '') + ((o && o.description) || '')) };

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/BPMLeaveRequestTestProject.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/BPMLeaveRequestTestProject.java
@@ -154,8 +154,11 @@ abstract class BPMLeaveRequestTestProject extends BaseTestProject {
         MimeMessage receivedEmail = getLatestReceivedEmailMessage();
 
         String decision = shouldApproveRequest() ? "approved" : "declined";
-        String bodyRegex = "<h4>Your leave request from \\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z] to "
-                + "\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z] has been " + decision + " by \\["
+        // The dates are the ones typed into the form. Harmonia's date picker holds a date-only model
+        // value (YYYY-MM-DD by its contract), where the retired AngularJS form bound a JS Date and so
+        // serialized a full ISO instant - hence the optional time part.
+        String isoDate = "\\d{4}-\\d{2}-\\d{2}(?:T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z)?";
+        String bodyRegex = "<h4>Your leave request from \\[" + isoDate + "] to " + "\\[" + isoDate + "] has been " + decision + " by \\["
                 + Pattern.quote(EMPLOYEE_MANAGER_USERNAME) + "]</h4>";
 
         EmailAssertion emailAssertion = new EmailAssertionBuilder().expectedFrom("leave-request-app@example.com")


### PR DESCRIPTION
Closes the BPM-form half of #6597. Follow-up to #6598, which repointed the BPM fixtures onto `template-form-builder-harmonia`.

Running those ITs — the "known gap" from #6598, since they are `@Tag("ui")` and the PR gate runs `!ui | smoke` — surfaced a real platform bug that had nothing to do with the fixtures.

## 1. The `$http` shim dropped the HTTP status on success

```js
const wrap = (p) => p.then((d) => ({ data: d }))   // <- no status
```

AngularJS resolves `$http` with `{ data, status, statusText, … }`, and legacy `.form` code branches on it:

```js
if (response.status != 202) { alert(`Unable to create new leave request: '${response.message}'`); return; }
```

`undefined != 202` is always true, so **every** such form took its error path — reporting `'undefined'`, because the success shape has no `message` either. That is exactly what the ITs showed. This contradicted the shim's own documented contract, that AngularJS-authored `.form` code "runs unchanged".

The fetch client now exposes `exchange()` returning `{ data, status }`; `request()` keeps the neutral `ctx.http` contract of resolving the body alone, and the shim uses `exchange()`.

## 2. String bodies were re-encoded

Legacy `.form` code posts `JSON.stringify(model)`; the client stringified it again, sending a quoted JSON string. AngularJS passes strings through untouched — now so does this. Latent and masked, because the server still answered 2xx.

## 3. Email assertion relaxed to a date-only value

The email now reads `from [2002-02-02] to [2002-03-03]` — precisely the dates the test types, which incidentally confirms that typing into the Harmonia picker's text input **does** bind to the model. Harmonia's date picker holds `YYYY-MM-DD` by contract, where the retired AngularJS form bound a JS `Date` and serialized a full ISO instant. The regex accepts either, with a comment recording why. Test-side change tracking a deliberate runtime difference, not a workaround.

## Verification

`ApproveLeaveRequestBpmIT`, `DeclineLeaveRequestBpmIT` and `BpmnMultitenancyIT` — **3/3 pass** against merged master. They are `@Tag("ui")`, so CI here will not run them; this was verified locally headless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
