### PR TITLE
fix(core-base): gate /services/data/** at the URL layer

### DIFF
--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfigurator.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfigurator.java
@@ -113,7 +113,23 @@ public class HttpSecurityURIConfigurator {
             "/services/native-apps", //
             "/services/native-apps/**"};
 
-    /** The roles allowed on the monitoring and native-app management surfaces. */
+    /**
+     * Data management surface. Every controller under {@code /services/data/} declares roles drawn from
+     * {ADMINISTRATOR, DEVELOPER, OPERATOR} - the metadata, definition and execution endpoints allow all
+     * three, while export / import / anonymize / datasource CRUD are the stricter ADMINISTRATOR +
+     * OPERATOR. Without a gate of its own the whole prefix falls through to
+     * {@link #AUTHENTICATED_PATTERNS}, leaving method security as the only thing standing between an
+     * ordinary authenticated user and the database.
+     * <p>
+     * The gate therefore uses the WIDEST legitimate set: it must not reject anyone the endpoints allow,
+     * and the finer per-endpoint {@code @RolesAllowed} checks stay in place to enforce the stricter
+     * half. This is defense in depth, not the authorization itself.
+     */
+    private static final String[] DATA_MANAGEMENT_PATTERNS = { //
+            "/services/data", //
+            "/services/data/**"};
+
+    /** The roles allowed on the monitoring, native-app management and data management surfaces. */
     private static final String[] OPERATIONS_ROLES = { //
             Roles.ADMINISTRATOR.getRoleName(), //
             Roles.DEVELOPER.getRoleName(), //
@@ -128,7 +144,8 @@ public class HttpSecurityURIConfigurator {
             new RoleGate(MONITORING_PATTERNS, OPERATIONS_ROLES), //
             new RoleGate(DEVELOPER_PATTERNS, new String[] {Roles.DEVELOPER.getRoleName()}), //
             new RoleGate(OPERATOR_PATTERNS, new String[] {Roles.OPERATOR.getRoleName()}), //
-            new RoleGate(NATIVE_APPS_MANAGEMENT_PATTERNS, OPERATIONS_ROLES));
+            new RoleGate(NATIVE_APPS_MANAGEMENT_PATTERNS, OPERATIONS_ROLES), //
+            new RoleGate(DATA_MANAGEMENT_PATTERNS, OPERATIONS_ROLES));
 
     /**
      * A role gate - the URI patterns it covers and the roles any of which grants access to them.

--- a/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfiguratorTest.java
+++ b/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfiguratorTest.java
@@ -67,6 +67,21 @@ class HttpSecurityURIConfiguratorTest {
     }
 
     /**
+     * The data management surface has a URL gate of its own, so it no longer falls through to "any
+     * authenticated user" with method security as the only check. The gate carries the widest set the
+     * endpoints declare - narrowing it here would reject callers the controllers allow, while the
+     * stricter half (export / import / anonymize / datasource CRUD, which are ADMINISTRATOR + OPERATOR)
+     * stays enforced by their own {@code @RolesAllowed}.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"/services/data", "/services/data/metadata", "/services/data/metadata/DefaultDB/PUBLIC",
+            "/services/data/definition/DefaultDB/PUBLIC/VABLE", "/services/data/DefaultDB/query", "/services/data/DefaultDB/update",
+            "/services/data/DefaultDB/procedure", "/services/data/sources", "/services/data/export/DefaultDB", "/services/data/import"})
+    void dataManagementIsGatedAtTheUrlLayer(String uri) {
+        assertEquals(OPERATIONS_ROLES, requiredRoles(uri), "the data surface must be gated to the operational roles at " + uri);
+    }
+
+    /**
      * The gates are evaluated in order and the monitoring patterns are all sub-paths of the DEVELOPER
      * ones - reordering them silently reinstates the 403.
      */

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/EndpointAuthorizationIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/EndpointAuthorizationIT.java
@@ -36,7 +36,14 @@ class EndpointAuthorizationIT extends IntegrationTest {
     private static final String ADMIN_USER = "endpoint-authz-it-admin";
     private static final String PASSWORD = "endpoint-authz-it-password";
 
-    /** Administrative surfaces that must never answer a role-less but authenticated caller. */
+    /**
+     * Administrative surfaces that must never answer a role-less but authenticated caller.
+     * <p>
+     * The two {@code /services/data/} entries are now rejected by the URL layer as well (that prefix
+     * gained a role gate), so they assert the outcome rather than which layer produced it. The three
+     * below them have no URL rule and are therefore the ones that still prove method security is
+     * switched on - keep at least one such path here.
+     */
     private static final String[] PRIVILEGED_ENDPOINTS = { //
             "/services/data/metadata/", // database metadata (the Database perspective)
             "/services/data/sources", // data source definitions - carry credentials


### PR DESCRIPTION
Every controller under `/services/data/` declares roles from {ADMINISTRATOR, DEVELOPER, OPERATOR} — metadata, definition and execution allow all three; export, import, anonymize and datasource CRUD are the stricter ADMINISTRATOR + OPERATOR. But the prefix carried no rule in the central URL configuration, so it fell through to `/services/**` → `authenticated()`, leaving JSR-250 method security as the only thing between an ordinary authenticated user and the database.

That is exactly the arrangement #6559 showed to be fragile: while the method-security switch was bound to the basic-authentication configuration, every single-sign-on profile turned it off and the annotations silently guarded nothing. The database surface is not one to leave resting on a single layer.

This adds the gate the monitoring surface got in #6613, with the same shape.

## Not a change of policy

The gate uses the **widest** set the endpoints declare, so it can never reject a caller the controllers allow; the stricter half stays enforced by its own `@RolesAllowed`. No caller who could reach these endpoints before loses access — this is defense in depth.

## Verification

- `HttpSecurityURIConfiguratorTest` gains the matrix rows for the new surface — 30 tests green. The existing rows still pin the design-time surface to DEVELOPER-only and the infrastructure surface to OPERATOR-only, so a future widening cannot pass unnoticed.
- `EndpointAuthorizationIT` keeps passing unchanged: a role-less authenticated user still gets 403. Two of its five paths now get that 403 from the URL layer rather than from method security, so its comment records which of the remaining paths are the ones still proving the JSR-250 switch is on — the test keeps its original teeth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)