### PR TITLE
test(integration): stop pinning the instance version in the OpenAPI assertion

### DIFF
--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/sample/EntityDecoratorsSampleProjectIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/sample/EntityDecoratorsSampleProjectIT.java
@@ -10,10 +10,13 @@
  */
 package org.eclipse.dirigible.integration.tests.ui.tests.sample;
 
+import java.util.regex.Pattern;
+
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 
 public class EntityDecoratorsSampleProjectIT extends SampleProjectRepositoryIT {
@@ -23,10 +26,23 @@ public class EntityDecoratorsSampleProjectIT extends SampleProjectRepositoryIT {
                     [{"Code2":"AF","Numeric":"004","Code3":"AFG","Id":1,"$type$":"CountryEntity","Name":"Afghanistan"},{"Code2":"AL","Numeric":"008","Code3":"ALB","Id":2,"$type$":"CountryEntity","Name":"Albania"},{"Code2":"DZ","Numeric":"012","Code3":"DZA","Id":3,"$type$":"CountryEntity","Name":"Algeria"}]
                     """;
 
+    /**
+     * The expected OpenAPI document with the instance's own version replaced by
+     * {@link #VERSION_PLACEHOLDER}. The served {@code info.version} is the real build version, which
+     * changes on every release and every development bump - so it is normalised out of BOTH sides of
+     * the comparison rather than pinned here. Pinning it made this test fail on both CI databases the
+     * first night after the version stopped being served as a literal {@code ${project.version}}
+     * (#6644).
+     */
+    private static final String VERSION_PLACEHOLDER = "<version>";
+
     private static final String OPENAPI_RESPONSE_BODY =
             """
-                    {"openapi":"3.0.1","info":{"title":"Applications Services Open API","description":"Services Open API provided by the applications","contact":{"name":"Eclipse Dirigible","url":"https://www.dirigible.io","email":"dirigible-dev@eclipse.org"},"license":{"name":"Eclipse Public License - v 2.0","url":"https://www.eclipse.org/legal/epl-v20.html"},"version":"${project.version}"},"servers":[{"url":"/services/ts"},{"url":"/services/ts"}],"security":[],"tags":[],"paths":{"/sample-entity-decorators/CountryController.ts/":{"get":{"tags":["CountryController"],"summary":"getAll CountryController ","operationId":"getAll","parameters":[],"responses":{"200":{"description":"Success","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/CountryEntity"}}}}}}}}},"components":{"schemas":{"number":{"type":"number"},"CountryEntity":{"type":"object","properties":{"Code2":{"type":"string"},"Numeric":{"type":"string"},"Code3":{"type":"string"},"Id":{"type":"number","description":"My Id"},"Name":{"type":"string","description":"My Name"}},"description":"Sample Country Entity"},"string":{"type":"string"},"any":{"type":"object"}},"responses":{},"parameters":{},"examples":{},"requestBodies":{},"headers":{},"securitySchemes":{},"links":{},"callbacks":{}}}
+                    {"openapi":"3.0.1","info":{"title":"Applications Services Open API","description":"Services Open API provided by the applications","contact":{"name":"Eclipse Dirigible","url":"https://www.dirigible.io","email":"dirigible-dev@eclipse.org"},"license":{"name":"Eclipse Public License - v 2.0","url":"https://www.eclipse.org/legal/epl-v20.html"},"version":"<version>"},"servers":[{"url":"/services/ts"},{"url":"/services/ts"}],"security":[],"tags":[],"paths":{"/sample-entity-decorators/CountryController.ts/":{"get":{"tags":["CountryController"],"summary":"getAll CountryController ","operationId":"getAll","parameters":[],"responses":{"200":{"description":"Success","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/CountryEntity"}}}}}}}}},"components":{"schemas":{"number":{"type":"number"},"CountryEntity":{"type":"object","properties":{"Code2":{"type":"string"},"Numeric":{"type":"string"},"Code3":{"type":"string"},"Id":{"type":"number","description":"My Id"},"Name":{"type":"string","description":"My Name"}},"description":"Sample Country Entity"},"string":{"type":"string"},"any":{"type":"object"}},"responses":{},"parameters":{},"examples":{},"requestBodies":{},"headers":{},"securitySchemes":{},"links":{},"callbacks":{}}}
                     """;
+
+    /** {@code "version":"<anything>"} inside the OpenAPI {@code info} block. */
+    private static final Pattern OPENAPI_VERSION = Pattern.compile("\"version\":\"[^\"]*\"");
 
     @Override
     protected void verifyProject() {
@@ -45,12 +61,28 @@ public class EntityDecoratorsSampleProjectIT extends SampleProjectRepositoryIT {
 
                     // TODO: documentation texts from @Document annotations are not added to the open api response. Fix
                     // this issue and adapt the test.
-                    given().when()
-                           .get("/services/openapi")
-                           .then()
-                           .statusCode(200)
-                           .body(equalToCompressingWhiteSpace(OPENAPI_RESPONSE_BODY));
+                    String openApi = given().when()
+                                            .get("/services/openapi")
+                                            .then()
+                                            .statusCode(200)
+                                            .extract()
+                                            .asString();
+                    assertThat("the served OpenAPI document should match, ignoring the instance's own version", //
+                            withoutVersion(openApi), equalToCompressingWhiteSpace(OPENAPI_RESPONSE_BODY));
                 }, 60);
+    }
+
+    /**
+     * The OpenAPI document with the instance's own {@code info.version} normalised to
+     * {@link #VERSION_PLACEHOLDER}, so the assertion survives every release and development version
+     * bump.
+     *
+     * @param openApi the served document
+     * @return the document with its version normalised
+     */
+    private static String withoutVersion(String openApi) {
+        return OPENAPI_VERSION.matcher(openApi)
+                              .replaceFirst("\"version\":\"" + VERSION_PLACEHOLDER + "\"");
     }
 
     @Override


### PR DESCRIPTION
Fixes the red nightly: [run 31453258683](https://github.com/eclipse-dirigible/dirigible/actions/runs/31453258683) failed `EntityDecoratorsSampleProjectIT` on **both** the H2 and the PostgreSQL leg.

## What broke

The test compares the served `/services/openapi` document against a literal that carried:

```
"version":"${project.version}"
```

— the **unfiltered placeholder** every stock instance used to report. #6644 made an instance report its real build version, so the literal stopped matching:

```
Expected: …\"version\":\"${project.version}\"…
  Actual: …"version":"15.0.0-SNAPSHOT"…
```

The assertion sits inside a `restAssuredExecutor.execute(…, 60)` retry, so instead of failing fast it retried for a full minute and surfaced as `ConditionTimeout` at `verifyProject:33` — which is why the cause was not obvious from the summary line. It is a string comparison, so it is database-independent: both legs failed identically.

## The fix

Normalise `info.version` out of **both** sides rather than pinning it. The served version changes on every release and every development bump, so any literal here is a landmine that fires on the next `version set to …` commit — this would have broken again at 14.21.0 and again at the following bump, regardless of #6644.

## Verification

Ran the IT locally against **current master** (so #6644's filtering is active) — green in 65s, and the log confirms the instance served `"version":"15.0.0-SNAPSHOT"`. That matters: the test now passes with a **real** version present, not because the placeholder happened to survive. `formatter:validate` clean.

Note for whoever reviews: this is `@Tag("ui")`, so it is not in the PR smoke gate — it only runs on the nightly and on push to master. The nightly is the gate that will confirm it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
