### PR TITLE
fix(csvim): bind the UPDATE's WHERE key at the table's column count

### DIFF
--- a/components/data/data-csvim/src/main/java/org/eclipse/dirigible/components/data/csvim/processor/CsvProcessor.java
+++ b/components/data/data-csvim/src/main/java/org/eclipse/dirigible/components/data/csvim/processor/CsvProcessor.java
@@ -157,21 +157,24 @@ public class CsvProcessor {
         UpdateBuilder updateBuilder = new UpdateBuilder(SqlFactory.deriveDialect(connection));
         updateBuilder.table(tableMetadata.getName());
 
+        // One name for both the skipped SET column and the WHERE column: the statement then always
+        // carries one placeholder per table column - N-1 SET slots plus the WHERE - which is the shape
+        // both binders rely on. Resolving them separately let a null pkName emit a SET for the key
+        // column too, so a headerless CSV produced N+1 placeholders and could never be bound.
+        String pkColumnName = pkName != null ? pkName
+                : availableTableColumns.get(0)
+                                       .getName();
+
         for (ColumnMetadata columnMetadata : availableTableColumns) {
             if (columnMetadata.getName()
-                              .equals(pkName)) {
+                              .equals(pkColumnName)) {
                 continue;
             }
 
             updateBuilder.set("\"" + columnMetadata.getName() + "\"", "?");
         }
 
-        if (pkName != null) {
-            updateBuilder.where(String.format("%s = ?", pkName));
-        } else {
-            updateBuilder.where(String.format("%s = ?", availableTableColumns.get(0)
-                                                                             .getName()));
-        }
+        updateBuilder.where(String.format("%s = ?", pkColumnName));
 
         try (PreparedStatement preparedStatement = connection.prepareStatement(updateBuilder.generate())) {
             for (CsvRecord next : csvRecords) {
@@ -258,7 +261,10 @@ public class CsvProcessor {
     }
 
     /**
-     * Insert csv without header.
+     * Insert csv without header. Values are matched to columns by position. The statement carries one
+     * placeholder per table column, so a record with fewer fields than the table has columns binds the
+     * uncovered trailing columns as null - the same outcome the header path produces for a column the
+     * CSV does not carry.
      *
      * @param csvRecord the csv record
      * @param tableColumns the table columns
@@ -267,10 +273,11 @@ public class CsvProcessor {
      */
     private void insertCsvWithoutHeader(CsvRecord csvRecord, List<ColumnMetadata> tableColumns, PreparedStatement statement)
             throws SQLException {
-        for (int i = 0; i < csvRecord.getCsvRecord()
-                                     .size(); i++) {
-            String value = csvRecord.getCsvRecord()
-                                    .get(i);
+        CSVRecord existingCsvRecord = csvRecord.getCsvRecord();
+        verifyPositionalRecordFitsTable(csvRecord, tableColumns);
+
+        for (int i = 0; i < tableColumns.size(); i++) {
+            String value = i < existingCsvRecord.size() ? existingCsvRecord.get(i) : null;
             String columnType = tableColumns.get(i)
                                             .getType();
 
@@ -279,7 +286,10 @@ public class CsvProcessor {
     }
 
     /**
-     * Update csv with header.
+     * Update csv with header. The statement built by {@link #update} carries one SET placeholder per
+     * non-primary-key table column followed by the WHERE placeholder, so the primary key is always
+     * bound at the table's column count - never at the CSV record's field count, which is a different
+     * number whenever the CSV does not carry every column of its table.
      *
      * @param csvRecord the csv record
      * @param tableColumns the table columns
@@ -288,8 +298,6 @@ public class CsvProcessor {
      */
     private void updateCsvWithHeader(CsvRecord csvRecord, List<ColumnMetadata> tableColumns, PreparedStatement statement)
             throws SQLException {
-        CSVRecord existingCsvRecord = csvRecord.getCsvRecord();
-
         for (int i = 1; i < tableColumns.size(); i++) {
             String columnName = tableColumns.get(i)
                                             .getName();
@@ -302,13 +310,14 @@ public class CsvProcessor {
 
         String pkColumnType = tableColumns.get(0)
                                           .getType();
-        int lastStatementPlaceholderIndex = existingCsvRecord.size();
 
-        setValue(statement, lastStatementPlaceholderIndex, pkColumnType, csvRecord.getCsvRecordPkValue(), csvRecord.getLocale());
+        setValue(statement, tableColumns.size(), pkColumnType, csvRecord.getCsvRecordPkValue(), csvRecord.getLocale());
     }
 
     /**
-     * Update csv without header.
+     * Update csv without header. Values are matched to columns by position; columns the record does not
+     * reach are bound as null, mirroring the header path, and the primary key is bound at the table's
+     * column count as in {@link #updateCsvWithHeader}.
      *
      * @param csvRecord the csv record
      * @param tableColumns the table columns
@@ -318,8 +327,10 @@ public class CsvProcessor {
     private void updateCsvWithoutHeader(CsvRecord csvRecord, List<ColumnMetadata> tableColumns, PreparedStatement statement)
             throws SQLException {
         CSVRecord existingCsvRecord = csvRecord.getCsvRecord();
-        for (int i = 1; i < existingCsvRecord.size(); i++) {
-            String value = existingCsvRecord.get(i);
+        verifyPositionalRecordFitsTable(csvRecord, tableColumns);
+
+        for (int i = 1; i < tableColumns.size(); i++) {
+            String value = i < existingCsvRecord.size() ? existingCsvRecord.get(i) : null;
             String columnType = tableColumns.get(i)
                                             .getType();
             setPreparedStatementValue(csvRecord.isDistinguishEmptyFromNull(), statement, i, value, columnType, csvRecord.getLocale());
@@ -327,8 +338,28 @@ public class CsvProcessor {
 
         String pkColumnType = tableColumns.get(0)
                                           .getType();
-        int lastStatementPlaceholderIndex = existingCsvRecord.size();
-        setValue(statement, lastStatementPlaceholderIndex, pkColumnType, existingCsvRecord.get(0), csvRecord.getLocale());
+        setValue(statement, tableColumns.size(), pkColumnType, existingCsvRecord.get(0), csvRecord.getLocale());
+    }
+
+    /**
+     * Verifies that a headerless CSV record can be matched to the table by position. Extra fields have
+     * no column to land in, and silently dropping them would import a record that does not say what the
+     * file says.
+     *
+     * @param csvRecord the csv record
+     * @param tableColumns the table columns
+     * @throws SQLException if the record carries more fields than the table has columns
+     */
+    private void verifyPositionalRecordFitsTable(CsvRecord csvRecord, List<ColumnMetadata> tableColumns) throws SQLException {
+        int csvFieldsCount = csvRecord.getCsvRecord()
+                                      .size();
+        if (csvFieldsCount > tableColumns.size()) {
+            throw new SQLException(String.format(
+                    "Headerless CSV record has [%d] fields but table [%s] has [%d] columns. Fields are matched by position, so the record cannot be imported. Add a header row to match by column name instead, or align the file with the table.",
+                    csvFieldsCount, csvRecord.getTableMetadataModel()
+                                             .getName(),
+                    tableColumns.size()));
+        }
     }
 
     /**

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/CsvimReimportIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/CsvimReimportIT.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api.java;
+
+import org.eclipse.dirigible.components.data.csvim.domain.CsvFile;
+import org.eclipse.dirigible.components.data.csvim.processor.CsvimProcessor;
+import org.eclipse.dirigible.components.data.sources.config.DefaultDataSourceName;
+import org.eclipse.dirigible.components.data.sources.manager.DataSourcesManager;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Re-importing a CSV whose value changed must reach the row, including when the CSV is narrower
+ * than its table - the shape of every seed CSV for a table carrying audit columns.
+ *
+ * <p>
+ * The assertions read the row's value rather than the statement: an equally wide CSV binds
+ * correctly by accident, so a fixture with as many fields as the table has columns passes even when
+ * the index arithmetic is wrong.
+ */
+class CsvimReimportIT extends IntegrationTest {
+
+    /** The default data source name. */
+    @Autowired
+    @DefaultDataSourceName
+    private String defaultDataSourceName;
+
+    /** The data source manager. */
+    @Autowired
+    private DataSourcesManager dataSourceManager;
+
+    /** The csvim processor. */
+    @Autowired
+    private CsvimProcessor csvimProcessor;
+
+    /**
+     * A changed value in a CSV that carries fewer columns than its table must be applied on re-import.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    void reimportAppliesChangedValueWhenCsvIsNarrowerThanTable() throws Exception {
+        try (Connection connection = dataSourceManager.getDefaultDataSource()
+                                                      .getConnection()) {
+            connection.createStatement()
+                      .execute("CREATE TABLE CSV_REIMPORT (R1 INT PRIMARY KEY, R2 VARCHAR(20), R3 VARCHAR(20))");
+            try {
+                csvimProcessor.setStrictMode(false);
+                CsvFile csvFile = new CsvFile(null, "CSV_REIMPORT", null, "import", true, true, ",", "\"", null, false, null);
+
+                csvimProcessor.process(csvFile, "R1,R2,R3\n1,r2_1,r3_1\n2,r2_2,r3_2".getBytes(), defaultDataSourceName);
+
+                // the same rows with one changed value, in a CSV one column narrower than the table
+                csvimProcessor.process(csvFile, "R1,R2\n1,r2_1_changed\n2,r2_2".getBytes(), defaultDataSourceName);
+
+                ResultSet rs = connection.createStatement()
+                                         .executeQuery("SELECT R2, R3 FROM CSV_REIMPORT WHERE R1 = 1");
+                assertTrue(rs.next(), "Row with R1 = 1 is missing after the re-import");
+                assertEquals("r2_1_changed", rs.getString("R2"), "The changed value did not reach the row");
+                assertNull(rs.getString("R3"), "A column the CSV does not carry must be set to null, not to the record's id");
+
+                rs = connection.createStatement()
+                               .executeQuery("SELECT COUNT(*) FROM CSV_REIMPORT");
+                assertTrue(rs.next());
+                assertEquals(2, rs.getInt(1), "The re-import must update the existing rows, not add new ones");
+            } finally {
+                connection.createStatement()
+                          .execute("DROP TABLE CSV_REIMPORT");
+            }
+        }
+    }
+
+    /**
+     * The same for a headerless CSV, where values are matched to columns by position.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    void reimportAppliesChangedValueWhenHeaderlessCsvIsNarrowerThanTable() throws Exception {
+        try (Connection connection = dataSourceManager.getDefaultDataSource()
+                                                      .getConnection()) {
+            connection.createStatement()
+                      .execute("CREATE TABLE CSV_REIMPORT_NH (N1 INT PRIMARY KEY, N2 VARCHAR(20), N3 VARCHAR(20))");
+            try {
+                csvimProcessor.setStrictMode(false);
+                CsvFile csvFile = new CsvFile(null, "CSV_REIMPORT_NH", null, "import", false, false, ",", "\"", null, false, null);
+
+                csvimProcessor.process(csvFile, "1,n2_1\n2,n2_2".getBytes(), defaultDataSourceName);
+
+                csvimProcessor.process(csvFile, "1,n2_1_changed\n2,n2_2".getBytes(), defaultDataSourceName);
+
+                ResultSet rs = connection.createStatement()
+                                         .executeQuery("SELECT N2, N3 FROM CSV_REIMPORT_NH WHERE N1 = 1");
+                assertTrue(rs.next(), "Row with N1 = 1 is missing after the re-import");
+                assertEquals("n2_1_changed", rs.getString("N2"), "The changed value did not reach the row");
+                assertNull(rs.getString("N3"), "A column the record does not reach must be bound as null");
+
+                rs = connection.createStatement()
+                               .executeQuery("SELECT COUNT(*) FROM CSV_REIMPORT_NH");
+                assertTrue(rs.next());
+                assertEquals(2, rs.getInt(1), "The re-import must update the existing rows, not add new ones");
+            } finally {
+                connection.createStatement()
+                          .execute("DROP TABLE CSV_REIMPORT_NH");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #6676.

`CsvProcessor.updateCsvWithHeader` bound the `UPDATE`'s `WHERE <pk> = ?` parameter at the CSV record's field count **M** instead of the table's column count **N**. The statement carries N−1 `SET` placeholders plus the `WHERE` at N, so the two agree only when the CSV is exactly as wide as its table.

- **M < N** — the id lands in `SET` slot #M and the real `WHERE` placeholder is never set. H2's `checkParameters` throws *before* execution, so it **fails closed**: no corruption, but no corrected seed value can ever reach an existing row.
- **M > N** — parameter index out of range.

`INSERT` binds by column name and is unaffected, which is why only re-imports broke. It stayed invisible because a plain nomenclature seed (`id,name` over a two-column table) is exactly as wide as its table by construction; any table with columns the CSV does not carry — most commonly the four audit columns — misses by that many.

### The two positional siblings from the issue

Both had the same assumption, and both are fixed here:

- `updateCsvWithoutHeader` bound `SET` slots for the record's fields only and the key at M, leaving the trailing `SET` slots *and* the `WHERE` unbound for a narrow record.
- `insertCsvWithoutHeader` bound M placeholders while `insert()` builds N.

They now iterate the **table's** columns and bind a column the record does not reach as `null` — the outcome the header path already produces for a column the CSV omits, so the two paths agree rather than diverging on the same file. The semantic call the issue asked for is therefore *bind null*, not *reject*, on the narrow side. A record with **more** fields than the table has columns has nowhere to put them: that now fails with a message naming the counts and the table, instead of an `IndexOutOfBoundsException`, because silently dropping trailing fields would import a row that does not say what the file says.

### One more cause found while testing

`update()` resolved the skipped `SET` column and the `WHERE` column separately. `getPkName` returns **null for a headerless CSV** (it only looks up the key column when header names are present), and `getName().equals(null)` is false — so nothing was skipped, the statement grew to **N+1** placeholders, and no binder could satisfy it. The headerless IT caught this as `Parameter "#4" is not set` on a 3-column table. One resolved name now drives both the skip and the `WHERE`, making the statement shape invariant.

### Tests

`CsvimReimportIT` (new, untagged so it runs in the PR smoke gate) asserts at the outermost layer per the issue's request: import, change a value, re-import, then assert the row holds the **new value** and that a column the CSV does not carry is `null` rather than the record's id. Both fixtures are deliberately narrower than their table — an `M == N` fixture passes with the arithmetic still wrong.

Verified **red before, green after**: with the fix reverted, `Tests run: 2, Failures: 2`; with it, `Tests run: 2, Failures: 0`. Neighbouring suites re-run green: `CsvimIdentityRestartIT`, `CsvimIT`. Formatter and release-profile javadoc clean on both changed modules.

### Note for maintainers, not addressed here

The existing `CsvProcessorTest` in `tests/tests-integrations/src/main/java` **never runs**: failsafe is configured with `testClassesDirectory=${project.build.outputDirectory}` and `**/*IT.java`, while surefire has no such override, so a `*Test` class in that module's `src/main/java` is compiled and then skipped by both. That is why the new coverage is an `IT` rather than an addition to that class. Worth a separate look — there may be other dead `*Test` classes in there.