### PR TITLE
test: run the two ITs that have been compiled but never executed

### DIFF
--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/CsvProcessorIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/CsvProcessorIT.java
@@ -24,7 +24,7 @@ import java.sql.SQLException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class CsvProcessorTest extends IntegrationTest {
+public class CsvProcessorIT extends IntegrationTest {
 
     /** The default data source name. */
     @Autowired

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/DatabaseMetadataHelperIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/DatabaseMetadataHelperIT.java
@@ -20,7 +20,7 @@ import java.sql.SQLException;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-class DatabaseMetadataHelperTest extends IntegrationTest {
+class DatabaseMetadataHelperIT extends IntegrationTest {
 
     @Autowired
     private DataSourcesManager datasourcesManager;


### PR DESCRIPTION
Found while adding coverage for #6676 (PR #6683): the test I wanted to extend had never run a single time.

`tests-integrations` keeps its tests under `src/main/java`, and failsafe is configured for exactly that — `testClassesDirectory=${project.build.outputDirectory}` with `includes **/*IT.java`. Surefire has no such override, so it looks in `target/test-classes`, which this module never produces. A `*Test` class there is compiled by every build and executed by **neither** runner. It reports no failure and no skip, so nothing in the build output distinguishes it from a passing test.

Two classes were in that state:

| class | tests | covers |
|---|---|---|
| `CsvProcessorTest` | 4 | strict / non-strict CSV import, column order and extra-column behavior of the header path |
| `DatabaseMetadataHelperTest` | 1 | database metadata helper |

Renamed to `CsvProcessorIT` / `DatabaseMetadataHelperIT` so failsafe picks them up. **No test body changed** — only the class names, so the diff stays legible as what it is. All 5 pass against `master`:

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- DatabaseMetadataHelperIT
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 -- CsvProcessorIT
```

(Re-run with a pristine `data-csvim` built from `master`, so this is independent of #6683 — those four tests exercise header-based inserts, which that PR does not touch.)

### The two other `*Test` names under that tree are correct and stay

- `MultitenancyUserInterfaceIntegrationTest` declares no tests; it is the base class of `BpmnMultitenancyIT` and `MultitenancyHarmoniaIT`, matching the `tests-framework` naming (`IntegrationTest`, `UserInterfaceIntegrationTest`).
- `repository-api-test`'s `RepositoryGeneric*Test` classes are shared bases in a test-support module; their concrete subclasses run under surefire in the repository implementations.

### Worth considering separately

Nothing stops this from recurring — a new `*Test` in this module is still silently inert. A failsafe/surefire `failIfNoSpecifiedTests`-style guard, or a build check that no `*Test.java` exists under `tests-integrations/src/main/java`, would make the next one loud. I did not add one here to keep this PR to the observation and its fix.