### PR TITLE
fix(core-tracing): scope task-state reads and deletes to the current tenant (#6607)

### DIFF
--- a/components/core/core-tracing/src/main/java/org/eclipse/dirigible/components/tracing/TaskStateService.java
+++ b/components/core/core-tracing/src/main/java/org/eclipse/dirigible/components/tracing/TaskStateService.java
@@ -15,6 +15,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.components.base.tenant.DefaultTenant;
+import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
 import org.javers.core.Javers;
 import org.javers.core.JaversBuilder;
 import org.javers.core.diff.Diff;
@@ -35,15 +38,25 @@ public class TaskStateService {
     static final String DIRIGIBLE_TRACING_TASK_ENABLED = "DIRIGIBLE_TRACING_TASK_ENABLED";
 
     /** The repository. */
-    private TaskStateRepository repository;
+    private final TaskStateRepository repository;
+
+    /** The tenant context. */
+    private final TenantContext tenantContext;
+
+    /** The default tenant. */
+    private final Tenant defaultTenant;
 
     /**
      * Instantiates a new task state service.
      *
      * @param repository the repository
+     * @param tenantContext the tenant context
+     * @param defaultTenant the default tenant
      */
-    public TaskStateService(TaskStateRepository repository) {
+    public TaskStateService(TaskStateRepository repository, TenantContext tenantContext, @DefaultTenant Tenant defaultTenant) {
         this.repository = repository;
+        this.tenantContext = tenantContext;
+        this.defaultTenant = defaultTenant;
     }
 
     /**
@@ -56,12 +69,36 @@ public class TaskStateService {
     }
 
     /**
+     * Gets the current tenant id, falling back to the default tenant when the tenant context is not yet
+     * initialized.
+     *
+     * @return the current tenant id
+     */
+    private String getCurrentTenantId() {
+        return tenantContext.isNotInitialized() ? defaultTenant.getId()
+                : tenantContext.getCurrentTenant()
+                               .getId();
+    }
+
+    /**
+     * Creates a task state stamped with the current tenant. Used both to build new records on write and
+     * as a tenant-scoped query-by-example probe for reads and deletes.
+     *
+     * @return the tenant-stamped task state
+     */
+    private TaskState createTaskState() {
+        TaskState taskState = new TaskState();
+        taskState.setTenant(getCurrentTenantId());
+        return taskState;
+    }
+
+    /**
      * Gets the all.
      *
      * @return the all
      */
     public List<TaskState> getAll() {
-        return getRepository().findAll();
+        return getRepository().findAll(Example.of(createTaskState()));
     }
 
     /**
@@ -71,7 +108,7 @@ public class TaskStateService {
      * @return the pages
      */
     public Page<TaskState> getPages(Pageable pageable) {
-        return getRepository().findAll(pageable);
+        return getRepository().findAll(Example.of(createTaskState()), pageable);
     }
 
     /**
@@ -97,7 +134,7 @@ public class TaskStateService {
      * Delete all.
      */
     public void deleteAll() {
-        getRepository().deleteAll();
+        getRepository().deleteAll(getRepository().findAll(Example.of(createTaskState())));
     }
 
     /**
@@ -110,6 +147,10 @@ public class TaskStateService {
         TaskState taskState = getRepository().findById(id)
                                              .orElseThrow(() -> new IllegalArgumentException(
                                                      this.getClass() + ": missing task state with [" + id + "]"));
+
+        if (!getCurrentTenantId().equals(taskState.getTenant())) {
+            throw new IllegalArgumentException(this.getClass() + ": missing task state with [" + id + "]");
+        }
 
         if (!TaskStatus.STARTED.equals(taskState.getStatus())) {
             Javers javers = JaversBuilder.javers()
@@ -129,7 +170,7 @@ public class TaskStateService {
      * @return the taskState
      */
     public List<TaskState> findByExecution(String execution) {
-        TaskState example = new TaskState();
+        TaskState example = createTaskState();
         example.setExecution(execution);
         return getRepository().findAll(Example.of(example));
     }
@@ -147,7 +188,7 @@ public class TaskStateService {
         if (!isTracingEnabled()) {
             return null;
         }
-        TaskState taskState = new TaskState();
+        TaskState taskState = createTaskState();
         taskState.setType(taskType);
         taskState.setExecution(execution != null ? execution : "NONE");
         taskState.setStep(step != null ? step : "NONE");

--- a/components/core/core-tracing/src/main/java/org/eclipse/dirigible/components/tracing/TaskStateService.java
+++ b/components/core/core-tracing/src/main/java/org/eclipse/dirigible/components/tracing/TaskStateService.java
@@ -93,6 +93,19 @@ public class TaskStateService {
     }
 
     /**
+     * Ensures the given task state belongs to the current tenant, otherwise fails as if it did not
+     * exist so that a tenant can neither read nor delete another tenant's task state.
+     *
+     * @param taskState the task state
+     * @param id the requested id, used for the failure message
+     */
+    private void ensureCurrentTenant(TaskState taskState, Long id) {
+        if (!getCurrentTenantId().equals(taskState.getTenant())) {
+            throw new IllegalArgumentException(this.getClass() + ": missing task state with [" + id + "]");
+        }
+    }
+
+    /**
      * Gets the all.
      *
      * @return the all
@@ -127,6 +140,7 @@ public class TaskStateService {
      * @param taskState the taskState
      */
     public void delete(TaskState taskState) {
+        ensureCurrentTenant(taskState, taskState.getId());
         getRepository().delete(taskState);
     }
 
@@ -148,9 +162,7 @@ public class TaskStateService {
                                              .orElseThrow(() -> new IllegalArgumentException(
                                                      this.getClass() + ": missing task state with [" + id + "]"));
 
-        if (!getCurrentTenantId().equals(taskState.getTenant())) {
-            throw new IllegalArgumentException(this.getClass() + ": missing task state with [" + id + "]");
-        }
+        ensureCurrentTenant(taskState, id);
 
         if (!TaskStatus.STARTED.equals(taskState.getStatus())) {
             Javers javers = JaversBuilder.javers()

--- a/components/core/core-tracing/src/test/java/org/eclipse/dirigible/components/tracing/TaskStateEndpointTest.java
+++ b/components/core/core-tracing/src/test/java/org/eclipse/dirigible/components/tracing/TaskStateEndpointTest.java
@@ -30,6 +30,7 @@ import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -51,6 +52,7 @@ import jakarta.persistence.EntityManager;
 @AutoConfigureMockMvc
 @ComponentScan(basePackages = {"org.eclipse.dirigible.components"})
 @EntityScan("org.eclipse.dirigible.components")
+@Import(TestConfig.class)
 @Transactional
 public class TaskStateEndpointTest {
 

--- a/components/core/core-tracing/src/test/java/org/eclipse/dirigible/components/tracing/TaskStateRepositoryTest.java
+++ b/components/core/core-tracing/src/test/java/org/eclipse/dirigible/components/tracing/TaskStateRepositoryTest.java
@@ -23,6 +23,7 @@ import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.persistence.EntityManager;
@@ -34,6 +35,7 @@ import jakarta.persistence.EntityManager;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ComponentScan(basePackages = {"org.eclipse.dirigible.components"})
 @EntityScan("org.eclipse.dirigible.components")
+@Import(TestConfig.class)
 @Transactional
 public class TaskStateRepositoryTest {
 

--- a/components/core/core-tracing/src/test/java/org/eclipse/dirigible/components/tracing/TaskStateServiceTest.java
+++ b/components/core/core-tracing/src/test/java/org/eclipse/dirigible/components/tracing/TaskStateServiceTest.java
@@ -13,13 +13,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Map;
 import java.util.TreeMap;
 
 import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
+import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +34,7 @@ import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,12 +46,17 @@ import org.springframework.transaction.annotation.Transactional;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ComponentScan(basePackages = {"org.eclipse.dirigible.components"})
 @EntityScan("org.eclipse.dirigible.components")
+@Import(TestConfig.class)
 @Transactional
 public class TaskStateServiceTest {
 
     /** The task state service. */
     @Autowired
     private TaskStateService taskStateService;
+
+    /** The task state repository. */
+    @Autowired
+    private TaskStateRepository taskStateRepository;
 
     /**
      * Setup.
@@ -180,6 +191,60 @@ public class TaskStateServiceTest {
         assertEquals("error1", result.getError());
 
 
+    }
+
+    /**
+     * Verifies that reads and deletes are scoped to the current tenant (regression for #6607). Records
+     * created under one tenant must never be visible to, or deletable by, another tenant.
+     */
+    @Test
+    public void readsAndDeletesAreTenantScoped() {
+        Tenant defaultTenant = mock(Tenant.class);
+        when(defaultTenant.getId()).thenReturn("default-tenant");
+        TenantContext tenantContext = mock(TenantContext.class);
+        when(tenantContext.isNotInitialized()).thenReturn(false);
+        Tenant tenantA = mock(Tenant.class);
+        when(tenantA.getId()).thenReturn("tenant-a");
+        Tenant tenantB = mock(Tenant.class);
+        when(tenantB.getId()).thenReturn("tenant-b");
+        TaskStateService service = new TaskStateService(taskStateRepository, tenantContext, defaultTenant);
+
+        // two traces under tenant A
+        when(tenantContext.getCurrentTenant()).thenReturn(tenantA);
+        service.taskStarted(TaskType.BPM, "execA1", "step", null);
+        service.taskStarted(TaskType.BPM, "execA2", "step", null);
+        Long tenantAId = service.getAll()
+                                .get(0)
+                                .getId();
+
+        // one trace under tenant B
+        when(tenantContext.getCurrentTenant()).thenReturn(tenantB);
+        service.taskStarted(TaskType.BPM, "execB1", "step", null);
+
+        // tenant B sees only its own trace and cannot read tenant A's by id
+        assertEquals(1, service.getAll()
+                               .size());
+        assertEquals(1, service.getPages(PageRequest.of(0, 100))
+                               .getTotalElements());
+        assertEquals(0, service.findByExecution("execA1")
+                               .size());
+        assertThrows(IllegalArgumentException.class, () -> service.findById(tenantAId));
+
+        // tenant A sees only its own traces and can read its own by id
+        when(tenantContext.getCurrentTenant()).thenReturn(tenantA);
+        assertEquals(2, service.getAll()
+                               .size());
+        assertEquals(1, service.findByExecution("execA1")
+                               .size());
+        assertNotNull(service.findById(tenantAId));
+
+        // deleting under tenant A leaves tenant B's trace intact
+        service.deleteAll();
+        assertEquals(0, service.getAll()
+                               .size());
+        when(tenantContext.getCurrentTenant()).thenReturn(tenantB);
+        assertEquals(1, service.getAll()
+                               .size());
     }
 
     /**

--- a/components/core/core-tracing/src/test/java/org/eclipse/dirigible/components/tracing/TaskStateServiceTest.java
+++ b/components/core/core-tracing/src/test/java/org/eclipse/dirigible/components/tracing/TaskStateServiceTest.java
@@ -236,7 +236,15 @@ public class TaskStateServiceTest {
                                .size());
         assertEquals(1, service.findByExecution("execA1")
                                .size());
-        assertNotNull(service.findById(tenantAId));
+        TaskState tenantAState = service.findById(tenantAId);
+        assertNotNull(tenantAState);
+
+        // tenant B cannot delete tenant A's trace
+        when(tenantContext.getCurrentTenant()).thenReturn(tenantB);
+        assertThrows(IllegalArgumentException.class, () -> service.delete(tenantAState));
+        when(tenantContext.getCurrentTenant()).thenReturn(tenantA);
+        assertEquals(2, service.getAll()
+                               .size());
 
         // deleting under tenant A leaves tenant B's trace intact
         service.deleteAll();

--- a/components/core/core-tracing/src/test/java/org/eclipse/dirigible/components/tracing/TestConfig.java
+++ b/components/core/core-tracing/src/test/java/org/eclipse/dirigible/components/tracing/TestConfig.java
@@ -21,7 +21,7 @@ import org.springframework.context.annotation.Bean;
  * core-tenants, so the context is given a mock tenant context that resolves to the default tenant.
  */
 @TestConfiguration
-public class TestConfig {
+class TestConfig {
 
     /** The default tenant id used across the tracing tests. */
     static final String DEFAULT_TENANT_ID = "default-tenant";

--- a/components/core/core-tracing/src/test/java/org/eclipse/dirigible/components/tracing/TestConfig.java
+++ b/components/core/core-tracing/src/test/java/org/eclipse/dirigible/components/tracing/TestConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tracing;
+
+import org.eclipse.dirigible.components.base.tenant.DefaultTenant;
+import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Supplies the tenant beans that {@link TaskStateService} depends on. The module does not pull in
+ * core-tenants, so the context is given a mock tenant context that resolves to the default tenant.
+ */
+@TestConfiguration
+public class TestConfig {
+
+    /** The default tenant id used across the tracing tests. */
+    static final String DEFAULT_TENANT_ID = "default-tenant";
+
+    /**
+     * Mock tenant context reporting an uninitialized context, so tenant resolution falls back to the
+     * default tenant.
+     *
+     * @return the tenant context
+     */
+    @Bean
+    TenantContext tenantContext() {
+        TenantContext tenantContext = Mockito.mock(TenantContext.class);
+        Mockito.when(tenantContext.isNotInitialized())
+               .thenReturn(true);
+        return tenantContext;
+    }
+
+    /**
+     * Mock default tenant with a stable id.
+     *
+     * @return the default tenant
+     */
+    @Bean
+    @DefaultTenant
+    Tenant defaultTenant() {
+        Tenant tenant = Mockito.mock(Tenant.class);
+        Mockito.when(tenant.getId())
+               .thenReturn(DEFAULT_TENANT_ID);
+        return tenant;
+    }
+}


### PR DESCRIPTION
## What

Fixes #6607.

The tracing engine's `TaskState` carries a `TASKSTATE_TENANT` column, but `TaskStateService` never stamped it on write and never filtered on it for reads/deletes. With tracing enabled (`DIRIGIBLE_TRACING_TASK_ENABLED=true`):

- `GET /services/core/tracing*` returned **every tenant's** traces — including the input/output variable maps, which can hold sensitive business data;
- `DELETE /services/core/tracing` wiped the **whole** table regardless of tenant.

## Fix

Mirror the existing `JobLogService` tenant model:

- Constructor-inject `TenantContext` + `@DefaultTenant Tenant`.
- A `createTaskState()` helper stamps the current tenant (falling back to the default tenant when the context is uninitialized) and doubles as the Query-by-Example probe — the same dual-use pattern as `JobLogService.createJobLog()`. No repository changes.
- `taskStarted(...)` now stamps the tenant on write.
- `getAll()`, `getPages(...)`, `findByExecution(...)` and `deleteAll()` filter by the current tenant; `findById(...)` rejects a cross-tenant id with the existing not-found exception. `deleteAll()` deletes the scoped entities individually so the `DIRIGIBLE_TASK_STATE_INPUT`/`_OUTPUT` element-collection rows are cleaned up.

## Tests

Added a tenant-isolation regression test (mocked `TenantContext`) asserting reads and `deleteAll()` are scoped per tenant and cross-tenant read-by-id is blocked. Added a shared `TestConfig` supplying the tenant beans the module does not otherwise pull in (same approach engine-jobs uses for `JobLogService`).

`mvn -pl components/core/core-tracing -am test` → all 11 tracing-package tests pass; formatter and release-profile javadoc checks are clean.

## Out of scope

The sibling job-log cross-tenant bug (#6606) is the same class of defect in a different module and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)