### PR TITLE
Adding a config-backed {appUrl} token for notify subject/body interpolation

### DIFF
--- a/components/core/core-configurations/src/main/java/org/eclipse/dirigible/components/configurations/tenant/TenantConfigurationKeyPolicy.java
+++ b/components/core/core-configurations/src/main/java/org/eclipse/dirigible/components/configurations/tenant/TenantConfigurationKeyPolicy.java
@@ -52,7 +52,10 @@ class TenantConfigurationKeyPolicy {
             // Whether the per-path CMS access grants are enforced at all. Per-tenant because whether
             // a tenant restricts folders by role is its own decision; the resolver reads it per
             // request, so switching it applies immediately.
-            "DIRIGIBLE_CMS_ROLES_ENABLED");
+            "DIRIGIBLE_CMS_ROLES_ENABLED", //
+            // The application's externally-reachable base URL (e.g. the {appUrl} notify token) -
+            // per-tenant because a tenant may be served from its own subdomain/host.
+            "DIRIGIBLE_APP_BASE_URL");
 
     /**
      * The full list of configuration keys a tenant may override, in display order.

--- a/components/core/core-configurations/src/test/java/org/eclipse/dirigible/components/configurations/tenant/TenantConfigurationKeyPolicyTest.java
+++ b/components/core/core-configurations/src/test/java/org/eclipse/dirigible/components/configurations/tenant/TenantConfigurationKeyPolicyTest.java
@@ -35,6 +35,8 @@ class TenantConfigurationKeyPolicyTest {
         assertTrue(policy.isInjectable("DIRIGIBLE_APPLICATION_LANGUAGES"));
         assertTrue(policy.isInjectable("DIRIGIBLE_DOCUMENTS_EXT_CONTENT_TYPE_MS_ENABLED"));
         assertTrue(policy.isInjectable("DIRIGIBLE_CMS_ROLES_ENABLED"));
+        // The app's external base URL (the {appUrl} notify token) is per-tenant overridable.
+        assertTrue(policy.isInjectable("DIRIGIBLE_APP_BASE_URL"));
     }
 
     @Test

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/NotificationSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/NotificationSupport.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
 import org.eclipse.dirigible.components.intent.model.EntityIntent;
 import org.eclipse.dirigible.components.intent.model.FieldIntent;
 import org.eclipse.dirigible.components.intent.model.NotificationIntent;
@@ -27,18 +28,42 @@ import org.eclipse.dirigible.components.intent.model.RelationIntent;
  * {@code @Listener} pastes in. Kept free of Spring/IO so the tricky bits are unit-tested directly.
  *
  * <p>
- * A value or {@code {placeholder}} is one of: a literal, a <b>direct field</b> of the event entity
- * (rendered {@code entity.<PascalField>}), or a one-hop <b>{@code relation.field}</b> of a to-one
- * relation (rendered against a related entity the listener loads once by FK id - the same one-hop
- * mechanism the decision resolvers use, see {@link ProcessResolverSupport}). Multi-hop paths are
- * not supported. The {@code when} guard supports a single {@code field ==|!= literal} comparison on
- * a direct field.
+ * A value or {@code {placeholder}} is one of: the reserved <b>{@code appUrl}</b> config token (the
+ * application's external base URL, see {@link #APP_URL_TOKEN}), a <b>direct field</b> of the event
+ * entity (rendered {@code entity.<PascalField>}), or a one-hop <b>{@code relation.field}</b> of a
+ * to-one relation (rendered against a related entity the listener loads once by FK id - the same
+ * one-hop mechanism the decision resolvers use, see {@link ProcessResolverSupport}). Multi-hop
+ * paths are not supported. The {@code when} guard supports a single {@code field ==|!= literal}
+ * comparison on a direct field.
  */
 public final class NotificationSupport {
 
     private static final Pattern PATH = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)?");
     private static final Pattern PLACEHOLDER = Pattern.compile("\\{([A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)?)\\}");
     private static final Pattern SIMPLE_COMPARISON = Pattern.compile("\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*(==|!=)\\s*(.+?)\\s*");
+
+    /**
+     * The reserved {@code {appUrl}} placeholder name - a config-backed token, not an entity field or
+     * relation. Resolves to the application's external base URL ({@link DirigibleConfig#APP_BASE_URL},
+     * tenant-overridable), so a body can compose a deep link by hand, e.g. {@code "Review it here:
+     * {appUrl}/orders/{id}"}. Deliberately supplies only the origin - the concrete per-entity route is
+     * the template layer's knowledge, not the intent layer's (see the engine-intent guide's
+     * path-agnostic rule), so the author appends the rest of the path as plain text and other
+     * placeholders.
+     * <p>
+     * <b>Known limitation:</b> the tenant override is resolved through {@code Configuration}'s
+     * thread-scoped map, which today is populated only for HTTP request threads (see
+     * {@code TenantConfigurationInitFilter}) - a notify block always fires from an async message
+     * listener, which re-establishes the tenant's <i>identity</i> but not its configuration overrides.
+     * Until that dispatch-path gap is closed platform-wide, a tenant override of
+     * {@code DIRIGIBLE_APP_BASE_URL} will not take effect here; the generated expression still falls
+     * back correctly to the global environment/default value.
+     */
+    static final String APP_URL_TOKEN = "appUrl";
+
+    /** The Java expression {@link #APP_URL_TOKEN} resolves to - see its own javadoc for the caveat. */
+    private static final String APP_URL_EXPRESSION =
+            "org.eclipse.dirigible.sdk.core.Configurations.get(\"" + DirigibleConfig.APP_BASE_URL.getKey() + "\", \"\")";
 
     private NotificationSupport() {}
 
@@ -283,6 +308,9 @@ public final class NotificationSupport {
          * relation load when needed. Returns {@code null} for an unresolvable relation.field.
          */
         private String access(String path) {
+            if (APP_URL_TOKEN.equals(path)) {
+                return APP_URL_EXPRESSION;
+            }
             int dot = path.indexOf('.');
             if (dot < 0) {
                 return "entity." + IntentNaming.pascalCase(path);

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -64,6 +64,12 @@ Treat it as the contract: anything you propose must parse and validate against i
   `to` / `subject` / `body` (+ `channel: email`), with `{field}` / `{relation.field}` interpolation in
   the subject and body, plus the optional **`attach: print`** that mails the record's own rendered
   document - see *send a document by e-mail*.
+- **`{appUrl}` is a reserved config token, not a field.** It resolves to the application's external
+  base URL (`DIRIGIBLE_APP_BASE_URL`, tenant-overridable), so a body can compose a deep link by hand,
+  e.g. `body: "Review it here: {appUrl}/orders/{id}"`. It supplies only the origin - the intent layer
+  does not know the generated app's routes, so the rest of the path is plain text plus other
+  placeholders, same as any other literal. Because `appUrl` is reserved, an entity must not declare a
+  field literally named `appUrl` (it would be shadowed in every notify block).
 - **A recipient that cannot be resolved is surfaced, not silent.** If `to` names a field/relation that
   does not exist, that notification or schedule is dropped and reported in the generate response's
   `warnings` (as well as the server log) - fix the reference so the glue is emitted.

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/NotificationSupportTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/NotificationSupportTest.java
@@ -87,6 +87,36 @@ class NotificationSupportTest {
     }
 
     @Test
+    void appUrlResolvesToTheConfigBackedTokenNotAnEntityField() {
+        Map<String, EntityIntent> byName = libraryModel();
+        NotificationSupport.Plan plan =
+                NotificationSupport.plan(notification("ops@x.com", "Order {id} total {total}. Review it here: {appUrl}/orders/{id}"),
+                        byName.get("Order"), byName, Map.of());
+
+        assertTrue(plan.loads()
+                       .isEmpty(),
+                "appUrl is a config token, not a relation - it must not register a relation load");
+        assertEquals("\"Order \" + entity.Id + \" total \" + entity.Total + \". Review it here: \""
+                + " + org.eclipse.dirigible.sdk.core.Configurations.get(\"DIRIGIBLE_APP_BASE_URL\", \"\")" + " + \"/orders/\""
+                + " + entity.Id", plan.subjectExpression());
+    }
+
+    @Test
+    void appUrlWorksAlongsideARelationFieldInTheSameBody() {
+        Map<String, EntityIntent> byName = libraryModel();
+        NotificationSupport.Plan plan =
+                NotificationSupport.plan(notification("customer.email", "Hi {customer.name}, review it here: {appUrl}/orders/{id}"),
+                        byName.get("Order"), byName, Map.of());
+
+        assertEquals(1, plan.loads()
+                            .size(),
+                "the relation.field placeholder still registers its own load");
+        assertEquals("\"Hi \" + (customer == null ? null : customer.Name) + \", review it here: \""
+                + " + org.eclipse.dirigible.sdk.core.Configurations.get(\"DIRIGIBLE_APP_BASE_URL\", \"\")" + " + \"/orders/\""
+                + " + entity.Id", plan.subjectExpression());
+    }
+
+    @Test
     void oneHopRelationFieldLoadsTheRelatedEntity() {
         Map<String, EntityIntent> byName = libraryModel();
         NotificationSupport.Plan plan = NotificationSupport.plan(notification("customer.email", "Order for {customer.name}"),

--- a/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
+++ b/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
@@ -70,6 +70,12 @@ public enum DirigibleConfig {
 
     HOME_URL("DIRIGIBLE_HOME_URL", "services/web/home/"), //
 
+    /**
+     * The application's externally-reachable base URL, used to build absolute links (e.g. in
+     * notification emails).
+     */
+    APP_BASE_URL("DIRIGIBLE_APP_BASE_URL", ""), //
+
     APPLICATION_LANGUAGES("DIRIGIBLE_APPLICATION_LANGUAGES", "en"), //
 
     MAIL_USERNAME("DIRIGIBLE_MAIL_USERNAME", null), //


### PR DESCRIPTION
## Problem

The notify block (shared by `notifications[]`, `schedules[].notify`, `transitions[].notify`, and a
`serviceTask`'s `args.notify`) interpolates `{field}` / `{relation.field}` placeholders in
`subject:`/`body:`, but has no concept of the application's own external base URL. An author writing
`{appUrl}` to link back to the record (e.g. "you have an approval waiting") got no error — the
resolver silently treated the bare word as an entity field, PascalCased it, and emitted
`entity.AppUrl` into the generated Java, which doesn't exist on any entity and fails `javac` for the
whole client-Java batch the moment the project is generated and published.

## Fix

`{appUrl}` is now a reserved, config-backed token instead of falling through to the "must be a real
entity field" assumption:

- `DirigibleConfig.APP_BASE_URL` — new entry, env var `DIRIGIBLE_APP_BASE_URL`, default `""`.
- `TenantConfigurationKeyPolicy` — added `DIRIGIBLE_APP_BASE_URL` to the explicit tenant-override
  allow-list.
- `NotificationSupport.Resolver.access()` — special-cases the literal token `appUrl` before the
  direct-field branch, resolving it to
  `org.eclipse.dirigible.sdk.core.Configurations.get("DIRIGIBLE_APP_BASE_URL", "")` instead of
  `entity.AppUrl`. Since this is the one shared resolver behind all four notify call sites, they all
  pick it up automatically — no template changes needed (they already import the `Configurations`
  facade for `DIRIGIBLE_MAIL_SENDER`).
- `intent-assistant-guide.md` — documented the token for the AI assistant: it supplies only the
  origin (`https://app.example.com`), never a full route — the intent layer stays path-agnostic, and
  the author appends the rest of the URL as plain text/other placeholders
      
## Example — before vs. after

- "bodyExpression": "... + entity.AppUrl + \"/orders/\" + entity.Id"   // entity.AppUrl doesn't exist -> javac failure
+ "bodyExpression": "... + org.eclipse.dirigible.sdk.core.Configurations.get(\"DIRIGIBLE_APP_BASE_URL\", \"\") + \"/orders/\" + entity.Id"

## Known limitation (documented, not fixed here)

Tenant overrides of DIRIGIBLE_APP_BASE_URL won't yet take effect when read from inside a generated
notification listener. The tenant-config thread map is only populated by
TenantConfigurationInitFilter, an HTTP-request-only filter; a notification always fires from an
async MessageHandler (ListenerClassConsumer), which re-establishes the tenant's identity but
not its config overrides — confirmed the same gap exists in the JS-side
AsynchronousMessageListener. This is a pre-existing, platform-wide limitation affecting every
listener that reads any tenant-configurable key, not something introduced by this change. It falls
back correctly to the global env var / default in the meantime. Flagged in
NotificationSupport.APP_URL_TOKEN's javadoc for discoverability; fixing it (wiring
Configuration.setThreadConfiguration(...) into listener dispatch) is a separate, cross-cutting
follow-up.