### PR TITLE
fix(core-tracing): disableTracing() now disables tracing (#6608)

### DIFF
--- a/components/core/core-tracing/src/main/java/org/eclipse/dirigible/components/tracing/TaskStateService.java
+++ b/components/core/core-tracing/src/main/java/org/eclipse/dirigible/components/tracing/TaskStateService.java
@@ -232,7 +232,7 @@ public class TaskStateService {
      * Disable tracing.
      */
     public void disableTracing() {
-        Configuration.set(TaskStateService.DIRIGIBLE_TRACING_TASK_ENABLED, "true");
+        Configuration.set(TaskStateService.DIRIGIBLE_TRACING_TASK_ENABLED, "false");
     }
 
 }

--- a/components/core/core-tracing/src/main/java/org/eclipse/dirigible/components/tracing/TracingFacade.java
+++ b/components/core/core-tracing/src/main/java/org/eclipse/dirigible/components/tracing/TracingFacade.java
@@ -128,7 +128,7 @@ public class TracingFacade implements InitializingBean {
      * Disable tracing.
      */
     public static void disableTracing() {
-        Configuration.set(TaskStateService.DIRIGIBLE_TRACING_TASK_ENABLED, "true");
+        Configuration.set(TaskStateService.DIRIGIBLE_TRACING_TASK_ENABLED, "false");
     }
 
 

--- a/components/core/core-tracing/src/test/java/org/eclipse/dirigible/components/tracing/TaskStateServiceTest.java
+++ b/components/core/core-tracing/src/test/java/org/eclipse/dirigible/components/tracing/TaskStateServiceTest.java
@@ -10,8 +10,10 @@
 package org.eclipse.dirigible.components.tracing;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import java.util.TreeMap;
@@ -65,6 +67,40 @@ public class TaskStateServiceTest {
     public void cleanup() throws Exception {
         // delete test task states
         taskStateService.deleteAll();
+    }
+
+    /**
+     * Resets the global tracing flag so the mutated runtime configuration does not leak into other test
+     * classes.
+     */
+    @AfterEach
+    public void resetTracingFlag() {
+        Configuration.remove(TaskStateService.DIRIGIBLE_TRACING_TASK_ENABLED);
+    }
+
+    /**
+     * Verifies the enable then disable round-trip on the service (regression for #6608).
+     */
+    @Test
+    public void enableThenDisableTracing() {
+        taskStateService.enableTracing();
+        assertTrue(taskStateService.isTracingEnabled());
+
+        taskStateService.disableTracing();
+        assertFalse(taskStateService.isTracingEnabled());
+    }
+
+    /**
+     * Verifies the enable then disable round-trip on the static facade the engines consult (regression
+     * for #6608).
+     */
+    @Test
+    public void enableThenDisableTracingViaFacade() {
+        TracingFacade.enableTracing();
+        assertTrue(TracingFacade.isTracingEnabled());
+
+        TracingFacade.disableTracing();
+        assertFalse(TracingFacade.isTracingEnabled());
     }
 
     /**


### PR DESCRIPTION
## What

Fixes #6608.

`disableTracing()` contained a copy-paste error: it set `DIRIGIBLE_TRACING_TASK_ENABLED` to `"true"` instead of `"false"`, so once tracing was enabled it could never be turned off without a restart or manual config override.

The same one-character bug existed in **two** places (the issue named only the first):

- `TracingFacade.disableTracing()` — the static facade the engines (camel/bpm/jobs) consult via `isTracingEnabled()`.
- `TaskStateService.disableTracing()` — the Spring service method behind the tracing perspective/UI toggle.

Both now set the flag to `"false"`. `enableTracing()` and `isTracingEnabled()` were already correct.

## Tests

Added enable→disable round-trip regression tests in `TaskStateServiceTest` for both the service and the static facade (they fail against the old `"true"` and pass now), plus an `@AfterEach` that clears the global `DIRIGIBLE_TRACING_TASK_ENABLED` flag so the mutated `Configuration` does not leak into other test classes.

`mvn -pl components/core/core-tracing test -Dtest=TaskStateServiceTest` → `Tests run: 4, Failures: 0, Errors: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)