### PR TITLE
fix(core-tenants): open the tenant scope for every request (#6636)

### DIFF
--- a/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/tenant/TenantContextInitFilter.java
+++ b/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/tenant/TenantContextInitFilter.java
@@ -28,7 +28,14 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 /**
- * The Class TenantContextInitFilter.
+ * Opens the tenant execution scope for the duration of the request.
+ * <p>
+ * It runs for <em>every</em> request, with no path opt-outs. The authentication filters sit
+ * downstream of it in the same chain and resolve the user against the current tenant, so a request
+ * reaching them without a tenant scope fails authentication - which turned a {@code permitAll}
+ * static path (webjars, favicon) into a 401 as soon as valid credentials were presented. Anything
+ * else that reads tenant-scoped state (configuration overrides, datasource routing, translations)
+ * would equally throw rather than fall back.
  */
 @Component
 public class TenantContextInitFilter extends OncePerRequestFilter {
@@ -127,24 +134,6 @@ public class TenantContextInitFilter extends OncePerRequestFilter {
             return false;
         }
         return lower.contains("text/html");
-    }
-
-    /**
-     * Should not filter.
-     *
-     * @param request the request
-     * @return true, if successful
-     */
-    @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) {
-        return request.getRequestURI()
-                      .startsWith("/webjars/")
-                || request.getRequestURI()
-                          .startsWith("/css/")
-                || request.getRequestURI()
-                          .startsWith("/js/")
-                || request.getRequestURI()
-                          .endsWith(".ico");
     }
 
 }

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/SecurityIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/SecurityIT.java
@@ -11,15 +11,19 @@ package org.eclipse.dirigible.integration.tests.api;
 
 import org.eclipse.dirigible.components.base.http.roles.Roles;
 import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -27,8 +31,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 public class SecurityIT extends IntegrationTest {
 
+    /** Public static paths served by the framework rather than by an application endpoint. */
+    private static final List<String> PUBLIC_STATIC_PATHS = List.of("/webjars/alpinejs/dist/cdn.min.js", "/favicon.ico");
+
     @Autowired
     private MockMvc mvc;
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
 
     @Test
     void testPublicEndpoint() throws Exception {
@@ -98,6 +108,35 @@ public class SecurityIT extends IntegrationTest {
     void testAdministratorCanReadNativeAppsManagement() throws Exception {
         mvc.perform(get("/services/native-apps"))
            .andExpect(status().is(anyOf(equalTo(HttpStatus.OK.value()), equalTo(HttpStatus.NOT_FOUND.value()))));
+    }
+
+    /**
+     * Presenting valid credentials must never change the outcome of a public static path. It did: those
+     * paths used to be opted out of the tenant execution scope, so the basic authentication filter ran
+     * unscoped, failed to resolve the user against a tenant, and the basic entry point answered 401 to
+     * credentials that authenticate everywhere else.
+     */
+    @Test
+    void testCredentialsDoNotBreakPublicStaticPaths() {
+        restAssuredExecutor.execute(() -> {
+            for (String path : PUBLIC_STATIC_PATHS) {
+                int anonymousStatus = given().auth()
+                                             .none()
+                                             .when()
+                                             .get(path)
+                                             .thenReturn()
+                                             .statusCode();
+                int authenticatedStatus = given().when()
+                                                 .get(path)
+                                                 .thenReturn()
+                                                 .statusCode();
+
+                assertThat(anonymousStatus).as("Anonymous status of the public path [%s]", path)
+                                           .isNotEqualTo(HttpStatus.UNAUTHORIZED.value());
+                assertThat(authenticatedStatus).as("Authenticated status of the public path [%s]", path)
+                                               .isEqualTo(anonymousStatus);
+            }
+        });
     }
 
 }


### PR DESCRIPTION
Fixes #6636.

## The bug

`/webjars/**` is `permitAll` and serves fine anonymously. Present **valid** credentials and the same URL answers `401`:

| Path | anonymous | with valid `-u admin:admin` |
|---|---|---|
| `/webjars/alpinejs/dist/cdn.min.js` | 200 | **401** |
| `/favicon.ico` | 404 | **401** |

`TenantContextInitFilter.shouldNotFilter()` opted `/webjars/`, `/css/`, `/js/` and `*.ico` out of the tenant execution scope. There is a single security filter chain, so `BasicAuthenticationFilter` still ran on those paths — with no tenant open. It reaches `CustomUserDetailsService.loadUserByUsername`, whose first line is `tenantContext.getCurrentTenant()`, and `TenantContextImpl.getCurrentTenant()` throws `IllegalStateException` when unscoped. Spring wraps that in an `InternalAuthenticationServiceException`, so the Basic entry point answers 401 — before resource resolution, which is why a non-existent `/favicon.ico` turns from 404 into 401.

Anonymous requests never attempt authentication, hence "works until you authenticate". It bites any client attaching a global `Authorization` header (API clients, smoke tests, monitoring probes, a reverse proxy injecting auth) and every webjar the UI loads in a browser that authenticated through the Basic challenge — a flow `BasicSecurityConfig` deliberately keeps for navigations.

## The fix

Option 2 from the issue: drop the skip. The opt-out bought a `ThreadLocal` set/restore plus a Caffeine-cached tenant lookup (a constant in single-tenant mode), so narrowing it is not worth the second list to keep in sync with `PUBLIC_PATTERNS` — note `/css/` and `/js/` are not even in `PUBLIC_PATTERNS`, so they are `denyAll` regardless.

Every request now runs tenant-scoped. That also closes the latent trap that anything reading tenant-scoped state on those paths — configuration overrides, datasource routing, the `Translator` — throws instead of falling back.

**Behaviour change:** on an *unregistered* tenant host these paths now answer 404 instead of serving, consistent with every other path on that host (`/` already 404s there). The SSO tenant-membership filters (`KeycloakTenantFilter`, `CognitoTenantFilter`) keep their own skip lists — those are an authorization allowance for pre-login assets, a different concern, and are untouched.

## Verification

`SecurityIT.testCredentialsDoNotBreakPublicStaticPaths` asserts the invariant rather than a hard-coded status: presenting credentials must not change the outcome of a public static path, and that path must not be 401 anonymously. This survives a webjar version bump.

- With the fix: `SecurityIT` 7/7 green — webjar 200/200, favicon 404/404.
- Against the unfixed filter (negative control, same test): fails with `Authenticated status of the public path [/webjars/alpinejs/dist/cdn.min.js] expected: 200 but was: 401` — exactly the reported symptom.

`mvn formatter:validate` and the release-profile javadoc build pass on the touched modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)