### PR TITLE
build(harmonia): bump 2.6.0 -> 2.9.0 and migrate the breaking changes

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/admin/admin-index.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/admin/admin-index.html.template
@@ -95,8 +95,8 @@
                             <span class="opacity-60 text-xs" x-show="p.fk" x-text="'-> ' + p.fk"></span>
                         </label>
                         <template x-if="p.lookup">
-                            <div x-h-select data-filter="contains" :data-disabled="p.readonly">
-                                <input x-h-select-input :id="'a_' + p.name" x-model="draft[p.name]" :placeholder="'Select ' + p.name + '...'" />
+                            <div x-h-select data-filter="contains">
+                                <input x-h-select-input :id="'a_' + p.name" x-model="draft[p.name]" :disabled="p.readonly" :placeholder="'Select ' + p.name + '...'" />
                                 <div x-h-select-content>
                                     <div x-h-select-search></div>
                                     <template x-for="opt in (options[p.name] || [])" :key="opt.value">

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -98,8 +98,8 @@
         <!-- Non-setting association: combobox + Add new (opens the target's own create page in an iframe
              dialog) + Refresh, all on one full-width row. -->
         <div class="hbox gap-1 items-center">
-          <div x-h-select data-filter="contains" class="grow" :data-disabled="isPreview">
-            <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="!!errors.${property.name}" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select ${label}...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '${label}') })" />
+          <div x-h-select data-filter="contains" class="grow">
+            <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="!!errors.${property.name}" :disabled="isPreview" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select ${label}...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '${label}') })" />
             <div x-h-select-content>
               <div x-h-select-search></div>
               <template x-for="opt in options${property.name}" :key="opt.value">
@@ -111,8 +111,8 @@
           <button type="button" x-h-button data-variant="transparent" class="shrink-0" x-show="!isPreview" aria-label="Refresh" @click="loadOptions()"><i x-h-lucide data-lucide="refresh-cw" class="size-4"></i></button>
         </div>
 #else
-        <div x-h-select data-filter="contains"#if($readonly) data-disabled="true"#else :data-disabled="isPreview"#end>
-          <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="!!errors.${property.name}" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select ${label}...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '${label}') })" />
+        <div x-h-select data-filter="contains">
+          <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="!!errors.${property.name}"#if($readonly) disabled#else :disabled="isPreview"#end :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select ${label}...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '${label}') })" />
           <div x-h-select-content>
             <div x-h-select-search></div>
             <template x-for="opt in options${property.name}" :key="opt.value">
@@ -557,7 +557,7 @@
               <label x-h-label x-text="T(col.tkey, col.label)"></label>
               <template x-if="!col.readonly && col.widget === 'DROPDOWN'">
                 <div>
-                  <div x-h-select data-filter="contains" :data-disabled="col.readonly">
+                  <div x-h-select data-filter="contains">
                     <input x-h-select-input x-model="draft[col.name]" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select...', { name: '' })" />
                     <div x-h-select-content>
                       <div x-h-select-search></div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
@@ -121,8 +121,8 @@
              dialog) and a Refresh button. -->
 #if($lookup)
         <div class="hbox gap-1 items-center">
-          <div x-h-select data-filter="contains" class="grow" :data-disabled="isPreview">
-            <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="!!errors.${property.name}" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select ${label}...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '${label}') })" />
+          <div x-h-select data-filter="contains" class="grow">
+            <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="!!errors.${property.name}" :disabled="isPreview" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select ${label}...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '${label}') })" />
             <div x-h-select-content>
               <div x-h-select-search></div>
               <template x-for="opt in options${property.name}" :key="opt.value">
@@ -134,9 +134,9 @@
           <button type="button" x-h-button data-variant="transparent" class="shrink-0" x-show="!isPreview" aria-label="Refresh" @click="loadOptions()"><i x-h-lucide data-lucide="refresh-cw" class="size-4"></i></button>
         </div>
 #else
-        <div x-h-select data-filter="contains"#if($readonly) data-disabled="true"#else :data-disabled="isPreview"#end>
+        <div x-h-select data-filter="contains">
           <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}"
-                 :aria-invalid="!!errors.${property.name}"
+                 :aria-invalid="!!errors.${property.name}"#if($readonly) disabled#else :disabled="isPreview"#end
                  :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select ${label}...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '${label}') })" />
           <div x-h-select-content>
             <div x-h-select-search></div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
@@ -89,57 +89,59 @@
         <!-- Hierarchy (intent `hierarchy:`): the records render as a Harmonia tree off
              ${hierarchyProperty} when no search/filter is active; searching falls back to the flat
              table so matches outside collapsed branches stay findable. Markup recursion is a fixed
-             6 levels deep (Alpine has no recursive template) - deeper nodes are not rendered. -->
+             6 levels deep - deeper nodes are not rendered. (Harmonia's x-h-template can render a
+             tree of any depth from data; folding these six copies into one is a worthwhile
+             follow-up, but it is a behaviour change and not part of the 2.9 API migration.) -->
         <div x-show="treeVisible" x-h-table-container.scroll class="flex-1" data-border="true">
           <ul x-h-tree class="p-2">
               <template x-for="n1 in childrenOf(null)" :key="n1.${primaryKeysString}">
-                <li x-h-tree-item.expanded="true">
-                  <button x-h-tree-button :data-indicator="isSelected(n1) ? 'information' : null" @click="selectRow(n1)">
-                    <i role="img" x-h-lucide :data-lucide="hasChildren(n1) ? 'folder' : 'file-text'"></i>
-                    <span x-text="nodeLabel(n1)"></span>
-                  </button>
+                <li x-h-tree-item="true" :aria-selected="isSelected(n1)" @tree-item-click.self="selectRow(n1)">
+                  <div x-h-tree-row>
+                    <svg x-h-lucide role="presentation" :data-lucide="hasChildren(n1) ? 'folder' : 'file-text'"></svg>
+                    <span x-h-tree-label x-text="nodeLabel(n1)"></span>
+                  </div>
                   <template x-if="hasChildren(n1)">
-                    <ul x-h-tree.sub data-border="true">
+                    <ul x-h-tree.sub data-line="true">
                       <template x-for="n2 in childrenOf(n1)" :key="n2.${primaryKeysString}">
-                <li x-h-tree-item.expanded="true">
-                  <button x-h-tree-button :data-indicator="isSelected(n2) ? 'information' : null" @click="selectRow(n2)">
-                    <i role="img" x-h-lucide :data-lucide="hasChildren(n2) ? 'folder' : 'file-text'"></i>
-                    <span x-text="nodeLabel(n2)"></span>
-                  </button>
+                <li x-h-tree-item="true" :aria-selected="isSelected(n2)" @tree-item-click.self="selectRow(n2)">
+                  <div x-h-tree-row>
+                    <svg x-h-lucide role="presentation" :data-lucide="hasChildren(n2) ? 'folder' : 'file-text'"></svg>
+                    <span x-h-tree-label x-text="nodeLabel(n2)"></span>
+                  </div>
                   <template x-if="hasChildren(n2)">
-                    <ul x-h-tree.sub data-border="true">
+                    <ul x-h-tree.sub data-line="true">
                       <template x-for="n3 in childrenOf(n2)" :key="n3.${primaryKeysString}">
-                <li x-h-tree-item.expanded="true">
-                  <button x-h-tree-button :data-indicator="isSelected(n3) ? 'information' : null" @click="selectRow(n3)">
-                    <i role="img" x-h-lucide :data-lucide="hasChildren(n3) ? 'folder' : 'file-text'"></i>
-                    <span x-text="nodeLabel(n3)"></span>
-                  </button>
+                <li x-h-tree-item="true" :aria-selected="isSelected(n3)" @tree-item-click.self="selectRow(n3)">
+                  <div x-h-tree-row>
+                    <svg x-h-lucide role="presentation" :data-lucide="hasChildren(n3) ? 'folder' : 'file-text'"></svg>
+                    <span x-h-tree-label x-text="nodeLabel(n3)"></span>
+                  </div>
                   <template x-if="hasChildren(n3)">
-                    <ul x-h-tree.sub data-border="true">
+                    <ul x-h-tree.sub data-line="true">
                       <template x-for="n4 in childrenOf(n3)" :key="n4.${primaryKeysString}">
-                <li x-h-tree-item.expanded="true">
-                  <button x-h-tree-button :data-indicator="isSelected(n4) ? 'information' : null" @click="selectRow(n4)">
-                    <i role="img" x-h-lucide :data-lucide="hasChildren(n4) ? 'folder' : 'file-text'"></i>
-                    <span x-text="nodeLabel(n4)"></span>
-                  </button>
+                <li x-h-tree-item="true" :aria-selected="isSelected(n4)" @tree-item-click.self="selectRow(n4)">
+                  <div x-h-tree-row>
+                    <svg x-h-lucide role="presentation" :data-lucide="hasChildren(n4) ? 'folder' : 'file-text'"></svg>
+                    <span x-h-tree-label x-text="nodeLabel(n4)"></span>
+                  </div>
                   <template x-if="hasChildren(n4)">
-                    <ul x-h-tree.sub data-border="true">
+                    <ul x-h-tree.sub data-line="true">
                       <template x-for="n5 in childrenOf(n4)" :key="n5.${primaryKeysString}">
-                <li x-h-tree-item.expanded="true">
-                  <button x-h-tree-button :data-indicator="isSelected(n5) ? 'information' : null" @click="selectRow(n5)">
-                    <i role="img" x-h-lucide :data-lucide="hasChildren(n5) ? 'folder' : 'file-text'"></i>
-                    <span x-text="nodeLabel(n5)"></span>
-                  </button>
+                <li x-h-tree-item="true" :aria-selected="isSelected(n5)" @tree-item-click.self="selectRow(n5)">
+                  <div x-h-tree-row>
+                    <svg x-h-lucide role="presentation" :data-lucide="hasChildren(n5) ? 'folder' : 'file-text'"></svg>
+                    <span x-h-tree-label x-text="nodeLabel(n5)"></span>
+                  </div>
                   <template x-if="hasChildren(n5)">
-                    <ul x-h-tree.sub data-border="true">
+                    <ul x-h-tree.sub data-line="true">
                       <template x-for="n6 in childrenOf(n5)" :key="n6.${primaryKeysString}">
-                <li x-h-tree-item.expanded="true">
-                  <button x-h-tree-button :data-indicator="isSelected(n6) ? 'information' : null" @click="selectRow(n6)">
-                    <i role="img" x-h-lucide :data-lucide="hasChildren(n6) ? 'folder' : 'file-text'"></i>
-                    <span x-text="nodeLabel(n6)"></span>
-                  </button>
+                <li x-h-tree-item="true" :aria-selected="isSelected(n6)" @tree-item-click.self="selectRow(n6)">
+                  <div x-h-tree-row>
+                    <svg x-h-lucide role="presentation" :data-lucide="hasChildren(n6) ? 'folder' : 'file-text'"></svg>
+                    <span x-h-tree-label x-text="nodeLabel(n6)"></span>
+                  </div>
                   <template x-if="hasChildren(n6)">
-                    <ul x-h-tree.sub data-border="true">
+                    <ul x-h-tree.sub data-line="true">
                       <!-- depth limit: 6 levels (see the page comment) -->
                     </ul>
                   </template>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/slots/slots-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/slots/slots-view.html.template
@@ -40,8 +40,11 @@
     <!--
       Harmonia 2.5+ - the slot picker renders only the day grid; the date-navigation toolbar is composed
       here from the x-h-slot-picker-* control directives (they must be descendants of x-h-slot-picker).
+      The `responsive` modifier (Harmonia 2.7) keeps the day columns stacking into one on a narrow
+      screen - since 2.7 that is opt-in rather than the default. No x-model is bound on purpose: a slot
+      is an action that routes to the create form, never a selection the picker should hold.
     -->
-    <div x-h-slot-picker="slotCfg" @slot-click="onSlotClick">
+    <div x-h-slot-picker.responsive="slotCfg" @slot-click="onSlotClick">
       <div x-h-toolbar data-variant="transparent">
         <div x-h-button-group>
           <button x-h-button data-variant="outline" data-size="icon" x-h-slot-picker-previous

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
         <bpmn-visualization.version>0.47.0</bpmn-visualization.version>
         <i18next.version>25.3.0</i18next.version>
         <alpinejs.version>3.15.11</alpinejs.version>
-        <harmonia.version>2.6.0</harmonia.version>
+        <harmonia.version>2.9.0</harmonia.version>
         <opensans.version>5.2.7</opensans.version>
         <lucide.version>1.8.0</lucide.version>
         <pinecone-router.version>7.5.2</pinecone-router.version>

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DependsOnHarmoniaTestProject.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DependsOnHarmoniaTestProject.java
@@ -80,10 +80,15 @@ class DependsOnHarmoniaTestProject extends BaseTestProject {
         // watcher that re-filters the City options.
         browser.assertElementExistByAttributePatternAndText(HtmlElementType.SPAN, HtmlAttribute.ROLE, "combobox", "Bulgaria");
 
-        // City depends on Country: opening it now must offer only Bulgaria's cities.
+        // City depends on Country: opening it now must offer only Bulgaria's cities. The offered
+        // options are asserted on the option element itself, not on a <span>: since Harmonia 2.7 an
+        // option renders its label inside a text COLUMN (a span wrapping the label span, so a
+        // description can sit under it), so a bare "one span contains Sofia" is two matches - which
+        // the ExistsByTypeAndContainsText finder rejects. div[role="option"] is the stable anchor,
+        // and it is what the Country selection above already clicks.
         browser.clickOnElementByAttributePatternAndText(HtmlElementType.SPAN, HtmlAttribute.ROLE, "combobox", "Select City...");
-        browser.assertElementExistsByTypeAndContainsText(HtmlElementType.SPAN, "Sofia");
-        browser.assertElementExistsByTypeAndContainsText(HtmlElementType.SPAN, "Varna");
+        browser.assertElementExistByAttributePatternAndText(HtmlElementType.DIV, HtmlAttribute.ROLE, "option", "Sofia");
+        browser.assertElementExistByAttributePatternAndText(HtmlElementType.DIV, HtmlAttribute.ROLE, "option", "Varna");
         browser.assertElementDoesNotExistsByTypeAndContainsText(HtmlElementType.SPAN, "Milano");
     }
 }


### PR DESCRIPTION
The Harmonia Tree was rebuilt in 2.9.0 (`x-h-tree-button` → row/label/actions/indicator, selection driven by a `tree-item-click` event). Anything built on the 2.6.0 tree API would be legacy on arrival, so this bumps first, on its own, keeping a platform-wide change separable from whatever builds on it.

**Why 2.9.0 and not 2.10.0:** 2.10.0 is published on npm but has no webjar on Maven Central yet, so 2.9.0 is the highest available — and it carries every breaking change that matters here. The 2.10.0 delta is a cross-origin iframe crash fix plus an inverted `getBreakpointListener` third argument; when its webjar lands, the six shells calling that listener will need to pass `true`.

## Migrated

- **Tree (2.9.0).** The hierarchy list view's six nested levels move to `x-h-tree-row` + `x-h-tree-label`, with selection on `aria-selected` and `@tree-item-click.self` instead of a `:data-indicator` dot on a button, and the stale `data-border` on nested trees becomes `data-line`. The icons become `<svg x-h-lucide>` — the shape the new markup wants, and the one a bound `:data-lucide` requires anyway.
- **Slot picker (2.7.0).** Day columns no longer collapse on narrow screens by themselves, so the slots view opts back in with `.responsive`. It deliberately binds no `x-model`: a slot is an action that routes to the create form, not a selection the picker should hold.
- **Select (2.9.0).** `data-disabled` is gone. It was already dead on these three templates — even in 2.6.0 `data-disabled` was a per-**option** attribute, and the whole control has always been disabled through native `disabled` on `x-h-select-input` — so preview-mode and read-only dropdowns were never actually disabled. They now are.

No sidebar group actions, no rating, no `h-mask`/`v-mask` and no `data-label` exist in this repo, so those breaking changes have no blast radius here.

## Verification

The six Harmonia/shell UI journeys, run headless: `DependsOnHarmoniaIT`, `DependsOnScenariosHarmoniaIT`, `MultitenancyHarmoniaIT`, `ShellSwitcherIT`, `IntentBuilderShellIT`, `MonitoringShellIT` — 13 tests green.

`DependsOnHarmoniaIT` needed one fix, and it is a consequence of 2.7.0 rather than of this migration: an option renders its label inside a text column now (so a `data-description` can sit under it), which makes "exactly one span contains Sofia" two matches. The assertion moves to `div[role="option"]` — the same anchor the test already clicks for the Country selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)