### PR TITLE
fix(build): green master - JDT.LS extraction race and PostgreSQL identifier quoting (#6604)

### DIFF
--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/classpath/ClasspathExpander.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/classpath/ClasspathExpander.java
@@ -106,6 +106,12 @@ public class ClasspathExpander {
     private void handleJarURLConnection(String root, URLConnection urlConnection) throws IOException {
         String jarRoot = "META-INF/" + root;
         JarURLConnection jarUrlConnection = (JarURLConnection) urlConnection;
+        // A cached JarURLConnection hands out the JVM-wide shared JarFile - the very instance the
+        // application class loader reads resources from. Closing it breaks every read of that JAR
+        // that is in flight elsewhere: the JDT.LS installer, which streams a ~50 MB tar.gz out of
+        // its own JAR on a background thread while this expansion runs, died with "ZipFile closed".
+        // Opting out of the cache yields a handle this method exclusively owns and may close.
+        jarUrlConnection.setUseCaches(false);
         try (JarFile jar = jarUrlConnection.getJarFile()) {
             Enumeration<JarEntry> entries = jar.entries();
             JarEntry maybeSkip = jar.getJarEntry("META-INF/dirigible/.skip");

--- a/components/ide/ide-java-lsp/src/main/java/org/eclipse/dirigible/components/ide/lsp/java/process/JdtLsManager.java
+++ b/components/ide/ide-java-lsp/src/main/java/org/eclipse/dirigible/components/ide/lsp/java/process/JdtLsManager.java
@@ -124,7 +124,7 @@ public class JdtLsManager implements DisposableBean, ApplicationRunner, Applicat
                           logger.warn("[java-lsp] Classpath pre-warm failed (will materialise lazily on first use)", warmEx);
                       }
                   } catch (Exception e) {
-                      logger.warn("[java-lsp] JDT.LS is not available: {}. Java language support will be disabled.", e.getMessage());
+                      logger.warn("[java-lsp] JDT.LS is not available. Java language support will be disabled.", e);
                   }
               });
     }
@@ -573,7 +573,10 @@ public class JdtLsManager implements DisposableBean, ApplicationRunner, Applicat
     }
 
     /**
-     * Extracts the JDT.LS tar.gz that was bundled into the JAR at build time.
+     * Extracts the JDT.LS tar.gz that was bundled into the JAR at build time. A half-written
+     * installation is removed before the failure propagates: {@link #isInstalled()} only looks for the
+     * Equinox launcher JAR, so leaving one behind would make every subsequent startup believe JDT.LS is
+     * present and silently keep Java language support broken.
      *
      * @return {@code true} if the bundled resource was found and extracted successfully
      */
@@ -586,17 +589,36 @@ public class JdtLsManager implements DisposableBean, ApplicationRunner, Applicat
             }
             logger.info("[java-lsp] Extracting bundled JDT.LS to {} ...", jdtlsHome);
             Files.createDirectories(jdtlsHome);
-            Process tar = new ProcessBuilder("tar", "xzf", "-", "-C", jdtlsHome.toString()).redirectError(ProcessBuilder.Redirect.INHERIT)
-                                                                                           .start();
-            bundled.transferTo(tar.getOutputStream());
-            tar.getOutputStream()
-               .close();
-            int rc = tar.waitFor();
-            if (rc != 0) {
-                throw new Exception("[java-lsp] tar extraction of bundled JDT.LS failed with exit code " + rc);
+            try {
+                Process tar =
+                        new ProcessBuilder("tar", "xzf", "-", "-C", jdtlsHome.toString()).redirectError(ProcessBuilder.Redirect.INHERIT)
+                                                                                         .start();
+                bundled.transferTo(tar.getOutputStream());
+                tar.getOutputStream()
+                   .close();
+                int rc = tar.waitFor();
+                if (rc != 0) {
+                    throw new Exception("[java-lsp] tar extraction of bundled JDT.LS failed with exit code " + rc);
+                }
+            } catch (Exception e) {
+                discardPartialInstallation();
+                throw e;
             }
             logger.info("[java-lsp] JDT.LS installed from bundled resource at {}", jdtlsHome);
             return true;
+        }
+    }
+
+    /**
+     * Removes an installation directory left behind by a failed extraction so the next startup extracts
+     * again from scratch.
+     */
+    private void discardPartialInstallation() {
+        try {
+            deleteDirectory(jdtlsHome);
+        } catch (IOException e) {
+            logger.warn("[java-lsp] Could not remove the partially extracted JDT.LS at {} - delete it manually, "
+                    + "otherwise Java language support stays disabled", jdtlsHome, e);
         }
     }
 

--- a/tests/tests-integrations/src/main/resources/CamelTransactionsCommitIT/camel-handler.ts
+++ b/tests/tests-integrations/src/main/resources/CamelTransactionsCommitIT/camel-handler.ts
@@ -3,7 +3,9 @@ import { Update } from "@aerokit/sdk/db";
 // The BOOK table comes from the generated schema; the rows are written with plain SQL rather than a
 // generated DAO because what this test asserts is the Camel transaction boundary, not the
 // persistence layer above it.
-const INSERT_BOOK = "INSERT INTO BOOK (BOOK_TITLE, BOOK_AUTHOR) VALUES (?, ?)";
+// The identifiers are quoted because the generated schema creates them in upper case and
+// PostgreSQL folds an unquoted name to lower case.
+const INSERT_BOOK = 'INSERT INTO "BOOK" ("BOOK_TITLE", "BOOK_AUTHOR") VALUES (?, ?)';
 
 export function onMessage(message: any) {
     Update.execute(INSERT_BOOK, ["test-camel-transactions-title-01", "test-camel-transactions-author-01"]);

--- a/tests/tests-integrations/src/main/resources/CamelTransactionsRollbackIT/camel-handler.ts
+++ b/tests/tests-integrations/src/main/resources/CamelTransactionsRollbackIT/camel-handler.ts
@@ -3,7 +3,9 @@ import { Update } from "@aerokit/sdk/db";
 // The BOOK table comes from the generated schema; the row is written with plain SQL rather than a
 // generated DAO because what this test asserts is the Camel transaction boundary, not the
 // persistence layer above it.
-const INSERT_BOOK = "INSERT INTO BOOK (BOOK_TITLE, BOOK_AUTHOR) VALUES (?, ?)";
+// The identifiers are quoted because the generated schema creates them in upper case and
+// PostgreSQL folds an unquoted name to lower case.
+const INSERT_BOOK = 'INSERT INTO "BOOK" ("BOOK_TITLE", "BOOK_AUTHOR") VALUES (?, ?)';
 
 export function onMessage(message: any) {
     Update.execute(INSERT_BOOK, ["test-camel-transactions-title-01", "test-camel-transactions-author-01"]);

--- a/tests/tests-integrations/src/main/resources/QuartzTransactionsCommitIT/jobs/test-job-handler.ts
+++ b/tests/tests-integrations/src/main/resources/QuartzTransactionsCommitIT/jobs/test-job-handler.ts
@@ -3,7 +3,9 @@ import { Update } from "@aerokit/sdk/db";
 // The BOOK table comes from the generated schema; the rows are written with plain SQL rather than a
 // generated DAO because what this test asserts is the Quartz transaction boundary, not the
 // persistence layer above it.
-const INSERT_BOOK = "INSERT INTO BOOK (BOOK_TITLE, BOOK_AUTHOR) VALUES (?, ?)";
+// The identifiers are quoted because the generated schema creates them in upper case and
+// PostgreSQL folds an unquoted name to lower case.
+const INSERT_BOOK = 'INSERT INTO "BOOK" ("BOOK_TITLE", "BOOK_AUTHOR") VALUES (?, ?)';
 
 Update.execute(INSERT_BOOK, ["test-title-01", "test-author-01"]);
 Update.execute(INSERT_BOOK, ["test-title-02", "test-author-02"]);

--- a/tests/tests-integrations/src/main/resources/QuartzTransactionsRollbackIT/jobs/test-job-handler.ts
+++ b/tests/tests-integrations/src/main/resources/QuartzTransactionsRollbackIT/jobs/test-job-handler.ts
@@ -3,7 +3,9 @@ import { Update } from "@aerokit/sdk/db";
 // The BOOK table comes from the generated schema; the row is written with plain SQL rather than a
 // generated DAO because what this test asserts is the Quartz transaction boundary, not the
 // persistence layer above it.
-const INSERT_BOOK = "INSERT INTO BOOK (BOOK_TITLE, BOOK_AUTHOR) VALUES (?, ?)";
+// The identifiers are quoted because the generated schema creates them in upper case and
+// PostgreSQL folds an unquoted name to lower case.
+const INSERT_BOOK = 'INSERT INTO "BOOK" ("BOOK_TITLE", "BOOK_AUTHOR") VALUES (?, ?)';
 
 Update.execute(INSERT_BOOK, ["test-title-01", "test-author-01"]);
 


### PR DESCRIPTION
Fixes #6604. `master` has failed the Build workflow on every push since `cadd62fdbe` (#6580); last green run was `0aa666868a`. Two independent causes, both fixed here.

### 1. `ClasspathExpander` closed a shared `JarFile` (`JavaLspIT`, `JavaDebugIT` — both DB legs)

`handleJarURLConnection` took its `JarFile` from a **cached** `JarURLConnection` and closed it. That handle is the JVM-wide shared instance — the same one the application class loader serves `getResourceAsStream` from — so closing it breaks every read of that JAR in flight elsewhere.

`JdtLsManager` streams the bundled ~50 MB `jdtls/jdtls.tar.gz` out of `ide-java-lsp.jar` on a background thread at exactly that point in startup:

```
12:12:23.692 [jdtls-install] [java-lsp] Extracting bundled JDT.LS ...
12:12:24.252 [main]          ClasspathExpander - Expanding the content of [dirigible]...
12:12:24.362 [jdtls-install] [java-lsp] JDT.LS is not available: ZipFile closed.
```

`setUseCaches(false)` gives this method a privately owned handle it may close, and leaves the class loader's alone.

The interrupted extraction was then permanent for the rest of the job — `isInstalled()` only looks for the Equinox launcher JAR, which the killed `tar` had already written, so every later context logged "JDT.LS is ready" over a tree with no `config_<platform>/` directories. That is literally what the two ITs reported ("did not respond to 'initialize'", "plugin is NOT registered in any config.ini"). A failed extraction now discards the partial installation so the next startup retries, and the failure logs the throwable instead of only `getMessage()` — the missing stack trace is why this took a while to pin down.

### 2. Unquoted identifiers on PostgreSQL (`CamelTransactionsCommitIT`, `QuartzTransactionsCommitIT` — pg leg)

#6596 moved the four transaction-IT handlers off the generated TS DAO onto plain SQL, and the SQL was not portable: the generated schema creates `"BOOK"` in upper case, PostgreSQL folds an unquoted `BOOK` to `book`, and the insert failed with `relation "book" does not exist` before the log line the test waits for. H2 folds the other way, hence the pg-only failure. The two rollback ITs carry the same SQL (`@Disabled` today), so all four are fixed.

### Verification

- `JavaLspIT` + `JavaDebugIT` — green locally against a **freshly extracted** JDT.LS whose extraction overlaps the classpath expansion, i.e. the exact CI window: extraction started 19:12:53.490, expansion 19:12:53.778, extraction completed 19:12:54.608 and registered the debug plugin in all 11 `config_*/config.ini` files.
- `CamelTransactionsCommitIT` + `QuartzTransactionsCommitIT` — green against PostgreSQL 16 (`postgresql:16` container, the CI credentials).
- The mechanism (and the fix) reproduce standalone in ~20 lines: a slow `getResourceAsStream` read of a JAR entry dies with `Stream closed`/`ZipFile closed` when another thread does a cached `getJarFile()` + `close()` on the same JAR, and survives with `setUseCaches(false)`.
- Full clean `-P unit-tests` run: green except `FtpRepositoryTest` and `DirigibleApplicationTest`, which fail locally with `Address already in use` (a Dirigible instance on this machine holds the FTP/SFTP ports) — unrelated to the change.
- `mvn -T 1C formatter:validate` clean; javadoc clean under `-P release` on both touched modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
