### PR TITLE
fix(ide-workspace): mark the registry mutation at the publisher, not at a URL (#6654)

### DIFF
--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/registry/RegistryMutationTracker.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/registry/RegistryMutationTracker.java
@@ -24,6 +24,15 @@ import org.springframework.stereotype.Component;
  * that are about to reappear as deleted. It therefore asks here whether a mutation was in flight,
  * rather than inferring it from "the registry changed" - the file-system watcher reports a genuine
  * deletion exactly the same way, and treating the two alike would delay every deletion by a pass.
+ *
+ * <p>
+ * <b>Marked by the publisher service itself, never by a URL.</b> This was first fed by a servlet
+ * filter mapped on the publisher and workspace endpoints, which left every other publish path
+ * invisible - and the most frequent publisher in practice is not that endpoint: the model-to-code
+ * generation service publishes through the JS {@code lifecycle} API from a {@code /services/js/...}
+ * URL the filter never saw, so passes kept walking into its holes (#6654). Marking the window where
+ * the write actually happens is correct for every caller by construction; enumerating callers is
+ * not. If you add another way to write the registry, bracket the write - do not add a mapping.
  */
 @Component
 public class RegistryMutationTracker {

--- a/components/ide/ide-workspace/src/main/java/org/eclipse/dirigible/components/ide/workspace/service/PublisherService.java
+++ b/components/ide/ide-workspace/src/main/java/org/eclipse/dirigible/components/ide/workspace/service/PublisherService.java
@@ -12,6 +12,7 @@ package org.eclipse.dirigible.components.ide.workspace.service;
 import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.components.api.security.UserFacade;
 import org.eclipse.dirigible.components.base.publisher.PublisherHandler;
+import org.eclipse.dirigible.components.base.registry.RegistryMutationTracker;
 import org.eclipse.dirigible.repository.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,15 +40,24 @@ public class PublisherService {
     private final IRepository repository;
 
     /**
+     * Marks the window in which the registry is half-written, so a synchronization pass that lands in
+     * it defers its cleanup instead of deleting artefacts whose sources are about to reappear.
+     */
+    private final RegistryMutationTracker registryMutationTracker;
+
+    /**
      * Instantiates a new publisher service.
      *
      * @param repository the repository
      * @param publisherHandlers the publisher handlers
+     * @param registryMutationTracker the registry mutation tracker
      */
     @Autowired
-    public PublisherService(IRepository repository, List<PublisherHandler> publisherHandlers) {
+    public PublisherService(IRepository repository, List<PublisherHandler> publisherHandlers,
+            RegistryMutationTracker registryMutationTracker) {
         this.repository = repository;
         this.publisherHandlers = publisherHandlers;
+        this.registryMutationTracker = registryMutationTracker;
     }
 
     /**
@@ -110,6 +120,16 @@ public class PublisherService {
      * @param afterPublishMetadata the after publish metadata
      */
     private void publishResource(String sourceLocation, String targetLocation, PublisherHandler.AfterPublishMetadata afterPublishMetadata) {
+        registryMutationTracker.enter();
+        try {
+            doPublishResource(sourceLocation, targetLocation, afterPublishMetadata);
+        } finally {
+            registryMutationTracker.exit();
+        }
+    }
+
+    private void doPublishResource(String sourceLocation, String targetLocation,
+            PublisherHandler.AfterPublishMetadata afterPublishMetadata) {
         for (PublisherHandler next : publisherHandlers) {
             try {
                 next.beforePublish(sourceLocation);
@@ -196,6 +216,15 @@ public class PublisherService {
      * @param targetLocation the targetLocation
      */
     private void unpublishResource(String targetLocation) {
+        registryMutationTracker.enter();
+        try {
+            doUnpublishResource(targetLocation);
+        } finally {
+            registryMutationTracker.exit();
+        }
+    }
+
+    private void doUnpublishResource(String targetLocation) {
 
         for (PublisherHandler next : publisherHandlers) {
             try {

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/SynchronizerCleanupRaceIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/SynchronizerCleanupRaceIT.java
@@ -16,8 +16,10 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
+import org.eclipse.dirigible.components.api.security.UserFacade;
 import org.eclipse.dirigible.components.base.registry.RegistryMutationTracker;
 import org.eclipse.dirigible.components.base.synchronizer.SynchronizationWatcher;
+import org.eclipse.dirigible.components.ide.workspace.service.PublisherService;
 import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
 import org.eclipse.dirigible.engine.java.service.JavaFileService;
 import org.eclipse.dirigible.repository.api.IRepository;
@@ -67,6 +69,13 @@ class SynchronizerCleanupRaceIT extends IntegrationTest {
             }
             """;
 
+    /** The project published through the service (not the HTTP endpoint) by the contract test below. */
+    private static final String WORKSPACE = "workspace";
+
+    private static final String PUBLISH_PROJECT = "cleanup-race-publish-it";
+
+    private static final String PUBLISH_SOURCE_PATH = "/Published.java";
+
     /** How long to keep driving passes while the publish is in flight, waiting for one to complete. */
     private static final long PASS_TIMEOUT_SECONDS = 120;
 
@@ -84,6 +93,9 @@ class SynchronizerCleanupRaceIT extends IntegrationTest {
 
     @Autowired
     private RegistryMutationTracker registryMutationTracker;
+
+    @Autowired
+    private PublisherService publisherService;
 
     @Test
     void an_artefact_survives_a_pass_that_races_a_publish() {
@@ -106,6 +118,39 @@ class SynchronizerCleanupRaceIT extends IntegrationTest {
 
         assertThat(javaFileService.findByLocation(LOCATION)).as("a genuinely deleted source is still cleaned up")
                                                             .isEmpty();
+    }
+
+    /**
+     * The deferral above is only as good as what feeds the tracker. It used to be fed by a servlet
+     * filter mapped on the publisher and workspace endpoints - so a publish performed by anything else
+     * was invisible, and the most common publisher in practice is NOT that endpoint: the model-to-code
+     * generation service publishes through the JS {@code lifecycle} API, from a
+     * {@code /services/js/...} URL the filter never sees. A pass racing that publish deleted the
+     * artefacts of the files it was about to copy back, the client-Java batch then compiled a
+     * half-empty codebase to ZERO class files, and no controller was left registered (#6654).
+     *
+     * <p>
+     * The tracker is therefore marked by {@code PublisherService} itself. This asserts that contract at
+     * the only place it can be asserted without racing anything: a publish that never touches the HTTP
+     * layer must still register as a completed registry mutation, because that count is exactly what
+     * the pass compares to decide whether to defer.
+     */
+    @Test
+    void a_publish_that_bypasses_the_http_layer_still_marks_the_registry_as_mutating() {
+        String user = UserFacade.getName();
+        String workspacePath = IRepositoryStructure.PATH_USERS + "/" + user + "/" + WORKSPACE + "/" + PUBLISH_PROJECT + PUBLISH_SOURCE_PATH;
+        repository.createResource(workspacePath, SOURCE.getBytes(StandardCharsets.UTF_8), false, "text/plain", true);
+
+        long publishesBefore = registryMutationTracker.completedMutations();
+        publisherService.publish(user, WORKSPACE, PUBLISH_PROJECT, "");
+        assertThat(registryMutationTracker.completedMutations()).as(
+                "a publish through the service - the path the generation service uses - must mark the registry mutation")
+                                                                .isGreaterThan(publishesBefore);
+
+        long unpublishesBefore = registryMutationTracker.completedMutations();
+        publisherService.unpublish(PUBLISH_PROJECT);
+        assertThat(registryMutationTracker.completedMutations()).as("so must the unpublish that opens the hole")
+                                                                .isGreaterThan(unpublishesBefore);
     }
 
     /**
@@ -133,7 +178,8 @@ class SynchronizerCleanupRaceIT extends IntegrationTest {
     @AfterEach
     void removeSourcesFromRegistry() {
         boolean removed = false;
-        for (String path : List.of(REGISTRY_PATH, PROBE_REGISTRY_PATH)) {
+        for (String path : List.of(REGISTRY_PATH, PROBE_REGISTRY_PATH,
+                IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PUBLISH_PROJECT + PUBLISH_SOURCE_PATH)) {
             if (repository.hasResource(path)) {
                 repository.removeResource(path);
                 removed = true;


### PR DESCRIPTION
Fixes #6654. Follow-up to #6641, which closed one instance of this race and left a second one open.

## Why it survived #6641

#6641 taught `SynchronizationProcessor` to defer artefact cleanup while the registry is half-written, and `JavaSynchronizer` not to compile a batch it knows is incomplete. Both ask `RegistryMutationTracker` — but the tracker was fed **only** by a servlet filter mapped on `/services/ide/publisher/**` and the workspace endpoints. Every other publish path stayed invisible, and the most frequent publisher in practice is not that endpoint:

```js
// components/ui/service-generate/.../generate.mjs
lifecycle.publish(user.getName(), workspace, project);        // line 107
lifecycle.unpublish(projectName + "/gen/" + genFolderName);   // line 195
```

Served from `/services/js/...`, so the filter never runs.

## What that cost

From PR #6644's smoke leg — a build that **already contained #6641** (verified: `b5021cf` is an ancestor of the run's head):

```
09:06:13.905  POST /services/js/service-generate/generate.mjs/...      <- not the publisher endpoint
09:06:14.783  PublisherService - Unpublished ...                        <- hole opens
09:06:15.372  JavaSynchronizer - Removing Java artefact
              [/retire-owner/gen/invoices/api/invoice/InvoiceController.java] - its source is gone  (x6)
09:06:15.463  PublisherService - Published ...                          <- hole closes, 680 ms later
09:06:20.619  Compiled batch: [12] units, [0] class file(s); [12] failed
              (cannot find symbol: class InvoiceRepository)
```

Client Java compiles all-or-nothing, so zero class files, no controllers registered, and `IntentCrossModelFieldRetirementIT`'s 60 s poll saw only 404s. That was the **last** batch of the run — nothing repaired it. The same window is the likeliest explanation for `IntentEmissionCoverageIT` reading `"Status": null` two seconds after a republish on #6647's leg.

## The fix

`PublisherService` brackets its own writes with `enter()` / `exit()`. Every caller is then covered by construction — the HTTP endpoint, the JS `lifecycle` API, generated client Java, tests. **Enumerating callers was the bug**; the service is the one place they all funnel through. The tracker's javadoc now states this, so the next publish path brackets its write instead of adding a mapping.

The bracket sits on `publishResource` / `unpublishResource` — the methods that actually touch the repository — so a disabled publish or a no-op path does not register a phantom mutation.

I deliberately left `RegistryMutationFilter` in place: it is now redundant for the publisher endpoint, and its workspace mapping was never about the registry, but removing it is a behaviour change beyond this bug. Worth a separate look.

## Verification

- `SynchronizerCleanupRaceIT` gains a contract test: a publish that never touches the HTTP layer must still register as a completed registry mutation, because that count is exactly what the pass compares. **Verified red-first** — stashed the fix, reinstalled, and it fails precisely at that assertion; restored, and both tests pass (30 s).
- `IntentCrossModelFieldRetirementIT` — the IT this race broke — green locally.
- 34 unit tests across `core-base` / `core-initializers` / `ide-workspace` green; `formatter:validate` and the release-profile javadoc clean.

Not claimed: neither CI failure was ever locally reproducible, so this fixes the mechanism the logs show rather than reproducing those two runs. The secondary point in #6654 stands separately — a batch that compiles to zero class files is not necessarily retried, so a missed hole is still a permanent outage rather than a transient one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
