### PR TITLE
fix(application): shared shell aggregates hosted apps' custom actions

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/customActions.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/customActions.js
@@ -49,6 +49,7 @@ document.addEventListener('alpine:init', () => {
     confirmId: null,
     confirmBusy: false,
     serverUnavailable: false,   // set once the backend is unreachable; stops re-fetching until a reload
+    extraPoints: [],            // extension points added via addProjects (the shared shell's hosted apps)
 
     init() {
       this.load();
@@ -65,11 +66,17 @@ document.addEventListener('alpine:init', () => {
       // (serverUnavailable back to false) and resumes.
       if (this.serverUnavailable) return;
       const project = (window.App && App.config && App.config.projectName) || '';
-      if (!project) return;
-      const point = project + '-custom-action';
+      // The hosting app's own point, plus every point added via addProjects: the SHARED application
+      // shell hosts OTHER apps' views, so it must ask for THEIR `<project>-custom-action` points -
+      // exactly as it adds their i18n namespaces - or contributed actions surface only in each
+      // app's standalone shell and silently vanish from the shared one.
+      const points = new Set(this.extraPoints);
+      if (project) points.add(project + '-custom-action');
+      if (!points.size) return;
       try {
+        const query = [...points].map((p) => 'extensionPoints=' + encodeURIComponent(p)).join('&');
         const data = await App.services.api.get(
-          '/services/js/platform-core/extension-services/views.js?extensionPoints=' + encodeURIComponent(point),
+          '/services/js/platform-core/extension-services/views.js?' + query,
           { baseUrl: '' });
         this.actions = Array.isArray(data) ? data : [];
         this.loaded = true;
@@ -88,6 +95,21 @@ document.addEventListener('alpine:init', () => {
     },
 
     refresh() { return this.load(); },
+
+    // Add hosted apps' custom-action points and re-read the contributions. The shared application
+    // shell calls this with the project names of the perspectives it aggregates (the same list it
+    // feeds AppI18nAddNamespaces); each app's standalone shell never needs it. Idempotent: already
+    // known projects are skipped, and load() always fetches the full accumulated point set, so a
+    // navigation-triggered reload keeps the merged actions instead of dropping back to one app's.
+    addProjects(projects) {
+      const added = [...new Set((projects || [])
+        .filter((p) => p && p !== 'application' && p !== 'application-core')
+        .map((p) => p + '-custom-action'))]
+        .filter((p) => !this.extraPoints.includes(p));
+      if (!added.length) return Promise.resolve();
+      this.extraPoints.push(...added);
+      return this.load();
+    },
 
     // The actions targeted at a given view. `view` is the entity name; the app-scoped extension point
     // (`<project>-custom-action`) already narrows to this app, so entity + type is unambiguous. `type`

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
@@ -423,12 +423,17 @@ document.addEventListener('alpine:init', () => {
           // Fire-and-forget: load the contributing apps' i18n catalogs so the sidebar / dashboard /
           // Settings entries translate. Each perspective's tkey is '<project>:<path>' - the project
           // is the catalog namespace, which the shell (having no project of its own) must add.
+          const hostedProjects = [...new Set(all.flatMap(g => Array.isArray(g.items) ? g.items : [g])
+            .map(it => (it.tkey || '').split(':')[0])
+            .filter(ns => ns && ns !== 'application-core'))];
           if (window.AppI18nAddNamespaces) {
-            const namespaces = [...new Set(all.flatMap(g => Array.isArray(g.items) ? g.items : [g])
-              .map(it => (it.tkey || '').split(':')[0])
-              .filter(ns => ns && ns !== 'application-core'))];
-            AppI18nAddNamespaces(namespaces);
+            AppI18nAddNamespaces(hostedProjects);
           }
+          // Same aggregation for the apps' contributed custom actions ('<project>-custom-action'
+          // extension points): the shell's own project contributes none, so without this the
+          // generate / create-from buttons exist in each app's standalone shell but not here.
+          const customActions = Alpine.store('customActions');
+          if (customActions && customActions.addProjects) customActions.addProjects(hostedProjects);
           // Fire-and-forget: scan which languages each embedded app provides translations for
           // (drives the missing-translations warnings in Settings).
           this.loadLanguageCoverage(all);


### PR DESCRIPTION
The `customActions` store loads the `<project>-custom-action` extension point of its own project — which for the shared application shell is `application`, a project that contributes no actions. Every generated create-from / generate / status action (Generate Invoice, Accept Quotation, Cancel RFQ, …) therefore surfaced only in each app's standalone shell and silently vanished from the shared one, with no diagnostic anywhere.

The shell already solves this exact problem for i18n: after aggregating perspectives it derives the hosted projects from their tkey namespaces and calls `AppI18nAddNamespaces`. Custom actions now ride the same list:

- the store gains `addProjects(projects)` — accumulates the hosted apps' extension points and re-reads the contributions
- `load()` always fetches the full accumulated point set, so navigation-triggered reloads keep the merged actions instead of dropping back to one app's
- each app's standalone shell is unaffected (no extra points, same single-point query as before)

Verified against a 56-module workspace (BusinessIntents solution-all-dev): before — `getActions('ProjectTimesheet','entity')` empty in the shared shell, action present in the module shell; after — the record panel shows Generate Invoice in both, and 30 previously-invisible actions across 31 hosted apps load in one aggregated query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)