### PR TITLE
fix(forms): an optional field with a format constraint must accept empty

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/formValidation.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/formValidation.js
@@ -47,6 +47,12 @@
     for (const [field, fieldRules] of Object.entries(schema)) {
       const value = data[field];
       for (const cfg of fieldRules) {
+        // Presence is `required`'s decision alone: a format/range rule (email, pattern, minLength,
+        // min/max) describes what a value must look like WHEN THERE IS ONE. Applying it to an empty
+        // value turns every optional field carrying a format constraint into a required one by the
+        // back door — a customer with no e-mail could not be saved at all ("Enter a valid email
+        // address." on a blank, non-required Email), and the only way through was to invent one.
+        if (cfg.rule !== 'required' && trim(value) === '') continue;
         if (!applyRule(cfg.rule, value, cfg)) {
           errors[field] = cfg.message;
           break; // first failing rule wins

--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
@@ -496,7 +496,12 @@ public class ${name}Controller {
         }
 #end
 #if($property.widgetPattern && $property.widgetPattern != "")
-        if (entity.${property.name} != null && !entity.${property.name}.toString().matches("${property.widgetPatternJava}")) {
+## A format constraint describes what a value must look like WHEN THERE IS ONE. On an OPTIONAL property
+## a blank string is "no value", so the pattern must not fire on it - otherwise the field is required by
+## the back door (a blank optional Email was rejected, and the only way to save was to invent an
+## address). The Harmonia form already posts '' as null, but a direct REST caller may send ''.
+## A REQUIRED property keeps the strict check: blank is not a legal value there.
+        if (entity.${property.name} != null#if($property.isRequiredProperty != "true") && !entity.${property.name}.toString().isBlank()#end && !entity.${property.name}.toString().matches("${property.widgetPatternJava}")) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The value of '${property.name}' does not match the required pattern '${property.widgetPatternJava}'");
         }
 #end


### PR DESCRIPTION
### What

A blank **optional** field cannot be saved.

Creating a Customer with only the required `Name` fails with *"Could not save — Fields that need attention: Email"* / *"Enter a valid email address."*, even though `Email` is not required. The only way through is to invent an address — which then pollutes the data, since the dunning and notify paths mail whatever is stored there.

### Cause

Both layers applied the format rule to the empty value:

- **Client** (`application-core` `formValidation.js`) ran every rule regardless of presence, so the `email` rule on an optional field rejected `''`.
- **Server** (`EntityController.java.template`) guarded the pattern on `!= null` only, so a direct REST caller sending `""` got a 400. The Harmonia form already posts `''` as `null`, so this path is REST-only.

A format constraint describes what a value must look like **when there is one**. Presence is `required`'s decision alone; applying a format rule to an empty value makes every optional field carrying one required by the back door.

### Fix

**Client** — skip any non-`required` rule when the value is blank. This covers `email` / `pattern` / `minLength` / `min` / `max` alike. No required field loses its check: the generator emits **either** the `required` rule **or** the format rule for a given field, never both.

This file is the **shared** runtime, so every generated app picks the fix up **without a regen**.

**Server** — emit the blank skip only for **optional** properties:

```java
// optional + pattern
if (entity.Email != null && !entity.Email.toString().isBlank() && !entity.Email.toString().matches(...))
// required + pattern — unchanged
if (entity.Code != null && !entity.Code.toString().matches(...))
```

A required property keeps the strict check, where blank is not a legal value — so nothing that is rejected today starts passing. Modules pick this up on their next regen.

### Verification

- The client validator against 11 cases: blank / null / whitespace accepted on an optional email; `"abc"` still refused; `required` still fails on `''` and `null`; optional `minLength`/`min` skip empty but still fail a present bad value.
- The controller template rendered through a real Velocity engine with an optional-patterned and a required-patterned property, confirming the emitted Java gains `&& !isBlank()` on the optional one **only**, and is byte-identical for the required one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
