### PR TITLE
fix(jobs): a disabled client-Java job stays disabled (#6626)

### DIFF
--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/scheduled/ScheduledClassConsumer.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/scheduled/ScheduledClassConsumer.java
@@ -53,7 +53,11 @@ import org.springframework.stereotype.Component;
  * <p>
  * The {@code Job} row is registered under the {@link JavaJobExecutor#RUNTIME_LOCATION_PREFIX}
  * synthetic location so the job synchronizer does not reap it as a registry orphan. Hot-reload
- * re-registers the schedule; a genuinely unloaded class unschedules and removes its rows.
+ * re-registers the schedule <b>onto the existing row</b>, which is what preserves the operator's
+ * enable/disable choice: that flag belongs to the Jobs perspective, not to the code, so a
+ * registration carries it over instead of switching the job back on - a class load happens at every
+ * server start and on every client-Java rebuild. A genuinely unloaded class, or a job that a
+ * reloaded class no longer declares, unschedules and removes its rows.
  */
 @Component
 @Order(400)
@@ -105,7 +109,10 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
             return;
         }
 
-        unregister(info.fqn());
+        // Register what the class declares NOW, then drop only the names it no longer declares -
+        // rather than unregistering everything first. A re-registration must find (and update) the
+        // existing Job row, because that row carries operator state - above all the enabled flag,
+        // which a delete-then-recreate would silently reset to true (#6626).
         List<String> names = new ArrayList<>();
 
         if (jobHandler) {
@@ -126,9 +133,11 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
         }
 
         if (names.isEmpty()) {
+            unregister(info.fqn());
             LOGGER.warn("Scheduled job [{}] produced no schedule.", info.fqn());
             return;
         }
+        retainOnly(info.fqn(), names);
         registered.put(info.fqn(), names);
     }
 
@@ -162,8 +171,15 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
                 // findByName THROWS when absent (it does not return null) - treat that as "new", and
                 // otherwise mutate the existing managed row so save() updates it rather than duplicating.
                 Job job;
+                boolean enabled = true;
                 try {
                     job = jobService.findByName(name);
+                    // The enabled flag belongs to the OPERATOR, not to the code: it is what the Jobs
+                    // perspective's enable/disable writes. Carry it over, so a disabled job stays
+                    // disabled across restarts and hot reloads instead of quietly firing again - and so
+                    // no spurious "job enabled" notification mail goes out (#6626). A brand-new job
+                    // starts enabled, like every other artefact-defined one.
+                    enabled = job.isEnabled();
                 } catch (Exception notFound) {
                     job = new Job();
                 }
@@ -174,7 +190,7 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
                 job.setEngine(JavaJobExecutor.ENGINE_JAVA);
                 job.setExpression(expression);
                 job.setSingleton(false);
-                job.setEnabled(true);
+                job.setEnabled(enabled);
                 job.setDescription("Client-Java scheduled job [" + handler + "]");
                 job.setType(Job.ARTEFACT_TYPE);
                 job.setLocation(JavaJobExecutor.RUNTIME_LOCATION_PREFIX + handler);
@@ -191,12 +207,32 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
         }
     }
 
+    /**
+     * Drop the jobs a class registered before but no longer declares - a {@code @Scheduled} method that
+     * was renamed or removed. The ones it still declares were just re-registered onto their existing
+     * rows, so they keep their operator state.
+     */
+    private void retainOnly(String fqn, List<String> current) {
+        List<String> previous = registered.get(fqn);
+        if (previous == null) {
+            return;
+        }
+        List<String> stale = new ArrayList<>(previous);
+        stale.removeAll(current);
+        remove(stale);
+    }
+
     /** Unschedule + remove the Job rows a class previously registered (per tenant). */
     private void unregister(String fqn) {
         List<String> names = registered.remove(fqn);
         if (names == null) {
             return;
         }
+        remove(names);
+    }
+
+    /** Unschedule + delete the given job rows, per tenant. */
+    private void remove(List<String> names) {
         for (String name : names) {
             try {
                 tenantContext.executeForEachTenant(() -> {

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/scheduled/ScheduledClassConsumerTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/scheduled/ScheduledClassConsumerTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.java.scheduled;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.dirigible.components.base.callable.CallableResultAndException;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.eclipse.dirigible.components.jobs.domain.Job;
+import org.eclipse.dirigible.components.jobs.manager.JobsManager;
+import org.eclipse.dirigible.components.jobs.service.JobService;
+import org.eclipse.dirigible.engine.java.component.ComponentContainer;
+import org.eclipse.dirigible.engine.java.spi.LoadedClass;
+import org.eclipse.dirigible.sdk.job.JobHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Registering a client-Java job keeps the operator's enable/disable choice (#6626): the flag lives
+ * on the {@code Job} row, and the row is re-registered on every class load - at every server start,
+ * and on every client-Java rebuild.
+ */
+class ScheduledClassConsumerTest {
+
+    /** A client job of the self-describing-interface style. */
+    static class CleanupJob implements JobHandler {
+
+        @Override
+        public String cron() {
+            return "0 0 3 * * ?";
+        }
+
+        @Override
+        public void run() {
+            // nothing - the schedule registration is what is under test
+        }
+    }
+
+    private static final String JOB_NAME = CleanupJob.class.getName();
+
+    private ComponentContainer componentContainer;
+    private JobsManager jobsManager;
+    private JobService jobService;
+    private ScheduledClassConsumer consumer;
+
+    @BeforeEach
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void setUp() throws Exception {
+        componentContainer = mock(ComponentContainer.class);
+        jobsManager = mock(JobsManager.class);
+        jobService = mock(JobService.class);
+        TenantContext tenantContext = mock(TenantContext.class);
+        // Registration runs per tenant; run the callable once so the test sees what it writes.
+        when(tenantContext.executeForEachTenant(any())).thenAnswer(invocation -> {
+            ((CallableResultAndException) invocation.getArgument(0)).call();
+            return List.of();
+        });
+        when(componentContainer.instanceOf(CleanupJob.class)).thenReturn(Optional.of(new CleanupJob()));
+
+        consumer = new ScheduledClassConsumer(componentContainer, jobsManager, jobService, tenantContext);
+    }
+
+    private static LoadedClass loadedClass() {
+        return new LoadedClass("sample", JOB_NAME, CleanupJob.class, CleanupJob.class.getClassLoader());
+    }
+
+    private Job savedJob() {
+        ArgumentCaptor<Job> saved = ArgumentCaptor.forClass(Job.class);
+        verify(jobService, times(1)).save(saved.capture());
+        return saved.getValue();
+    }
+
+    @Test
+    void aNewJobStartsEnabled() {
+        // findByName THROWS when the row is absent - that is what "brand new" looks like here.
+        when(jobService.findByName(JOB_NAME)).thenThrow(new IllegalArgumentException("Job with name does not exist: " + JOB_NAME));
+
+        consumer.onClassLoaded(loadedClass());
+
+        assertTrue(savedJob().isEnabled(), "a job registered for the first time should be scheduled");
+    }
+
+    @Test
+    void aDisabledJobStaysDisabledWhenItIsRegisteredAgain() {
+        Job existing = new Job();
+        existing.setName(JOB_NAME);
+        existing.setEnabled(false);
+        when(jobService.findByName(JOB_NAME)).thenReturn(existing);
+
+        consumer.onClassLoaded(loadedClass());
+
+        // The flag is the operator's, not the code's: a restart or an unrelated client-Java rebuild
+        // must not turn a job the operator switched off back on.
+        assertFalse(savedJob().isEnabled(), "the operator's disable must survive re-registration");
+    }
+
+    @Test
+    void aReloadUpdatesTheExistingRowInsteadOfDeletingIt() throws Exception {
+        Job existing = new Job();
+        existing.setName(JOB_NAME);
+        existing.setEnabled(false);
+        when(jobService.findByName(JOB_NAME)).thenReturn(existing);
+
+        consumer.onClassLoaded(loadedClass());
+        consumer.onClassLoaded(loadedClass()); // the hot reload
+
+        // Deleting and recreating the row would drop the flag with it, so the row must survive.
+        verify(jobService, never()).delete(any());
+        verify(jobsManager, never()).unscheduleJob(anyString(), anyString());
+    }
+
+    @Test
+    void anUnloadedClassLosesItsJob() throws Exception {
+        Job existing = new Job();
+        existing.setName(JOB_NAME);
+        when(jobService.findByName(JOB_NAME)).thenReturn(existing);
+
+        consumer.onClassLoaded(loadedClass());
+        consumer.onClassUnloaded(loadedClass());
+
+        verify(jobsManager).unscheduleJob(JOB_NAME, "defined");
+        verify(jobService).delete(existing);
+    }
+}


### PR DESCRIPTION
Closes #6626. Noticed while fixing #6305 / #6625.

## The problem

A client-Java scheduled job can be disabled from the Jobs perspective like any other job — and then quietly turns itself back on. `ScheduledClassConsumer` re-registers its jobs on every class load, and the registration hard-coded the flag:

```java
job.setEnabled(true);
```

A class load happens at **every server start** and on **every client-Java rebuild** — the compile is one registry-wide batch, so publishing *any* `.java` anywhere reloads *all* client classes. So an operator who switches a misbehaving job off finds it firing again after the next restart or the next unrelated publish, with no way to keep it off short of deleting the code. As a side effect `JobService.save` sees a disabled→enabled transition and mails the job's subscribers the "job enabled" notification every time.

## Two paths lost the choice, both fixed

1. **Registration overwrote the flag.** It now reads `enabled` off the existing row and carries it over. A brand-new job still starts enabled, like every other artefact-defined one. No scheduling change is needed: `JobsManager.scheduleJob` already refuses to schedule a disabled job and deletes an existing Quartz job for it.
2. **A reload deleted the row.** `onClassLoaded` called `unregister(fqn)` first, which unschedules *and* `jobService.delete`s the rows — so re-registration created a fresh row that defaulted to enabled, and preserving the flag in (1) alone would not have helped. It now **reconciles**: register what the class declares now, then drop only the previously registered names it no longer declares (a renamed or removed `@Scheduled` method). `onClassUnloaded` still removes everything.

## `.job` artefacts were never affected

Worth recording, because it makes this a divergence rather than platform-wide behaviour — I initially assumed the opposite. `SynchronizationProcessor.parseDefinitions` only calls `synchronizer.parse(...)` for a definition in state `NEW` / `MODIFIED` / `BROKEN` / `DELETED`; an unchanged one is `PARSED` and goes through `retrieve(...)`. `Definition` is persisted (`DIRIGIBLE_DEFINITIONS`), so an unchanged `.job` stays `PARSED` across a restart and `JobSynchronizer.parseImpl` — which rebuilds the row from the file — never runs. A `.job` keeps its Disable until the file itself changes.

## Tests

`ScheduledClassConsumerTest` (new): a new job starts enabled; a disabled one stays disabled when registered again; a reload updates the row instead of deleting it; an unloaded class still loses its job. **Both new tests fail on the code before this change** (`expected: <false> but was: <true>`, and the delete/unschedule the reload used to perform). The whole `engine-java` suite is green (76), and `formatter:validate` plus the release javadoc pass are clean.

The engine-java guide's job bullet is rewritten in #6625 (the trigger-now fix), so I left it alone here to keep the two PRs conflict-free — the class javadoc in this PR carries the same note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)