### PR TITLE
feat(templates): a field's defaultValue seeds a new line in the item dialog

### DIFF
--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -106,9 +106,17 @@ entities:
 **Rules:** PK integer; field `type` from the allowed list; relation `kind` from the allowed list;
 composition is opt-in.
 
-**Field attributes (faithfulness):** besides `required`, `primaryKey`, `generated`, `length` and
-`defaultValue`, a field may declare:
+**Field attributes (faithfulness):** besides `required`, `primaryKey`, `generated` and `length`, a
+field may declare:
 
+- `defaultValue: <value>` - the field's default, in three places at once: the column's **DB DEFAULT**
+  (a row inserted without the column gets it), the reason a `required` field's **presence check is
+  skipped** (the value is guaranteed), and the **seed for a new line in a document's item dialog** -
+  the dialog opens on the standard value instead of a blank one, which is what makes a one-click
+  affordance like **Fill Month** actually one click. An existing row is never re-defaulted, so a value
+  the user deliberately cleared stays cleared. The to-one relation analogue is `init:`.
+  `- { name: hours, type: decimal, defaultValue: 8 }` /
+  `- { name: billable, type: boolean, defaultValue: true }`.
 - `unique: true` - a UNIQUE constraint (e.g. a `uuid` business key or a code).
 - `major: false` - keep the field <b>off the entity list table</b> (it is still shown in forms and the
   record details pane). Defaults to `true` (every field is a list column). Use it to declutter the list

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -996,7 +996,12 @@ document.addEventListener('alpine:init', () => {
           if (col.widget === 'DROPDOWN') v = String(v);
           else if (col.date) v = this.toDateInput(v, col.widget);
         }
-        draft[col.name] = v == null ? (col.widget === 'CHECKBOX' ? false : (col.widget === 'NUMBER' ? null : '')) : v;
+        // A NEW line takes the column's authored default (intent `defaultValue:`, emitted as col.def)
+        // so the dialog opens on the standard values instead of blank ones - what makes a one-click
+        // affordance like Fill Month actually one click. An EXISTING row keeps what is stored,
+        // including a value the user deliberately cleared: re-defaulting that would silently undo it.
+        const blank = col.widget === 'CHECKBOX' ? false : (col.widget === 'NUMBER' ? null : '');
+        draft[col.name] = v == null ? (!row && col.def !== undefined ? col.def : blank) : v;
       }
       if (row && row[pk] != null) draft[pk] = row[pk];
       if (preset) {

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/detail-register.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/detail-register.js.template
@@ -30,6 +30,14 @@
 ## (my) surface must drop it entirely - the personal controller nulls the value on the wire, so
 ## rendering it would only show a permanently empty column the owner is not meant to see.
 #macro(sensitiveMeta $property)#if($property.sensitiveProperty), sensitive: true#end#end
+## The authored field default (intent `defaultValue:`) as the seed for a NEW line in the item dialog.
+## The column already carries this value as a DB DEFAULT and as the reason its required-check is
+## skipped; seeding the dialog is what makes it VISIBLE and editable before the row is posted, so a
+## one-click affordance (Fill Month) books the standard values without the user retyping them.
+## Emitted in the shape the draft holds: a checkbox takes a real boolean, a numeric column a real
+## number, and everything else a string - including a DROPDOWN's FK, which the draft keeps stringified
+## so it matches an option's data-value.
+#macro(defaultMeta $property)#if($property.dataDefaultValue && $property.dataDefaultValue != "")#if($property.widgetType == "CHECKBOX"), def: #if($property.dataDefaultValue == "true")true#{else}false#end#elseif($property.widgetType == "DROPDOWN"), def: '${property.dataDefaultValue}'#elseif($property.isNumberType), def: ${property.dataDefaultValue}#{else}, def: '${property.dataDefaultValue}'#end#end#end
 App.registerDetail('${masterEntity}', {
   entity: '${name}',
   label: '${menuLabel}',
@@ -82,9 +90,9 @@ App.registerDetail('${masterEntity}', {
 #if($property.widgetLabel)#set($elabel = $property.widgetLabel)#else#set($elabel = $property.name)#end
 #set($ereadonly = ($property.isCalculatedProperty == "true" || $property.isReadOnlyProperty == "true"))
 #if($property.widgetType == "DROPDOWN")
-    { name: '${property.name}', label: '${elabel}', tkey: '$projectName:${tprefix}.t.${property.dataName}', widget: 'DROPDOWN', required: #if($property.isRequiredProperty == "true")true#{else}false#end, readonly: #if($ereadonly)true#{else}false#end, lookup: { url: '${property.widgetDropdownControllerUrl}', key: '${property.widgetDropDownKey}', text: '${property.widgetDropDownValue}', entity: '${property.relationshipEntityName}', creatable: #if($property.relationshipEntityName && $property.relationshipEntityPerspectiveName != "Settings")true#{else}false#end }#dependsOnMeta($property)#optionsFilterMeta($property)#hierMeta($property)#sensitiveMeta($property) },
+    { name: '${property.name}', label: '${elabel}', tkey: '$projectName:${tprefix}.t.${property.dataName}', widget: 'DROPDOWN', required: #if($property.isRequiredProperty == "true")true#{else}false#end, readonly: #if($ereadonly)true#{else}false#end, lookup: { url: '${property.widgetDropdownControllerUrl}', key: '${property.widgetDropDownKey}', text: '${property.widgetDropDownValue}', entity: '${property.relationshipEntityName}', creatable: #if($property.relationshipEntityName && $property.relationshipEntityPerspectiveName != "Settings")true#{else}false#end }#dependsOnMeta($property)#optionsFilterMeta($property)#hierMeta($property)#sensitiveMeta($property)#defaultMeta($property) },
 #else
-    { name: '${property.name}', label: '${elabel}', tkey: '$projectName:${tprefix}.t.${property.dataName}', widget: '${property.widgetType}', required: #if($property.isRequiredProperty == "true")true#{else}false#end, readonly: #if($ereadonly)true#{else}false#end, date: #if($property.isDateType)true#{else}false#end#if($property.isNumberType), number: true#end#if($property.isFloatType), float: true, pattern: '${property.formatPattern}'#end#calcMeta($property)#dependsOnMeta($property)#patternMeta($property)#sensitiveMeta($property) },
+    { name: '${property.name}', label: '${elabel}', tkey: '$projectName:${tprefix}.t.${property.dataName}', widget: '${property.widgetType}', required: #if($property.isRequiredProperty == "true")true#{else}false#end, readonly: #if($ereadonly)true#{else}false#end, date: #if($property.isDateType)true#{else}false#end#if($property.isNumberType), number: true#end#if($property.isFloatType), float: true, pattern: '${property.formatPattern}'#end#calcMeta($property)#dependsOnMeta($property)#patternMeta($property)#sensitiveMeta($property)#defaultMeta($property) },
 #end
 #end
 #end


### PR DESCRIPTION
### What

`defaultValue:` on a field already reached the model — it becomes the column's **DB DEFAULT** and suppresses a required field's presence check — but **no UI ever seeded from it**. A document's item dialog built a new line out of blanks (`false` for a checkbox, `null` for a number, `''` otherwise), so every authored default was invisible until the row was posted.

The visible cost is **Fill Month**. The guide promises it *"creates an 8-hour line for every working day (Mon–Fri)"*, and the dialog's skip-existing-days and Mon–Fri rules do match — but `Hours` opened empty and `Billable` opened off, so the one-click promise was really *type-8-toggle-billable-click*.

### Change

The detail registry emits the authored default as `def` on the column, in the shape the draft holds:

| column | emitted |
|---|---|
| `NUMBER` | `def: 8` (real number) |
| `CHECKBOX` | `def: true` (real boolean) |
| `DROPDOWN` (numeric FK) | `def: '2'` (string — the draft keeps FKs stringified so they match an option's `data-value`) |
| no default declared | no key at all |

`openRowDialog` seeds a **new** line from it. An **existing** row is untouched — re-defaulting a value the user deliberately cleared would silently undo it.

### Scope

Deliberately **item-dialog only**. The main create form is left alone: every entity with an `init:` status carries a `dataDefaultValue` too, so seeding forms as well would visibly change create screens across the whole fleet — a separate change with its own blast radius, not something to smuggle in behind a dialog fix.

The DSL key itself needed no work — it already binds and already emits. It was, however, undocumented beyond a passing mention, so `intent-assistant-guide.md` now describes all three things it does.

### Verification

Both templates rendered through a real Velocity engine with a NUMBER / CHECKBOX / numeric-DROPDOWN / no-default / text-default property set, confirming the table above and that the rendered registry parses as JS (`node --check`).

The seeding line was then simulated over new / edit / cleared rows:

- new line takes the defaults → `{Hours: 8, Billable: true, Status: '2', Note: ''}`
- edited row keeps its stored values
- a cleared value is **not** re-defaulted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
