### PR TITLE
fix(core-base): gate the data transfer websocket

### DIFF
--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfigurator.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfigurator.java
@@ -123,11 +123,23 @@ public class HttpSecurityURIConfigurator {
      * <p>
      * The gate therefore uses the WIDEST legitimate set: it must not reject anyone the endpoints allow,
      * and the finer per-endpoint {@code @RolesAllowed} checks stay in place to enforce the stricter
-     * half. This is defense in depth, not the authorization itself.
+     * half. For the REST endpoints this is defense in depth, not the authorization itself.
+     * <p>
+     * For the data transfer WEBSOCKET it is the only authorization there is.
+     * {@code DataTransferWebsocketHandler} declares no roles at all, and being registered outside
+     * {@code /websockets/ide/} it matched nothing but the {@code /websockets/**} catch-all - so any
+     * authenticated user, including one with no platform role, could drive a transfer between
+     * datasources. The role set is the trio rather than the stricter ADMINISTRATOR + OPERATOR that
+     * guards export / import, because the feature's only UI is the Transfer view of the IDE's Database
+     * perspective and it populates itself from {@code /services/data/definition/}, which the trio may
+     * read; narrowing it here would take the tool away from the developers it was built for. Whether a
+     * DEVELOPER should be able to copy data between datasources at all is a policy question, and a
+     * separate one from closing this hole.
      */
     private static final String[] DATA_MANAGEMENT_PATTERNS = { //
             "/services/data", //
-            "/services/data/**"};
+            "/services/data/**", //
+            "/websockets/data/transfer"};
 
     /** The roles allowed on the monitoring, native-app management and data management surfaces. */
     private static final String[] OPERATIONS_ROLES = { //

--- a/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfiguratorTest.java
+++ b/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfiguratorTest.java
@@ -82,6 +82,16 @@ class HttpSecurityURIConfiguratorTest {
     }
 
     /**
+     * The data transfer websocket has no {@code @RolesAllowed} of its own, so this gate is the whole of
+     * its authorization - a regression here does not degrade the defense, it removes it.
+     */
+    @Test
+    void theDataTransferWebsocketIsGated() {
+        assertEquals(OPERATIONS_ROLES, requiredRoles("/websockets/data/transfer"),
+                "the data transfer websocket has no method-level check - this gate is all there is");
+    }
+
+    /**
      * The gates are evaluated in order and the monitoring patterns are all sub-paths of the DEVELOPER
      * ones - reordering them silently reinstates the 403.
      */

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/EndpointAuthorizationIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/EndpointAuthorizationIT.java
@@ -113,6 +113,23 @@ class EndpointAuthorizationIT extends IntegrationTest {
     }
 
     /**
+     * Data transfer copies data between datasources, and its websocket handler declares no roles at all
+     * - so until it was gated at the URL layer, any authenticated user could drive one. The handshake
+     * is an ordinary HTTP request, so it passes the security filter chain and a role-less caller is
+     * rejected there, before any upgrade is attempted.
+     */
+    @Test
+    void data_transfer_is_not_drivable_without_a_platform_role() {
+        securityUtil.createUserInDefaultTenant(PLAIN_USER, PASSWORD);
+
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get("/websockets/data/transfer")
+                                                 .then()
+                                                 .statusCode(403),
+                PLAIN_USER, PASSWORD);
+    }
+
+    /**
      * A task's variables carry its business payload, so reading them is scoped to the caller's own
      * inbox exactly like acting on the task - a bare task id must not address them.
      */


### PR DESCRIPTION
> **Stacked on #6657.** Both touch the same gate list, so this is based on it to avoid a conflict. Merge #6657 first; GitHub will retarget this to `master` automatically.

`DataTransferWebsocketHandler` declares **no roles at all**, and being registered at `/websockets/data/transfer` — outside `/websockets/ide/` — it matched nothing in the URL configuration but the `/websockets/**` catch-all, which is merely `authenticated()`.

So any authenticated user, including one holding **no platform role whatsoever**, could open the socket and copy data between datasources. Every REST sibling in `components/data` (export, import, anonymize, schema processes, datasource CRUD) is restricted to ADMINISTRATOR + OPERATOR.

Unlike the `/services/data/**` gate this builds on, this one is **not defense in depth — it is the only authorization the feature has.**

## Why the trio and not ADMINISTRATOR + OPERATOR

Data transfer's only UI is the **Transfer view of the IDE's Database perspective**, and that view populates its datasource lists from `/services/data/definition/`, which the full trio may read. Narrowing the gate to match export/import would take a working tool away from the developers it was built for — a regression dressed as a fix.

Whether a DEVELOPER should be able to copy data between datasources *at all* is a real policy question, and worth asking separately. It is not what this change decides; this change closes the hole without moving anyone's access.

## Verification

**Red-first.** With the pattern removed, the new unit assertion fails with `no role gate matches /websockets/data/transfer` — the hole itself, stated by the test. 31 tests green with it in place.

`EndpointAuthorizationIT` gains the runtime proof that the filter chain actually rejects a role-less caller: the websocket handshake is an ordinary HTTP request, so it passes the security chain and is rejected there, before any upgrade is attempted. That test is untagged, so it runs on the PR gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)