### PR TITLE
feat(resources-database): a Database shell for the application layer

### DIFF
--- a/DATABASE_SHELL_PLAN.md
+++ b/DATABASE_SHELL_PLAN.md
@@ -1,0 +1,270 @@
+# Database shell (Harmonia) — plan, feasibility & cost
+
+A new **Database** shell at the application layer: a Harmonia/Alpine re-imagining of the IDE's
+Database perspective, scoped to **support essentials only** — browse the schema, look at data, run a
+SQL fix. It gives operators and support engineers a way to touch the database without opening the
+IDE, exactly the way the Monitoring shell answers "is the system healthy?" without the IDE.
+
+Status: **in delivery.** PR 0 is the Harmonia bump (#6656), PR 1 the URL-layer gate (#6657), PR 2
+this shell. Prior art: the Monitoring shell (`components/resources/resources-monitoring`,
+PRs #6613–#6615) — the only existing single-purpose operations shell and the construction template
+this plan clones.
+
+### Corrections to this plan, found while building it
+
+- **The bump is to 2.9.0, not 2.10.0.** 2.10.0 is published on npm but has no webjar on Maven
+  Central, and 2.9.0 carries every breaking change that mattered (the tree rewrite included). The
+  2.10.0 delta — a cross-origin iframe crash fix and an inverted `getBreakpointListener` third
+  argument — is a follow-up; when its webjar lands, the six shells calling that listener must pass
+  `true`.
+- **The `data-disabled` sweep was a bug fix, not a rename.** `data-disabled` on a root `x-h-select`
+  never did anything, even on 2.6.0: it was always a per-*option* attribute, and the whole control
+  is disabled through native `disabled` on `x-h-select-input`. Preview-mode and read-only dropdowns
+  in the generated apps were never actually disabled. They are now.
+- **Two breaking changes the plan did not list** turned out to matter: the 2.7.0 slot-picker stopped
+  collapsing its day columns on narrow screens by itself (`.responsive` restores it), and 2.7.0
+  moved an option's label into a text column, which broke one IT assertion that demanded exactly one
+  `<span>` per label.
+- **Lazy tree loading must not own the expanded state.** A 2.9 tree item detects its own children
+  and owns whether it is expanded, so a second owner in the store fights it. The shell instead
+  renders one placeholder child under an unloaded node — which is what gives the row its chevron
+  before anything has been fetched — and the `tree-item-click` handler only loads.
+
+## Goal
+
+- A standalone Harmonia shell served at `/services/web/database/`, registered on `platform-shells`
+  (shell id `databaseShell`, icon `database`, order 38 — between Monitoring 37 and the IDE 40).
+- Two pages: an **Explorer** (datasource → schema → tables/views/procedures → columns tree, "show
+  contents" grid, DDL view) and a **SQL Console** (statement area, results grid, messages strip).
+- **Zero new backend.** Every read and execute goes through endpoints that already ship in
+  `components/data/*`, all method-gated `@RolesAllowed({ADMINISTRATOR, DEVELOPER, OPERATOR})`.
+- Role gate: `database.access` on `/database/` for ADMINISTRATOR / OPERATOR / DEVELOPER — the same
+  trio the endpoints declare, so the shell never renders a page its user cannot use.
+
+## Verdict
+
+**Highly feasible, low risk.** The backend surface exists 1:1; the shell skeleton, shared runtime,
+page pattern, registration plumbing and IT pattern are all proven by the Monitoring shell; Harmonia
+(as of 2.10.0) carries every component the UI needs (`tree`, `table`, `split`, `tabs`, `select`,
+`menu`/`popover`). Estimated cost: **~2.5–3k LOC across 2–3 PRs, roughly 1–1.5 weeks** of focused
+effort, of which the single real prerequisite — the Harmonia webjar bump 2.6.0 → 2.10.0 — carries
+most of the risk.
+
+## Scope
+
+### In (support essentials)
+
+- Datasource picker (names from `GET /services/data/metadata`), current selection in an Alpine
+  store, persisted to localStorage (the IDE does the same via
+  `${brand.prefix}.view-db-explorer.database`).
+- Lazy metadata tree: schema → tables / views / procedures → columns. Fixed depth, so plain nested
+  `x-for` — no recursive templates needed.
+- "Show contents" — a generated `SELECT` executed through `/query`, rendered in an `x-h-table` with
+  dynamic columns and client-side pagination.
+- Object DDL via `GET /services/data/definition/{ds}/{schema}/{structure}`.
+- SQL Console: monospace textarea (NOT Monaco — see decisions), Ctrl/Cmd+Enter to execute, results
+  grid, update counts / errors in a messages strip, statement text persisted in localStorage.
+- Explorer row actions: Show contents, Copy name, Generate SELECT into the console.
+- Metadata cache refresh (`GET /services/data/metadata/invalidate-cache`).
+- i18n en-US + bg-BG, following the `i18n/<locale>/<project>.json` aggregator convention.
+
+### Out (deliberate — decided 2026-08-11)
+
+- **Import / export** (sync + async), **anonymization**, **data transfer** (the WebSocket), **schema
+  export/import processes** — not support essentials; also exactly the endpoints restricted to
+  ADMINISTRATOR/OPERATOR-only, so cutting them keeps the role story uniform.
+- **Datasource CRUD** (`/services/data/sources`) — the shell consumes datasources, it does not
+  manage them.
+- **Row-edit dialogs** (the IDE's `result-view-crud` + the server-side JS `databaseTable.js` path) —
+  the SQL console covers support writes; optional later phase.
+- **Monaco** — a support console does not justify embedding a multi-MB editor in an app-layer shell.
+- Re-implementing anything the Workbench Database perspective does deeply (script generation beyond
+  a SELECT, project exports, topology). Each page links to the IDE instead — the Monitoring shell's
+  scope line, applied here.
+
+## Backend inventory (all existing, no changes required)
+
+Prefix from `BaseEndpoint`: `/services/data/`. Datasource/schema are **always path variables** —
+no server-side "current datasource" session state; every request is self-describing.
+
+| Need | Endpoint | Roles |
+|---|---|---|
+| List datasources | `GET /services/data/metadata` | ADMIN, DEV, OPERATOR |
+| Datasource → schemas | `GET /services/data/metadata/{ds}` | ADMIN, DEV, OPERATOR |
+| Schema → objects | `GET /services/data/metadata/{ds}/{schema}` | ADMIN, DEV, OPERATOR |
+| Object metadata (columns…) | `GET /services/data/metadata/{ds}/{schema}/{structure}?kind=` — structure name **Base64-encoded** in the path | ADMIN, DEV, OPERATOR |
+| Object DDL | `GET /services/data/definition/{ds}/{schema}/{structure}` | ADMIN, DEV, OPERATOR |
+| Run SELECT | `POST /services/data/{ds}/query` — body raw SQL, `Content-Type: text/plain` | ADMIN, DEV, OPERATOR |
+| Run UPDATE / DDL | `POST /services/data/{ds}/update` | ADMIN, DEV, OPERATOR |
+| Call procedure | `POST /services/data/{ds}/procedure` | ADMIN, DEV, OPERATOR |
+| Refresh metadata cache | `GET /services/data/metadata/invalidate-cache` | ADMIN, DEV, OPERATOR |
+
+### Server contracts the new client must knowingly inherit
+
+These are de-facto contracts of `DatabaseExecutionEndpoint` / `DatabaseExecutionService`, not bugs
+to fix in this effort:
+
+- **Statement dispatch is a prefix sniff**, not parsing (the IDE's `result.js` does the same):
+  `select …` → `/query`, `call …` → `/procedure`, `query: …` → `/query` with the prefix stripped
+  (NoSQL, e.g. MongoDB find), `update: …` → `/update` stripped, everything else → `/update`.
+  Replicate exactly.
+- **Response format branches on an *exact* `Accept` match** (`text/plain` → monospaced table,
+  `text/csv` → CSV, anything else → JSON). Send a plain `Accept: application/json` and always take
+  the JSON branch.
+- **Results are silently capped** server-side at `DIRIGIBLE_DATABASE_DEFAULT_QUERY_LIMIT`
+  (default 1000) with **no truncation marker in the payload**. The grid must label honestly:
+  "showing N rows — the server may cap results" (at least when N looks like a round cap). The IDE
+  never surfaced this; the support shell should.
+- **Procedure results are double-encoded**: a JSON array whose elements are JSON *strings* —
+  `JSON.parse` each element.
+- The service splits multi-statement bodies on `;` (on `--` when the body contains
+  `CREATE PROCEDURE`/`CREATE TRIGGER`) and streams results per statement; an error mid-stream
+  surfaces as a 500 on an already-committed response — render whatever arrived plus the error.
+- **Encode names consistently from day one.** Metadata/definition paths take the structure name
+  Base64-encoded; anywhere else, encode per path segment. The IDE breaks on schema/table names
+  containing `.` (it splits `"schema.table"` on the dot); greenfield code must not copy that.
+
+### Optional hardening (recommended, own small PR)
+
+`/services/data/**` has **no URL-layer gate** in `HttpSecurityURIConfigurator` — it falls through to
+`AUTHENTICATED_PATTERNS` (`/services/**` → `authenticated()`), so method-level `@RolesAllowed` is
+the only rejection. Mirror what the Monitoring shell did in #6613: add `/services/data/**` to the
+operations `RoleGate` (ADMINISTRATOR/DEVELOPER/OPERATOR) ahead of the catch-all, and extend
+`HttpSecurityURIConfiguratorTest`'s matrix. ~60 LOC of defense-in-depth. Note the endpoints are
+mixed-role (export/import/anonymize are ADMIN/OPERATOR-only, stricter than the gate) — the URL gate
+must use the **widest** legitimate set and leave the finer method-level checks in place.
+
+**Independent platform gap found while mapping — report it privately, do NOT open a public issue.**
+The `/websockets/data/transfer` handler (`DataTransferWebsocketHandler`, `data-transfer`) carries no
+role check at all and `/websockets/**` is merely `authenticated()` — any authenticated user can
+drive data transfer, unlike every REST sibling in `components/data/` (all ADMINISTRATOR + OPERATOR).
+`SECURITY.md` routes undisclosed vulnerabilities to the Eclipse Security Team or a committers-only
+Bugzilla entry, so this belongs there rather than in the issue tracker. It is deliberately kept out
+of PR 1: that PR is a strict no-op for every existing caller, while fixing this changes who may use
+a feature, and the right role set is a policy call (DEVELOPER opens the IDE's Transfer view).
+
+## Target architecture
+
+New module **`components/resources/resources-database`** (`dirigible-components-resources-database`),
+web assets under `src/main/resources/META-INF/dirigible/database/`. A straight clone of the
+`resources-monitoring` skeleton — the only live single-purpose operations shell (admin / personal /
+application are *host* shells whose large `appShell.js` exists to mount extension-contributed
+perspectives; not the right template).
+
+```
+pom.xml                                   (no webjar deps needed — unlike monitoring's bpmn-visualization)
+META-INF/dirigible/database/
+├── index.html                            sidebar + toolbar chrome, Pinecone routes into #app
+├── database.access                       /database/ → ADMINISTRATOR, OPERATOR, DEVELOPER
+├── configs/shell.js                      id 'databaseShell', path, label, icon 'database', order 38
+├── extensions/shell.extension            platform-shells registration
+├── css/app.css                           shell-local styles only
+├── i18n/en-US/database.json + bg-BG/     namespace = file basename
+├── js/
+│   ├── config.js                         window.App.config { projectName, basePath, restBase: '' }
+│   ├── appShell.js                       thin: currentPath tracking + Harmonia breakpoint drawer
+│   ├── services/dbops.js                 one wrapper per endpoint + soft(); owns the dispatch sniff,
+│   │                                     Base64/segment encoding, procedure double-decode
+│   ├── stores/
+│   │   ├── explorer.js                   datasource list + selection (localStorage), lazy tree state,
+│   │   │                                 contents grid state, DDL state
+│   │   └── sql.js                        statement text (localStorage), execute, results, messages
+│   └── components/pages/
+│       ├── explorerPage.js
+│       └── sqlPage.js
+└── views/
+    ├── _explorer.html                    x-h-split: tree (x-h-tree, nested x-for) | contents/DDL tabs
+    └── _sql.html                         textarea + run toolbar + results x-h-table + messages
+```
+
+Everything cross-cutting comes from the **shared** runtime at
+`/services/web/application-core/shell/` by absolute URL (app.js, i18n/api/apiError/format/branding
+services, theme/locale/currentUser/shells stores, base css) — no per-project copies. Script order in
+`index.html` is load-bearing (Pinecone → shared runtime → config → local services/stores/pages →
+appShell → Alpine → Harmonia bundle, which auto-starts Alpine → Lucide last).
+
+Registration edits outside the module: `components/pom.xml` (module + dependencyManagement),
+`components/group/group-ui/pom.xml` (assembly dependency), `resources-home`'s `home.js` (icon map,
+description, SECONDARY list — a support tool is a secondary destination, like Monitoring).
+
+### Page conventions (carried from Monitoring)
+
+- Per page: an Alpine **store** (data + async actions, never touches DOM), an Alpine **page
+  component** (`Alpine.data('explorerPage')` — formatting, derived getters, calls
+  `$store.explorer.load()` in `init()`), and a **view fragment**.
+- Every endpoint read goes through `dbops.js`; aggregate reads wrap in `soft()` so an unavailable
+  datasource degrades to a marked tile, not an empty screen.
+- Stable ids for the IT: sidebar buttons `database-nav-<section>`, page roots
+  `database-<section>-page`.
+- Alpine/Lucide trap: a bound `:data-lucide` goes on `<svg x-h-lucide>`, never `<i x-h-lucide>` —
+  the plugin replaces the element and the throw silently aborts Alpine's walk (the failure mode
+  `MonitoringShellIT` exists to catch).
+- Tree: Harmonia ≥2.9 API (`x-h-tree-row` / `x-h-tree-label` / `x-h-tree-actions`, selection driven
+  by the `tree-item-click` event — the tree keeps no selection model of its own). Lazy loading =
+  fetch children on first expand, cache in the store.
+
+## Prerequisite: Harmonia 2.6.0 → 2.10.0 (PR 0)
+
+The root pom pins `harmonia.version` 2.6.0; the **tree was rebuilt with breaking changes in 2.9.0**
+(`x-h-tree-button` → row/label/actions/indicator, new `tree-item-click` event). Building the
+explorer on the 2.6.0 tree API would be instant legacy — bump first. Measured blast radius:
+
+- Old tree API: **one file** — `template-application-ui-harmonia-java`'s
+  `ui/perspective/manage/list-view.html.template` (the tree-list layout).
+- Removed `data-disabled` / `data-label`: **three templates** (`admin-index.html.template`,
+  `document/document-view.html.template`, `manage/form-view.html.template`). The
+  `resources-karavan-libs` grep hit is a bundled third-party React app — not Harmonia markup.
+- 2.9.0 also reworked **sidebar group actions** and the **`aria-disabled` keyboard behaviour** —
+  verification pass over the five existing shells' `index.html` (application, monitoring, admin,
+  personal, partner) plus the Harmonia templates.
+- Per the established bump procedure: read the upstream CHANGELOG (2.7 → 2.10), regenerate the
+  sample apps after the template migrations, full IT run.
+
+## Phasing / PR sequence
+
+| PR | Content | Size | Status |
+|---|---|---|---|
+| 0 | Harmonia bump 2.6.0 → **2.9.0**: pom pin, tree-template migration, slot-picker `.responsive`, `data-disabled` fix, one IT assertion | 7 files | **#6656 open**, 6 UI journeys green |
+| 1 | `/services/data/**` URL-layer gate + `HttpSecurityURIConfiguratorTest` matrix rows | 3 files | **#6657 open**, 30 unit tests green |
+| 2 | The shell: module skeleton, `dbops.js`, two store/page/view triples, registration edits, i18n, `DatabaseShellIT` | ~1,300 LOC, 18 files | in progress |
+
+Calibration: the Monitoring shell landed as three PRs totalling +3,932 LOC over 46 files, six pages,
+zero Java in the module. This shell has fewer pages (2 vs 6) but denser ones — the lazy tree and the
+arbitrary-columns results grid are the two components Monitoring never needed. **Total: ~1–1.5 weeks
+end to end including the bump** — materially less if the bump happens anyway for other reasons.
+
+## Testing
+
+- **`DatabaseShellIT`** (`@Tag("ui")`, `UserInterfaceIntegrationTest`) — the MonitoringShellIT
+  pattern, ~100 LOC: (1) the Explorer renders shell chrome, the tree shows `DefaultDB` schemas, and
+  a store poll resolved (catches the Alpine-bootstrap abort, which has no DOM or server symptom);
+  (2) every section reachable by `database-nav-<x>` id, asserted on `database-<x>-page` with
+  deployment-independent text; (3) the SQL console executes a `SELECT 1`-class statement against
+  DefaultDB and the grid renders a row — the one end-to-end journey worth the browser.
+- The backend needs no new tests (unchanged); PR 1's gate change extends the existing
+  `HttpSecurityURIConfiguratorTest`.
+
+## Key decisions & risks
+
+1. **Textarea, not Monaco** (decision). Support usage doesn't justify a multi-MB editor; localStorage
+   persistence and Ctrl/Cmd+Enter match the IDE's muscle memory. Revisit only on real demand
+   (CodeMirror-class, lazy-loaded like Monitoring's bpmn-visualization, would be the shape).
+2. **The Harmonia bump is the main risk** — a platform-wide change riding ahead of a feature.
+   Mitigated by its own PR, the small measured breaking-change inventory above, and the full IT
+   suite.
+3. **Silent row cap UX** — inherent to the backend; label it, don't fix it here.
+4. **Write access is the point, and the gate is roles, not the shell.** The shell deliberately
+   allows UPDATE/DDL (a support tool that can't fix data is a dashboard). Safety comes from the
+   `.access` file + the endpoints' `@RolesAllowed` (+ PR 1's URL gate), not from hiding buttons.
+   No confirmation theatre beyond a destructive-statement confirm on non-`select` execution.
+5. **Don't port the IDE's bugs.** Known in the AngularJS stack and out of scope to copy: a dead
+   `delete` branch in `result.js` row CRUD, a `$destroy` throw on an undeclared listener, the
+   dot-splitting of `schema.table`, and the never-wired `database.database.selection.changed`
+   (database-kind) topic. Greenfield code replaces the whole MessageHub topic web with two Alpine
+   stores.
+
+## Explicitly out of scope
+
+Import/export (sync/async), anonymization, data transfer, schema export/import processes,
+datasource CRUD, row-edit dialogs, Monaco, procedure/script generation beyond SELECT, project
+exports, topology — the Workbench Database perspective remains the deep tool; this shell links to it.

--- a/components/group/group-ui/pom.xml
+++ b/components/group/group-ui/pom.xml
@@ -57,6 +57,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-resources-database</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
             <artifactId>dirigible-components-resources-inbox</artifactId>
         </dependency>
         <dependency>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -254,6 +254,7 @@
         <module>resources/resources-partner</module>
         <module>resources/resources-admin</module>
         <module>resources/resources-monitoring</module>
+        <module>resources/resources-database</module>
         <module>resources/resources-inbox</module>
         <module>resources/resources-documents</module>
         <module>resources/resources-karavan-libs</module>
@@ -1379,6 +1380,11 @@
             <dependency>
                 <groupId>org.eclipse.dirigible</groupId>
                 <artifactId>dirigible-components-resources-monitoring</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.dirigible</groupId>
+                <artifactId>dirigible-components-resources-database</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/components/resources/resources-database/pom.xml
+++ b/components/resources/resources-database/pom.xml
@@ -1,0 +1,25 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.dirigible</groupId>
+		<artifactId>dirigible-components-parent</artifactId>
+		<version>15.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+
+	<name>Components - Resources - Database</name>
+	<artifactId>dirigible-components-resources-database</artifactId>
+	<packaging>jar</packaging>
+
+	<!-- No dependencies on purpose: the shell is pure web assets over the SHARED runtime served from
+		application-core, and every endpoint it calls already ships in components/data. Unlike the
+		Monitoring shell it loads no third-party viewer, so it brings no webjar of its own. -->
+
+	<properties>
+		<license.header.location>../../../licensing-header.txt</license.header.location>
+		<parent.pom.folder>../../../</parent.pom.folder>
+	</properties>
+
+</project>

--- a/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/configs/shell.js
+++ b/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/configs/shell.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+const shellData = {
+    id: 'databaseShell',
+    path: '/services/web/database/index.html',
+    label: 'Database',
+    icon: 'database',
+    description: 'Browse the schema, look at the data, run a SQL fix.',
+    order: 38
+};
+if (typeof exports !== 'undefined') {
+    exports.getShell = () => shellData;
+}

--- a/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/css/app.css
+++ b/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/css/app.css
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Minimal shell styles on top of Harmonia. Layout is Harmonia's (vbox/hbox/size-full/x-h-*); this
+ * only hides x-cloak content until Alpine initialises.
+ */
+[x-cloak] {
+  display: none !important;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+}

--- a/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/database.access
+++ b/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/database.access
@@ -1,0 +1,14 @@
+{
+    "constraints": [
+        {
+            "scope": "HTTP",
+            "path": "/database/",
+            "method": "*",
+            "roles": [
+                "ADMINISTRATOR",
+                "OPERATOR",
+                "DEVELOPER"
+            ]
+        }
+    ]
+}

--- a/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/extensions/shell.extension
+++ b/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/extensions/shell.extension
@@ -1,0 +1,5 @@
+{
+    "module": "database/configs/shell.js",
+    "extensionPoint": "platform-shells",
+    "description": "Database Shell"
+}

--- a/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/i18n/bg-BG/database.json
+++ b/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/i18n/bg-BG/database.json
@@ -1,0 +1,47 @@
+{
+  "errors": {
+    "forbidden": "Нямате права да четете това."
+  },
+  "explorer": {
+    "close": "Затвори",
+    "contents": "Съдържание",
+    "copied": "Копирано {{name}}",
+    "copyName": "Копирай името",
+    "datasource": "Източник на данни",
+    "ddl": "DDL",
+    "generateSelect": "Генерирай SELECT",
+    "loading": "Зарежда се...",
+    "noDatasources": "Няма източници на данни",
+    "noDatasourcesHint": "На тази инсталация няма конфигуриран източник на данни.",
+    "noRows": "Няма редове.",
+    "noSchemas": "Няма схеми в този източник на данни.",
+    "refresh": "Опресни",
+    "rowsCapped": "Показани са {{count}} реда - сървърът ограничава резултата, така че може да има още.",
+    "rowsShown": "Показани са {{count}} реда.",
+    "showContents": "Покажи съдържанието",
+    "showDdl": "Покажи DDL",
+    "title": "Изследовател"
+  },
+  "shell": {
+    "nav": {
+      "explorer": "Изследовател",
+      "group": "База данни",
+      "sql": "SQL конзола",
+      "workbench": "Отвори в Workbench"
+    },
+    "title": "База данни"
+  },
+  "sql": {
+    "cancel": "Отказ",
+    "capped": "Сървърът ограничава резултата, така че може да има повече редове от показаните.",
+    "clear": "Изчисти",
+    "confirmBody": "Тази заявка не е четене. Ще бъде изпълнена върху {{datasource}}.",
+    "confirmTitle": "Изпълнение на променяща заявка?",
+    "placeholder": "SELECT * FROM ...   (Ctrl/Cmd+Enter за изпълнение)",
+    "rowsReturned": "Редове: {{count}}",
+    "rowsUpdated": "Променени редове: {{count}}",
+    "run": "Изпълни",
+    "statementExecuted": "Заявката беше изпълнена.",
+    "title": "SQL конзола"
+  }
+}

--- a/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/i18n/en-US/database.json
+++ b/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/i18n/en-US/database.json
@@ -1,0 +1,47 @@
+{
+  "errors": {
+    "forbidden": "You do not have permission to read this."
+  },
+  "explorer": {
+    "close": "Close",
+    "contents": "Contents",
+    "copied": "Copied {{name}}",
+    "copyName": "Copy name",
+    "datasource": "Datasource",
+    "ddl": "DDL",
+    "generateSelect": "Generate SELECT",
+    "loading": "Loading...",
+    "noDatasources": "No datasources",
+    "noDatasourcesHint": "This instance has no datasource configured.",
+    "noRows": "No rows.",
+    "noSchemas": "No schemas in this datasource.",
+    "refresh": "Refresh",
+    "rowsCapped": "Showing {{count}} rows - the server caps results, so there may be more.",
+    "rowsShown": "Showing {{count}} rows.",
+    "showContents": "Show contents",
+    "showDdl": "Show DDL",
+    "title": "Explorer"
+  },
+  "shell": {
+    "nav": {
+      "explorer": "Explorer",
+      "group": "Database",
+      "sql": "SQL Console",
+      "workbench": "Open in Workbench"
+    },
+    "title": "Database"
+  },
+  "sql": {
+    "cancel": "Cancel",
+    "capped": "The server caps results, so there may be more rows than shown.",
+    "clear": "Clear",
+    "confirmBody": "This statement is not a read. It will be executed against {{datasource}}.",
+    "confirmTitle": "Run a write statement?",
+    "placeholder": "SELECT * FROM ...   (Ctrl/Cmd+Enter to run)",
+    "rowsReturned": "Rows: {{count}}",
+    "rowsUpdated": "Rows updated: {{count}}",
+    "run": "Run",
+    "statementExecuted": "The statement was executed.",
+    "title": "SQL Console"
+  }
+}

--- a/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/index.html
+++ b/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/index.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<!--
+  Copyright (c) 2010-2026 Eclipse Dirigible contributors
+  SPDX-License-Identifier: EPL-2.0
+
+  The Database shell - browse the schema, look at the data, run a SQL fix, without opening the IDE.
+  Pure Harmonia over the SHARED shell runtime served from /services/web/application-core/shell; both
+  pages read existing, role-gated endpoints under /services/data/. The deep tooling (import/export,
+  anonymization, data transfer, datasource management, script generation, topology) deliberately
+  stays in the Workbench's Database perspective, which this shell links to.
+-->
+<!-- data-brand-title: services/branding.js sets the tab title to the instance brand name. -->
+<html lang="en" data-brand-title>
+
+  <head>
+    <meta charset="UTF-8" />
+    <!-- Placeholder favicon, replaced at runtime by services/branding.js (DIRIGIBLE_BRANDING_FAVICON). -->
+    <link rel="icon" sizes="any" href="data:;base64,iVBORw0KGgo=" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Database</title>
+
+    <link href="/webjars/codbex__harmonia/dist/harmonia.css" rel="stylesheet" />
+    <link href="/services/web/application-core/shell/css/app.css" rel="stylesheet" />
+    <link href="./css/app.css" rel="stylesheet" />
+
+    <script>
+      (function () {
+        try { if (!localStorage.getItem('codbex.harmonia.colorMode')) localStorage.setItem('codbex.harmonia.colorMode', 'light'); } catch (e) { /* no storage */ }
+      })();
+    </script>
+  </head>
+
+  <body class="vbox size-full" x-data="app">
+
+    <!-- Narrow-viewport drawer host. -->
+    <div x-h-sheet-overlay="isOpen">
+      <div x-h-sheet data-align="left" x-ref="overlay"></div>
+    </div>
+
+    <!-- x-cloak hides the shell until Alpine + Harmonia upgrade the markup (no raw-chrome flash). -->
+    <div x-cloak x-h-split class="size-full" data-orientation="horizontal" data-variant="border">
+
+      <!-- Sidebar -->
+      <div x-h-split-panel :data-hidden="hiddenPanels.left" data-max="280" data-min="220"
+           data-locked="true" data-gutterless="true" x-ref="sidebarPanel">
+        <div x-h-sidebar x-ref="sidebar">
+          <div x-h-sidebar-header>
+            <div class="hbox items-center gap-2 p-1">
+              <img :src="$store.branding.logo" :alt="$store.branding.name" class="size-5" />
+              <div class="vbox gap-0">
+                <span class="font-bold leading-tight" x-text="$store.branding.name"></span>
+                <span x-h-text.muted class="text-xs leading-tight" x-text="T('database:shell.title', 'Database')"></span>
+              </div>
+            </div>
+          </div>
+
+          <div x-h-sidebar-content>
+            <div x-h-sidebar-group>
+              <div x-h-sidebar-group-label x-text="T('database:shell.nav.group', 'Database')"></div>
+              <div x-h-sidebar-group-content>
+                <ul x-h-sidebar-menu>
+                  <li x-h-sidebar-menu-item>
+                    <button id="database-nav-explorer" x-h-sidebar-menu-button :data-active="isActive('/explorer')" @click="navigate('/explorer')">
+                      <i role="img" x-h-lucide data-lucide="database"></i>
+                      <span class="flex-1" x-text="T('database:shell.nav.explorer', 'Explorer')"></span>
+                    </button>
+                  </li>
+                  <li x-h-sidebar-menu-item>
+                    <button id="database-nav-sql" x-h-sidebar-menu-button :data-active="isActive('/sql')" @click="navigate('/sql')">
+                      <i role="img" x-h-lucide data-lucide="square-terminal"></i>
+                      <span class="flex-1" x-text="T('database:shell.nav.sql', 'SQL Console')"></span>
+                    </button>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+
+          <!-- The deep tooling lives in the Workbench; the shell links to it rather than cloning it. -->
+          <div x-h-sidebar-footer>
+            <ul x-h-sidebar-menu>
+              <li x-h-sidebar-menu-item>
+                <a x-h-sidebar-menu-button href="/services/web/shell-ide/" target="_blank" rel="noopener">
+                  <i role="img" x-h-lucide data-lucide="external-link"></i>
+                  <span x-text="T('database:shell.nav.workbench', 'Open in Workbench')"></span>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <!-- Main panel -->
+      <div x-h-split-panel>
+        <div class="vbox size-full">
+          <div x-h-toolbar data-variant="transparent" x-cloak>
+            <button x-show="hiddenPanels.left" x-h-button data-variant="transparent"
+                    aria-label="Navigation" @click="openSideNav()" data-size="icon">
+              <i role="img" x-h-lucide data-lucide="menu"></i>
+            </button>
+            <span x-h-toolbar-title class="shrink-0" x-text="T('database:shell.title', 'Database')"></span>
+            <div x-h-toolbar-spacer></div>
+            <button x-h-button data-variant="transparent" data-size="icon-sm" @click="$store.theme.toggle()"
+                    :aria-label="$store.theme.value === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'" title="Toggle theme">
+              <svg x-h-lucide x-show="$store.theme.value !== 'dark'" role="img" data-lucide="moon"></svg>
+              <svg x-h-lucide x-show="$store.theme.value === 'dark'" role="img" data-lucide="sun"></svg>
+            </button>
+
+            <button id="user-menu-trigger" x-h-button x-h-menu-trigger.dropdown data-variant="transparent" data-size="icon-sm"
+                    :aria-label="$store.currentUser.name || 'Account'">
+              <i role="img" x-h-lucide data-lucide="circle-user"></i>
+            </button>
+            <ul x-h-menu aria-label="User menu" data-align="bottom-end">
+              <div x-h-tile class="mb-1">
+                <div x-h-tile-media><i role="img" x-h-lucide data-lucide="circle-user" class="size-6"></i></div>
+                <div x-h-tile-content>
+                  <div x-h-tile-title x-text="$store.currentUser.name || T('application-core:shell.user.user', 'User')"></div>
+                </div>
+              </div>
+              <div x-h-menu-separator></div>
+              <!-- Switch shells without the detour through Home: the same `platform-shells` list the
+                   launchpad renders, minus this one (the shared `shells` store). -->
+              <div x-h-menu-label x-text="T('application-core:shell.switch.title', 'Switch to')"></div>
+              <li x-h-menu-item @click="$store.shells.openHome()">
+                <i role="img" x-h-lucide data-lucide="house"></i>
+                <span x-text="T('application-core:shell.switch.home', 'Home')"></span>
+              </li>
+              <template x-for="shell in $store.shells.items" :key="shell.id">
+                <li x-h-menu-item @click="$store.shells.open(shell)">
+                  <!-- svg, not <i>: the Lucide plugin REPLACES the element it upgrades, so a bound
+                       :data-lucide on an <i> throws and aborts Alpine's walk over the rest of the menu. -->
+                  <svg x-h-lucide role="img" :data-lucide="$store.shells.iconFor(shell)"></svg>
+                  <span x-text="shell.label"></span>
+                </li>
+              </template>
+              <div x-h-menu-separator></div>
+              <li x-h-menu-item data-variant="negative" @click="$store.currentUser.logout()">
+                <i role="img" x-h-lucide data-lucide="log-out"></i>
+                <span x-text="T('application-core:shell.user.logout', 'Log out')"></span>
+              </li>
+            </ul>
+          </div>
+
+          <!-- Pinecone Router renders the matched view fragment here. -->
+          <div id="app" class="size-full overflow-auto flex-1"></div>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- Routes -->
+    <template x-route="/" x-template.target.app="./views/_explorer.html"></template>
+    <template x-route="/explorer" x-template.target.app="./views/_explorer.html"></template>
+    <template x-route="/sql" x-template.target.app="./views/_sql.html"></template>
+    <template x-route="notfound" x-template.target.app="/services/web/application-core/shell/views/_notfound.html"></template>
+
+    <!-- 1. Plugins -->
+    <script src="/webjars/pinecone-router/dist/router.min.js"></script>
+
+    <!-- 2. Shared Harmonia runtime (served from application-core) + local config/pages (defer keeps order) -->
+    <script src="/services/web/application-core/shell/js/app.js" defer></script>
+    <script src="./js/config.js" defer></script>
+    <script src="/services/web/application-core/shell/js/services/i18n.js" defer></script>
+    <script src="/services/web/application-core/shell/js/services/api.js" defer></script>
+    <script src="/services/web/application-core/shell/js/services/apiError.js" defer></script>
+    <script src="/services/web/application-core/shell/js/services/format.js"></script>
+    <!-- Instance branding (the DIRIGIBLE_BRANDING_* env vars): the platform service sets
+         top.PlatformBranding; the adapter applies the favicon/title and exposes the `branding` store. -->
+    <script src="/services/js/platform-branding/branding.js" defer></script>
+    <script src="/services/web/application-core/shell/js/services/branding.js" defer></script>
+    <script src="/services/web/application-core/shell/js/stores/theme.js" defer></script>
+    <script src="/services/web/application-core/shell/js/stores/locale.js" defer></script>
+    <script src="/services/web/application-core/shell/js/stores/currentUser.js" defer></script>
+    <script src="/services/web/application-core/shell/js/stores/shells.js" defer></script>
+    <script src="./js/services/dbops.js" defer></script>
+    <script src="./js/stores/explorer.js" defer></script>
+    <script src="./js/stores/sql.js" defer></script>
+    <script src="./js/components/pages/explorerPage.js" defer></script>
+    <script src="./js/components/pages/sqlPage.js" defer></script>
+    <script src="./js/appShell.js" defer></script>
+
+    <!-- 3. Alpine LAST (the Harmonia bundle auto-starts Alpine - do NOT call Alpine.start()) -->
+    <script defer src="/webjars/alpinejs/dist/cdn.min.js"></script>
+    <script src="/webjars/codbex__harmonia/dist/harmonia.min.js"></script>
+
+    <!-- 4. Lucide icons (x-h-lucide renders and keeps them in sync, incl. router-swapped views) -->
+    <script src="/webjars/lucide/dist/umd/lucide.min.js"></script>
+    <script src="/webjars/codbex__harmonia/dist/harmonia-lucide.min.js"></script>
+  </body>
+
+</html>

--- a/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/js/appShell.js
+++ b/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/js/appShell.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * The Database shell controller. Deliberately thin, like the Monitoring shell's: two fixed pages,
+ * no aggregated perspectives and no hosted iframes, so it only tracks the current route for the
+ * sidebar highlight and hands the narrow-viewport drawer to Harmonia. Everything cross-page - theme,
+ * user, branding, language - is a store from the shared runtime.
+ */
+document.addEventListener('alpine:init', () => {
+  window.PineconeRouter.settings({
+    basePath: (App.config && App.config.basePath) || '',
+    hash: true
+  });
+
+  Alpine.data('app', () => ({
+    hiddenPanels: { left: false },
+    isOpen: false,
+    currentPath: '/explorer',
+
+    init() {
+      // Keep the sidebar highlight in step with the URL, including deep links and back/forward.
+      const applyRoute = () => {
+        const hash = window.location.hash || '';
+        const path = (hash.charAt(0) === '#' ? hash.slice(1) : hash) || '/';
+        this.currentPath = path === '/' ? '/explorer' : path;
+      };
+      window.addEventListener('popstate', applyRoute);
+      document.addEventListener('pinecone:end', applyRoute);
+      applyRoute();
+
+      // Below 1024px the sidebar moves into the Harmonia drawer.
+      this._breakpoint = Harmonia.getBreakpointListener((isNarrow) => {
+        this.hiddenPanels.left = isNarrow;
+        if (isNarrow) {
+          this.$refs.overlay.appendChild(this.$refs.sidebar);
+        } else {
+          this.$refs.sidebarPanel.appendChild(this.$refs.sidebar);
+        }
+      }, 1024);
+    },
+
+    destroy() {
+      if (this._breakpoint) this._breakpoint.remove();
+    },
+
+    navigate(route) {
+      window.PineconeRouter.navigate(route);
+      this.closeSideNav();
+    },
+
+    isActive(route) {
+      return this.currentPath === route;
+    },
+
+    openSideNav() { this.isOpen = true; },
+    closeSideNav() { if (window.matchMedia('(max-width: 1024px)').matches) this.isOpen = false; },
+  }));
+}, { once: true });

--- a/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/js/components/pages/explorerPage.js
+++ b/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/js/components/pages/explorerPage.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * The Explorer page: the metadata tree on the left, the selected object's contents or DDL on the
+ * right. The store owns the data and the actions; this component only formats what they hold and
+ * carries the two row actions that reach outside the page (copy, and hand a SELECT to the console).
+ */
+document.addEventListener('alpine:init', () => {
+  Alpine.data('explorerPage', () => ({
+    copied: '',
+
+    init() {
+      // Only the first visit pays for the datasource list; coming back from the console keeps it.
+      if (!this.$store.explorer.datasources.length) this.$store.explorer.load();
+    },
+
+    get state() {
+      return this.$store.explorer;
+    },
+
+    /** The lucide icon for a tree node kind. */
+    iconFor(kind) {
+      switch (kind) {
+        case 'TABLE': return 'table';
+        case 'VIEW': return 'eye';
+        case 'PROCEDURE': return 'square-function';
+        default: return 'file-text';
+      }
+    },
+
+    /** Contents is a read of rows - it means nothing for a procedure. */
+    canShowContents(object) {
+      return object.kind === 'TABLE' || object.kind === 'VIEW';
+    },
+
+    /** A column's type with its size, the way a DDL would write it. */
+    columnType(column) {
+      if (!column) return '';
+      const size = column.size !== undefined && column.size !== null && column.size !== 0
+        ? '(' + column.size + ')' : '';
+      return String(column.type || '') + size;
+    },
+
+    /** A cell as text. NULL is shown as such - an empty cell would read as an empty string. */
+    cellText(value) {
+      if (value === null || value === undefined) return 'NULL';
+      if (typeof value === 'object') return JSON.stringify(value);
+      return String(value);
+    },
+
+    /**
+     * The results are capped server-side with nothing in the payload to say so, so the grid says it
+     * itself rather than presenting a truncated read as the whole table.
+     */
+    get contentsCapped() {
+      return DatabaseOps.looksCapped(this.state.rows.length);
+    },
+
+    qualifiedName(subject) {
+      return subject ? subject.schema + '.' + subject.name : '';
+    },
+
+    async copyName(object) {
+      const name = object.schema + '.' + object.name;
+      try {
+        await navigator.clipboard.writeText(name);
+        this.copied = name;
+        setTimeout(() => { if (this.copied === name) this.copied = ''; }, 2000);
+      } catch (e) {
+        console.error('database: could not copy to the clipboard', e);
+      }
+    },
+
+    /** Put a SELECT for this object into the console and go there. */
+    selectInConsole(object) {
+      this.$store.sql.setStatement(DatabaseOps.selectAll(object.schema, object.name));
+      window.PineconeRouter.navigate('/sql');
+    },
+  }));
+});

--- a/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/js/components/pages/sqlPage.js
+++ b/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/js/components/pages/sqlPage.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * The SQL console page: a statement area, a results grid and a messages strip.
+ *
+ * A plain textarea, not Monaco. A support console is opened to run a handful of statements, and an
+ * editor of that size is not worth loading into an application-layer shell for it; Ctrl/Cmd+Enter
+ * and the persisted buffer are what carries over from the IDE, not the syntax highlighting.
+ */
+document.addEventListener('alpine:init', () => {
+  Alpine.data('sqlPage', () => ({
+    confirmOpen: false,
+
+    init() {
+      // The console runs against the Explorer's datasource, so the list has to be there even when
+      // the console is the first page opened (a deep link, or a reload on /sql).
+      if (!this.$store.explorer.datasources.length) this.$store.explorer.load();
+    },
+
+    get state() {
+      return this.$store.sql;
+    },
+
+    get datasource() {
+      return this.$store.explorer.datasource;
+    },
+
+    /**
+     * Run, asking first when the statement is not a read. The shell deliberately allows writes -
+     * a support tool that cannot fix data is a dashboard - so the safeguard is this one prompt plus
+     * the role gate, not a hidden button.
+     */
+    run() {
+      if (this.state.isWrite) {
+        this.confirmOpen = true;
+        return;
+      }
+      this.state.execute(this.datasource);
+    },
+
+    confirmRun() {
+      this.confirmOpen = false;
+      this.state.execute(this.datasource);
+    },
+
+    /** Ctrl+Enter / Cmd+Enter runs, matching the IDE console. */
+    onKeydown(event) {
+      if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+        event.preventDefault();
+        this.run();
+      }
+    },
+
+    cellText(value) {
+      if (value === null || value === undefined) return 'NULL';
+      if (typeof value === 'object') return JSON.stringify(value);
+      return String(value);
+    },
+
+    /** See DatabaseOps.looksCapped - the server caps a read and says nothing about it. */
+    get capped() {
+      return DatabaseOps.looksCapped(this.state.rows.length);
+    },
+
+    /** What the messages strip says once a statement has run. */
+    get message() {
+      if (this.state.error) return null;
+      if (this.state.operation === null) return null;
+      if (this.state.updateCount !== null) {
+        return T('database:sql.rowsUpdated', 'Rows updated: {{count}}', { count: this.state.updateCount });
+      }
+      if (this.state.operation === 'update') {
+        return T('database:sql.statementExecuted', 'The statement was executed.');
+      }
+      return T('database:sql.rowsReturned', 'Rows: {{count}}', { count: this.state.rows.length });
+    },
+  }));
+});

--- a/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/js/config.js
+++ b/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/js/config.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Runtime configuration for the Database Harmonia shell. The shared shell runtime
+ * (/services/web/application-core/shell/...) reads its wiring from window.App.config, exactly like a
+ * generated app does. This shell has no entities of its own - every page reads an existing platform
+ * endpoint under /services/data/ (see js/services/dbops.js), so there is no REST base to configure.
+ */
+window.App = window.App || {};
+App.config = {
+  projectName: 'database',
+  basePath: '/services/web/database',
+  // No own entities; the pages call the platform endpoints directly by absolute URL.
+  restBase: '',
+  // A support tool - it does not aggregate the applications' reports.
+  aggregateReports: false
+};

--- a/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/js/services/dbops.js
+++ b/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/js/services/dbops.js
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * The Database shell's access layer: one thin wrapper per platform endpoint under /services/data/,
+ * so no page ever spells out a URL, encodes a name, or knows how a statement is dispatched.
+ *
+ * Two things live here and nowhere else, because getting either wrong is silent rather than loud:
+ *
+ * 1. NAME ENCODING. Datasource and schema names go into the path as ordinary segments and are
+ *    encoded per segment; a STRUCTURE name is additionally Base64-encoded, which is what the
+ *    metadata and definition endpoints expect. Encoding the whole path in one go turns a '/' into
+ *    %2F and every request 400s, and splitting a qualified name on '.' (which the IDE's explorer
+ *    does) breaks any schema or table whose name contains a dot.
+ *
+ * 2. STATEMENT DISPATCH. The server has no single "run this" endpoint - /execute is just /query
+ *    under another name - so the client decides which endpoint a statement goes to, by sniffing its
+ *    first word. This mirrors the IDE's result.js exactly, so a support engineer's muscle memory
+ *    (including the `query:` / `update:` prefixes, which exist for NoSQL datasources) carries over.
+ *
+ * Every read goes through the shared fetch client with `{ baseUrl: '' }` - these are absolute
+ * platform paths, so nothing must be prepended. Execution cannot: the endpoints consume text/plain
+ * and take the raw SQL as the body, while the shared client always sends JSON. postSql() below is
+ * the deliberate exception, and it reproduces the client's ApiError contract so callers handle
+ * failures the same way either side of that line.
+ *
+ * The endpoints are role-gated to ADMINISTRATOR / DEVELOPER / OPERATOR and so is the shell
+ * (database.access), so a user who can reach a page can call what it reads.
+ */
+window.DatabaseOps = (() => {
+  const ABSOLUTE = { baseUrl: '' };
+  const METADATA = '/services/data/metadata';
+  const DEFINITION = '/services/data/definition';
+
+  const get = (url) => App.services.api.get(url, ABSOLUTE);
+
+  /** One path segment, encoded. Never call this on a whole path - it would encode the separators. */
+  const segment = (value) => encodeURIComponent(value);
+
+  /**
+   * A structure name as the metadata/definition endpoints want it: Base64 of the raw name, then
+   * URL-encoded because Base64's alphabet includes '+' and '/'. btoa() only accepts Latin-1, so a
+   * non-ASCII identifier is UTF-8 encoded first.
+   */
+  const structureSegment = (name) =>
+    encodeURIComponent(btoa(String.fromCharCode(...new TextEncoder().encode(name))));
+
+  /**
+   * POST raw SQL to one of the execution endpoints. The shared client cannot be used: it sets
+   * Content-Type: application/json and JSON-encodes the body, while these endpoints declare
+   * `consumes = "text/plain"` and read the body as the statement itself.
+   *
+   * Accept matters too. The endpoint branches on an EXACT header match - 'text/plain' renders a
+   * monospaced table and 'text/csv' renders CSV - so anything else takes the JSON branch. We ask
+   * for application/json explicitly and always parse JSON.
+   *
+   * @param {string} datasource the datasource name
+   * @param {string} operation query | update | procedure
+   * @param {string} sql the statement, already stripped of any dispatch prefix
+   * @returns {Promise<*>} the parsed JSON payload (or the raw text when the body is not JSON)
+   */
+  async function postSql(datasource, operation, sql) {
+    const url = '/services/data/' + segment(datasource) + '/' + operation;
+    let response;
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'text/plain',
+          'Accept': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest'
+        },
+        body: sql,
+        credentials: 'same-origin'
+      });
+    } catch (e) {
+      throw new App.services.ApiError({ httpStatus: 0, errorType: 'NetworkError', errorMessage: e.message });
+    }
+
+    const text = await response.text().catch(() => '');
+    if (!response.ok) {
+      let parsed = null;
+      if (text) {
+        try { parsed = JSON.parse(text); } catch (_) { /* the server often answers plain text here */ }
+      }
+      throw new App.services.ApiError({
+        httpStatus: response.status,
+        errorType: (parsed && parsed.errorType) || App.services.api.typeFromStatus(response.status),
+        errorMessage: (parsed && (parsed.errorMessage || parsed.message)) || text || response.statusText
+      });
+    }
+    if (!text) return null;
+    try { return JSON.parse(text); } catch (_) { return text; }
+  }
+
+  return {
+    /** The datasource names configured on this instance. */
+    datasources: () => get(METADATA + '/'),
+
+    /** One datasource's metadata: `{ name, kind, schemas: [{ name, tables, views, procedures }] }`. */
+    datasourceMetadata: (datasource) => get(METADATA + '/' + segment(datasource)),
+
+    /** One schema's objects, without their columns. */
+    schemaMetadata: (datasource, schema) =>
+      get(METADATA + '/' + segment(datasource) + '/' + segment(schema)),
+
+    /**
+     * One object's own metadata - `{ name, type, columns: [{ name, type, size, nullable, key }] }`.
+     *
+     * @param {string} datasource the datasource
+     * @param {string} schema the schema
+     * @param {string} structure the raw object name (Base64-encoded here, not by the caller)
+     * @param {string} kind TABLE | VIEW | PROCEDURE - the endpoint needs it to pick its reader
+     */
+    structureMetadata: (datasource, schema, structure, kind) =>
+      get(METADATA + '/' + segment(datasource) + '/' + segment(schema) + '/' + structureSegment(structure)
+        + '?kind=' + segment(String(kind).toUpperCase())),
+
+    /** The object's DDL, as text. */
+    definition: (datasource, schema, structure) =>
+      get(DEFINITION + '/' + segment(datasource) + '/' + segment(schema) + '/' + structureSegment(structure)),
+
+    /** Drop the server-side metadata cache, so the next read re-reads the live database. */
+    invalidateCache: () => get(METADATA + '/invalidate-cache'),
+
+    /**
+     * Decide which endpoint a statement belongs to, from its first word. Returns
+     * `{ operation, sql }` where `sql` is the statement with any dispatch prefix removed.
+     *
+     * The `query:` / `update:` prefixes are how a NoSQL datasource (e.g. MongoDB) is addressed:
+     * the body after the prefix is passed through verbatim rather than treated as SQL. Anything
+     * that is not a SELECT, a CALL, or an explicitly prefixed statement goes to /update - which is
+     * also where DDL and every other write ends up.
+     *
+     * @param {string} statement the raw statement text
+     */
+    dispatch(statement) {
+      const text = String(statement || '').trim();
+      const lower = text.toLowerCase();
+      if (lower.startsWith('select')) return { operation: 'query', sql: text };
+      if (lower.startsWith('call')) return { operation: 'procedure', sql: text };
+      if (lower.startsWith('query: ')) return { operation: 'query', sql: text.substring(7).trim() };
+      if (lower.startsWith('update: ')) return { operation: 'update', sql: text.substring(8).trim() };
+      return { operation: 'update', sql: text };
+    },
+
+    /**
+     * Run a statement against a datasource, dispatching it as `dispatch()` decides.
+     *
+     * A procedure's payload is DOUBLE-encoded - a JSON array whose elements are themselves JSON
+     * strings - so each element is parsed again here; callers see the same row-array shape a query
+     * returns, and never learn which endpoint answered.
+     *
+     * @param {string} datasource the datasource
+     * @param {string} statement the raw statement text
+     * @returns {Promise<{operation: string, rows: object[]|null, updateCount: number|null}>}
+     */
+    async execute(datasource, statement) {
+      const { operation, sql } = this.dispatch(statement);
+      const payload = await postSql(datasource, operation, sql);
+
+      if (operation === 'procedure') {
+        const results = Array.isArray(payload) ? payload : [];
+        const rows = results.flatMap((result) => {
+          if (typeof result !== 'string') return Array.isArray(result) ? result : [];
+          try {
+            const parsed = JSON.parse(result);
+            return Array.isArray(parsed) ? parsed : [parsed];
+          } catch (_) {
+            return [];
+          }
+        });
+        return { operation, rows, updateCount: null };
+      }
+
+      if (operation === 'query') {
+        return { operation, rows: Array.isArray(payload) ? payload : [], updateCount: null };
+      }
+
+      // /update answers with the affected-row count. It arrives as a number, or as text when the
+      // statement was DDL and the driver reported nothing meaningful.
+      const count = typeof payload === 'number' ? payload : Number.parseInt(payload, 10);
+      return { operation, rows: null, updateCount: Number.isFinite(count) ? count : null };
+    },
+
+    /**
+     * Whether a result of this size looks like it hit the server's row cap.
+     *
+     * The server caps every read at DIRIGIBLE_DATABASE_DEFAULT_QUERY_LIMIT (1000 by default) and
+     * puts NOTHING in the payload to say it did, so a truncated read is indistinguishable from a
+     * complete one. The client cannot know the configured value either, so this is a heuristic: a
+     * round hundred is what a cap looks like and an arbitrary table almost never is. It over-warns
+     * on a table that genuinely holds a round number of rows, and that is the right way round -
+     * presenting a truncated read as the whole table is the failure that matters.
+     *
+     * @param {number} count the number of rows returned
+     */
+    looksCapped: (count) => count >= 100 && count % 100 === 0,
+
+    /**
+     * The SELECT the Explorer's "Show contents" runs. The identifiers are double-quoted so a
+     * lower-case or reserved-word name survives; a name containing a double quote would be invalid
+     * in every dialect we support, so it is not something to escape around.
+     *
+     * @param {string} schema the schema
+     * @param {string} table the table or view
+     */
+    selectAll: (schema, table) => 'SELECT * FROM "' + schema + '"."' + table + '"',
+
+    /**
+     * Run a read that must not take the page down with it. One unavailable datasource (a database
+     * that is down, a driver that refuses a metadata call) degrades to a marked-unavailable entry
+     * instead of an empty screen.
+     *
+     * @param {string} name the source name, used as the key under which the failure is recorded
+     * @param {object} errors the accumulator receiving { <name>: <message> } for failed reads
+     * @param {function} read the call to make
+     * @param {*} fallback the value to return when the read fails
+     */
+    async soft(name, errors, read, fallback) {
+      try {
+        return await read();
+      } catch (e) {
+        errors[name] = e && e.httpStatus === 403 ? 'forbidden' : 'unavailable';
+        console.error('database: could not read ' + name, e);
+        return fallback;
+      }
+    },
+  };
+})();

--- a/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/js/stores/explorer.js
+++ b/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/js/stores/explorer.js
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * The Explorer's state: which datasource is selected, the lazily-filled metadata tree, and whatever
+ * the right-hand pane is currently showing (a table's contents or an object's DDL).
+ *
+ * The tree is loaded a level at a time, on first expand, and cached on the node - a schema with a
+ * few thousand tables is not something to read up front, and the metadata endpoints are per-object
+ * anyway. `loaded` distinguishes "not fetched yet" from "fetched and genuinely empty", which is why
+ * an empty children array is not enough on its own.
+ *
+ * The store holds data and performs async work; it never touches the DOM. Formatting and derived
+ * view state live on the page component (js/components/pages/explorerPage.js).
+ */
+document.addEventListener('alpine:init', () => {
+  // Survives a reload the way the IDE's explorer does, so a support engineer returns to the
+  // database they were looking at.
+  const SELECTED_KEY = 'dirigible.database.datasource';
+
+  const readSelected = () => {
+    try { return localStorage.getItem(SELECTED_KEY); } catch (e) { return null; }
+  };
+  const writeSelected = (name) => {
+    try { localStorage.setItem(SELECTED_KEY, name); } catch (e) { /* private mode - selection is per-session then */ }
+  };
+
+  Alpine.store('explorer', {
+    datasources: [],
+    datasource: null,
+    schemas: [],
+    loading: false,
+    errors: {},
+
+    // The right-hand pane: 'contents' | 'ddl' | null, plus what it is showing.
+    pane: null,
+    subject: null,          // { schema, name, kind }
+    columns: [],
+    rows: [],
+    rowColumns: [],
+    ddl: '',
+    paneLoading: false,
+    paneError: '',
+
+    /** Load the datasource list and select one - the remembered choice when it still exists. */
+    async load() {
+      this.loading = true;
+      this.errors = {};
+      const names = await DatabaseOps.soft('datasources', this.errors, () => DatabaseOps.datasources(), []);
+      this.datasources = Array.isArray(names) ? names : [];
+      this.loading = false;
+
+      if (!this.datasources.length) return;
+      const remembered = readSelected();
+      await this.select(this.datasources.includes(remembered) ? remembered : this.datasources[0]);
+    },
+
+    /** Switch datasource: remember it, drop the old tree, read the new one's schemas. */
+    async select(name) {
+      if (!name) return;
+      this.datasource = name;
+      await this.onDatasourceChanged();
+    },
+
+    /**
+     * React to `datasource` having been set. The picker is an x-h-select whose x-model writes the
+     * value straight onto the store, so the change arrives already applied - this is what runs after
+     * it, and what `select()` delegates to when the change comes from code instead.
+     */
+    async onDatasourceChanged() {
+      if (!this.datasource) return;
+      writeSelected(this.datasource);
+      this.closePane();
+      await this.loadSchemas();
+    },
+
+    async loadSchemas() {
+      this.loading = true;
+      this.errors = {};
+      const metadata = await DatabaseOps.soft(
+        'schemas', this.errors, () => DatabaseOps.datasourceMetadata(this.datasource), null);
+      this.schemas = ((metadata && metadata.schemas) || []).map((schema) => ({
+        name: schema.name,
+        loaded: false,
+        loading: false,
+        groups: []
+      }));
+      this.loading = false;
+    },
+
+    /**
+     * Read a schema's objects, once. Called when the tree activates the schema's row.
+     *
+     * Expansion itself is the tree component's business, not the store's - an item detects its own
+     * children and owns its expanded state, so a second owner here would only fight it. The view
+     * keeps a placeholder child under an unloaded schema so the row is expandable from the start,
+     * which is what makes this the only thing left to do on activation.
+     *
+     * The objects are grouped by kind rather than listed flat: the endpoint returns them in separate
+     * fields anyway, and a schema's tables are what someone is looking for far more often than its
+     * procedures.
+     */
+    async loadSchema(schema) {
+      if (schema.loaded || schema.loading) return;
+
+      schema.loading = true;
+      const metadata = await DatabaseOps.soft(
+        'schema:' + schema.name, this.errors,
+        () => DatabaseOps.schemaMetadata(this.datasource, schema.name), null);
+
+      const group = (label, kind, items) => ({
+        label,
+        kind,
+        objects: (items || []).map((item) => ({
+          name: item.name,
+          kind,
+          schema: schema.name,
+          loaded: false,
+          loading: false,
+          columns: []
+        }))
+      });
+
+      schema.groups = [
+        group('Tables', 'TABLE', metadata && metadata.tables),
+        group('Views', 'VIEW', metadata && metadata.views),
+        group('Procedures', 'PROCEDURE', metadata && metadata.procedures)
+      ].filter((g) => g.objects.length);
+
+      schema.loaded = true;
+      schema.loading = false;
+    },
+
+    /** Read an object's columns, once. Called when the tree activates the object's row. */
+    async loadObject(object) {
+      if (object.loaded || object.loading) return;
+
+      object.loading = true;
+      const metadata = await DatabaseOps.soft(
+        'object:' + object.schema + '.' + object.name, this.errors,
+        () => DatabaseOps.structureMetadata(this.datasource, object.schema, object.name, object.kind), null);
+      object.columns = (metadata && metadata.columns) || [];
+      object.loaded = true;
+      object.loading = false;
+    },
+
+    /**
+     * Show a table's or view's contents. The generated SELECT is capped server-side (see
+     * showContents' caller for how that is surfaced), which is why the statement carries no LIMIT
+     * of its own - adding one would make the shell's number disagree with the server's.
+     */
+    async showContents(object) {
+      this.pane = 'contents';
+      this.subject = { schema: object.schema, name: object.name, kind: object.kind };
+      this.paneLoading = true;
+      this.paneError = '';
+      this.rows = [];
+      this.rowColumns = [];
+
+      try {
+        const result = await DatabaseOps.execute(
+          this.datasource, DatabaseOps.selectAll(object.schema, object.name));
+        this.rows = result.rows || [];
+        this.rowColumns = this.rows.length ? Object.keys(this.rows[0]) : [];
+      } catch (e) {
+        this.paneError = (e && e.errorMessage) || String(e);
+      } finally {
+        this.paneLoading = false;
+      }
+    },
+
+    /** Show an object's DDL. */
+    async showDefinition(object) {
+      this.pane = 'ddl';
+      this.subject = { schema: object.schema, name: object.name, kind: object.kind };
+      this.paneLoading = true;
+      this.paneError = '';
+      this.ddl = '';
+
+      try {
+        const definition = await DatabaseOps.definition(this.datasource, object.schema, object.name);
+        this.ddl = typeof definition === 'string' ? definition : JSON.stringify(definition, null, 2);
+      } catch (e) {
+        this.paneError = (e && e.errorMessage) || String(e);
+      } finally {
+        this.paneLoading = false;
+      }
+    },
+
+    closePane() {
+      this.pane = null;
+      this.subject = null;
+      this.rows = [];
+      this.rowColumns = [];
+      this.ddl = '';
+      this.paneError = '';
+    },
+
+    /** Drop the server's metadata cache and re-read the tree, so a just-created table shows up. */
+    async refresh() {
+      await DatabaseOps.soft('invalidate', this.errors, () => DatabaseOps.invalidateCache(), null);
+      this.closePane();
+      await this.loadSchemas();
+    },
+  });
+});

--- a/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/js/stores/sql.js
+++ b/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/js/stores/sql.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * The SQL console's state: the statement being written, the last result, and the messages strip.
+ *
+ * The statement is persisted to localStorage on every change. A support engineer who reloads the
+ * page - or is bounced through a login - keeps what they were about to run; losing a carefully
+ * built UPDATE to a stray refresh is the console's most annoying possible failure.
+ */
+document.addEventListener('alpine:init', () => {
+  const STATEMENT_KEY = 'dirigible.database.statement';
+
+  const read = () => {
+    try { return localStorage.getItem(STATEMENT_KEY) || ''; } catch (e) { return ''; }
+  };
+  const write = (text) => {
+    try { localStorage.setItem(STATEMENT_KEY, text); } catch (e) { /* private mode - no persistence */ }
+  };
+
+  Alpine.store('sql', {
+    statement: read(),
+    running: false,
+
+    // The last result: rows for a query/procedure, an update count for everything else.
+    columns: [],
+    rows: [],
+    updateCount: null,
+    operation: null,
+    error: '',
+
+    /** Set the statement from code (the Explorer's "Generate SELECT"). */
+    setStatement(text) {
+      this.statement = text;
+      this.persist();
+    },
+
+    /**
+     * Write the current statement to storage. The textarea binds `statement` with x-model, so this
+     * is called from its input handler rather than owning the value itself.
+     */
+    persist() {
+      write(this.statement);
+    },
+
+    clear() {
+      this.setStatement('');
+      this.reset();
+    },
+
+    reset() {
+      this.columns = [];
+      this.rows = [];
+      this.updateCount = null;
+      this.operation = null;
+      this.error = '';
+    },
+
+    /**
+     * Whether the statement would go to /update - i.e. it is not a SELECT, a CALL, or an explicitly
+     * prefixed read. The page asks before running one of these; that is the console's only
+     * confirmation, and it exists because the shell deliberately allows writes.
+     */
+    get isWrite() {
+      const statement = String(this.statement || '').trim();
+      if (!statement) return false;
+      return DatabaseOps.dispatch(statement).operation === 'update';
+    },
+
+    /**
+     * Run the statement against the given datasource.
+     *
+     * @param {string} datasource the datasource to run against
+     */
+    async execute(datasource) {
+      const statement = String(this.statement || '').trim();
+      if (!statement || !datasource || this.running) return;
+
+      this.running = true;
+      this.reset();
+      try {
+        const result = await DatabaseOps.execute(datasource, statement);
+        this.operation = result.operation;
+        this.updateCount = result.updateCount;
+        this.rows = result.rows || [];
+        this.columns = this.rows.length ? Object.keys(this.rows[0]) : [];
+      } catch (e) {
+        // The service splits a multi-statement body and streams results per statement, so a failure
+        // part-way through arrives as a 500 on a response that already carried rows. Whatever the
+        // server managed to say is the most useful thing to show.
+        this.error = (e && e.errorMessage) || String(e);
+      } finally {
+        this.running = false;
+      }
+    },
+  });
+});

--- a/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/views/_explorer.html
+++ b/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/views/_explorer.html
@@ -1,0 +1,233 @@
+<!--
+  Copyright (c) 2010-2026 Eclipse Dirigible contributors
+  SPDX-License-Identifier: EPL-2.0
+
+  Explorer: the metadata tree (datasource -> schema -> tables/views/procedures -> columns) on the
+  left, the selected object's contents or DDL on the right. The tree is a fixed four levels deep, so
+  plain nested x-for is enough - no recursive template.
+-->
+<div id="database-explorer-page" x-data="explorerPage" class="vbox size-full">
+
+  <div x-h-toolbar data-variant="transparent">
+    <span x-h-toolbar-title class="shrink-0" x-text="T('database:explorer.title', 'Explorer')"></span>
+    <div x-h-toolbar-spacer></div>
+
+    <div x-h-select data-filter="contains" class="w-64" x-show="state.datasources.length">
+      <!-- x-model on x-h-select-input holds the VALUE; the input displays the matched option's
+           label. It writes straight onto the store, so the handler only reacts to the change. -->
+      <input x-h-select-input id="database-datasource" x-model="state.datasource"
+             @change="state.onDatasourceChanged()"
+             :aria-label="T('database:explorer.datasource', 'Datasource')"
+             :placeholder="T('database:explorer.datasource', 'Datasource')" />
+      <div x-h-select-content>
+        <template x-for="name in state.datasources" :key="name">
+          <div x-h-select-option="name" :data-value="name"></div>
+        </template>
+      </div>
+    </div>
+
+    <button x-h-button data-variant="outline" data-size="sm" @click="state.refresh()"
+            :disabled="!state.datasource || state.loading">
+      <svg x-h-lucide role="presentation" data-lucide="refresh-cw" class="size-4"></svg>
+      <span x-text="T('database:explorer.refresh', 'Refresh')"></span>
+    </button>
+  </div>
+
+  <!-- No datasource at all: the shell has nothing to explore, and that is worth saying plainly. -->
+  <div x-show="!state.loading && !state.datasources.length" x-h-info-page class="p-4">
+    <div x-h-info-page-header>
+      <div x-h-info-page-media.icon><svg x-h-lucide role="presentation" data-lucide="database-zap"></svg></div>
+      <div x-h-info-page-title x-text="T('database:explorer.noDatasources', 'No datasources')"></div>
+      <div x-h-info-page-description
+           x-text="state.errors.datasources === 'forbidden'
+             ? T('database:errors.forbidden', 'You do not have permission to read this.')
+             : T('database:explorer.noDatasourcesHint', 'This instance has no datasource configured.')"></div>
+    </div>
+  </div>
+
+  <div x-show="state.datasources.length" x-h-split class="bk-stretch flex-1"
+       data-orientation="horizontal" data-variant="border">
+
+    <!-- The metadata tree -->
+    <div x-h-split-panel data-size="35%" data-min="260">
+      <div class="vbox size-full overflow-auto p-2">
+        <div x-show="state.loading" class="p-2"><div x-h-spinner></div></div>
+
+        <div x-show="!state.loading && !state.schemas.length" class="p-2">
+          <span x-h-text.muted x-text="T('database:explorer.noSchemas', 'No schemas in this datasource.')"></span>
+        </div>
+
+        <!--
+          Expansion belongs to the tree component: an item detects its own children and owns its
+          expanded state, so the handlers here only LOAD - they never toggle, which would fight it.
+          An unloaded schema/object renders one placeholder child so the row is expandable from the
+          start; without children it would look and behave like a leaf and never offer the chevron
+          whose first click is what triggers the read.
+        -->
+        <ul x-h-tree :aria-label="T('database:explorer.title', 'Explorer')" x-show="state.schemas.length">
+          <template x-for="schema in state.schemas" :key="schema.name">
+            <li x-h-tree-item @tree-item-click.self="state.loadSchema(schema)">
+              <div x-h-tree-row>
+                <svg x-h-lucide role="presentation" data-lucide="folder"></svg>
+                <span x-h-tree-label x-text="schema.name"></span>
+              </div>
+
+              <template x-if="!schema.loaded">
+                <ul x-h-tree.sub data-line="true">
+                  <li x-h-tree-item>
+                    <div x-h-tree-row>
+                      <span x-h-tree-label class="text-muted-foreground"
+                            x-text="T('database:explorer.loading', 'Loading...')"></span>
+                    </div>
+                  </li>
+                </ul>
+              </template>
+
+              <template x-if="schema.loaded && schema.groups.length">
+                <ul x-h-tree.sub data-line="true">
+                  <template x-for="group in schema.groups" :key="group.kind">
+                    <li x-h-tree-item>
+                      <div x-h-tree-row>
+                        <svg x-h-lucide role="presentation" data-lucide="folder"></svg>
+                        <span x-h-tree-label x-text="group.label"></span>
+                        <span x-h-tree-indicator x-text="group.objects.length"></span>
+                      </div>
+
+                        <ul x-h-tree.sub data-line="true">
+                          <template x-for="object in group.objects" :key="object.name">
+                            <li x-h-tree-item @tree-item-click.self="state.loadObject(object)">
+                              <div x-h-tree-row>
+                                <svg x-h-lucide role="presentation" :data-lucide="iconFor(object.kind)"></svg>
+                                <span x-h-tree-label x-text="object.name"></span>
+                                <div x-h-tree-actions.autohide>
+                                  <button x-h-tree-action x-show="canShowContents(object)"
+                                          :aria-label="T('database:explorer.showContents', 'Show contents')"
+                                          @click="state.showContents(object)">
+                                    <svg x-h-lucide role="presentation" data-lucide="table-2"></svg>
+                                  </button>
+                                  <button x-h-tree-action
+                                          :aria-label="T('database:explorer.showDdl', 'Show DDL')"
+                                          @click="state.showDefinition(object)">
+                                    <svg x-h-lucide role="presentation" data-lucide="file-code"></svg>
+                                  </button>
+                                  <button x-h-tree-action x-show="canShowContents(object)"
+                                          :aria-label="T('database:explorer.generateSelect', 'Generate SELECT')"
+                                          @click="selectInConsole(object)">
+                                    <svg x-h-lucide role="presentation" data-lucide="square-terminal"></svg>
+                                  </button>
+                                  <button x-h-tree-action
+                                          :aria-label="T('database:explorer.copyName', 'Copy name')"
+                                          @click="copyName(object)">
+                                    <svg x-h-lucide role="presentation" data-lucide="copy"></svg>
+                                  </button>
+                                </div>
+                              </div>
+
+                              <template x-if="!object.loaded">
+                                <ul x-h-tree.sub data-line="true">
+                                  <li x-h-tree-item>
+                                    <div x-h-tree-row>
+                                      <span x-h-tree-label class="text-muted-foreground"
+                                            x-text="T('database:explorer.loading', 'Loading...')"></span>
+                                    </div>
+                                  </li>
+                                </ul>
+                              </template>
+
+                              <template x-if="object.loaded && object.columns.length">
+                                <ul x-h-tree.sub data-line="true">
+                                  <template x-for="column in object.columns" :key="column.name">
+                                    <li x-h-tree-item>
+                                      <div x-h-tree-row>
+                                        <svg x-h-lucide role="presentation" data-lucide="columns-3"></svg>
+                                        <span x-h-tree-label x-text="column.name"></span>
+                                        <span x-h-text.muted class="text-xs" x-text="columnType(column)"></span>
+                                      </div>
+                                    </li>
+                                  </template>
+                                </ul>
+                              </template>
+                            </li>
+                          </template>
+                        </ul>
+                    </li>
+                  </template>
+                </ul>
+              </template>
+            </li>
+          </template>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Contents / DDL. Collapsed until something is selected. -->
+    <div x-h-split-panel data-size="65%" :data-hidden="!state.pane">
+      <div class="vbox size-full">
+        <div x-h-toolbar data-variant="transparent" data-size="sm" x-show="state.subject">
+          <span x-h-toolbar-title class="shrink-0" x-text="qualifiedName(state.subject)"></span>
+          <span x-h-badge data-variant="outline"
+                x-text="state.pane === 'ddl' ? T('database:explorer.ddl', 'DDL') : T('database:explorer.contents', 'Contents')"></span>
+          <div x-h-toolbar-spacer></div>
+          <button x-h-button data-variant="transparent" data-size="icon-sm" @click="state.closePane()"
+                  :aria-label="T('database:explorer.close', 'Close')">
+            <svg x-h-lucide role="presentation" data-lucide="x"></svg>
+          </button>
+        </div>
+
+        <div x-show="state.paneLoading" class="p-4"><div x-h-spinner></div></div>
+
+        <div x-show="state.paneError" x-h-alert data-variant="negative" role="alert" class="m-4">
+          <div x-h-alert-description x-text="state.paneError"></div>
+        </div>
+
+        <!-- Contents -->
+        <div x-show="state.pane === 'contents' && !state.paneLoading && !state.paneError"
+             class="vbox flex-1 overflow-hidden">
+          <div x-show="!state.rows.length" class="p-4">
+            <span x-h-text.muted x-text="T('database:explorer.noRows', 'No rows.')"></span>
+          </div>
+          <div x-show="state.rows.length" x-h-table-container.scroll class="flex-1" data-border="true">
+            <table x-h-table data-borders="rows">
+              <thead x-h-table-header>
+                <tr x-h-table-row>
+                  <template x-for="column in state.rowColumns" :key="column">
+                    <th x-h-table-head scope="col" x-text="column"></th>
+                  </template>
+                </tr>
+              </thead>
+              <tbody x-h-table-body>
+                <template x-for="(row, index) in state.rows" :key="index">
+                  <tr x-h-table-row data-hoverable="true">
+                    <template x-for="column in state.rowColumns" :key="column">
+                      <td x-h-table-cell x-text="cellText(row[column])"></td>
+                    </template>
+                  </tr>
+                </template>
+              </tbody>
+            </table>
+          </div>
+          <!-- The server caps a read and puts nothing in the payload to say so - so the page does. -->
+          <div class="p-2" x-show="state.rows.length">
+            <span x-h-text.muted class="text-xs"
+                  x-text="contentsCapped
+                    ? T('database:explorer.rowsCapped', 'Showing {{count}} rows - the server caps results, so there may be more.', { count: state.rows.length })
+                    : T('database:explorer.rowsShown', 'Showing {{count}} rows.', { count: state.rows.length })"></span>
+          </div>
+        </div>
+
+        <!-- DDL -->
+        <div x-show="state.pane === 'ddl' && !state.paneLoading && !state.paneError" class="flex-1 overflow-auto p-4">
+          <pre class="text-sm whitespace-pre-wrap" x-text="state.ddl"></pre>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- Copy feedback: quiet and self-clearing, no notification for a one-word action. -->
+  <div x-show="copied" x-cloak class="p-2">
+    <span x-h-text.muted class="text-xs"
+          x-text="T('database:explorer.copied', 'Copied {{name}}', { name: copied })"></span>
+  </div>
+
+</div>

--- a/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/views/_sql.html
+++ b/components/resources/resources-database/src/main/resources/META-INF/dirigible/database/views/_sql.html
@@ -1,0 +1,121 @@
+<!--
+  Copyright (c) 2010-2026 Eclipse Dirigible contributors
+  SPDX-License-Identifier: EPL-2.0
+
+  SQL console: a statement area over a results grid, with a messages strip between them. Deliberately
+  a textarea rather than an editor - see js/components/pages/sqlPage.js.
+-->
+<div id="database-sql-page" x-data="sqlPage" class="vbox size-full">
+
+  <div x-h-toolbar data-variant="transparent">
+    <span x-h-toolbar-title class="shrink-0" x-text="T('database:sql.title', 'SQL Console')"></span>
+    <div x-h-toolbar-spacer></div>
+
+    <div x-h-select data-filter="contains" class="w-64" x-show="$store.explorer.datasources.length">
+      <input x-h-select-input id="database-sql-datasource" x-model="$store.explorer.datasource"
+             @change="$store.explorer.onDatasourceChanged()"
+             :aria-label="T('database:explorer.datasource', 'Datasource')"
+             :placeholder="T('database:explorer.datasource', 'Datasource')" />
+      <div x-h-select-content>
+        <template x-for="name in $store.explorer.datasources" :key="name">
+          <div x-h-select-option="name" :data-value="name"></div>
+        </template>
+      </div>
+    </div>
+
+    <button id="database-sql-run" x-h-button data-variant="primary" data-size="sm" @click="run()"
+            :disabled="!datasource || !state.statement.trim() || state.running">
+      <span x-show="state.running" x-h-spinner data-size="sm"></span>
+      <svg x-h-lucide role="presentation" x-show="!state.running" data-lucide="play" class="size-4"></svg>
+      <span x-text="T('database:sql.run', 'Run')"></span>
+    </button>
+    <button x-h-button data-variant="outline" data-size="sm" @click="state.clear()"
+            :disabled="state.running">
+      <span x-text="T('database:sql.clear', 'Clear')"></span>
+    </button>
+  </div>
+
+  <div x-h-split class="bk-stretch flex-1" data-orientation="vertical" data-variant="border">
+
+    <!-- The statement -->
+    <div x-h-split-panel data-size="40%" data-min="120">
+      <div class="vbox size-full p-2">
+        <textarea id="database-sql-statement" class="size-full font-mono text-sm rounded-md border border-border bg-transparent p-2"
+                  spellcheck="false"
+                  :placeholder="T('database:sql.placeholder', 'SELECT * FROM ...   (Ctrl/Cmd+Enter to run)')"
+                  :aria-label="T('database:sql.title', 'SQL Console')"
+                  x-model="state.statement"
+                  @input.debounce.300ms="state.persist()"
+                  @keydown="onKeydown"></textarea>
+      </div>
+    </div>
+
+    <!-- Results + messages -->
+    <div x-h-split-panel data-size="60%">
+      <div class="vbox size-full">
+
+        <div class="px-2 py-1" x-show="state.error || message">
+          <div x-show="state.error" x-h-alert data-variant="negative" role="alert">
+            <div x-h-alert-description x-text="state.error"></div>
+          </div>
+          <span x-show="!state.error && message" id="database-sql-message" x-h-text.muted class="text-xs"
+                x-text="message"></span>
+        </div>
+
+        <div x-show="state.running" class="p-4"><div x-h-spinner></div></div>
+
+        <div x-show="!state.running && state.rows.length" x-h-table-container.scroll class="flex-1" data-border="true">
+          <table id="database-sql-results" x-h-table data-borders="rows">
+            <thead x-h-table-header>
+              <tr x-h-table-row>
+                <template x-for="column in state.columns" :key="column">
+                  <th x-h-table-head scope="col" x-text="column"></th>
+                </template>
+              </tr>
+            </thead>
+            <tbody x-h-table-body>
+              <template x-for="(row, index) in state.rows" :key="index">
+                <tr x-h-table-row data-hoverable="true">
+                  <template x-for="column in state.columns" :key="column">
+                    <td x-h-table-cell x-text="cellText(row[column])"></td>
+                  </template>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- The server caps a read and puts nothing in the payload to say so - so the page does. -->
+        <div class="p-2" x-show="!state.running && capped">
+          <span x-h-text.muted class="text-xs"
+                x-text="T('database:sql.capped', 'The server caps results, so there may be more rows than shown.')"></span>
+        </div>
+
+      </div>
+    </div>
+
+  </div>
+
+  <!-- The one confirmation. Everything that is not a read goes to /update, including DDL. -->
+  <div x-h-dialog-overlay :data-open="confirmOpen">
+    <div x-h-dialog>
+      <div x-h-dialog-header>
+        <h2 x-h-dialog-title x-text="T('database:sql.confirmTitle', 'Run a write statement?')"></h2>
+        <p x-h-dialog-description></p>
+        <button x-h-dialog-close @click="confirmOpen = false" :aria-label="T('database:explorer.close', 'Close')">
+          <svg x-h-lucide role="presentation" data-lucide="x"></svg>
+        </button>
+      </div>
+      <div x-h-dialog-content>
+        <p x-text="T('database:sql.confirmBody', 'This statement is not a read. It will be executed against {{datasource}}.', { datasource: datasource })"></p>
+      </div>
+      <div x-h-dialog-footer>
+        <button x-h-button data-variant="outline" @click="confirmOpen = false"
+                x-text="T('database:sql.cancel', 'Cancel')"></button>
+        <button id="database-sql-confirm" x-h-button data-variant="negative" @click="confirmRun()"
+                x-text="T('database:sql.run', 'Run')"></button>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/components/resources/resources-home/src/main/resources/META-INF/dirigible/home/js/home.js
+++ b/components/resources/resources-home/src/main/resources/META-INF/dirigible/home/js/home.js
@@ -18,13 +18,14 @@
 document.addEventListener('alpine:init', () => {
     // Fallbacks for shells that do not declare their own icon/description (older registrations).
     const ICONS = { applicationShell: 'layout-grid', personalShell: 'inbox', partnerShell: 'handshake', adminShell: 'shield',
-        monitoringShell: 'activity', shellIde: 'code' };
+        monitoringShell: 'activity', databaseShell: 'database', shellIde: 'code' };
     const DESCRIPTIONS = {
         applicationShell: 'All business applications in one workspace.',
         personalShell: 'Your tasks and your records - the personal workspace.',
         partnerShell: 'The portal for external partners.',
         adminShell: 'Every record as a plain table and form - one level above the database.',
         monitoringShell: 'Is the system healthy - and if not, what broke.',
+        databaseShell: 'Browse the schema, look at the data, run a SQL fix.',
         builderShell: 'Describe an application in plain language and publish it.',
         shellIde: 'The development workbench for building on the platform.',
     };
@@ -46,12 +47,14 @@ document.addEventListener('alpine:init', () => {
      *  - adminShell: an operator tool. Everything it shows is reachable through the applications
      *    themselves; it is the way in only when someone needs the plain, every-column view.
      *  - monitoringShell: an operations tool - opened when something looks wrong, not every morning.
+     *  - databaseShell: the same kind of tool one level lower - opened to look at the data behind a
+     *    problem, or to fix it. Support essentials only; the Workbench remains the deep tool.
      *  - builderShell: like the Workbench, a way of BUILDING applications rather than working in
      *    one, and gated to developers/administrators - so it belongs next to it, not above.
      *  - shellIde: a developer tool. Every developer is also an employee, so it must stay visible,
      *    but it should not compete with the two shells the rest of the company opens every morning.
      */
-    const SECONDARY = ['partnerShell', 'adminShell', 'monitoringShell', 'builderShell', 'shellIde'];
+    const SECONDARY = ['partnerShell', 'adminShell', 'monitoringShell', 'databaseShell', 'builderShell', 'shellIde'];
 
     Alpine.data('home', () => ({
         branding: { name: '', subtitle: '', logo: '' },

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/admin/admin-index.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/admin/admin-index.html.template
@@ -95,8 +95,8 @@
                             <span class="opacity-60 text-xs" x-show="p.fk" x-text="'-> ' + p.fk"></span>
                         </label>
                         <template x-if="p.lookup">
-                            <div x-h-select data-filter="contains" :data-disabled="p.readonly">
-                                <input x-h-select-input :id="'a_' + p.name" x-model="draft[p.name]" :placeholder="'Select ' + p.name + '...'" />
+                            <div x-h-select data-filter="contains">
+                                <input x-h-select-input :id="'a_' + p.name" x-model="draft[p.name]" :disabled="p.readonly" :placeholder="'Select ' + p.name + '...'" />
                                 <div x-h-select-content>
                                     <div x-h-select-search></div>
                                     <template x-for="opt in (options[p.name] || [])" :key="opt.value">

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -98,8 +98,8 @@
         <!-- Non-setting association: combobox + Add new (opens the target's own create page in an iframe
              dialog) + Refresh, all on one full-width row. -->
         <div class="hbox gap-1 items-center">
-          <div x-h-select data-filter="contains" class="grow" :data-disabled="isPreview">
-            <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="!!errors.${property.name}" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select ${label}...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '${label}') })" />
+          <div x-h-select data-filter="contains" class="grow">
+            <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="!!errors.${property.name}" :disabled="isPreview" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select ${label}...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '${label}') })" />
             <div x-h-select-content>
               <div x-h-select-search></div>
               <template x-for="opt in options${property.name}" :key="opt.value">
@@ -111,8 +111,8 @@
           <button type="button" x-h-button data-variant="transparent" class="shrink-0" x-show="!isPreview" aria-label="Refresh" @click="loadOptions()"><i x-h-lucide data-lucide="refresh-cw" class="size-4"></i></button>
         </div>
 #else
-        <div x-h-select data-filter="contains"#if($readonly) data-disabled="true"#else :data-disabled="isPreview"#end>
-          <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="!!errors.${property.name}" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select ${label}...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '${label}') })" />
+        <div x-h-select data-filter="contains">
+          <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="!!errors.${property.name}"#if($readonly) disabled#else :disabled="isPreview"#end :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select ${label}...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '${label}') })" />
           <div x-h-select-content>
             <div x-h-select-search></div>
             <template x-for="opt in options${property.name}" :key="opt.value">
@@ -557,7 +557,7 @@
               <label x-h-label x-text="T(col.tkey, col.label)"></label>
               <template x-if="!col.readonly && col.widget === 'DROPDOWN'">
                 <div>
-                  <div x-h-select data-filter="contains" :data-disabled="col.readonly">
+                  <div x-h-select data-filter="contains">
                     <input x-h-select-input x-model="draft[col.name]" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select...', { name: '' })" />
                     <div x-h-select-content>
                       <div x-h-select-search></div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
@@ -121,8 +121,8 @@
              dialog) and a Refresh button. -->
 #if($lookup)
         <div class="hbox gap-1 items-center">
-          <div x-h-select data-filter="contains" class="grow" :data-disabled="isPreview">
-            <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="!!errors.${property.name}" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select ${label}...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '${label}') })" />
+          <div x-h-select data-filter="contains" class="grow">
+            <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="!!errors.${property.name}" :disabled="isPreview" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select ${label}...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '${label}') })" />
             <div x-h-select-content>
               <div x-h-select-search></div>
               <template x-for="opt in options${property.name}" :key="opt.value">
@@ -134,9 +134,9 @@
           <button type="button" x-h-button data-variant="transparent" class="shrink-0" x-show="!isPreview" aria-label="Refresh" @click="loadOptions()"><i x-h-lucide data-lucide="refresh-cw" class="size-4"></i></button>
         </div>
 #else
-        <div x-h-select data-filter="contains"#if($readonly) data-disabled="true"#else :data-disabled="isPreview"#end>
+        <div x-h-select data-filter="contains">
           <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}"
-                 :aria-invalid="!!errors.${property.name}"
+                 :aria-invalid="!!errors.${property.name}"#if($readonly) disabled#else :disabled="isPreview"#end
                  :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select ${label}...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '${label}') })" />
           <div x-h-select-content>
             <div x-h-select-search></div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
@@ -89,57 +89,59 @@
         <!-- Hierarchy (intent `hierarchy:`): the records render as a Harmonia tree off
              ${hierarchyProperty} when no search/filter is active; searching falls back to the flat
              table so matches outside collapsed branches stay findable. Markup recursion is a fixed
-             6 levels deep (Alpine has no recursive template) - deeper nodes are not rendered. -->
+             6 levels deep - deeper nodes are not rendered. (Harmonia's x-h-template can render a
+             tree of any depth from data; folding these six copies into one is a worthwhile
+             follow-up, but it is a behaviour change and not part of the 2.9 API migration.) -->
         <div x-show="treeVisible" x-h-table-container.scroll class="flex-1" data-border="true">
           <ul x-h-tree class="p-2">
               <template x-for="n1 in childrenOf(null)" :key="n1.${primaryKeysString}">
-                <li x-h-tree-item.expanded="true">
-                  <button x-h-tree-button :data-indicator="isSelected(n1) ? 'information' : null" @click="selectRow(n1)">
-                    <i role="img" x-h-lucide :data-lucide="hasChildren(n1) ? 'folder' : 'file-text'"></i>
-                    <span x-text="nodeLabel(n1)"></span>
-                  </button>
+                <li x-h-tree-item="true" :aria-selected="isSelected(n1)" @tree-item-click.self="selectRow(n1)">
+                  <div x-h-tree-row>
+                    <svg x-h-lucide role="presentation" :data-lucide="hasChildren(n1) ? 'folder' : 'file-text'"></svg>
+                    <span x-h-tree-label x-text="nodeLabel(n1)"></span>
+                  </div>
                   <template x-if="hasChildren(n1)">
-                    <ul x-h-tree.sub data-border="true">
+                    <ul x-h-tree.sub data-line="true">
                       <template x-for="n2 in childrenOf(n1)" :key="n2.${primaryKeysString}">
-                <li x-h-tree-item.expanded="true">
-                  <button x-h-tree-button :data-indicator="isSelected(n2) ? 'information' : null" @click="selectRow(n2)">
-                    <i role="img" x-h-lucide :data-lucide="hasChildren(n2) ? 'folder' : 'file-text'"></i>
-                    <span x-text="nodeLabel(n2)"></span>
-                  </button>
+                <li x-h-tree-item="true" :aria-selected="isSelected(n2)" @tree-item-click.self="selectRow(n2)">
+                  <div x-h-tree-row>
+                    <svg x-h-lucide role="presentation" :data-lucide="hasChildren(n2) ? 'folder' : 'file-text'"></svg>
+                    <span x-h-tree-label x-text="nodeLabel(n2)"></span>
+                  </div>
                   <template x-if="hasChildren(n2)">
-                    <ul x-h-tree.sub data-border="true">
+                    <ul x-h-tree.sub data-line="true">
                       <template x-for="n3 in childrenOf(n2)" :key="n3.${primaryKeysString}">
-                <li x-h-tree-item.expanded="true">
-                  <button x-h-tree-button :data-indicator="isSelected(n3) ? 'information' : null" @click="selectRow(n3)">
-                    <i role="img" x-h-lucide :data-lucide="hasChildren(n3) ? 'folder' : 'file-text'"></i>
-                    <span x-text="nodeLabel(n3)"></span>
-                  </button>
+                <li x-h-tree-item="true" :aria-selected="isSelected(n3)" @tree-item-click.self="selectRow(n3)">
+                  <div x-h-tree-row>
+                    <svg x-h-lucide role="presentation" :data-lucide="hasChildren(n3) ? 'folder' : 'file-text'"></svg>
+                    <span x-h-tree-label x-text="nodeLabel(n3)"></span>
+                  </div>
                   <template x-if="hasChildren(n3)">
-                    <ul x-h-tree.sub data-border="true">
+                    <ul x-h-tree.sub data-line="true">
                       <template x-for="n4 in childrenOf(n3)" :key="n4.${primaryKeysString}">
-                <li x-h-tree-item.expanded="true">
-                  <button x-h-tree-button :data-indicator="isSelected(n4) ? 'information' : null" @click="selectRow(n4)">
-                    <i role="img" x-h-lucide :data-lucide="hasChildren(n4) ? 'folder' : 'file-text'"></i>
-                    <span x-text="nodeLabel(n4)"></span>
-                  </button>
+                <li x-h-tree-item="true" :aria-selected="isSelected(n4)" @tree-item-click.self="selectRow(n4)">
+                  <div x-h-tree-row>
+                    <svg x-h-lucide role="presentation" :data-lucide="hasChildren(n4) ? 'folder' : 'file-text'"></svg>
+                    <span x-h-tree-label x-text="nodeLabel(n4)"></span>
+                  </div>
                   <template x-if="hasChildren(n4)">
-                    <ul x-h-tree.sub data-border="true">
+                    <ul x-h-tree.sub data-line="true">
                       <template x-for="n5 in childrenOf(n4)" :key="n5.${primaryKeysString}">
-                <li x-h-tree-item.expanded="true">
-                  <button x-h-tree-button :data-indicator="isSelected(n5) ? 'information' : null" @click="selectRow(n5)">
-                    <i role="img" x-h-lucide :data-lucide="hasChildren(n5) ? 'folder' : 'file-text'"></i>
-                    <span x-text="nodeLabel(n5)"></span>
-                  </button>
+                <li x-h-tree-item="true" :aria-selected="isSelected(n5)" @tree-item-click.self="selectRow(n5)">
+                  <div x-h-tree-row>
+                    <svg x-h-lucide role="presentation" :data-lucide="hasChildren(n5) ? 'folder' : 'file-text'"></svg>
+                    <span x-h-tree-label x-text="nodeLabel(n5)"></span>
+                  </div>
                   <template x-if="hasChildren(n5)">
-                    <ul x-h-tree.sub data-border="true">
+                    <ul x-h-tree.sub data-line="true">
                       <template x-for="n6 in childrenOf(n5)" :key="n6.${primaryKeysString}">
-                <li x-h-tree-item.expanded="true">
-                  <button x-h-tree-button :data-indicator="isSelected(n6) ? 'information' : null" @click="selectRow(n6)">
-                    <i role="img" x-h-lucide :data-lucide="hasChildren(n6) ? 'folder' : 'file-text'"></i>
-                    <span x-text="nodeLabel(n6)"></span>
-                  </button>
+                <li x-h-tree-item="true" :aria-selected="isSelected(n6)" @tree-item-click.self="selectRow(n6)">
+                  <div x-h-tree-row>
+                    <svg x-h-lucide role="presentation" :data-lucide="hasChildren(n6) ? 'folder' : 'file-text'"></svg>
+                    <span x-h-tree-label x-text="nodeLabel(n6)"></span>
+                  </div>
                   <template x-if="hasChildren(n6)">
-                    <ul x-h-tree.sub data-border="true">
+                    <ul x-h-tree.sub data-line="true">
                       <!-- depth limit: 6 levels (see the page comment) -->
                     </ul>
                   </template>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/slots/slots-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/slots/slots-view.html.template
@@ -40,8 +40,11 @@
     <!--
       Harmonia 2.5+ - the slot picker renders only the day grid; the date-navigation toolbar is composed
       here from the x-h-slot-picker-* control directives (they must be descendants of x-h-slot-picker).
+      The `responsive` modifier (Harmonia 2.7) keeps the day columns stacking into one on a narrow
+      screen - since 2.7 that is opt-in rather than the default. No x-model is bound on purpose: a slot
+      is an action that routes to the create form, never a selection the picker should hold.
     -->
-    <div x-h-slot-picker="slotCfg" @slot-click="onSlotClick">
+    <div x-h-slot-picker.responsive="slotCfg" @slot-click="onSlotClick">
       <div x-h-toolbar data-variant="transparent">
         <div x-h-button-group>
           <button x-h-button data-variant="outline" data-size="icon" x-h-slot-picker-previous

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
         <bpmn-visualization.version>0.47.0</bpmn-visualization.version>
         <i18next.version>25.3.0</i18next.version>
         <alpinejs.version>3.15.11</alpinejs.version>
-        <harmonia.version>2.6.0</harmonia.version>
+        <harmonia.version>2.9.0</harmonia.version>
         <opensans.version>5.2.7</opensans.version>
         <lucide.version>1.8.0</lucide.version>
         <pinecone-router.version>7.5.2</pinecone-router.version>

--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/browser/HtmlElementType.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/browser/HtmlElementType.java
@@ -13,6 +13,7 @@ public enum HtmlElementType {
     PARAGRAPH("p"), //
     BUTTON("button"), //
     INPUT("input"), //
+    TEXTAREA("textarea"), //
     ANCHOR("a"), //
     HEADER1("h1"), //
     HEADER2("h2"), //

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DatabaseShellIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DatabaseShellIT.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.ui.tests;
+
+import org.eclipse.dirigible.tests.base.UserInterfaceIntegrationTest;
+import org.eclipse.dirigible.tests.framework.browser.HtmlAttribute;
+import org.eclipse.dirigible.tests.framework.browser.HtmlElementType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Smoke test for the Database shell. It asserts what only a real browser can: that the Harmonia +
+ * Alpine bootstrap completed and each page rendered content produced by its store.
+ * <p>
+ * This matters more than it looks - a single mistake in the markup (an Alpine binding on an
+ * {@code <i x-h-lucide>}, for instance) aborts Alpine's walk with no DOM or server-side symptom,
+ * and every binding below that node silently stays raw markup.
+ * <p>
+ * The page roots carry a stable id, so the assertions do not depend on what the instance happens to
+ * have deployed. The one thing that IS depended on is DefaultDB, which every instance has.
+ */
+public class DatabaseShellIT extends UserInterfaceIntegrationTest {
+
+    private static final String DATABASE_PATH = "/services/web/database/index.html";
+
+    /**
+     * A one-row query that needs no table and returns the same thing on every dialect the CI runs. A
+     * platform table would have been a stronger read, but the grid derives its columns from the first
+     * row, so a table that happens to be empty would assert nothing - and the column NAME is unusable
+     * either way, since an unquoted alias folds to upper case on H2 and to lower case on PostgreSQL.
+     * The literal is distinctive enough that finding it in the grid means it came from the database and
+     * not from the page.
+     */
+    private static final String SMOKE_QUERY = "SELECT 'dirigible-smoke' AS SMOKE";
+
+    @Test
+    void theExplorerReadsTheDefaultDatasource() {
+        ide.openPath(DATABASE_PATH);
+
+        // The shell chrome, rendered by Alpine from the shell component. Asserted on the sidebar
+        // entry's id: "Explorer" is also the page's toolbar title, so a bare label match is two
+        // elements, which the finder rejects.
+        browser.assertElementExistsByIdAndContainsText("database-nav-explorer", "Explorer");
+        // The datasource picker's options are rendered from /services/data/metadata, so the name
+        // being on the page at all means the store's first read resolved and its bindings evaluated.
+        // Asserted on the page root rather than on the input's value: the schema names below it
+        // differ between H2 and PostgreSQL, and the picker's displayed text is Harmonia's business.
+        browser.assertElementExistsByIdAndContainsText("database-explorer-page", "DefaultDB");
+    }
+
+    @Test
+    void everySectionIsReachable() {
+        ide.openPath(DATABASE_PATH);
+
+        openSection("explorer", "Explorer");
+        openSection("sql", "SQL Console");
+    }
+
+    /**
+     * The one end-to-end journey worth a browser: type a statement, run it, and see rows come back. It
+     * goes the whole way through the client's statement dispatch, the text/plain POST that the shared
+     * JSON fetch client cannot make, and the results grid's arbitrary-column rendering.
+     */
+    @Test
+    void theConsoleRunsAQueryAndRendersTheRows() {
+        ide.openPath(DATABASE_PATH);
+
+        browser.clickOnElementById("database-nav-sql");
+        // Not enterTextInElementById - that helper looks for an <input>, and the console is a
+        // <textarea> (a statement is multi-line by nature).
+        browser.enterTextInElementByAttributePattern(HtmlElementType.TEXTAREA, HtmlAttribute.ID, "database-sql-statement", SMOKE_QUERY);
+        browser.clickOnElementById("database-sql-run");
+
+        // The value in the grid proves the row travelled all the way from the database into a cell
+        // the page built from columns it did not know in advance; the message strip proves the shell
+        // counted the rows rather than only drawing a table.
+        browser.assertElementExistsByIdAndContainsText("database-sql-results", "dirigible-smoke");
+        browser.assertElementExistsByIdAndContainsText("database-sql-message", "Rows: 1");
+    }
+
+    /**
+     * Click a sidebar entry and assert its page rendered. The entry is addressed by its id, not its
+     * label, so a label that also appears in page content cannot satisfy the assertion by accident.
+     *
+     * @param section the sidebar entry / page name
+     * @param expectedText text the page renders regardless of what the instance holds
+     */
+    private void openSection(String section, String expectedText) {
+        browser.clickOnElementById("database-nav-" + section);
+        browser.assertElementExistsByIdAndContainsText("database-" + section + "-page", expectedText);
+    }
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DependsOnHarmoniaTestProject.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DependsOnHarmoniaTestProject.java
@@ -80,10 +80,15 @@ class DependsOnHarmoniaTestProject extends BaseTestProject {
         // watcher that re-filters the City options.
         browser.assertElementExistByAttributePatternAndText(HtmlElementType.SPAN, HtmlAttribute.ROLE, "combobox", "Bulgaria");
 
-        // City depends on Country: opening it now must offer only Bulgaria's cities.
+        // City depends on Country: opening it now must offer only Bulgaria's cities. The offered
+        // options are asserted on the option element itself, not on a <span>: since Harmonia 2.7 an
+        // option renders its label inside a text COLUMN (a span wrapping the label span, so a
+        // description can sit under it), so a bare "one span contains Sofia" is two matches - which
+        // the ExistsByTypeAndContainsText finder rejects. div[role="option"] is the stable anchor,
+        // and it is what the Country selection above already clicks.
         browser.clickOnElementByAttributePatternAndText(HtmlElementType.SPAN, HtmlAttribute.ROLE, "combobox", "Select City...");
-        browser.assertElementExistsByTypeAndContainsText(HtmlElementType.SPAN, "Sofia");
-        browser.assertElementExistsByTypeAndContainsText(HtmlElementType.SPAN, "Varna");
+        browser.assertElementExistByAttributePatternAndText(HtmlElementType.DIV, HtmlAttribute.ROLE, "option", "Sofia");
+        browser.assertElementExistByAttributePatternAndText(HtmlElementType.DIV, HtmlAttribute.ROLE, "option", "Varna");
         browser.assertElementDoesNotExistsByTypeAndContainsText(HtmlElementType.SPAN, "Milano");
     }
 }


### PR DESCRIPTION
> **Stacked on #6656** (the Harmonia 2.9.0 bump), because the Explorer's tree uses the 2.9 tree API — `x-h-tree-row` / `x-h-tree-label` / `tree-item-click` / `data-line`. Merge #6656 first; this PR is based on it, so its diff shows only the shell.

A standalone Harmonia shell at `/services/web/database/`, registered on `platform-shells` (`databaseShell`, order 38 — between Monitoring and the IDE) and gated to ADMINISTRATOR / OPERATOR / DEVELOPER. It answers "what is in the database, and can I fix this row?" without opening the IDE, the way the Monitoring shell answers "is the system healthy?".

**Two pages.** An **Explorer** — datasource picker, lazy schema → tables/views/procedures → columns tree, "show contents" grid, DDL view, plus row actions (show contents, DDL, generate SELECT into the console, copy name). And a **SQL Console** — statement area, results grid, messages strip, `Ctrl`/`Cmd`+`Enter`, statement persisted to localStorage.

**Zero new backend.** Every read and execute goes to an endpoint that already ships in `components/data`, all method-gated to the same three roles the shell is — so it never renders a page its user cannot use. Everything cross-cutting (theme, locale, branding, user, shell switcher) comes from the **shared** runtime at `/services/web/application-core/shell` by absolute URL; only the two pages and a thin shell controller are local. No webjar of its own.

## Scope

Support essentials. Import/export, anonymization, data transfer, schema processes, datasource CRUD, row-edit dialogs and Monaco stay out — the Workbench remains the deep tool, and the sidebar links to it. Full reasoning in `DATABASE_SHELL_PLAN.md`, added here.

## Server contracts inherited knowingly

`js/services/dbops.js` is the only place that knows about these:

- **Statement dispatch is a first-word sniff, not parsing** — `/execute` is just `/query` under another name, so the client decides: `select` → `/query`, `call` → `/procedure`, the `query:` / `update:` prefixes stripped and routed (that is how a NoSQL datasource is addressed), everything else → `/update`. Same rules as the IDE's `result.js`, so muscle memory carries over.
- **A procedure's payload is double-encoded** — a JSON array of JSON *strings* — and is parsed twice here, so callers see the row shape a query returns.
- **Reads are capped server-side with nothing in the payload to say so.** The grid labels its own count and flags a round hundred as probably truncated. It over-warns on a table that genuinely holds a round number of rows, which is the right way round: presenting a truncated read as the whole table is the failure that matters.

## Two client-side notes worth keeping

- **The shared fetch client cannot execute statements.** It sends JSON; these endpoints consume `text/plain` with the raw SQL as the body. `postSql()` is the deliberate exception and reproduces the client's `ApiError` contract so callers handle failures the same way either side of that line.
- **Names are encoded per path segment**, and a structure name additionally in Base64. Encoding a whole path turns `/` into `%2F` and 400s; splitting a qualified name on `.` (which the IDE's explorer does) breaks any schema or table whose name contains a dot.

## Write access

Allowed on purpose — a support tool that cannot fix data is a dashboard. Safety is the `.access` file plus the endpoints' own `@RolesAllowed` (and the URL gate in #6657), not hidden buttons. The console asks once before running anything that is not a read.

## Verification

`DatabaseShellIT` — 3 tests green. It covers the Alpine-bootstrap failure mode (which has no DOM or server-side symptom), both pages by stable id, and one real end-to-end journey: type a statement, run it, see the row in the grid. `ShellSwitcherIT` stays green with the new shell registered.

`HtmlElementType` gains `TEXTAREA`: `enterTextInElementById` only looks for an `<input>`, and a SQL console is multi-line by nature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)