### PR TITLE
refactor(java-lsp): one shared default classpath for all Java projects

### DIFF
--- a/components/ide/ide-java-lsp/src/main/java/org/eclipse/dirigible/components/ide/lsp/java/process/JdtLsManager.java
+++ b/components/ide/ide-java-lsp/src/main/java/org/eclipse/dirigible/components/ide/lsp/java/process/JdtLsManager.java
@@ -87,6 +87,12 @@ public class JdtLsManager implements DisposableBean, ApplicationRunner, Applicat
      */
     private volatile boolean available = false;
 
+    /**
+     * Memoised default {@code .classpath} XML, shared by every project. See
+     * {@link #defaultClasspathXml()}.
+     */
+    private volatile String defaultClasspathXml;
+
     public JdtLsManager(ClassPathIndex classPathIndex, Optional<JavaCompiledOutputDirectory> compiledOutputDirectory) {
         this.classPathIndex = classPathIndex;
         this.compiledOutputDir = compiledOutputDirectory.map(JavaCompiledOutputDirectory::get)
@@ -274,7 +280,7 @@ public class JdtLsManager implements DisposableBean, ApplicationRunner, Applicat
         logger.debug("[java-lsp] Wrote .project for {}", sanitize(project));
 
         Path dotClasspath = projectRoot.resolve(".classpath");
-        Files.writeString(dotClasspath, buildClasspathXml(), StandardCharsets.UTF_8);
+        Files.writeString(dotClasspath, defaultClasspathXml(), StandardCharsets.UTF_8);
         logger.debug("[java-lsp] Wrote .classpath for {}", sanitize(project));
     }
 
@@ -289,21 +295,51 @@ public class JdtLsManager implements DisposableBean, ApplicationRunner, Applicat
                 + "        </buildCommand>\n" + "    </buildSpec>\n" + "</projectDescription>\n";
     }
 
-    private String buildClasspathXml() {
-        StringBuilder libs = new StringBuilder();
-        for (Path entry : classPathIndex.classPathEntries()) {
-            libs.append("    <classpathentry kind=\"lib\" path=\"")
-                .append(entry.toString())
-                .append("\"/>\n");
+    /**
+     * The single default classpath shared by every Java project in the workspace. It is byte-identical
+     * for every project (nothing in it is project-specific), so it is rendered once and reused. It is
+     * composed of exactly the three things client Java needs to resolve:
+     * <ul>
+     * <li><b>Java standard library</b> - the {@code JRE_CONTAINER};</li>
+     * <li><b>the Dirigible SDK + platform jars</b> - one {@code lib} entry per {@link ClassPathIndex}
+     * entry. This is the full platform jar set: it contains {@code org.eclipse.dirigible.sdk.*} as well
+     * as the Spring / Flowable / etc. jars that generated controllers and BPMN handlers depend on (an
+     * SDK-only subset does not compile real projects);</li>
+     * <li><b>the registry / published projects</b> - one {@code lib} entry for the flat compiled-output
+     * directory ({@code <repoRoot>/dirigible/java-compiled/bin}). Every client {@code .java} on the
+     * platform (registry-published and sibling workspace projects) compiles into that one tree, so this
+     * single entry resolves cross-project and published types.</li>
+     * </ul>
+     * Plus the project's own sources via {@code src path=""}. Memoised because
+     * {@link ClassPathIndex#classPathEntries()} is itself cached for the application lifetime and
+     * {@code compiledOutputDir} is a fixed path, so the rendered XML never changes within a run.
+     */
+    private String defaultClasspathXml() {
+        String cached = defaultClasspathXml;
+        if (cached != null) {
+            return cached;
         }
-        if (compiledOutputDir != null) {
-            libs.append("    <classpathentry kind=\"lib\" path=\"")
-                .append(compiledOutputDir.toString())
-                .append("\"/>\n");
+        synchronized (this) {
+            if (defaultClasspathXml != null) {
+                return defaultClasspathXml;
+            }
+            StringBuilder libs = new StringBuilder();
+            for (Path entry : classPathIndex.classPathEntries()) {
+                libs.append("    <classpathentry kind=\"lib\" path=\"")
+                    .append(entry.toString())
+                    .append("\"/>\n");
+            }
+            if (compiledOutputDir != null) {
+                libs.append("    <classpathentry kind=\"lib\" path=\"")
+                    .append(compiledOutputDir.toString())
+                    .append("\"/>\n");
+            }
+            defaultClasspathXml =
+                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<classpath>\n" + "    <classpathentry kind=\"src\" path=\"\"/>\n"
+                            + "    <classpathentry kind=\"con\" path=\"org.eclipse.jdt.launching.JRE_CONTAINER\"/>\n" + libs
+                            + "    <classpathentry kind=\"output\" path=\"bin\"/>\n" + "</classpath>\n";
+            return defaultClasspathXml;
         }
-        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<classpath>\n" + "    <classpathentry kind=\"src\" path=\"\"/>\n"
-                + "    <classpathentry kind=\"con\" path=\"org.eclipse.jdt.launching.JRE_CONTAINER\"/>\n" + libs
-                + "    <classpathentry kind=\"output\" path=\"bin\"/>\n" + "</classpath>\n";
     }
 
     private List<String> buildCommand(String launcherJar, String configDir, String dataDir) {


### PR DESCRIPTION
## What

Every Java project's generated `.classpath` was byte-identical — nothing in it is project-specific
(`src=""`, the JRE container, the full platform lib set, the compiled-output dir, `bin` output) — yet it
was re-rendered per project on every LSP connect.

This consolidates it into a single documented, memoised **default classpath** shared by every Java
project in the workspace, composed of exactly what client Java needs to resolve:

- the Java standard library (`JRE_CONTAINER`);
- the Dirigible SDK + platform jars, one `lib` entry per `ClassPathIndex` entry — the full set, because
  generated controllers and BPMN handlers pull in Spring and Flowable, and an SDK-only subset would not
  compile real projects;
- the registry / published projects, via the flat compiled-output dir
  (`<repoRoot>/dirigible/java-compiled/bin`) that every client `.java` on the platform compiles into, so
  one entry resolves both cross-project and published types;
- plus the project's own sources (`src=""`).

Behaviour is unchanged — the emitted XML is identical. It is now rendered once and reused
(`ClassPathIndex.classPathEntries()` is cached for the app lifetime and the compiled-output path is
fixed). `buildClasspathXml()` is renamed to `defaultClasspathXml()`.

One file, `+50/-14`.

## Provenance and staleness — please read before merging

Full disclosure: this commit was authored **2026-06-18** and sat unpushed on a local branch until now; I
found it while cleaning up stale worktrees and branches. I did not write it and have not exercised it
beyond the checks below, so it wants a real review rather than a rubber stamp.

What I did verify:

- It **merges cleanly into current master** (`git merge-tree` reports no conflict), and the PR contains
  exactly this one commit against the current merge base.
- The refactor is **not already in master** — master has no `defaultClasspathXml` and no memoised shared
  classpath.
- `JdtLsManager` has however **moved on substantially** since the commit was written (roughly 115
  insertions / 68 deletions elsewhere in the file): master now fingerprints the classpath, reuses a
  cached JDT.LS index across restarts, and pre-warms the compile classpath at startup. A clean textual
  merge is not proof those interact correctly — in particular whether the new memoisation should
  participate in the existing `classpathFingerprint()` invalidation, so a changed platform classpath does
  not leave a stale cached `.classpath` behind. That is the thing to look at closest.
- The commit message says it is "best paired with the JDT.LS symlink fix (separate PR)", which makes the
  `.classpath` generate for git-backed projects in the first place. That companion appears to have landed
  already — most likely #6148 (`fix(java-lsp): resolve symlinked git-clone project paths to virtual
  URIs`), with #6038 earlier — so the prerequisite is in place.

No local test run: this touches the JDT.LS launch path, which has no automated coverage in the repo, so
CI plus a manual "open a Java project, check completion resolves platform and cross-project types" is the
real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
