### PR TITLE
fix(engine-java): @Body binding and webhook ingest accept near-ISO date/time strings

### DIFF
--- a/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/utils/Json.java
+++ b/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/utils/Json.java
@@ -77,6 +77,20 @@ public final class Json {
                         return null;
                     }
                     String text = in.nextString();
+                    // The entity date/time types tolerate near-ISO input (an inbound webhook receives
+                    // whatever the external system emits — see LenientJavaTime); every other
+                    // java.time type keeps the strict parse-only contract.
+                    Object lenient = null;
+                    if (raw == java.time.Instant.class) {
+                        lenient = LenientJavaTime.parseInstant(text);
+                    } else if (raw == java.time.LocalDate.class) {
+                        lenient = LenientJavaTime.parseLocalDate(text);
+                    } else if (raw == java.time.LocalDateTime.class) {
+                        lenient = LenientJavaTime.parseLocalDateTime(text);
+                    }
+                    if (lenient != null) {
+                        return (T) lenient;
+                    }
                     try {
                         return (T) parse.invoke(null, text);
                     } catch (ReflectiveOperationException e) {

--- a/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/utils/LenientJavaTime.java
+++ b/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/utils/LenientJavaTime.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.sdk.utils;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Tolerant parsing for the {@code java.time} values that reach the platform as JSON strings.
+ * <p>
+ * The generated REST layer is a boundary with parties that cannot be re-taught to send strict
+ * ISO-8601: an {@code inbound:} webhook receives whatever shape the external system already emits,
+ * and a browser form may pass a user-typed value through verbatim when its own conversion could not
+ * parse it (WebKit's {@code new Date()} rejects the common {@code "2026-08-10 12:30"}). Rejecting
+ * such a value with a 400 turns an obvious intent into a dead end, so the binding layers accept the
+ * unambiguous near-ISO shapes too:
+ * <ul>
+ * <li>{@code "2026-08-10T12:30:00Z"} / {@code "…+03:00"} — strict ISO, as before;</li>
+ * <li>{@code "2026-08-10 12:30"} / {@code "2026-08-10T12:30[:ss[.n]]"} — a zoneless local
+ * date-time, interpreted at <b>UTC</b> (deterministic across server time zones);</li>
+ * <li>{@code "2026-08-10"} — a bare date, midnight UTC when an instant is required.</li>
+ * </ul>
+ * For a date-only target the date part is taken <b>as written</b> ({@code "2026-08-10T22:00:00Z"} →
+ * {@code 2026-08-10}), never shifted through a zone.
+ * <p>
+ * Each method returns {@code null} when the text matches none of these shapes, so a caller can fall
+ * back to its stricter default and keep its original diagnostics for genuinely malformed input.
+ */
+public final class LenientJavaTime {
+
+    private LenientJavaTime() {}
+
+    /**
+     * Parse an {@link Instant} from any accepted shape.
+     *
+     * @param text the raw string value
+     * @return the instant, or {@code null} when the text matches no accepted shape
+     */
+    public static Instant parseInstant(String text) {
+        String t = normalize(text);
+        if (t == null) {
+            return null;
+        }
+        try {
+            return Instant.parse(t);
+        } catch (DateTimeParseException e) {
+            // fall through
+        }
+        try {
+            return OffsetDateTime.parse(t)
+                                 .toInstant();
+        } catch (DateTimeParseException e) {
+            // fall through
+        }
+        try {
+            return LocalDateTime.parse(t)
+                                .toInstant(ZoneOffset.UTC);
+        } catch (DateTimeParseException e) {
+            // fall through
+        }
+        try {
+            return LocalDate.parse(t)
+                            .atStartOfDay(ZoneOffset.UTC)
+                            .toInstant();
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Parse a {@link LocalDate} from any accepted shape. A date-time string contributes its date part
+     * as written — no zone conversion is applied.
+     *
+     * @param text the raw string value
+     * @return the date, or {@code null} when the text matches no accepted shape
+     */
+    public static LocalDate parseLocalDate(String text) {
+        String t = normalize(text);
+        if (t == null) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(t);
+        } catch (DateTimeParseException e) {
+            // fall through
+        }
+        if (t.length() > 10) {
+            try {
+                return LocalDate.parse(t.substring(0, 10));
+            } catch (DateTimeParseException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Parse a {@link LocalDateTime} from any accepted shape. An offset/zoned string contributes its
+     * local fields as written; a bare date becomes midnight.
+     *
+     * @param text the raw string value
+     * @return the date-time, or {@code null} when the text matches no accepted shape
+     */
+    public static LocalDateTime parseLocalDateTime(String text) {
+        String t = normalize(text);
+        if (t == null) {
+            return null;
+        }
+        try {
+            return LocalDateTime.parse(t);
+        } catch (DateTimeParseException e) {
+            // fall through
+        }
+        try {
+            return OffsetDateTime.parse(t)
+                                 .toLocalDateTime();
+        } catch (DateTimeParseException e) {
+            // fall through
+        }
+        try {
+            return LocalDate.parse(t)
+                            .atStartOfDay();
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Trim and turn the single space separating date and time into the ISO {@code 'T'}
+     * ({@code "2026-08-10 12:30"} → {@code "2026-08-10T12:30"}); blank input becomes {@code null}.
+     */
+    private static String normalize(String text) {
+        if (text == null) {
+            return null;
+        }
+        String t = text.trim();
+        if (t.isEmpty()) {
+            return null;
+        }
+        if (t.length() > 10 && t.charAt(10) == ' ') {
+            t = t.substring(0, 10) + 'T' + t.substring(11);
+        }
+        return t;
+    }
+}

--- a/components/api/api-modules-java/src/test/java/org/eclipse/dirigible/sdk/utils/JsonTest.java
+++ b/components/api/api-modules-java/src/test/java/org/eclipse/dirigible/sdk/utils/JsonTest.java
@@ -47,6 +47,21 @@ class JsonTest {
         assertEquals(holder.name, back.name);
     }
 
+    /**
+     * An {@code inbound:} webhook parses whatever shape the external system emits — a near-ISO
+     * date-time ("2026-08-10 12:30") must bind instead of failing the whole ingest, and a full ISO
+     * instant aimed at a date-only field contributes its date part as written (see LenientJavaTime).
+     */
+    @Test
+    void parses_near_iso_date_time_strings_an_inbound_webhook_receives() {
+        Holder back = Json.parse(
+                "{\"instant\":\"2026-08-10 12:30\",\"date\":\"2026-08-10T00:00:00.000Z\"," + "\"dateTime\":\"2026-08-10 12:30\"}",
+                Holder.class);
+        assertEquals(Instant.parse("2026-08-10T12:30:00Z"), back.instant);
+        assertEquals(LocalDate.of(2026, 8, 10), back.date);
+        assertEquals(LocalDateTime.of(2026, 8, 10, 12, 30), back.dateTime);
+    }
+
     static class Holder {
         public LocalDate date;
         public LocalDateTime dateTime;

--- a/components/api/api-modules-java/src/test/java/org/eclipse/dirigible/sdk/utils/LenientJavaTimeTest.java
+++ b/components/api/api-modules-java/src/test/java/org/eclipse/dirigible/sdk/utils/LenientJavaTimeTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.sdk.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+class LenientJavaTimeTest {
+
+    /**
+     * The reported shape: a user typed "2026-08-10 12:30" into a browser form (WebKit's new Date()
+     * rejects the space separator, so the client passed it through verbatim) and the generated
+     * controller answered 400. A zoneless local date-time reads as UTC — deterministic across server
+     * time zones.
+     */
+    @Test
+    void instant_accepts_space_separated_local_date_time_as_utc() {
+        assertEquals(Instant.parse("2026-08-10T12:30:00Z"), LenientJavaTime.parseInstant("2026-08-10 12:30"));
+        assertEquals(Instant.parse("2026-08-10T12:30:45Z"), LenientJavaTime.parseInstant("2026-08-10 12:30:45"));
+    }
+
+    @Test
+    void instant_accepts_strict_iso_and_offset_forms() {
+        assertEquals(Instant.parse("2026-08-10T12:30:00Z"), LenientJavaTime.parseInstant("2026-08-10T12:30:00Z"));
+        assertEquals(Instant.parse("2026-08-10T09:30:00Z"), LenientJavaTime.parseInstant("2026-08-10T12:30:00+03:00"));
+        assertEquals(Instant.parse("2026-08-10T09:30:00Z"), LenientJavaTime.parseInstant("2026-08-10 12:30:00+03:00"));
+    }
+
+    @Test
+    void instant_accepts_zoneless_t_form_and_bare_date() {
+        assertEquals(Instant.parse("2026-08-10T12:30:00Z"), LenientJavaTime.parseInstant("2026-08-10T12:30"));
+        assertEquals(Instant.parse("2026-08-10T00:00:00Z"), LenientJavaTime.parseInstant("2026-08-10"));
+    }
+
+    /**
+     * The generated UI converts a picked date to a full ISO instant even when the target column is
+     * date-only; the date part is taken AS WRITTEN, never shifted through a zone.
+     */
+    @Test
+    void local_date_accepts_date_time_strings_taking_the_date_part_as_written() {
+        assertEquals(LocalDate.of(2026, 8, 10), LenientJavaTime.parseLocalDate("2026-08-10"));
+        assertEquals(LocalDate.of(2026, 8, 10), LenientJavaTime.parseLocalDate("2026-08-10T00:00:00.000Z"));
+        assertEquals(LocalDate.of(2026, 8, 10), LenientJavaTime.parseLocalDate("2026-08-10 22:30"));
+        assertEquals(LocalDate.of(2026, 8, 10), LenientJavaTime.parseLocalDate("2026-08-10T22:30:00+03:00"));
+    }
+
+    @Test
+    void local_date_time_accepts_space_offset_and_bare_date_forms() {
+        assertEquals(LocalDateTime.of(2026, 8, 10, 12, 30), LenientJavaTime.parseLocalDateTime("2026-08-10 12:30"));
+        assertEquals(LocalDateTime.of(2026, 8, 10, 12, 30), LenientJavaTime.parseLocalDateTime("2026-08-10T12:30"));
+        // an offset form contributes its local fields as written
+        assertEquals(LocalDateTime.of(2026, 8, 10, 12, 30), LenientJavaTime.parseLocalDateTime("2026-08-10T12:30:00+03:00"));
+        assertEquals(LocalDateTime.of(2026, 8, 10, 0, 0), LenientJavaTime.parseLocalDateTime("2026-08-10"));
+    }
+
+    /** Unrecognized input yields null so callers keep their stricter default and its diagnostics. */
+    @Test
+    void unrecognized_shapes_yield_null() {
+        assertNull(LenientJavaTime.parseInstant("not a date"));
+        assertNull(LenientJavaTime.parseInstant("10/08/2026 12:30"));
+        assertNull(LenientJavaTime.parseInstant(""));
+        assertNull(LenientJavaTime.parseInstant(null));
+        assertNull(LenientJavaTime.parseLocalDate("12:30"));
+        assertNull(LenientJavaTime.parseLocalDateTime("garbage"));
+    }
+}

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/controller/ControllerInvoker.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/controller/ControllerInvoker.java
@@ -58,9 +58,15 @@ public class ControllerInvoker {
         // java.time.* handlers by default, so a raw Spring mapper rejects LocalDate / Instant fields
         // with REQUIRE_HANDLERS_FOR_JAVA8_TIMES; this ensures generated entities with audit / date
         // fields bind cleanly from @Body JSON.
+        //
+        // On top of jsr310, @Body binding accepts near-ISO date/time strings ("2026-08-10 12:30",
+        // zoneless T-forms, bare dates) — an inbound webhook receives whatever the external system
+        // emits, and a browser can pass a user-typed value through verbatim. Registered AFTER the
+        // discovered modules so its per-type deserializers win; see LenientJavaTimeModule.
         this.objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new)
                                                 .copy()
-                                                .findAndRegisterModules();
+                                                .findAndRegisterModules()
+                                                .registerModule(new LenientJavaTimeModule());
     }
 
     /** Test-friendly constructor — bypasses Spring's ObjectProvider. */

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/controller/LenientJavaTimeModule.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/controller/LenientJavaTimeModule.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.java.controller;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.eclipse.dirigible.sdk.utils.LenientJavaTime;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+
+/**
+ * Jackson module making {@code @Body} binding tolerant of near-ISO date/time strings for the three
+ * {@code java.time} types the generated entities use ({@code timestamp} → {@link Instant},
+ * {@code date} → {@link LocalDate}, plus {@link LocalDateTime} for hand-written controllers).
+ * <p>
+ * A generated controller is a boundary with parties that cannot be re-taught strict ISO-8601: an
+ * {@code inbound:} webhook forwards whatever the external system emits, and a browser form can pass
+ * a user-typed {@code "2026-08-10 12:30"} through verbatim (WebKit's {@code new Date()} rejects the
+ * space separator, so the client-side ISO conversion is skipped). The accepted shapes and their
+ * semantics (zoneless local date-time reads as UTC; a date-only target takes the date part as
+ * written) are defined by {@link LenientJavaTime}.
+ * <p>
+ * Only STRING values take the lenient path — and it is attempted first, since it also covers strict
+ * ISO. Everything else (epoch numbers, {@code [y,m,d]} arrays) and any string no lenient shape
+ * matches falls through to the standard jsr310 deserializer, preserving its behavior and its
+ * diagnostics for genuinely malformed input.
+ */
+class LenientJavaTimeModule extends SimpleModule {
+
+    private static final long serialVersionUID = 1L;
+
+    LenientJavaTimeModule() {
+        super("dirigible-lenient-java-time");
+        addDeserializer(Instant.class, new JsonDeserializer<Instant>() {
+            @Override
+            public Instant deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+                if (p.hasToken(JsonToken.VALUE_STRING)) {
+                    Instant lenient = LenientJavaTime.parseInstant(p.getText());
+                    if (lenient != null) {
+                        return lenient;
+                    }
+                }
+                return InstantDeserializer.INSTANT.deserialize(p, ctxt);
+            }
+        });
+        addDeserializer(LocalDate.class, new JsonDeserializer<LocalDate>() {
+            @Override
+            public LocalDate deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+                if (p.hasToken(JsonToken.VALUE_STRING)) {
+                    LocalDate lenient = LenientJavaTime.parseLocalDate(p.getText());
+                    if (lenient != null) {
+                        return lenient;
+                    }
+                }
+                return LocalDateDeserializer.INSTANCE.deserialize(p, ctxt);
+            }
+        });
+        addDeserializer(LocalDateTime.class, new JsonDeserializer<LocalDateTime>() {
+            @Override
+            public LocalDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+                if (p.hasToken(JsonToken.VALUE_STRING)) {
+                    LocalDateTime lenient = LenientJavaTime.parseLocalDateTime(p.getText());
+                    if (lenient != null) {
+                        return lenient;
+                    }
+                }
+                return LocalDateTimeDeserializer.INSTANCE.deserialize(p, ctxt);
+            }
+        });
+    }
+}

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/controller/LenientJavaTimeModuleTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/controller/LenientJavaTimeModuleTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.java.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+/**
+ * The mapper is assembled the same way {@link ControllerInvoker} builds its body binder:
+ * ServiceLoader-discovered modules (jsr310) plus {@link LenientJavaTimeModule} on top.
+ */
+class LenientJavaTimeModuleTest {
+
+    private final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules()
+                                                          .registerModule(new LenientJavaTimeModule());
+
+    /** The reported failure: a user-typed "2026-08-10 12:30" reaching an Instant field verbatim. */
+    @Test
+    void space_separated_date_time_binds_into_an_instant_field() throws Exception {
+        Fine fine = mapper.readValue("{\"ViolationAt\":\"2026-08-10 12:30\"}", Fine.class);
+        assertEquals(Instant.parse("2026-08-10T12:30:00Z"), fine.ViolationAt);
+    }
+
+    @Test
+    void strict_iso_and_zoneless_forms_bind_into_an_instant_field() throws Exception {
+        assertEquals(Instant.parse("2026-08-10T09:30:00Z"),
+                mapper.readValue("{\"ViolationAt\":\"2026-08-10T12:30:00+03:00\"}", Fine.class).ViolationAt);
+        assertEquals(Instant.parse("2026-08-10T12:30:00Z"),
+                mapper.readValue("{\"ViolationAt\":\"2026-08-10T12:30\"}", Fine.class).ViolationAt);
+        assertEquals(Instant.parse("2026-08-10T00:00:00Z"), mapper.readValue("{\"ViolationAt\":\"2026-08-10\"}", Fine.class).ViolationAt);
+    }
+
+    /**
+     * The generated UI turns a picked date into a full ISO instant even when the target column is
+     * date-only — the date part binds as written.
+     */
+    @Test
+    void full_iso_instant_binds_into_a_local_date_field() throws Exception {
+        Fine fine = mapper.readValue("{\"DeclaredAt\":\"2026-08-10T00:00:00.000Z\"}", Fine.class);
+        assertEquals(LocalDate.of(2026, 8, 10), fine.DeclaredAt);
+    }
+
+    @Test
+    void space_separated_date_time_binds_into_a_local_date_time_field() throws Exception {
+        Fine fine = mapper.readValue("{\"At\":\"2026-08-10 12:30\"}", Fine.class);
+        assertEquals(LocalDateTime.of(2026, 8, 10, 12, 30), fine.At);
+    }
+
+    /** Non-string shapes keep the standard jsr310 behavior (epoch seconds for Instant). */
+    @Test
+    void epoch_number_still_binds_through_the_default_deserializer() throws Exception {
+        Fine fine = mapper.readValue("{\"ViolationAt\":1786712345}", Fine.class);
+        assertEquals(Instant.ofEpochSecond(1786712345L), fine.ViolationAt);
+    }
+
+    /** Garbage still fails with the standard Jackson diagnostics — leniency is not silence. */
+    @Test
+    void malformed_string_still_fails_with_jackson_diagnostics() {
+        assertThrows(InvalidFormatException.class, () -> mapper.readValue("{\"ViolationAt\":\"10/08/2026 12:30\"}", Fine.class));
+    }
+
+    static class Fine {
+        public Instant ViolationAt;
+        public LocalDate DeclaredAt;
+        public LocalDateTime At;
+    }
+}

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/format.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/format.js
@@ -64,6 +64,10 @@
 
   const pad = (n) => String(n).padStart(2, '0');
 
+  // "2026-08-10 12:30" -> "2026-08-10T12:30": the single space separating date and time becomes the
+  // ISO 'T', so both new Date() (WebKit rejects the space form) and 'T'-splitting consumers accept it.
+  const isoT = (s) => (s.length > 10 && s[10] === ' ' ? s.slice(0, 10) + 'T' + s.slice(11) : s);
+
   const firstOf = (p, chars) => {
     for (const c of chars) {
       if (p.indexOf(c) >= 0) return c;
@@ -209,7 +213,10 @@
         if (isNaN(d.getTime())) return '';
         y = d.getFullYear(); mo = d.getMonth() + 1; da = d.getDate(); h = d.getHours(); mi = d.getMinutes();
       } else {
-        const s = String(value);
+        // A backend/user string may separate date and time with a space ("2026-08-10 12:30:00");
+        // normalize to the ISO 'T' so the slice below yields a value the datetime input (and the
+        // picker's 'T'-splitting seed logic) accepts.
+        const s = isoT(String(value));
         switch (w) {
           case 'DATETIME-LOCAL': return s.slice(0, 16);
           case 'TIME': return s.slice(0, 5);
@@ -237,7 +244,9 @@
       if (value === null || value === undefined || value === '') return null;
       const w = String(widget || 'DATE').toUpperCase();
       if (w === 'TIME' || w === 'MONTH' || w === 'WEEK') return value;
-      const d = new Date(value);
+      // Normalize a space-separated date-time before parsing: WebKit's new Date() rejects
+      // "2026-08-10 12:30" (a shape a user can type), which would pass the raw string through.
+      const d = new Date(typeof value === 'string' ? isoT(value) : value);
       return isNaN(d.getTime()) ? value : d.toISOString();
     },
   };

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -557,10 +557,7 @@ document.addEventListener('alpine:init', () => {
       }
 #foreach($property in $properties)
 #if($property.isDateType && $property.aggregate != "true")
-      if (payload.${property.name} != null) {
-        const _d${property.name} = new Date(payload.${property.name});
-        if (!isNaN(_d${property.name}.getTime())) payload.${property.name} = _d${property.name}.toISOString();
-      }
+      payload.${property.name} = window.HarmoniaFormat.toPayload(payload.${property.name}, '${property.widgetType}');
 #end
 #end
       return payload;
@@ -1043,7 +1040,7 @@ document.addEventListener('alpine:init', () => {
       for (const col of this.editColumns) {
         let v = this.draft[col.name];
         if (v === '') v = null;
-        if (col.date && v != null) { const d = new Date(v); if (!isNaN(d.getTime())) v = d.toISOString(); }
+        if (col.date && v != null) v = window.HarmoniaFormat.toPayload(v, col.widget || 'DATETIME-LOCAL');
         payload[col.name] = v;
       }
       return payload;

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
@@ -551,9 +551,11 @@ document.addEventListener('alpine:init', () => {
     //     as ProcessId null on create, so a process trigger's `ProcessId != null` guard fires (an
     //     empty string would trip it and the process would never start); on edit a populated value
     //     round-trips unchanged.
-    //  2. Date/time widgets -> the backend java.time format: an HTML date/datetime value (local, no
-    //     zone) becomes a full ISO instant (…Z) so an Instant/Timestamp binds; a bare TIME ("16:04",
-    //     not a valid Date) passes through so a LocalTime still parses.
+    //  2. Date/time widgets -> the backend java.time format via HarmoniaFormat.toPayload: an HTML
+    //     date/datetime value (local, no zone) becomes a full ISO instant (…Z) so an Instant/Timestamp
+    //     binds — including a space-separated "2026-08-10 12:30" (normalized before parsing; WebKit's
+    //     new Date() rejects the space form); a bare TIME ("16:04", not a valid Date) passes through
+    //     so a LocalTime still parses.
     toPayload() {
       const payload = { ...this.form };
       for (const _k of Object.keys(payload)) {
@@ -561,10 +563,7 @@ document.addEventListener('alpine:init', () => {
       }
 #foreach($property in $properties)
 #if($property.isDateType)
-      if (payload.${property.name} != null) {
-        const _d${property.name} = new Date(payload.${property.name});
-        if (!isNaN(_d${property.name}.getTime())) payload.${property.name} = _d${property.name}.toISOString();
-      }
+      payload.${property.name} = window.HarmoniaFormat.toPayload(payload.${property.name}, '${property.widgetType}');
 #end
 #end
       return payload;

--- a/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/form.js.template
+++ b/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/form.js.template
@@ -252,8 +252,11 @@ document.addEventListener('alpine:init', () => {
     },
 
     // An HTML datetime-local value ("YYYY-MM-DDTHH:mm", local, no zone) -> a full ISO instant (…Z).
+    // A space-separated "YYYY-MM-DD HH:mm" (user-typed) is normalized first — WebKit's new Date()
+    // rejects the space form, which would pass the raw string through to the backend.
     toInstant(value) {
-      const d = new Date(String(value));
+      const s = String(value);
+      const d = new Date(s.length > 10 && s[10] === ' ' ? s.slice(0, 10) + 'T' + s.slice(11) : s);
       return isNaN(d.getTime()) ? String(value) : d.toISOString();
     },
 


### PR DESCRIPTION
Fixes #6667.

A generated controller is a boundary with parties that cannot be re-taught strict ISO-8601: an
`inbound:` webhook receives whatever shape the external system emits, and a browser form can pass a
user-typed value through verbatim. Today `{"ViolationAt":"2026-08-10 12:30"}` answers
**400 Failed to parse request body as `<Entity>`** — an unambiguous value turned into a dead end
(reported against a builder-generated `traffic-fines` app, `Fine.violationAt`).

Two defects lined up: the typed-body binders accept only strict ISO, and every generated client-side
conversion silently forwards a string its `new Date()` could not parse — which Chrome always can for
the space form and **WebKit never can**, so the raw string reaches the server on Safari.

## Server

New `org.eclipse.dirigible.sdk.utils.LenientJavaTime` (api-modules-java, which engine-java already
depends on) parses the three `java.time` types the generated entities use:

- strict ISO and offset forms — unchanged;
- zoneless local date-times, `T` **or space** separated (`2026-08-10 12:30`), read at **UTC** so the
  result does not depend on the server time zone;
- bare dates (midnight UTC when an `Instant` is required).

For a **date-only** target the date part is taken **as written**, never shifted through a zone — the
generated UI sends a full ISO instant even for a picked date, and that must bind to `2026-08-10` on
any server. Each method returns `null` on no match, so callers fall back to their strict default and
keep its diagnostics: **leniency is not silence.**

Wired into both typed-body binders:

- **`ControllerInvoker`'s mapper** via `LenientJavaTimeModule`, registered after
  `findAndRegisterModules()`. Only `VALUE_STRING` takes the lenient path (attempted first, since it
  also covers strict ISO); epoch numbers, `[y,m,d]` arrays and unmatched strings delegate to the
  stock jsr310 deserializers, preserving their behavior and their `InvalidFormatException`.
- **`sdk.utils.Json`'s Gson `JAVA_TIME` adapter** (webhook ingest — `Webhook.java.template` calls
  `Json.parse`), lenient for those three types, reflective strict `parse` fallback for them and
  unchanged for every other `java.time` type.

## Client

Closes the WebKit hole at its source rather than relying on the server's tolerance:

- `HarmoniaFormat` (shared shell `format.js`) normalizes the date/time separator to `'T'` before
  `new Date()` in `toPayload`, and before slicing in `toDateInput` — a space-shaped backend value
  also broke the datetime picker's `'T'`-splitting seed logic.
- The manage/document form templates route their per-property conversion through
  `HarmoniaFormat.toPayload(value, widgetType)` instead of an inline `new Date()`, deduping the
  logic; `TIME`/`MONTH`/`WEEK` keep passing through unchanged, so a `"16:04"` still binds as
  `LocalTime` and a `YYYY-MM` month-period column is not turned into an instant.
- The BPM task form's `toInstant()` normalizes likewise.

## Verification

- New unit tests: `LenientJavaTimeTest` (6), `LenientJavaTimeModuleTest` (6, end-to-end through a
  mapper assembled exactly as `ControllerInvoker` builds it), plus a `JsonTest` case for the webhook
  path. Every acceptance criterion in the issue is a named test, including the two negative ones —
  an epoch number still binds through the default deserializer, and `"10/08/2026 12:30"` still fails
  with the standard Jackson `InvalidFormatException`.
- `mvn -P unit-tests` green on both changed modules (16 + 82 tests); repo-wide
  `formatter:validate` green; `-P release` javadoc clean on both modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
