### PR TITLE
fix(templates): a user update must not take system-owned fields from the payload

### DIFF
--- a/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
+++ b/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
@@ -1,6 +1,10 @@
 package gen.${javaGenFolderName}.data.${javaPerspectiveName};
 
+#set($preservedOnUpdate = [])
 #foreach ($property in $properties)
+    #if($property.dataPrimaryKey)
+        #set($pkPropertyName = $property.name)
+    #end
     #if($property.isCalculatedProperty && ($property.calculatedPropertyExpressionCreate || $property.calculatedActionOnCreate))
         #set($haveCalculatedPropertyOnCreate = "true")
     #end
@@ -12,6 +16,16 @@ package gen.${javaGenFolderName}.data.${javaPerspectiveName};
     #end
     #if($property.isCalculatedProperty && ($property.calculatedActionOnCreate || $property.calculatedActionOnUpdate))
         #set($haveCalculatedPropertyAction = "true")
+    #end
+    ## System-owned columns a user update must never take from the payload (consumed by update()):
+    ## platform-managed read-only fields (an author's readOnly, roll-up targets, the document number
+    ## and uuid) and aggregate footer fields (an invoice's Net/Total/Paid). An aggregate that is
+    ## recomputed on update (an expressionUpdate such as Balance) is exempt here - update() reassigns
+    ## it AFTER recalculate(), from the resummed aggregates and the preserved values. A calculated
+    ## create-only field that stays user-editable (a defaulted Currency relation) carries neither
+    ## flag, so a user's edit of it is respected.
+    #if(!$property.dataPrimaryKey && ($property.isReadOnlyProperty || ($property.aggregate && !$property.calculatedPropertyExpressionUpdate && !$property.calculatedActionOnUpdate)))
+        #set($ignore = $preservedOnUpdate.add($property))
     #end
 #end
 ## Decimal places of a calculated property: its own scale, else 2 for floating-point types, else 0.
@@ -239,6 +253,21 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
     public ${name}Entity update(${name}Entity entity) {
 #rollupGuardCheck()
 #aggregateGuardCheck()
+#if($preservedOnUpdate.size() > 0)
+        // System-owned fields survive a partial payload: a caller's update carries only the fields
+        // its form edits, and a value it leaves null must not erase what the write path computed -
+        // the roll-up/aggregate targets (an invoice's Paid, a timesheet's total hours) and the
+        // platform-managed identifiers (document number, uuid). The #6226/#6306 lost-update family,
+        // user-update edition: read the stored row once and take the system-owned values from THERE,
+        // never from the payload. System writers stay on the targeted primitives (updateProperty /
+        // updateProperties / updateDerived), so this preservation cannot fight a workflow write.
+        ${name}Entity existingRow = entity.${pkPropertyName} == null ? null : findById(entity.${pkPropertyName});
+        if (existingRow != null) {
+#foreach($property in $preservedOnUpdate)
+            entity.${property.name} = existingRow.${property.name};
+#end
+        }
+#end
 #if($aggregateKeys && $aggregateKeys.size() > 0)
         // Aggregate rekey: this entity groups an aggregate, so a change to one of its grouping keys
         // MOVES the row between tuples. The tuple it moves into is recomputed off the "-updated" event
@@ -252,7 +281,14 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
 #if($hasLabel)
         computeName(entity);
 #end
+#if($documentMaster)
+        recalculate(entity);
+#end
 #if($haveCalculatedPropertyOnUpdate)
+## The update-time recomputes run AFTER recalculate() and the preservation block above, so an
+## expression like Balance = Total - Paid reads the freshly resummed Total and the preserved Paid -
+## computing it from the incoming payload read nulls as zeros and persisted Balance 0 on a header
+## edit (the 2026-08-12 prod invoice corruption).
 #foreach ($property in $properties)
 #if($property.isCalculatedProperty && $property.calculatedActionOnUpdate)
 #actionAssign($property $property.calculatedActionOnUpdate)
@@ -260,9 +296,6 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
 #calcAssign($property $property.calculatedPropertyExpressionUpdate)
 #end
 #end
-#end
-#if($documentMaster)
-        recalculate(entity);
 #end
 #if($documentChecks && $documentChecks.size() > 0)
         enforceChecks(entity);


### PR DESCRIPTION
### What

A generated `update()` persisted the caller's partial payload whole, so a header-only edit erased the system-owned money columns.

The UI form PUTs only the fields it edits. `Paid` (the allocation roll-up target) took the payload's `null`, and `Balance` was recomputed **before** `recalculate()` from those nulls and persisted as `0`.

Observed in production: invoice `0000000181` printed a total due of `0` on an 8,556.00 invoice after exactly one draft header edit. The data was repaired by hand.

### Fix

In `Repository.java.template`:

- Collect the **system-owned** properties at generation time — an author's `readOnly`, roll-up/aggregate targets, the document number and `uuid` — into `$preservedOnUpdate`.
- In `update()`, read the stored row once (`findById`) and take those values from **there**, never from the payload.
- Move `recalculate(entity)` **before** the update-time calculated fields, so an expression like `Balance = Total - Paid` reads the freshly resummed `Total` and the preserved `Paid`.

This is the `#6226`/`#6306` lost-update family, user-update edition.

### Deliberately not preserved

An aggregate that is itself recomputed on update (an `expressionUpdate` such as `Balance`) is exempt — `update()` reassigns it after `recalculate()`. A calculated **create-only** field that stays user-editable (a `Currency` relation defaulted from the company) carries neither flag, so a user's edit of it is respected.

Safe against workflow writes by construction: every system writer (number stamp, status transitions, roll-ups) uses the targeted `updateProperty` / `updateProperties` / `updateDerived` primitives, which bypass `update()` entirely.

### Verification

On a live instance (registry wipe + template reseed + regen of sales-invoices and timesheets):

- the emitted `update()` preserves `Number` / `Net` / `Vat` / `Discount` / `Total` / `Paid` / `Uuid` / `ProcessId` / audit, and recomputes `Balance` after `recalculate()`;
- runtime reproduction — create invoice + item, then PUT a header-only payload — keeps `Paid 0.00` / `Balance 120.00` / `Number` intact, where the previous build persisted `Paid null` / `Balance 0`;
- client-Java batch: 256 units, 261 class files;
- `audit-dsl-emission.py`: 729 OK, 1 pre-existing unrelated FAIL (timesheets personal-group, regen owed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
