### PR TITLE
fix(api): db facades accept null parameter values

### DIFF
--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/db/query.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/db/query.ts
@@ -70,7 +70,7 @@ export class Query {
    */
   public static execute(
     sql: string,
-    parameters?: (string | number | boolean | Date | TypedQueryParameter | NamedQueryParameter)[] | string,
+    parameters?: (string | number | boolean | Date | null | TypedQueryParameter | NamedQueryParameter)[] | string,
     datasourceName?: string,
     formatting?: FormattingParameter,
   ): any[] {
@@ -124,10 +124,12 @@ export class Query {
       return JSON.parse(resultset);
     }
 
-    // Primitive array
+    // Primitive array; null/undefined are valid values - they bind as SQL NULL
     if (
       arr.every(
         (v) =>
+          v === null ||
+          v === undefined ||
           typeof v === "string" ||
           typeof v === "number" ||
           typeof v === "boolean" ||

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/db/store.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/db/store.ts
@@ -184,7 +184,7 @@ export class Store {
 	 * @param offset Number of results to skip.
 	 * @returns An array of JavaScript objects.
 	 */
-	public static query(query: string, parameters?: (string | number | boolean | Date | TypedQueryParameter | NamedQueryParameter)[], limit: number = 100, offset: number = 0): any[] {
+	public static query(query: string, parameters?: (string | number | boolean | Date | null | TypedQueryParameter | NamedQueryParameter)[], limit: number = 100, offset: number = 0): any[] {
 		let arr: any[] = [];
 		if (parameters == null) {
 			arr = [];
@@ -223,10 +223,12 @@ export class Store {
 			return Store.parseResult(result);
 		}
 
-		// Primitive array
+		// Primitive array; null/undefined are valid values - they bind as SQL NULL
 		if (
 			arr.every(
 				(v) =>
+					v === null ||
+					v === undefined ||
 					typeof v === "string" ||
 					typeof v === "number" ||
 					typeof v === "boolean" ||
@@ -246,7 +248,7 @@ export class Store {
 	 * @param query The entity/table name.
 	 * @returns An array of all JavaScript objects.
 	 */
-	public static queryNative(query: string, parameters?: (string | number | boolean | Date | TypedQueryParameter | NamedQueryParameter)[], limit: number = 100, offset: number = 0): any[] {
+	public static queryNative(query: string, parameters?: (string | number | boolean | Date | null | TypedQueryParameter | NamedQueryParameter)[], limit: number = 100, offset: number = 0): any[] {
 		let arr: any[] = [];
 		if (parameters == null) {
 			arr = [];
@@ -285,10 +287,12 @@ export class Store {
 			return Store.parseResult(result);
 		}
 
-		// Primitive array
+		// Primitive array; null/undefined are valid values - they bind as SQL NULL
 		if (
 			arr.every(
 				(v) =>
+					v === null ||
+					v === undefined ||
 					typeof v === "string" ||
 					typeof v === "number" ||
 					typeof v === "boolean" ||

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/db/update.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/db/update.ts
@@ -71,7 +71,7 @@ export class Update {
 	 * @param datasourceName The name of the database connection to use (optional).
 	 * @returns The number of rows affected by the statement.
 	 */
-	public static execute(sql: string, parameters?: (string | number | boolean | Date | TypedUpdateParameter | NamedUpdateParameter)[], datasourceName?: string): number {
+	public static execute(sql: string, parameters?: (string | number | boolean | Date | null | TypedUpdateParameter | NamedUpdateParameter)[], datasourceName?: string): number {
 		let arr: any[] = [];
 
 	    if (parameters == null) {
@@ -111,10 +111,12 @@ export class Update {
 	      return result;
 	    }
 
-	    // Primitive array
+	    // Primitive array; null/undefined are valid values - they bind as SQL NULL
 	    if (
 	      arr.every(
 	        (v) =>
+	          v === null ||
+	          v === undefined ||
 	          typeof v === "string" ||
 	          typeof v === "number" ||
 	          typeof v === "boolean" ||

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/DatabaseCrudNullValuesIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/DatabaseCrudNullValuesIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Base64;
+
+import org.eclipse.dirigible.components.data.sources.manager.DataSourcesManager;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.restassured.http.ContentType;
+
+/**
+ * Regression test for dirigible#6680: the db API facades rejected {@code null} parameter values
+ * with "Unsupported parameter format", so the Database perspective's Results view could not save an
+ * edited row whenever any column carried NULL - even though the JDBC layer binds a JSON null as SQL
+ * NULL. Drives the same CRUD endpoint the Results view uses.
+ */
+class DatabaseCrudNullValuesIT extends IntegrationTest {
+
+    /**
+     * Quoted in every statement so both H2 (upper-folding) and PostgreSQL (lower-folding) keep the
+     * exact case.
+     */
+    private static final String TABLE_NAME = "DB_NULL_PARAMS_IT";
+
+    @Autowired
+    private DataSourcesManager dataSourcesManager;
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @BeforeEach
+    void createAndSeedTable() throws Exception {
+        try (Connection connection = dataSourcesManager.getDefaultDataSource()
+                                                       .getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE TABLE \"" + TABLE_NAME
+                    + "\" (\"ID\" INTEGER NOT NULL PRIMARY KEY, \"NAME\" VARCHAR(64), \"NOTE\" VARCHAR(64))");
+            statement.executeUpdate("INSERT INTO \"" + TABLE_NAME + "\" (\"ID\", \"NAME\", \"NOTE\") VALUES (1, 'John', 'seed')");
+        }
+    }
+
+    @AfterEach
+    void dropTable() throws Exception {
+        try (Connection connection = dataSourcesManager.getDefaultDataSource()
+                                                       .getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.executeUpdate("DROP TABLE \"" + TABLE_NAME + "\"");
+        }
+    }
+
+    @Test
+    void a_row_updates_to_null_through_the_results_view_endpoint() throws Exception {
+        String datasourceName = dataSourcesManager.getDefaultDataSource()
+                                                  .getName();
+        String schemaName;
+        try (Connection connection = dataSourcesManager.getDefaultDataSource()
+                                                       .getConnection()) {
+            schemaName = connection.getSchema();
+        }
+        // The Results view base64-encodes the table name in the path (see result.js).
+        String encodedTableName = Base64.getEncoder()
+                                        .encodeToString(TABLE_NAME.getBytes(StandardCharsets.UTF_8));
+        String url = "/services/js/view-databases/js/databaseTable.js/" + datasourceName + "/" + schemaName + "/" + encodedTableName;
+
+        // NAME: null used to make Update.execute throw before reaching the database.
+        restAssuredExecutor.execute(() -> given().contentType(ContentType.JSON)
+                                                 .body("{\"data\":{\"ID\":1,\"NAME\":null,\"NOTE\":\"kept\"},\"primaryKey\":[\"ID\"]}")
+                                                 .when()
+                                                 .put(url)
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body("success", equalTo(true)));
+
+        try (Connection connection = dataSourcesManager.getDefaultDataSource()
+                                                       .getConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("SELECT \"NAME\", \"NOTE\" FROM \"" + TABLE_NAME + "\" WHERE \"ID\" = 1");
+                ResultSet resultSet = statement.executeQuery()) {
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getString("NAME")).isNull();
+            assertThat(resultSet.getString("NOTE")).isEqualTo("kept");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #6680.

## Problem

Editing a row in the Database perspective's Results view failed with `Unsupported parameter format: [...]` whenever any column carried NULL (or a field was cleared to NULL). The Results view's CRUD service passes a plain value array to `Update.execute`, and the facade's "primitive array" gate

```js
arr.every(v => typeof v === "string" || typeof v === "number" ||
               typeof v === "boolean" || v instanceof Date || Array.isArray(v))
```

rejects `null`, throwing before anything reaches the database — even though the JDBC layer (`ParametersSetter.setIndexedParameter`) explicitly binds a JSON `null` element as SQL NULL using the statement's `ParameterMetaData` type.

## Change

- Accept `null` / `undefined` in the primitive-array gate at all four copy-pasted sites (a JS `undefined` array element serializes to JSON `null`, which the binder handles identically):
  - `db/update.ts` — `Update.execute` (the Results view edit/create path)
  - `db/query.ts` — `Query.execute`
  - `db/store.ts` — `Store.query` and `Store.queryNative`
- Widen the public parameter type unions with `| null` so TypeScript callers can pass nulls without casts.

No Java changes; no behavior change for currently-working calls.

## Test

`DatabaseCrudNullValuesIT` (HTTP-only, untagged → runs in the PR smoke leg): creates a table with nullable columns via JDBC (quoted identifiers so both H2 and PostgreSQL keep exact case), seeds a row, updates it to NULL through the same Results-view CRUD endpoint (`PUT /services/js/view-databases/js/databaseTable.js/{ds}/{schema}/{base64(table)}`), asserts `success: true` and verifies the persisted NULL (and that the sibling column kept its updated value) over JDBC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
