### PR TITLE
Export a folder as a zip or a file as itself from the Repository view

### DIFF
--- a/components/core/core-repository/src/main/java/org/eclipse/dirigible/components/repository/endpoint/RepositoryEndpoint.java
+++ b/components/core/core-repository/src/main/java/org/eclipse/dirigible/components/repository/endpoint/RepositoryEndpoint.java
@@ -13,6 +13,9 @@ import static java.text.MessageFormat.format;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
 import org.eclipse.dirigible.components.repository.service.RepositoryService;
@@ -20,6 +23,7 @@ import org.eclipse.dirigible.repository.api.ICollection;
 import org.eclipse.dirigible.repository.api.IRepositoryStructure;
 import org.eclipse.dirigible.repository.api.IResource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -42,6 +46,9 @@ import jakarta.annotation.security.RolesAllowed;
 @RequestMapping(BaseEndpoint.PREFIX_ENDPOINT_CORE + "repository")
 @RolesAllowed({"ADMINISTRATOR", "OPERATOR"})
 public class RepositoryEndpoint {
+
+    /** The time stamp appended to the name of an exported archive. */
+    private static final DateTimeFormatter EXPORT_TIMESTAMP = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
 
     /** The repository service. */
     private final RepositoryService repositoryService;
@@ -82,6 +89,62 @@ public class RepositoryEndpoint {
         }
         httpHeaders.setContentType(MediaType.valueOf(resource.getContentType()));
         return new ResponseEntity(resource.getContent(), httpHeaders, HttpStatus.OK);
+    }
+
+    /**
+     * Exports the collection or the resource at the given path as a download. A collection is exported
+     * as a zip archive of its content, including all its subfolders; a resource is exported as the file
+     * itself.
+     *
+     * @param path the path
+     * @return the download
+     */
+    @GetMapping(value = "/{*path}", params = "export")
+    public ResponseEntity<byte[]> exportRepositoryResource(@PathVariable("path") String path) {
+
+        IResource resource = repositoryService.getResource(path);
+        if (resource.exists()) {
+            byte[] content = resource.getContent();
+            return download(content == null ? new byte[0] : content, resource.getName());
+        }
+        ICollection collection = repositoryService.getCollection(path);
+        if (!collection.exists()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, path);
+        }
+        return download(repositoryService.exportZip(path), zipFileName(collection));
+    }
+
+    /**
+     * Builds an attachment response. The content type is deliberately opaque - the response is a
+     * download and the file name carries the extension.
+     *
+     * @param content the content
+     * @param fileName the file name to download as
+     * @return the response
+     */
+    private static ResponseEntity<byte[]> download(byte[] content, String fileName) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+        httpHeaders.setContentDisposition(ContentDisposition.attachment()
+                                                            .filename(fileName, StandardCharsets.UTF_8)
+                                                            .build());
+        return new ResponseEntity<>(content, httpHeaders, HttpStatus.OK);
+    }
+
+    /**
+     * The archive name for a collection export - its own name, stamped with the export time.
+     *
+     * @param collection the collection
+     * @return the file name
+     */
+    private static String zipFileName(ICollection collection) {
+        String name = collection.getName();
+        if (name == null || name.isBlank()) {
+            name = "repository";
+        }
+        return name + "-" + LocalDateTime.now()
+                                         .format(EXPORT_TIMESTAMP)
+                + ".zip";
     }
 
     /**

--- a/components/core/core-repository/src/main/java/org/eclipse/dirigible/components/repository/service/RepositoryService.java
+++ b/components/core/core-repository/src/main/java/org/eclipse/dirigible/components/repository/service/RepositoryService.java
@@ -144,6 +144,18 @@ public class RepositoryService {
     }
 
     /**
+     * Exports the content under the given path as a zip archive. The last segment of the path is kept
+     * as the archive's root folder, so a collection unpacks as the folder itself with all its
+     * subfolders beneath it.
+     *
+     * @param path the path
+     * @return the zip content
+     */
+    public byte[] exportZip(String path) {
+        return getRepository().exportZip(path, true);
+    }
+
+    /**
      * Gets the uri.
      *
      * @param path the path

--- a/components/core/core-repository/src/test/java/org/eclipse/dirigible/components/repository/endpoint/RepositoryEndpointExportTest.java
+++ b/components/core/core-repository/src/test/java/org/eclipse/dirigible/components/repository/endpoint/RepositoryEndpointExportTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.repository.endpoint;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Tests the export representation of the repository endpoint: the {@code export} parameter selects
+ * a download without shadowing the plain listing.
+ */
+@WithMockUser(roles = {"ADMINISTRATOR"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ComponentScan(basePackages = {"org.eclipse.dirigible.components.*"})
+class RepositoryEndpointExportTest {
+
+    private static final String FOLDER = "/registry/public/export-test";
+
+    private static final byte[] CONTENT = "content".getBytes(StandardCharsets.UTF_8);
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void createFolderWithASubfolder() {
+        repository.createResource(FOLDER + "/top.txt", CONTENT, false, "text/plain", true);
+        repository.createResource(FOLDER + "/nested/deep.txt", CONTENT, false, "text/plain", true);
+    }
+
+    @Test
+    void exportsACollectionAsAnAttachedArchive() throws Exception {
+        mockMvc.perform(get("/services/core/repository" + FOLDER).param("export", "true"))
+               .andExpect(status().isOk())
+               .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, Matchers.containsString("attachment")))
+               .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, Matchers.containsString(".zip")));
+    }
+
+    @Test
+    void exportsAResourceAsAnAttachedFile() throws Exception {
+        mockMvc.perform(get("/services/core/repository" + FOLDER + "/top.txt").param("export", "true"))
+               .andExpect(status().isOk())
+               .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, Matchers.containsString("top.txt")))
+               .andExpect(content().bytes(CONTENT));
+    }
+
+    @Test
+    void answersNotFoundForAPathThatDoesNotExist() throws Exception {
+        mockMvc.perform(get("/services/core/repository" + FOLDER + "/there-is-no-such-file.txt").param("export", "true"))
+               .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void stillListsACollectionWithoutTheExportParameter() throws Exception {
+        mockMvc.perform(get("/services/core/repository" + FOLDER))
+               .andExpect(status().isOk())
+               .andExpect(content().string(Matchers.containsString("top.txt")));
+    }
+
+    /**
+     * The Class TestConfiguration.
+     */
+    @SpringBootApplication
+    static class TestConfiguration {
+    }
+}

--- a/components/ui/service-repository/src/main/resources/META-INF/dirigible/service-repository/repository.js
+++ b/components/ui/service-repository/src/main/resources/META-INF/dirigible/service-repository/repository.js
@@ -11,7 +11,7 @@
  */
 angular.module('RepositoryService', []).provider('RepositoryService', function RepositoryServiceProvider() {
     this.repositoryServiceUrl = '/services/core/repository';
-    this.$get = ['$http', function repositoryApiFactory($http) {
+    this.$get = ['$http', '$window', function repositoryApiFactory($http, $window) {
         const getMetadata = function (resourceUrl) {
             return $http.get(resourceUrl, { headers: { 'describe': 'application/json' } });
         };
@@ -44,6 +44,17 @@ angular.module('RepositoryService', []).provider('RepositoryService', function R
             return $http.post(url);
         }.bind(this);
 
+        /**
+         * Downloads a repository path. A collection is downloaded as a zip archive of its content,
+         * including all its subfolders; a resource is downloaded as the file itself.
+         * @param {string} resourcePath - Full resource path.
+         */
+        const exportPath = function (resourcePath) {
+            if (!resourcePath) throw Error('exportPath: resourcePath must be a path');
+            const url = UriBuilder().path(this.repositoryServiceUrl.split('/')).path(resourcePath.split('/')).build() + '?export=true';
+            $window.open(url, '_blank');
+        }.bind(this);
+
         const remove = function (resourcePath) {
             if (resourcePath !== undefined && !(typeof resourcePath === 'string'))
                 throw Error("remove: resourcePath must be a path");
@@ -57,6 +68,7 @@ angular.module('RepositoryService', []).provider('RepositoryService', function R
             load: loadRepository,
             createCollection: createCollection,
             createResource: createResource,
+            exportPath: exportPath,
             remove: remove,
         };
     }];

--- a/components/ui/view-repository/src/main/resources/META-INF/dirigible/view-repository/js/repository.js
+++ b/components/ui/view-repository/src/main/resources/META-INF/dirigible/view-repository/js/repository.js
@@ -259,6 +259,12 @@ repositoryView.controller('RepositoryViewController', ($scope, $document, client
                     });
                 }
                 items.push({
+                    id: 'export',
+                    label: 'Export',
+                    leftIconClass: 'sap-icon--download-from-cloud',
+                    separator: true,
+                });
+                items.push({
                     id: 'delete',
                     label: 'Delete',
                     shortcut: inMacOS ? '⌘⌫' : 'Del',
@@ -343,6 +349,8 @@ repositoryView.controller('RepositoryViewController', ($scope, $document, client
                             preformatted: false,
                         });
                     });
+                } else if (id === 'export') {
+                    RepositoryService.exportPath(selectedNode.data.path);
                 } else if (id === 'delete') {
                     openDeleteDialog(selectedNode);
                 }

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/RepositoryExportIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/RepositoryExportIT.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * End-to-end test for the export representation of {@code GET /services/core/repository}: a
+ * collection downloads as a zip of its content including its subfolders, a resource downloads as
+ * the file itself, and the plain listing representation stays untouched.
+ */
+class RepositoryExportIT extends IntegrationTest {
+
+    private static final String ENDPOINT = "/services/core/repository";
+
+    private static final String FOLDER = IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/repository-export-it";
+
+    private static final String FOLDER_NAME = "repository-export-it";
+
+    private static final String TOP_FILE = FOLDER + "/top.txt";
+
+    private static final String NESTED_FILE = FOLDER + "/nested/deep.txt";
+
+    private static final byte[] CONTENT = "exported content".getBytes(StandardCharsets.UTF_8);
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @BeforeEach
+    void createFolderWithASubfolder() {
+        repository.createResource(TOP_FILE, CONTENT, false, "text/plain", true);
+        repository.createResource(NESTED_FILE, CONTENT, false, "text/plain", true);
+    }
+
+    @AfterEach
+    void removeFolder() {
+        if (repository.hasCollection(FOLDER)) {
+            repository.removeCollection(FOLDER);
+        }
+    }
+
+    @Test
+    void exportsAFolderAsAZipOfItsContentWithItsSubfolders() {
+        restAssuredExecutor.execute(() -> {
+            byte[] zip = given().queryParam("export", "true")
+                                .when()
+                                .get(ENDPOINT + FOLDER)
+                                .then()
+                                .statusCode(200)
+                                .header(HttpHeaders.CONTENT_DISPOSITION, containsString("attachment"))
+                                .header(HttpHeaders.CONTENT_DISPOSITION, containsString(FOLDER_NAME + "-"))
+                                .header(HttpHeaders.CONTENT_DISPOSITION, containsString(".zip"))
+                                .extract()
+                                .asByteArray();
+
+            assertThat(entryNames(zip)).contains(FOLDER_NAME + "/top.txt", FOLDER_NAME + "/nested/deep.txt");
+        });
+    }
+
+    @Test
+    void exportsAFileAsTheFileItself() {
+        restAssuredExecutor.execute(() -> {
+            byte[] content = given().queryParam("export", "true")
+                                    .when()
+                                    .get(ENDPOINT + TOP_FILE)
+                                    .then()
+                                    .statusCode(200)
+                                    .header(HttpHeaders.CONTENT_DISPOSITION, containsString("attachment"))
+                                    .header(HttpHeaders.CONTENT_DISPOSITION, containsString("top.txt"))
+                                    .extract()
+                                    .asByteArray();
+
+            assertThat(content).isEqualTo(CONTENT);
+        });
+    }
+
+    @Test
+    void answersNotFoundForAPathThatDoesNotExist() {
+        restAssuredExecutor.execute(() -> given().queryParam("export", "true")
+                                                 .when()
+                                                 .get(ENDPOINT + FOLDER + "/there-is-no-such-file.txt")
+                                                 .then()
+                                                 .statusCode(404));
+    }
+
+    /** The export representation must not shadow the listing the Repository tree is built from. */
+    @Test
+    void stillListsACollectionWithoutTheExportParameter() {
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get(ENDPOINT + FOLDER)
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .contentType(containsString("application/json"))
+                                                 .body(containsString("top.txt")));
+    }
+
+    private static List<String> entryNames(byte[] zip) {
+        List<String> names = new ArrayList<>();
+        try (ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(zip))) {
+            for (ZipEntry entry = zipInputStream.getNextEntry(); entry != null; entry = zipInputStream.getNextEntry()) {
+                names.add(entry.getName());
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read the exported archive", e);
+        }
+        return names;
+    }
+}


### PR DESCRIPTION
## What

The Operations perspective's **Repository** tree could create and delete, but never get anything out of the repository: the only export was the whole-repository snapshot button in the toolbar. Every folder and every file in the tree now carries an **Export** action in its context menu.

- **Folder** downloads as a zip of its content, including all its subfolders (the folder itself is the archive's root, the same shape a project export has).
- **File** downloads as the file itself.

## How

The export is a second representation of the resource that already backs the tree, selected by an `export` request parameter on `GET /services/core/repository/{*path}`. `IRepository.exportZip(path, true)` does the packing, so no new zip machinery.

Two decisions worth a reviewer's attention:

- **Why not `/services/ide/transport`,** which already exports project zips: that prefix is gated on DEVELOPER alone in `HttpSecurityURIConfigurator`, while the Repository view is an ADMINISTRATOR / OPERATOR surface, so an OPERATOR would have been rejected at the URL layer before method security ran. On the core endpoint the export inherits exactly the policy that reading the bytes already has, which is the honest rule here: if you can read it, you can download it. No new exposure either, since the whole-repository snapshot export is already offered to the same roles.
- **Why a request parameter rather than an `/export/` sub-path:** a literal path segment would permanently shadow a repository collection named `export`. Spring prefers the parameter-qualified mapping deterministically, and a plain GET is untouched.

The attachment header is built with `ContentDisposition.attachment().filename(name, UTF_8)` so a name carrying a quote cannot inject a header and a non-ASCII name survives, and the time stamp uses a `DateTimeFormatter` rather than a shared `SimpleDateFormat` with a 12-hour pattern. Both are deliberate departures from the older `TransportEndpoint` code this follows in shape.

The frontend half is one function on the shared `RepositoryService`, so the view only knows the path: the backend decides zip versus raw.

## Scope

Repository view only. The Registry view's tree carries the same repository-absolute paths and already reads content through this endpoint, so the same action can be added there in a follow-up with no backend work. Export is single-node; `exportZip(List)` already supports several roots, so multi-select export is a natural follow-up.

## Verification

- `RepositoryEndpointExportTest` (MockMvc, surefire): both representations, 404, and routing.
- `RepositoryExportIT` (real HTTP, untagged so it runs in the PR smoke gate): folder export unpacks with its nested entries, file export is byte-identical, 404, and the plain listing still answers JSON.
- Both suites assert the plain listing the tree is built from is unchanged, since a mapping that shadowed it would break the view outright.
- Ran against a local instance: a 48-entry zip for a folder with subfolders, correct `Content-Disposition` on both, unchanged JSON listing, 404 for a missing path.
- `formatter:validate` clean, javadoc clean under `-P release`.