### PR TITLE
fix(ide): Report Editor round-trip guard - stop corrupting authored queries

### DIFF
--- a/components/ui/editor-report/src/main/resources/META-INF/dirigible/editor-report/editor.html
+++ b/components/ui/editor-report/src/main/resources/META-INF/dirigible/editor-report/editor.html
@@ -70,7 +70,7 @@
                     </bk-panel>
                     <!-- End General Section-->
                     <!-- Begin Base Table Section-->
-                    <bk-panel expanded="true">
+                    <bk-panel ng-if="queryMode === 'structured'" expanded="true">
                         <bk-panel-header>
                             <bk-panel-expand hint="expand base table section"></bk-panel-expand>
                             <h4 bk-panel-title>Base Table</h4>
@@ -100,7 +100,7 @@
                     </bk-panel>
                     <!-- End Base Table Section-->
                     <!-- Begin Columns -->
-                    <bk-panel expanded="true">
+                    <bk-panel ng-if="queryMode === 'structured'" expanded="true">
                         <bk-panel-header>
                             <bk-panel-expand hint="expand columns section"></bk-panel-expand>
                             <h4 bk-panel-title>Columns</h4>
@@ -149,7 +149,7 @@
                     </bk-panel>
                     <!-- End Columns -->
                     <!-- Begin Joins -->
-                    <bk-panel expanded="true">
+                    <bk-panel ng-if="queryMode === 'structured'" expanded="true">
                         <bk-panel-header>
                             <bk-panel-expand hint="expand joins section"></bk-panel-expand>
                             <h4 bk-panel-title>Joins</h4>
@@ -193,7 +193,7 @@
                     </bk-panel>
                     <!-- End Joins -->
                     <!-- Begin Conditions -->
-                    <bk-panel expanded="true">
+                    <bk-panel ng-if="queryMode === 'structured'" expanded="true">
                         <bk-panel-header>
                             <bk-panel-expand hint="expand conditions section"></bk-panel-expand>
                             <h4 bk-panel-title>Conditions</h4>
@@ -232,7 +232,7 @@
                     </bk-panel>
                     <!-- End Conditions -->
                     <!-- Begin Havings -->
-                    <bk-panel expanded="false">
+                    <bk-panel ng-if="queryMode === 'structured'" expanded="false">
                         <bk-panel-header>
                             <bk-panel-expand hint="expand havings section"></bk-panel-expand>
                             <h4 bk-panel-title>Havings</h4>
@@ -271,7 +271,7 @@
                     </bk-panel>
                     <!-- End Conditions -->
                     <!-- Begin Ordering -->
-                    <bk-panel expanded="false">
+                    <bk-panel ng-if="queryMode === 'structured'" expanded="false">
                         <bk-panel-header>
                             <bk-panel-expand hint="expand ordering section"></bk-panel-expand>
                             <h4 bk-panel-title>Ordering</h4>
@@ -347,16 +347,24 @@
                     </bk-panel>
                     <!-- End Parameters -->
                     <!-- Begin Query -->
-                    <bk-panel expanded="false">
+                    <bk-panel expanded="queryPanelExpanded">
                         <bk-panel-header>
                             <bk-panel-expand hint="expand query section"></bk-panel-expand>
                             <h4 bk-panel-title>Query</h4>
                         </bk-panel-header>
                         <bk-panel-content aria-label="Query Content">
+                            <bk-message-strip ng-if="queryMode === 'freestyle'" state="information" class="fd-margin-bottom--tiny">
+                                This query cannot be reproduced by the visual builder, so the SQL below is the source of truth and the builder sections are hidden. 'Convert to structured'
+                                rebuilds the query from the builder, discarding the custom SQL.
+                            </bk-message-strip>
                             <bk-form-item horizontal="false">
-                                <bk-form-label for="idQuery" colon="true">Generated Query</bk-form-label>
-                                <bk-textarea id="idQuery" name="query" ng-model="query" rows="10" ng-readonly="true"></bk-textarea>
+                                <bk-form-label for="idQuery" colon="true">{{ queryMode === 'structured' ? 'Generated Query' : 'Query' }}</bk-form-label>
+                                <bk-textarea id="idQuery" name="query" ng-model="report.query" rows="10" ng-readonly="queryMode === 'structured'"></bk-textarea>
                             </bk-form-item>
+                            <div class="bk-hbox bk-full-width bk-padding-bottom--tiny bk-flex-end bk-box--gap">
+                                <bk-button ng-if="queryMode === 'structured'" compact="true" label="Edit as free-style SQL" ng-click="switchToFreestyle()"></bk-button>
+                                <bk-button ng-if="queryMode === 'freestyle'" compact="true" label="Convert to structured" ng-click="convertToStructured()"></bk-button>
+                            </div>
                         </bk-panel-content>
                     </bk-panel>
                     <!-- End Query -->

--- a/components/ui/editor-report/src/main/resources/META-INF/dirigible/editor-report/js/editor.js
+++ b/components/ui/editor-report/src/main/resources/META-INF/dirigible/editor-report/js/editor.js
@@ -18,6 +18,12 @@ angular.module('page', ['blimpKit', 'platformView', 'platformShortcuts', 'Worksp
 	let workspace = '';
 	let contents;
 	$scope.changed = false;
+	// 'structured': the visual builder owns report.query and regenerates it on every model
+	// edit. 'freestyle': the stored SQL is richer than what the builder can reproduce
+	// (expressions, custom joins, quoting), so the query string is the source of truth,
+	// the query-shaping builder sections are hidden and the query is edited directly.
+	$scope.queryMode = 'structured';
+	$scope.queryPanelExpanded = false;
 	$scope.nameErrorMessage = 'Allowed characters include all letters, numbers, \'_\', \'-\', \'.\', \':\' and \'"\'. Maximum length is 255.';
 	$scope.errorMessage = 'An unknown error was encountered. Please see console for more information.';
 	$scope.forms = {
@@ -125,6 +131,11 @@ angular.module('page', ['blimpKit', 'platformView', 'platformShortcuts', 'Worksp
 		return report;
 	}
 
+	// angular.toJson drops Angular's $$-prefixed bookkeeping (e.g. the $$hashKey that
+	// ng-repeat stamps on rows) so it never leaks into the saved artefact; the 2-space
+	// indentation matches the intent generator's output.
+	const serializeReport = () => angular.toJson($scope.report, 2);
+
 	const loadFileContents = () => {
 		if (!$scope.state.error) {
 			$scope.state.isBusy = true;
@@ -136,8 +147,12 @@ angular.module('page', ['blimpKit', 'platformView', 'platformShortcuts', 'Worksp
 					// Absent means shown on the dashboard - make it explicit so the checkbox binds
 					// cleanly (before the dirty-tracking snapshot below, so this is not a change).
 					if ($scope.report.dashboard === undefined) $scope.report.dashboard = true;
-					contents = JSON.stringify($scope.report, null, 4);
-					$scope.query = $scope.report.query;
+					contents = serializeReport();
+					// Round-trip guard: the builder may only own the query when it can actually
+					// reproduce the stored one. Otherwise (intent-generated or hand-tuned SQL)
+					// the query string is the source of truth and is never regenerated.
+					$scope.queryMode = !$scope.report.query || $scope.report.query === buildQuery($scope.report) ? 'structured' : 'freestyle';
+					$scope.queryPanelExpanded = $scope.queryMode === 'freestyle';
 					$scope.state.isBusy = false;
 				});
 			}, (response) => {
@@ -284,7 +299,7 @@ angular.module('page', ['blimpKit', 'platformView', 'platformShortcuts', 'Worksp
 				$scope.state.busyText = 'Saving...';
 				$scope.state.isBusy = true;
 				$scope.state.error = false;
-				saveContents(JSON.stringify($scope.report, null, 4));
+				saveContents(serializeReport());
 			}
 		}
 	};
@@ -329,13 +344,17 @@ angular.module('page', ['blimpKit', 'platformView', 'platformShortcuts', 'Worksp
 
 	$scope.$watch('report', () => {
 		if (!$scope.state.isBusy) {
+			// Regenerate before the dirty check so both see the same state. In free-style
+			// mode the stored SQL is authoritative and must never be overwritten.
+			if ($scope.queryMode === 'structured' && $scope.report) {
+				$scope.report.query = buildQuery($scope.report);
+			}
 			if (!$scope.state.error) {
-				const isDirty = contents !== JSON.stringify($scope.report, null, 4);
+				const isDirty = contents !== serializeReport();
 				if ($scope.changed !== isDirty) {
 					$scope.fileChanged();
 				}
 			}
-			$scope.generateQuery();
 		}
 	}, true);
 
@@ -1330,72 +1349,113 @@ angular.module('page', ['blimpKit', 'platformView', 'platformShortcuts', 'Worksp
 	};
 	// End Parameters Section ---------------------------------------------------------------------------------
 
-	$scope.generateQuery = () => {
-		$scope.query = "SELECT ";
-		if ($scope.report.columns) {
-			for (let i = 0; i < $scope.report.columns.length; i++) {
-				if ($scope.report.columns[i].select === true) {
-					if ($scope.report.columns[i].aggregate !== undefined && $scope.report.columns[i].aggregate !== "NONE") {
-						$scope.query += $scope.report.columns[i].aggregate + "(";
+	// Physical identifiers (table and column names) are stored unquoted on the model;
+	// quoting happens on emission, mirroring ReportIntentGenerator.buildQuery(). '*' and
+	// already-quoted values (legacy hand-edited files) pass through untouched.
+	function quoteIdentifier(name) {
+		return !name || name === '*' || name.startsWith('"') ? name : `"${name}"`;
+	}
+
+	// The SELECT/GROUP BY term of a column: a verbatim SQL expression when present
+	// (computed dimensions like date buckets), else the quoted qualified column.
+	function columnTerm(column) {
+		if (column.expression) return column.expression;
+		if (column.name === '*') return '*';
+		return column.table + '.' + quoteIdentifier(column.name);
+	}
+
+	// Rebuild the SQL from the structured model. Emission is aligned token-for-token with
+	// ReportIntentGenerator.buildQuery() so generated reports round-trip unchanged.
+	function buildQuery(report) {
+		let query = 'SELECT ';
+		if (report.columns) {
+			const selectParts = [];
+			for (let i = 0; i < report.columns.length; i++) {
+				const column = report.columns[i];
+				if (column.select === true) {
+					let part = columnTerm(column);
+					if (column.aggregate !== undefined && column.aggregate !== 'NONE') {
+						part = column.aggregate + '(' + part + ')';
 					}
-					$scope.query += $scope.report.columns[i].table + "." + $scope.report.columns[i].name;
-					if ($scope.report.columns[i].aggregate !== undefined && $scope.report.columns[i].aggregate !== "NONE") {
-						$scope.query += ")";
-					}
-					$scope.query += ` as "${$scope.report.columns[i].alias}", `;
+					selectParts.push(`${part} as "${column.alias}"`);
 				}
 			}
+			query += selectParts.join(', ');
 		}
-		if ($scope.query.substring($scope.query.length - 2) === ', ')
-			$scope.query = $scope.query.substring(0, $scope.query.length - 2);
-		if ($scope.report.table && $scope.report.alias)
-			$scope.query += "\nFROM " + $scope.report.table + " as " + $scope.report.alias;
+		if (report.table && report.alias)
+			query += '\nFROM ' + quoteIdentifier(report.table) + ' as ' + report.alias;
 
-		if ($scope.report.joins) {
-			for (let i = 0; i < $scope.report.joins.length; i++) {
-				$scope.query += "\n  " + $scope.report.joins[i].type + " JOIN " + $scope.report.joins[i].name + " " + $scope.report.joins[i].alias + " ON " + $scope.report.joins[i].condition;
+		if (report.joins) {
+			for (let i = 0; i < report.joins.length; i++) {
+				query += '\n' + report.joins[i].type + ' JOIN ' + quoteIdentifier(report.joins[i].name) + ' as ' + report.joins[i].alias + ' ON ' + report.joins[i].condition;
 			}
 		}
 
-		if ($scope.report.conditions) {
-			$scope.query += "\nWHERE ";
-			for (let i = 0; i < $scope.report.conditions.length; i++) {
-				if (i > 0) { $scope.query += ' AND ' }
-				$scope.query += $scope.report.conditions[i].left + " " + $scope.report.conditions[i].operation + " " + $scope.report.conditions[i].right;
+		if (report.conditions && report.conditions.length > 0) {
+			query += '\nWHERE ';
+			for (let i = 0; i < report.conditions.length; i++) {
+				if (i > 0) { query += ' AND ' }
+				query += report.conditions[i].left + ' ' + report.conditions[i].operation + ' ' + report.conditions[i].right;
 			}
 		}
 
-		if ($scope.report.columns) {
-			let g = false;
-			for (let i = 0; i < $scope.report.columns.length; i++) {
-				if ($scope.report.columns[i].grouping === true) {
-					if (!g) {
-						$scope.query += "\nGROUP BY ";
-						g = true;
-					}
-					$scope.query += $scope.report.columns[i].table + "." + $scope.report.columns[i].name + ', ';
+		if (report.columns) {
+			const groupParts = [];
+			for (let i = 0; i < report.columns.length; i++) {
+				if (report.columns[i].grouping === true) {
+					groupParts.push(columnTerm(report.columns[i]));
 				}
 			}
+			if (groupParts.length > 0) query += '\nGROUP BY ' + groupParts.join(', ');
 		}
-		if ($scope.query.substring($scope.query.length - 2) === ', ')
-			$scope.query = $scope.query.substring(0, $scope.query.length - 2);
 
-		if ($scope.report.havings) {
-			$scope.query += "\nHAVING ";
-			for (let i = 0; i < $scope.report.havings.length; i++) {
-				if (i > 0) { $scope.query += ', ' }
-				$scope.query += $scope.report.havings[i].left + " " + $scope.report.havings[i].operation + " " + $scope.report.havings[i].right;
+		if (report.havings && report.havings.length > 0) {
+			query += '\nHAVING ';
+			for (let i = 0; i < report.havings.length; i++) {
+				if (i > 0) { query += ' AND ' }
+				query += report.havings[i].left + ' ' + report.havings[i].operation + ' ' + report.havings[i].right;
 			}
 		}
 
-		if ($scope.report.orderings) {
-			$scope.query += "\nORDER BY ";
-			for (let i = 0; i < $scope.report.orderings.length; i++) {
-				if (i > 0) { $scope.query += ', ' }
-				$scope.query += $scope.report.orderings[i].column + " " + $scope.report.orderings[i].direction;
+		if (report.orderings && report.orderings.length > 0) {
+			query += '\nORDER BY ';
+			for (let i = 0; i < report.orderings.length; i++) {
+				if (i > 0) { query += ', ' }
+				query += report.orderings[i].column + ' ' + report.orderings[i].direction;
 			}
 		}
-		$scope.report.query = $scope.query;
+		return query;
+	}
+
+	// Structured -> free-style is always safe: the current query is kept as-is and simply
+	// stops being regenerated.
+	$scope.switchToFreestyle = () => {
+		$scope.queryMode = 'freestyle';
+		$scope.queryPanelExpanded = true;
+	};
+
+	$scope.convertToStructured = () => {
+		dialogHub.showDialog({
+			title: 'Convert to structured editing?',
+			message: 'The query will be rebuilt from the visual builder. Custom SQL that the builder cannot represent (expressions, joins, filters) will be lost.',
+			buttons: [{
+				id: 'bconv',
+				state: ButtonStates.Emphasized,
+				label: 'Convert',
+			},
+			{
+				id: 'bc',
+				state: ButtonStates.Transparent,
+				label: 'Cancel',
+			}]
+		}).then((buttonId) => {
+			if (buttonId === 'bconv') {
+				$scope.$evalAsync(() => {
+					$scope.queryMode = 'structured';
+					$scope.report.query = buildQuery($scope.report);
+				});
+			}
+		});
 	};
 
 	$scope.dataParameters = ViewParameters.get();


### PR DESCRIPTION
Part 1 of #6675 (the editor side; the `ReportIntentGenerator` follow-up is part 2).

## Problem

Opening an intent-generated `*.report` in the Report Editor immediately marked the editor dirty, and saving destroyed the authored SQL: identifier quoting lost, `COUNT(*)` → `COUNT(alias.*)` (H2 rejects it), the `INNER JOIN` deleted, a bare empty `WHERE` emitted, computed dimensions (date buckets) silently degraded to the raw column, and Angular's `$$hashKey` leaked into the saved JSON. Root cause analysis in #6675: the editor regenerated `report.query` from the structured model on every digest — including the load one — while the generator writes queries richer than what the structured model can represent.

## Change

**Round-trip guard with two modes.** On open the editor rebuilds the query from the structured model into a local value and compares it with the stored `query`:

- **Match → structured mode** (behavior as today): the builder owns the query and regenerates it on user edits — and only on user edits, never in the load digest.
- **Mismatch → free-style mode**: the query string is the source of truth; the query-shaping builder panels (Base Table, Columns, Joins, Conditions, Havings, Ordering) are hidden, the query textarea becomes directly editable, and nothing ever overwrites `query`. Open + save leaves the file unchanged.

The mode is inferred, not a file flag: no format migration, and any future generator/editor drift fails safe into free-style instead of corrupting. Explicit switches exist both ways — structured → free-style is always safe; the reverse asks for confirmation because it rebuilds the query and discards custom SQL.

**`buildQuery` correctness**, aligned token-for-token with `ReportIntentGenerator.buildQuery()` so generated reports can round-trip once part 2 emits the full structured model:

- physical identifiers quoted on emission (already-quoted legacy values and `*` pass through; the model keeps storing them unquoted),
- `name: "*"` emits `COUNT(*)`, not `COUNT(alias.*)`,
- joins emit `<TYPE> JOIN "TABLE" as Alias ON <condition>`,
- empty `conditions`/`havings`/`orderings` arrays emit no clause (previously a truthy empty array produced a bare `WHERE` / `HAVING` / `ORDER BY`),
- `HAVING` predicates are joined with `AND` (previously `, `, which is invalid SQL),
- an optional `columns[].expression` is honored verbatim in SELECT and GROUP BY (the hook part 2 uses for computed dimensions).

**Serialization**: saves go through `angular.toJson` (drops `$$hashKey`) with 2-space indentation matching the generator's output.

## Verification

- `node --check` on the edited controller.
- A harness that `eval`s the actual `buildQuery` source from the edited file:
  - a real intent-generated report (joins/expressions only in the query string) is detected as free-style;
  - a simulated part-2 model (joins array, unquoted stored identifiers, `count(*)`, empty `conditions`) reproduces the generator's SQL byte-for-byte;
  - expression columns appear verbatim in SELECT/GROUP BY;
  - already-quoted legacy identifiers pass through;
  - empty arrays emit no clause.
- `mvn -P quick-build install -pl components/ui/editor-report` passes. No integration test drives the Report Editor UI; generation (`generateUtils.js` and the Java port) never touches `query`, so this is editor-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
