### PR TITLE
fix(database-sql): BIT and NUMERIC unify with the BOOLEAN/DECIMAL they alias

### DIFF
--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/DataTypeUtils.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/DataTypeUtils.java
@@ -288,8 +288,13 @@ public class DataTypeUtils {
         UNIFIED_STRING_FROM_DATABASE_TYPE.put(DOUBLE_PRECISION, DOUBLE);
         UNIFIED_STRING_FROM_DATABASE_TYPE.put(FLOAT4, REAL);
         UNIFIED_STRING_FROM_DATABASE_TYPE.put(FLOAT8, DOUBLE);
-        // booleans
+        // booleans - PostgreSQL JDBC reports a boolean column as java.sql.Types.BIT, so a
+        // BOOLEAN model column must unify with BIT or every alter over it fails as incompatible
         UNIFIED_STRING_FROM_DATABASE_TYPE.put(BOOL, BOOLEAN);
+        UNIFIED_STRING_FROM_DATABASE_TYPE.put(BIT, BOOLEAN);
+        // decimals - DECIMAL is an alias of NUMERIC in PostgreSQL (and interchangeable per the SQL
+        // standard), so a DECIMAL model column comes back from the metadata as NUMERIC
+        UNIFIED_STRING_FROM_DATABASE_TYPE.put(NUMERIC, DECIMAL);
         // clobs
         UNIFIED_STRING_FROM_DATABASE_TYPE.put(CHARACTER_LARGE_OBJECT, CLOB);
         // blobs

--- a/modules/database/database-sql/src/test/java/org/eclipse/dirigible/database/sql/DataTypeUtilsTest.java
+++ b/modules/database/database-sql/src/test/java/org/eclipse/dirigible/database/sql/DataTypeUtilsTest.java
@@ -96,6 +96,30 @@ public class DataTypeUtilsTest {
     }
 
     /**
+     * PostgreSQL JDBC metadata reports a boolean column as java.sql.Types.BIT, so BIT (and the BOOL
+     * alias) must unify with the BOOLEAN a table definition declares - otherwise every alter over a
+     * table with a boolean column fails as an incompatible change.
+     */
+    @Test
+    public void bitUnifiesWithBoolean() {
+        assertEquals("BOOLEAN", DataTypeUtils.getUnifiedDatabaseType("BIT"));
+        assertEquals("BOOLEAN", DataTypeUtils.getUnifiedDatabaseType("BOOL"));
+        assertEquals("BOOLEAN", DataTypeUtils.getUnifiedDatabaseType(DataTypeUtils.getDatabaseTypeName(Types.BIT)));
+    }
+
+    /**
+     * DECIMAL is an alias of NUMERIC in PostgreSQL (and interchangeable per the SQL standard), so a
+     * DECIMAL model column reported back by the metadata as NUMERIC is the same column, not an
+     * incompatible change.
+     */
+    @Test
+    public void numericUnifiesWithDecimal() {
+        assertEquals(DataTypeUtils.getUnifiedDatabaseType("DECIMAL"), DataTypeUtils.getUnifiedDatabaseType("NUMERIC"));
+        assertEquals(DataTypeUtils.getUnifiedDatabaseType("DECIMAL"),
+                DataTypeUtils.getUnifiedDatabaseType(DataTypeUtils.getDatabaseTypeName(Types.NUMERIC)));
+    }
+
+    /**
      * The character types are one family, aliases included - a CLOB column reported back as VARCHAR (or
      * CHARACTER VARYING) holds the same kind of value.
      */


### PR DESCRIPTION
## Problem

`TableAlterProcessor` compares each existing column's JDBC metadata type against the model's declared type through `DataTypeUtils.getUnifiedDatabaseType`, and fails the whole table's alter when they differ. PostgreSQL reports:

- a `BOOLEAN` column as `java.sql.Types.BIT`,
- a `DECIMAL` column as `NUMERIC` (`DECIMAL` is an alias of `NUMERIC` in PostgreSQL, and the two are interchangeable per the SQL standard).

Neither alias is in the unified map, so a re-publish of any table with a boolean or decimal column over an existing PostgreSQL database throws:

```
java.sql.SQLException: Incompatible change of table ["..."] by adding a column [...] which is [of type BIT to be changed to BOOLEAN]
java.sql.SQLException: Incompatible change of table ["..."] by adding a column [...] which is [of type NUMERIC to be changed to DECIMAL]
```

and the table's entire alter is skipped — silently dropping every genuinely new column of that table. On one production instance this failed the alter of 86 tables after a release (69 NUMERIC/DECIMAL, 17 BIT/BOOLEAN), with csvim `BATCH UPDATE` imports then failing on the never-added columns (`No value specified for parameter N`).

## Fix

Add the two aliases to `UNIFIED_STRING_FROM_DATABASE_TYPE`, next to the existing `BOOL → BOOLEAN` entry:

- `BIT → BOOLEAN` (consistent with `DATABASE_TYPE_TO_JAVA_TYPE`, which already maps `Types.BIT` to `boolean`)
- `NUMERIC → DECIMAL`

Tests cover both directions through `getDatabaseTypeName(Types.BIT/NUMERIC)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)