### PR TITLE
feat(monitoring): server-side prerequisites for the Monitoring shell

### DIFF
--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/artefact/endpoint/ArtefactStatus.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/artefact/endpoint/ArtefactStatus.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.artefact.endpoint;
+
+import org.eclipse.dirigible.components.base.artefact.Artefact;
+
+/**
+ * The synchronization status of a single artefact, as exposed by {@link ArtefactStatusEndpoint}.
+ *
+ * @param location the registry-relative location of the source file
+ * @param name the artefact name
+ * @param type the artefact type, e.g. {@code job} or {@code table}
+ * @param phase the last lifecycle phase applied to the artefact, e.g. {@code CREATE}
+ * @param status the outcome of that phase, e.g. {@code CREATED} or {@code FAILED}
+ * @param error the error message of a failed phase, or null
+ * @param running whether the artefact is currently running
+ */
+record ArtefactStatus(String location, String name, String type, String phase, String status, String error, Boolean running) {
+
+    /**
+     * Projects an artefact onto its status.
+     *
+     * @param artefact the artefact
+     * @return the status
+     */
+    static ArtefactStatus of(Artefact artefact) {
+        return new ArtefactStatus(artefact.getLocation(), artefact.getName(), artefact.getType(), name(artefact.getPhase()),
+                name(artefact.getLifecycle()), artefact.getError(), artefact.getRunning());
+    }
+
+    private static String name(Enum<?> value) {
+        return value == null ? null : value.name();
+    }
+}

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/artefact/endpoint/ArtefactStatusEndpoint.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/artefact/endpoint/ArtefactStatusEndpoint.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.artefact.endpoint;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.dirigible.components.base.artefact.ArtefactService;
+import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.annotation.security.RolesAllowed;
+
+/**
+ * Exposes what is deployed and whether it synchronized, aggregated across every artefact type. Each
+ * synchronizer registers its own {@link ArtefactService} bean, so the injected bean list is the
+ * complete inventory - there is no registration step for a new artefact type.
+ */
+@RestController
+@RequestMapping(BaseEndpoint.PREFIX_ENDPOINT_CORE + "artefacts")
+@RolesAllowed({"ADMINISTRATOR", "DEVELOPER", "OPERATOR"})
+class ArtefactStatusEndpoint {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArtefactStatusEndpoint.class);
+
+    private final List<ArtefactService<?, ?>> artefactServices;
+
+    ArtefactStatusEndpoint(List<ArtefactService<?, ?>> artefactServices) {
+        this.artefactServices = artefactServices;
+    }
+
+    /**
+     * Gets the status of all artefacts known to the instance.
+     *
+     * @return the artefact statuses
+     */
+    @GetMapping
+    ResponseEntity<List<ArtefactStatus>> getArtefacts() {
+        List<ArtefactStatus> statuses = new ArrayList<>();
+        for (ArtefactService<?, ?> artefactService : artefactServices) {
+            statuses.addAll(getStatuses(artefactService));
+        }
+        return ResponseEntity.ok(statuses);
+    }
+
+    /**
+     * Reads one artefact type. A type that cannot be read - a table missing because its engine is not
+     * enabled on this instance, for example - must not take down the whole inventory, which is the one
+     * screen an operator uses to find out what is broken.
+     *
+     * @param artefactService the service to read
+     * @return the statuses of its artefacts, empty when it cannot be read
+     */
+    private List<ArtefactStatus> getStatuses(ArtefactService<?, ?> artefactService) {
+        try {
+            return artefactService.getAll()
+                                  .stream()
+                                  .map(ArtefactStatus::of)
+                                  .toList();
+        } catch (RuntimeException e) {
+            LOGGER.warn("Failed to read the artefacts of [{}]", artefactService.getClass()
+                                                                               .getName(),
+                    e);
+            return List.of();
+        }
+    }
+}

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfigurator.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfigurator.java
@@ -73,6 +73,28 @@ public class HttpSecurityURIConfigurator {
             "/api-docs/**", //
             "/swagger-ui/**"};
 
+    /**
+     * Monitoring surface. The controllers behind these paths all declare
+     * {@code @RolesAllowed({ADMINISTRATOR, DEVELOPER, OPERATOR})}, but they live under
+     * {@code /services/ide/**} and {@code /services/bpm/**}, which the URL layer gates on DEVELOPER
+     * alone - so an OPERATOR was rejected before method security ever ran. These patterns re-align the
+     * URL layer with the declared method policy; they are matched before {@link #DEVELOPER_PATTERNS},
+     * so the rest of those prefixes (workspaces, git, publisher, the BPMN modeler, ...) stays
+     * DEVELOPER-only.
+     */
+    private static final String[] MONITORING_PATTERNS = { //
+            "/services/bpm/bpm-processes", //
+            "/services/bpm/bpm-processes/**", //
+            "/services/ide/monitoring", //
+            "/services/ide/monitoring/**", //
+            "/services/ide/logs", //
+            "/services/ide/logs/**", //
+            "/services/ide/loggers", //
+            "/services/ide/loggers/**", //
+            "/services/ide/messaging-monitoring", //
+            "/services/ide/messaging-monitoring/**", //
+            "/websockets/ide/console"};
+
     /** The Constant DEVELOPER_PATTERNS. */
     private static final String[] DEVELOPER_PATTERNS = { //
             "/services/bpm/**", //
@@ -91,6 +113,32 @@ public class HttpSecurityURIConfigurator {
             "/services/native-apps", //
             "/services/native-apps/**"};
 
+    /** The roles allowed on the monitoring and native-app management surfaces. */
+    private static final String[] OPERATIONS_ROLES = { //
+            Roles.ADMINISTRATOR.getRoleName(), //
+            Roles.DEVELOPER.getRoleName(), //
+            Roles.OPERATOR.getRoleName()};
+
+    /**
+     * The role gates in the order they are applied - the first gate whose pattern matches a request
+     * decides the roles required for it. Both {@link #configure(HttpSecurity)} and the test that guards
+     * the matrix read this single declaration.
+     */
+    static final List<RoleGate> ROLE_GATES = List.of( //
+            new RoleGate(MONITORING_PATTERNS, OPERATIONS_ROLES), //
+            new RoleGate(DEVELOPER_PATTERNS, new String[] {Roles.DEVELOPER.getRoleName()}), //
+            new RoleGate(OPERATOR_PATTERNS, new String[] {Roles.OPERATOR.getRoleName()}), //
+            new RoleGate(NATIVE_APPS_MANAGEMENT_PATTERNS, OPERATIONS_ROLES));
+
+    /**
+     * A role gate - the URI patterns it covers and the roles any of which grants access to them.
+     *
+     * @param patterns the Ant patterns
+     * @param roles the role names, any of which is sufficient
+     */
+    record RoleGate(String[] patterns, String[] roles) {
+    }
+
     private final BeanProvider beanProvider;
 
     HttpSecurityURIConfigurator(BeanProvider beanProvider) {
@@ -106,40 +154,35 @@ public class HttpSecurityURIConfigurator {
     public void configure(HttpSecurity http) throws Exception {
         applyCustomConfigurations(http);
 
-        http.authorizeHttpRequests((authz) -> //
+        http.authorizeHttpRequests((authz) -> {
 
-        authz.requestMatchers(PUBLIC_PATTERNS)
-             .permitAll()
+            authz.requestMatchers(PUBLIC_PATTERNS)
+                 .permitAll();
 
-             // NOTE!: the order is important - role checks should be before just
-             // authenticated paths
+            // NOTE!: the order is important - role checks should be before just
+            // authenticated paths
 
-             // Fine grained configurations
-             .requestMatchers(HttpMethod.GET, "/services/bpm/bpm-processes/tasks")
-             .authenticated()
+            // Fine grained configurations
+            authz.requestMatchers(HttpMethod.GET, "/services/bpm/bpm-processes/tasks")
+                 .authenticated();
 
-             .requestMatchers(HttpMethod.POST, "/services/bpm/bpm-processes/tasks/*")
-             .authenticated()
+            authz.requestMatchers(HttpMethod.POST, "/services/bpm/bpm-processes/tasks/*")
+                 .authenticated();
 
-             // "DEVELOPER" role required
-             .requestMatchers(DEVELOPER_PATTERNS)
-             .hasRole(Roles.DEVELOPER.getRoleName())
+            // Role gates, in declaration order
+            for (RoleGate gate : ROLE_GATES) {
+                authz.requestMatchers(gate.patterns())
+                     .hasAnyRole(gate.roles());
+            }
 
-             // "OPERATOR" role required
-             .requestMatchers(OPERATOR_PATTERNS)
-             .hasRole(Roles.OPERATOR.getRoleName())
+            // Authenticated
+            authz.requestMatchers(authenticatedPatterns())
+                 .authenticated();
 
-             // Native-apps management: any of DEVELOPER, ADMINISTRATOR, OPERATOR
-             .requestMatchers(NATIVE_APPS_MANAGEMENT_PATTERNS)
-             .hasAnyRole(Roles.DEVELOPER.getRoleName(), Roles.ADMINISTRATOR.getRoleName(), Roles.OPERATOR.getRoleName())
-
-             // Authenticated
-             .requestMatchers(authenticatedPatterns())
-             .authenticated()
-
-             // Deny all other requests
-             .anyRequest()
-             .denyAll());
+            // Deny all other requests
+            authz.anyRequest()
+                 .denyAll();
+        });
     }
 
     /**

--- a/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/artefact/endpoint/ArtefactStatusEndpointTest.java
+++ b/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/artefact/endpoint/ArtefactStatusEndpointTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.artefact.endpoint;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+
+import org.eclipse.dirigible.components.base.artefact.Artefact;
+import org.eclipse.dirigible.components.base.artefact.ArtefactLifecycle;
+import org.eclipse.dirigible.components.base.artefact.ArtefactPhase;
+import org.eclipse.dirigible.components.base.artefact.ArtefactService;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * The Class ArtefactStatusEndpointTest.
+ */
+class ArtefactStatusEndpointTest {
+
+    @Test
+    void aggregatesEveryArtefactServiceInTheContext() {
+        ArtefactStatusEndpoint endpoint = new ArtefactStatusEndpoint(List.of(
+                serviceOf(artefact("/project/first.job", "first", "job", ArtefactPhase.CREATE, ArtefactLifecycle.CREATED, null)),
+                serviceOf(artefact("/project/second.table", "second", "table", ArtefactPhase.UPDATE, ArtefactLifecycle.FAILED, "boom"))));
+
+        List<ArtefactStatus> statuses = endpoint.getArtefacts()
+                                                .getBody();
+
+        assertIterableEquals(
+                List.of(new ArtefactStatus("/project/first.job", "first", "job", "CREATE", "CREATED", null, Boolean.TRUE),
+                        new ArtefactStatus("/project/second.table", "second", "table", "UPDATE", "FAILED", "boom", Boolean.TRUE)),
+                statuses);
+    }
+
+    @Test
+    void anUnreadableArtefactTypeDoesNotTakeDownTheInventory() {
+        ArtefactService<?, ?> failing = new TestArtefactService(null) {
+            @Override
+            public List<TestArtefact> getAll() {
+                throw new IllegalStateException("table is missing");
+            }
+        };
+        ArtefactStatusEndpoint endpoint = new ArtefactStatusEndpoint(List.of(failing,
+                serviceOf(artefact("/project/first.job", "first", "job", ArtefactPhase.CREATE, ArtefactLifecycle.CREATED, null))));
+
+        List<ArtefactStatus> statuses = endpoint.getArtefacts()
+                                                .getBody();
+
+        assertEquals(1, statuses.size());
+        assertEquals("first", statuses.get(0)
+                                      .name());
+    }
+
+    @Test
+    void aNeverSynchronizedArtefactReportsNoPhase() {
+        TestArtefact artefact = artefact("/project/third.csvim", "third", "csvim", null, null, null);
+        ArtefactStatusEndpoint endpoint = new ArtefactStatusEndpoint(List.of(serviceOf(artefact)));
+
+        ArtefactStatus status = endpoint.getArtefacts()
+                                        .getBody()
+                                        .get(0);
+
+        assertNull(status.phase());
+        assertNull(status.status());
+    }
+
+    private static TestArtefact artefact(String location, String name, String type, ArtefactPhase phase, ArtefactLifecycle lifecycle,
+            String error) {
+        TestArtefact artefact = new TestArtefact(location, name, type);
+        artefact.setPhase(phase);
+        artefact.setLifecycle(lifecycle);
+        artefact.setError(error);
+        artefact.setRunning(true);
+        return artefact;
+    }
+
+    private static ArtefactService<?, ?> serviceOf(TestArtefact artefact) {
+        return new TestArtefactService(artefact);
+    }
+
+    /** A minimal concrete artefact - {@link Artefact} itself is abstract. */
+    private static final class TestArtefact extends Artefact {
+
+        private TestArtefact(String location, String name, String type) {
+            super(location, name, type, null, null);
+        }
+    }
+
+    /** A service over a single artefact; only {@link #getAll()} is exercised by the endpoint. */
+    private static class TestArtefactService implements ArtefactService<TestArtefact, Long> {
+
+        private final TestArtefact artefact;
+
+        private TestArtefactService(TestArtefact artefact) {
+            this.artefact = artefact;
+        }
+
+        @Override
+        public List<TestArtefact> getAll() {
+            return List.of(artefact);
+        }
+
+        @Override
+        public Page<TestArtefact> getPages(Pageable pageable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TestArtefact findById(Long id) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TestArtefact findByName(String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<TestArtefact> findByLocation(String location) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TestArtefact findByKey(String key) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TestArtefact save(TestArtefact a) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void delete(TestArtefact a) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setRunningToAll(boolean running) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfiguratorTest.java
+++ b/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfiguratorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.http.access;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.dirigible.components.base.http.access.HttpSecurityURIConfigurator.RoleGate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+
+/**
+ * Guards the URL-layer role matrix.
+ * <p>
+ * The monitoring endpoints declare {@code @RolesAllowed({ADMINISTRATOR, DEVELOPER, OPERATOR})} but
+ * sit under the DEVELOPER-gated {@code /services/ide/**} and {@code /services/bpm/**} prefixes, so
+ * an OPERATOR used to be rejected by the filter chain before method security ever ran. These tests
+ * fail if that regresses, and equally if the alignment ever spills over onto the design-time
+ * surfaces.
+ */
+class HttpSecurityURIConfiguratorTest {
+
+    private static final PathMatcher MATCHER = new AntPathMatcher();
+
+    private static final Set<String> OPERATIONS_ROLES = Set.of("ADMINISTRATOR", "DEVELOPER", "OPERATOR");
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/services/ide/monitoring/metrics", "/services/ide/monitoring/counts", "/services/ide/monitoring/threads",
+            "/services/ide/logs", "/services/ide/logs/dirigible.log", "/services/ide/loggers", "/services/ide/messaging-monitoring/summary",
+            "/services/bpm/bpm-processes/instances", "/services/bpm/bpm-processes/instance/42/jobs", "/websockets/ide/console"})
+    void monitoringSurfacesAreReachableByOperators(String uri) {
+        assertEquals(OPERATIONS_ROLES, requiredRoles(uri), "the monitoring surface must match the declared @RolesAllowed of " + uri);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/services/ide/workspaces/workspace", "/services/ide/git/workspace/project/clone", "/services/ide/problems",
+            "/services/ide/publisher/request/workspace/project", "/services/bpm/models/workspace/project/process.bpmn",
+            "/services/bpm/stencil-sets", "/websockets/ide/java-lsp"})
+    void designTimeSurfacesStayDeveloperOnly(String uri) {
+        assertEquals(Set.of("DEVELOPER"), requiredRoles(uri), "the alignment must not widen the design-time surface at " + uri);
+    }
+
+    @Test
+    void operationalInfrastructureStaysOperatorOnly() {
+        assertEquals(Set.of("OPERATOR"), requiredRoles("/actuator/metrics"));
+        assertEquals(Set.of("OPERATOR"), requiredRoles("/spring-admin/applications"));
+    }
+
+    @Test
+    void nativeAppManagementStaysOpenToAllOperationalRoles() {
+        assertEquals(OPERATIONS_ROLES, requiredRoles("/services/native-apps"));
+        assertEquals(OPERATIONS_ROLES, requiredRoles("/services/native-apps/my-app/start"));
+    }
+
+    /**
+     * The gates are evaluated in order and the monitoring patterns are all sub-paths of the DEVELOPER
+     * ones - reordering them silently reinstates the 403.
+     */
+    @Test
+    void theMonitoringGateIsEvaluatedBeforeTheDeveloperGate() {
+        List<RoleGate> gates = HttpSecurityURIConfigurator.ROLE_GATES;
+        int monitoringIndex = indexOfGateMatching(gates, "/services/ide/monitoring/metrics");
+        int developerIndex = indexOfGateMatching(gates, "/services/ide/workspaces/workspace");
+
+        assertTrue(monitoringIndex < developerIndex,
+                "the monitoring gate must precede the DEVELOPER gate, otherwise the broader pattern wins");
+    }
+
+    private static Set<String> requiredRoles(String uri) {
+        int index = indexOfGateMatching(HttpSecurityURIConfigurator.ROLE_GATES, uri);
+        assertTrue(index >= 0, "no role gate matches " + uri);
+        return Set.of(HttpSecurityURIConfigurator.ROLE_GATES.get(index)
+                                                            .roles());
+    }
+
+    private static int indexOfGateMatching(List<RoleGate> gates, String uri) {
+        for (int i = 0; i < gates.size(); i++) {
+            if (Arrays.stream(gates.get(i)
+                                   .patterns())
+                      .anyMatch(pattern -> MATCHER.match(pattern, uri))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/ArtefactStatusEndpointIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/ArtefactStatusEndpointIT.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * End-to-end test for {@code GET /services/core/artefacts}: publishes an artefact into the
+ * registry, synchronizes, and asserts the endpoint reports it with the lifecycle the synchronizer
+ * left behind.
+ */
+class ArtefactStatusEndpointIT extends IntegrationTest {
+
+    private static final String ENDPOINT = "/services/core/artefacts";
+
+    private static final String LOCATION = "/artefact-status-it/monitoring.extensionpoint";
+
+    private static final String REGISTRY_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + LOCATION;
+
+    private static final String CONTENT = """
+            {
+              "name": "artefact-status-it-point",
+              "description": "Artefact status endpoint test"
+            }
+            """;
+
+    /** The synchronization is forced synchronously, but the artefact row can lag it slightly. */
+    private static final long ASSERTION_TIMEOUT_SECONDS = 30;
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @Test
+    void reports_a_synchronized_artefact_with_its_lifecycle() {
+        repository.createResource(REGISTRY_PATH, CONTENT.getBytes(StandardCharsets.UTF_8), false, "application/json", true);
+        synchronizationProcessor.forceProcessSynchronizers();
+
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get(ENDPOINT)
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body(byLocation() + ".type", contains("extensionpoint"))
+                                                 .body(byLocation() + ".name", contains("artefact-status-it-point"))
+                                                 .body(byLocation() + ".status", contains("CREATED")),
+                ASSERTION_TIMEOUT_SECONDS);
+    }
+
+    @Test
+    void drops_an_artefact_removed_from_the_registry() {
+        repository.createResource(REGISTRY_PATH, CONTENT.getBytes(StandardCharsets.UTF_8), false, "application/json", true);
+        synchronizationProcessor.forceProcessSynchronizers();
+
+        repository.removeResource(REGISTRY_PATH);
+        synchronizationProcessor.forceProcessSynchronizers();
+
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get(ENDPOINT)
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body(byLocation(), empty()),
+                ASSERTION_TIMEOUT_SECONDS);
+    }
+
+    @AfterEach
+    void removeArtefactFromRegistry() {
+        if (repository.hasResource(REGISTRY_PATH)) {
+            repository.removeResource(REGISTRY_PATH);
+            synchronizationProcessor.forceProcessSynchronizers();
+        }
+    }
+
+    /** A JsonPath filter selecting the artefacts this test published, whatever else is deployed. */
+    private static String byLocation() {
+        return "findAll { it.location == '" + LOCATION + "' }";
+    }
+}


### PR DESCRIPTION
Phase 0 of the Monitoring shell plan — the two backend prerequisites, split out because they are security-sensitive and independently reviewable. No UI in this PR.

## 1. URL-gate alignment (`HttpSecurityURIConfigurator`)

`/services/ide/**` and `/services/bpm/**` are gated on `ROLE_DEVELOPER` at the filter chain, even though the controllers underneath declare `@RolesAllowed({ADMINISTRATOR, DEVELOPER, OPERATOR})` — so an OPERATOR is rejected before method security ever runs, for exactly the endpoints an operations surface needs:

- `/services/ide/monitoring/**` (JVM metrics / counts / threads)
- `/services/ide/logs/**`, `/services/ide/loggers/**`
- `/services/ide/messaging-monitoring/**`
- `/services/bpm/bpm-processes/**`
- `/websockets/ide/console`

Those prefixes now form their own gate, matched **before** the DEVELOPER gate. Everything else under the same roots — workspaces, git, publisher, problems, the BPMN modeler (`/services/bpm/models/**`, `/services/bpm/stencil-sets`), the LSP/debug sockets — stays DEVELOPER-only. This is an alignment with the declared method policy, not a widening beyond it.

The gates became one ordered declaration (`ROLE_GATES`) that both `configure()` and the new test read, so the ordering the alignment depends on cannot change silently. `HttpSecurityURIConfiguratorTest` asserts the whole matrix (monitoring → three roles, design-time → DEVELOPER, actuator → OPERATOR, native-apps → three roles, plus the ordering invariant).

## 2. `GET /services/core/artefacts`

"What is deployed and did it synchronize" had no Java REST endpoint: the IDE's Artefacts view reads it through `/services/js/perspective-operations/api/artefacts/artefacts.mjs`, which fans out over the `platform-operations-artefacts` extension point issuing per-table SQL. Depending on an IDE perspective's internal JS API from elsewhere is a workaround, not a design.

`ArtefactStatusEndpoint` (ADMINISTRATOR/DEVELOPER/OPERATOR) constructor-injects `List<ArtefactService<?, ?>>` — every synchronizer already registers one bean, so the bean list *is* the inventory and a new artefact type needs no registration step — and returns `[{location, name, type, phase, status, error, running}]`. An artefact type that cannot be read (engine not enabled, table missing) is logged and skipped rather than taking down the whole inventory. The IDE's Artefacts view can migrate to it later; not required here.

## Verification

- `mvn -pl components/core/core-base test` — green (36 tests, incl. the new matrix + endpoint tests).
- `mvn -pl tests/tests-integrations -P integration-tests verify -Dit.test=ArtefactStatusEndpointIT` — green: publishes an artefact into the registry, synchronizes, asserts the endpoint reports it as `CREATED`, then removes it and asserts it is gone.
- `mvn -T 1C clean install -P quick-build` — green.
- `formatter:validate` — clean; `-P release` javadoc on `core-base` — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)