### PR TITLE
fix(templates): the BPM starter's form calls its client-Java service

### DIFF
--- a/components/template/template-bpm/src/main/resources/META-INF/dirigible/template-bpm/tasks/MyServiceTask.java.template
+++ b/components/template/template-bpm/src/main/resources/META-INF/dirigible/template-bpm/tasks/MyServiceTask.java.template
@@ -21,8 +21,7 @@ public class MyServiceTask implements JavaDelegate {
 
     @Override
     public void execute(DelegateExecution execution) {
-        LOGGER.info("Hello World! Process instance [{}] with variables: {}", execution.getProcessInstanceId(),
-                execution.getVariables());
+        LOGGER.info("Hello World! Process variables: {}", execution.getVariables());
     }
 
 }

--- a/components/template/template-bpm/src/main/resources/META-INF/dirigible/template-bpm/trigger-new-process.form.template
+++ b/components/template/template-bpm/src/main/resources/META-INF/dirigible/template-bpm/trigger-new-process.form.template
@@ -2,7 +2,7 @@
 {
     "feeds": [],
     "scripts": [],
-    "code": "${dollar}scope.model.param1 = \"\";\n${dollar}scope.model.param2 = 0;\n\n${dollar}scope.onTriggerClicked = function(){\n    ${dollar}http.post(\"/services/ts/${projectName}/api/ProcessService.ts/processes\", JSON.stringify(${dollar}scope.model)).then(function (response) {\n        if (response.status != 202) {\n            alert(`Unable to trigger a new process: '${dollar}{response.message}'`);\n            return;\n        }\n        alert(\"A new process instance has been triggered.\\nResponse: \" + JSON.stringify(response.data));\n    });\n}\n",
+    "code": "${dollar}scope.model.param1 = \"\";\n${dollar}scope.model.param2 = 0;\n\n${dollar}scope.onTriggerClicked = function(){\n    ${dollar}http.post(\"/services/java/${projectName}/${javaPackageName}/ProcessService/processes\", JSON.stringify(${dollar}scope.model)).then(function (response) {\n        alert(\"A new process instance has been triggered.\\nResponse: \" + JSON.stringify(response.data));\n    }, function (error) {\n        alert(`Unable to trigger a new process: '${dollar}{(error && error.data && error.data.message) || error}'`);\n    });\n}\n",
     "form": [
         {
             "controlId": "header",

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/BPMStarterTemplateIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/BPMStarterTemplateIT.java
@@ -49,7 +49,11 @@ public class BPMStarterTemplateIT extends UserInterfaceIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        this.consoleLogAsserter = new LogsAsserter("app.out", Level.INFO);
+        // The service task is client Java now and logs through the SDK logger, which nests the name it
+        // is given under the platform's "app." root - not the "app.out" console stream the retired
+        // TypeScript task wrote to. Watch the whole application tree, so the assertion does not depend
+        // on the package name the template derives from the project.
+        this.consoleLogAsserter = new LogsAsserter("app", Level.INFO);
     }
 
     @Test


### PR DESCRIPTION
## Fixes red master nightly

`BPMStarterTemplateIT` is failing on master on **both** the H2 and the PostgreSQL leg.

#6619 migrated the BPM starter's two TypeScript files to client Java but left everything that *talks*
to them pointing at the retired TypeScript, so the sample does not work at all:

- The form posted to `/services/ts/<project>/api/ProcessService.ts/processes` — a file that PR deleted
  — and branched on `response.status != 202`, the status the TS service used to set, where the
  client-Java `@Controller` answers 200. That is the failure the nightly reports: the alert reads
  `Unable to trigger a new process: 'undefined'`, because the error branch prints `response.message`,
  which the form-builder's `$http` shim never sets. It now posts to
  `/services/java/<project>/<javaPackageName>/ProcessService/processes` and uses a proper error
  callback instead of an exact-status branch, which also gives the failure path a real message.
- The service task logged a different line than before the migration (`Process instance [id] with
  variables` vs `Process variables`), which the test asserts. Restored, so the sample's observable
  behaviour is unchanged by the port.

The test itself also watched the wrong logger: `console.log` from the retired TypeScript landed on
`app.out`, while the SDK logger nests the given name under `app.`, so the Java task logs to
`app.<package>.MyServiceTask` — which an appender bound to `app.out` never sees, and which
`logback-test.xml` pins to ERROR. It now watches the `app` tree, so it observes any client-application
log and does not depend on the package name derived from the project.

Verified locally by the commit's author: the process starts through the Java controller and the task
logs `app.bpmtestproject.MyServiceTask - Hello World! Process variables: {param1=string-param-value,
param2=777.0}`.

Full rationale is in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
