### PR TITLE
fix(engine-jobs): repair job-notification-email removal (#6609)

### DIFF
--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/endpoint/JobEndpoint.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/endpoint/JobEndpoint.java
@@ -229,7 +229,7 @@ public class JobEndpoint extends BaseEndpoint {
      * @param id the id
      * @return the response entity
      */
-    @DeleteMapping(value = "/emailremove/{id}", produces = "application/json")
+    @DeleteMapping(value = "/emails/{id}", produces = "application/json")
     public ResponseEntity<?> removeJobEmail(@PathVariable("id") Long id) {
 
         jobEmailService.removeEmail(id);

--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/endpoint/JobEndpoint.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/endpoint/JobEndpoint.java
@@ -31,6 +31,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -228,8 +229,8 @@ public class JobEndpoint extends BaseEndpoint {
      * @param id the id
      * @return the response entity
      */
-    @PostMapping(value = "/emailremove/{id}", produces = "application/json")
-    public ResponseEntity<?> removeJobEmail(@PathVariable("job") Long id) {
+    @DeleteMapping(value = "/emails/{id}", produces = "application/json")
+    public ResponseEntity<?> removeJobEmail(@PathVariable("id") Long id) {
 
         jobEmailService.removeEmail(id);
 

--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/endpoint/JobEndpoint.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/endpoint/JobEndpoint.java
@@ -31,6 +31,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -228,8 +229,8 @@ public class JobEndpoint extends BaseEndpoint {
      * @param id the id
      * @return the response entity
      */
-    @PostMapping(value = "/emailremove/{id}", produces = "application/json")
-    public ResponseEntity<?> removeJobEmail(@PathVariable("job") Long id) {
+    @DeleteMapping(value = "/emailremove/{id}", produces = "application/json")
+    public ResponseEntity<?> removeJobEmail(@PathVariable("id") Long id) {
 
         jobEmailService.removeEmail(id);
 

--- a/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/endpoint/JobEndpointTest.java
+++ b/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/endpoint/JobEndpointTest.java
@@ -11,6 +11,8 @@ package org.eclipse.dirigible.components.jobs.endpoint;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -24,8 +26,10 @@ import jakarta.persistence.EntityManager;
 
 import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
 import org.eclipse.dirigible.components.jobs.domain.Job;
+import org.eclipse.dirigible.components.jobs.domain.JobEmail;
 import org.eclipse.dirigible.components.jobs.domain.JobParameter;
 import org.eclipse.dirigible.components.jobs.repository.JobRepository;
+import org.eclipse.dirigible.components.jobs.service.JobEmailService;
 import org.eclipse.dirigible.components.jobs.service.JobService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,6 +69,10 @@ public class JobEndpointTest {
     /** The job service. */
     @Autowired
     private JobService jobService;
+
+    /** The job email service. */
+    @Autowired
+    private JobEmailService jobEmailService;
 
     /** The job repository. */
     @Autowired
@@ -171,6 +179,28 @@ public class JobEndpointTest {
                .andDo(print());
         // .andExpect(status().is2xxSuccessful());
 
+    }
+
+    /**
+     * Removes a job notification email by id (regression for #6609: DELETE verb + matching {id} path
+     * variable).
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void removeJobEmail() throws Exception {
+        jobEmailService.addEmail(testJob.getName(), "admin@example.com");
+        List<JobEmail> emails = jobEmailService.findAllByJobName(testJob.getName());
+        assertEquals(1, emails.size());
+        Long emailId = emails.get(0)
+                             .getId();
+
+        mockMvc.perform(delete("/services/jobs/emails/{id}", emailId).with(csrf()))
+               .andDo(print())
+               .andExpect(status().isOk());
+
+        assertEquals(0, jobEmailService.findAllByJobName(testJob.getName())
+                                       .size());
     }
 
     /**

--- a/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/endpoint/JobEndpointTest.java
+++ b/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/endpoint/JobEndpointTest.java
@@ -11,6 +11,8 @@ package org.eclipse.dirigible.components.jobs.endpoint;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -24,8 +26,10 @@ import jakarta.persistence.EntityManager;
 
 import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
 import org.eclipse.dirigible.components.jobs.domain.Job;
+import org.eclipse.dirigible.components.jobs.domain.JobEmail;
 import org.eclipse.dirigible.components.jobs.domain.JobParameter;
 import org.eclipse.dirigible.components.jobs.repository.JobRepository;
+import org.eclipse.dirigible.components.jobs.service.JobEmailService;
 import org.eclipse.dirigible.components.jobs.service.JobService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,6 +69,10 @@ public class JobEndpointTest {
     /** The job service. */
     @Autowired
     private JobService jobService;
+
+    /** The job email service. */
+    @Autowired
+    private JobEmailService jobEmailService;
 
     /** The job repository. */
     @Autowired
@@ -171,6 +179,28 @@ public class JobEndpointTest {
                .andDo(print());
         // .andExpect(status().is2xxSuccessful());
 
+    }
+
+    /**
+     * Removes a job notification email by id (regression for #6609: DELETE verb + matching {id} path
+     * variable).
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void removeJobEmail() throws Exception {
+        jobEmailService.addEmail(testJob.getName(), "admin@example.com");
+        List<JobEmail> emails = jobEmailService.findAllByJobName(testJob.getName());
+        assertEquals(1, emails.size());
+        Long emailId = emails.get(0)
+                             .getId();
+
+        mockMvc.perform(delete("/services/jobs/emailremove/{id}", emailId).with(csrf()))
+               .andDo(print())
+               .andExpect(status().isOk());
+
+        assertEquals(0, jobEmailService.findAllByJobName(testJob.getName())
+                                       .size());
     }
 
     /**

--- a/components/ui/view-jobs/src/main/resources/META-INF/dirigible/view-jobs/dialogs/job-assign.html
+++ b/components/ui/view-jobs/src/main/resources/META-INF/dirigible/view-jobs/dialogs/job-assign.html
@@ -86,7 +86,7 @@
                     });
                 });
 
-                $scope.removeEmail = (id) => $http.delete(`/services/jobs/emailremove/${id}`).then((response) => {
+                $scope.removeEmail = (id) => $http.delete(`/services/jobs/emails/${id}`).then((response) => {
                     getEmails($scope.job);
                 }, (response) => {
                     console.error(response.data);


### PR DESCRIPTION
## What & why

Fixes #6609.

Removing a job notification email (the Jobs perspective's Assign dialog) was broken on two independent axes, so the feature never worked end to end:

1. **Server — path-variable name mismatch.** `JobEndpoint.removeJobEmail` declared `{id}` in the route but bound `@PathVariable("job")`, a name absent from the URI template → `MissingPathVariableException` (HTTP 500) on any call.
2. **Client — wrong HTTP verb.** `job-assign.html` issued `DELETE` against a `@PostMapping`, so the request 405'd during dispatch, before the binding bug was even reached.

## The fix

Aligned all three sides to the issue's recommended **natural REST shape** — `DELETE /services/jobs/emails/{id}` — pairing with the existing `GET /services/jobs/emails/{*job}` collection:

- **`JobEndpoint.java`** — `@PostMapping("/emailremove/{id}")` → `@DeleteMapping("/emails/{id}")`, and `@PathVariable("job")` → `@PathVariable("id")`.
- **`job-assign.html`** — the DELETE URL moves from `/emailremove/${id}` to `/emails/${id}`.

`GET /emails/{*job}` and `DELETE /emails/{id}` coexist without conflict (distinct HTTP methods); a context-boot test confirms no ambiguous mapping.

## Tests

New `JobEndpointTest.removeJobEmail` (MockMvc): adds an email, sends `DELETE /services/jobs/emails/{id}` (with the CSRF token, per the repo's `WorkspaceEndpointTest` convention), asserts **200** and that the email is gone. It fails against the pre-fix code (405/500).

`Tests run: 5, Failures: 0, Errors: 0`. `formatter:validate` and the release-profile javadoc build both pass on `engine-jobs`.

> Note: `job-assign.html` is a bundled UI resource, so a locally running jar needs a `view-jobs` + `build/application` repackage to reflect the URL change — not relevant for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
