### PR TITLE
fix(csvim): change detection spans the referenced CSV files (#6686)

### DIFF
--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/synchronizer/Synchronizer.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/synchronizer/Synchronizer.java
@@ -61,6 +61,21 @@ public interface Synchronizer<A extends Artefact, ID> {
     List<A> parse(String location, byte[] content) throws ParseException;
 
     /**
+     * Returns the content whose checksum decides whether the definition at the given location has been
+     * modified. By default the definition file's own bytes. A synchronizer whose artefact imports other
+     * files by reference (e.g. CSVIM referencing CSV files) extends the result with the referenced
+     * files' content, so that editing only a referenced file marks the definition MODIFIED and the
+     * UPDATE flow re-processes it.
+     *
+     * @param location the definition location
+     * @param content the definition file's own content
+     * @return the content to checksum for change detection
+     */
+    default byte[] checksumContent(String location, byte[] content) {
+        return content;
+    }
+
+    /**
      * Retrieve all the processed artefacts by the definition location.
      *
      * @param location the location

--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationProcessor.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationProcessor.java
@@ -787,6 +787,11 @@ public class SynchronizationProcessor implements SynchronizationWalkerCallback, 
         Definition definition = new Definition(location, FilenameUtils.getBaseName(file.getFileName()
                                                                                        .toString()),
                 type, content);
+        // change detection may span more than the file's own bytes (e.g. CSVIM + its referenced CSVs)
+        byte[] checksumContent = synchronizer.checksumContent(location, content);
+        if (checksumContent != content) {
+            definition.updateChecksum(checksumContent);
+        }
         // check whether this artefact has been processed in the past already
         Definition maybe = definitionService.findByKey(definition.getKey());
         Map<String, Definition> map = checkSynchronizerMap(synchronizer);

--- a/components/data/data-csvim/src/main/java/org/eclipse/dirigible/components/data/csvim/synchronizer/CsvimSynchronizer.java
+++ b/components/data/data-csvim/src/main/java/org/eclipse/dirigible/components/data/csvim/synchronizer/CsvimSynchronizer.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.dirigible.components.data.csvim.synchronizer;
 
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.text.ParseException;
@@ -150,6 +151,40 @@ public class CsvimSynchronizer extends MultitenantBaseSynchronizer<Csvim, Long> 
         } catch (Exception e) {
             logger.error("Failed to save CSVIM [{}], content: [{}]", csvim, new String(content), e);
             throw new ParseException(e.getMessage(), 0);
+        }
+    }
+
+    /**
+     * The referenced CSV files are read at import time but their bytes are part of what a CSVIM import
+     * produces, so they must take part in the change detection as well - otherwise editing only a CSV
+     * re-imports nothing, silently. Appends each referenced CSV's content to the CSVIM's own bytes. A
+     * CSV that does not exist (yet) contributes nothing, so its later appearance changes the checksum
+     * and triggers the import.
+     *
+     * @param location the definition location
+     * @param content the CSVIM definition content
+     * @return the content extended with the referenced CSV files' content
+     */
+    @Override
+    public byte[] checksumContent(String location, byte[] content) {
+        try {
+            Csvim csvim = JsonHelper.fromJson(new String(content, StandardCharsets.UTF_8), Csvim.class);
+            if (csvim == null || csvim.getFiles() == null || csvim.getFiles()
+                                                                  .isEmpty()) {
+                return content;
+            }
+            ByteArrayOutputStream extended = new ByteArrayOutputStream();
+            extended.write(content);
+            for (CsvFile csvFile : csvim.getFiles()) {
+                IResource resource = CsvimProcessor.getCsvResource(csvFile);
+                if (resource.exists()) {
+                    extended.write(resource.getContent());
+                }
+            }
+            return extended.toByteArray();
+        } catch (Exception e) {
+            logger.warn("Failed to extend the checksum of CSVIM [{}] with its referenced CSV files", location, e);
+            return content;
         }
     }
 

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/CsvimReimportIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/CsvimReimportIT.java
@@ -13,12 +13,19 @@ import org.eclipse.dirigible.components.data.csvim.domain.CsvFile;
 import org.eclipse.dirigible.components.data.csvim.processor.CsvimProcessor;
 import org.eclipse.dirigible.components.data.sources.config.DefaultDataSourceName;
 import org.eclipse.dirigible.components.data.sources.manager.DataSourcesManager;
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
 import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -32,8 +39,67 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * The assertions read the row's value rather than the statement: an equally wide CSV binds
  * correctly by accident, so a fixture with as many fields as the table has columns passes even when
  * the index arithmetic is wrong.
+ *
+ * <p>
+ * Also covers the other half of the same finding: the re-import must be TRIGGERED when only the
+ * referenced CSV changes, since the .csvim itself is a stable pointer that stays byte-identical.
  */
 class CsvimReimportIT extends IntegrationTest {
+
+    /** The project holding the synchronizer-path fixture. */
+    private static final String PROJECT = "csvim-csv-edit-it";
+
+    /** The table fixture path. */
+    private static final String TABLE_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/tables/city.table";
+
+    /** The CSV fixture path. */
+    private static final String CSV_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/data/cities.csv";
+
+    /** The CSVIM fixture path. */
+    private static final String CSVIM_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/data/cities.csvim";
+
+    /** The table fixture name. */
+    private static final String TABLE_NAME = "CSVIM_CSV_EDIT";
+
+    /** The table fixture source. */
+    private static final String TABLE_SOURCE = """
+            {
+                "name": "CSVIM_CSV_EDIT",
+                "type": "TABLE",
+                "columns": [
+                    {
+                        "type": "INTEGER",
+                        "primaryKey": true,
+                        "nullable": false,
+                        "name": "CITY_ID"
+                    },
+                    {
+                        "type": "VARCHAR",
+                        "length": 40,
+                        "nullable": false,
+                        "name": "CITY_NAME"
+                    }
+                ]
+            }
+            """;
+
+    /** The CSVIM fixture source - a stable pointer that is NEVER touched after the initial import. */
+    private static final String CSVIM_SOURCE = """
+            {
+                "files": [
+                    {
+                        "table": "CSVIM_CSV_EDIT",
+                        "schema": "PUBLIC",
+                        "file": "/%s/data/cities.csv",
+                        "header": true,
+                        "useHeaderNames": true,
+                        "delimField": ",",
+                        "distinguishEmptyFromNull": true,
+                        "version": "1.0"
+                    }
+                ]
+            }
+            """.formatted(PROJECT);
 
     /** The default data source name. */
     @Autowired
@@ -47,6 +113,89 @@ class CsvimReimportIT extends IntegrationTest {
     /** The csvim processor. */
     @Autowired
     private CsvimProcessor csvimProcessor;
+
+    /** The repository. */
+    @Autowired
+    private IRepository repository;
+
+    /** The synchronization processor. */
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    /**
+     * Editing ONLY the referenced CSV must re-import - the .csvim is a stable pointer and does not
+     * change when a seed value does, so the change detection has to span the referenced files. The
+     * assertion reads the row's value after the second sync; a fixture that also touched the .csvim
+     * would pass while missing the bug entirely.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    void editingOnlyTheCsvTriggersReimport() throws Exception {
+        write(TABLE_PATH, TABLE_SOURCE);
+        write(CSV_PATH, "CITY_ID,CITY_NAME\n1,Sofia\n2,Plovdiv");
+        write(CSVIM_PATH, CSVIM_SOURCE);
+        synchronizationProcessor.forceProcessSynchronizers();
+
+        assertEquals("Sofia", cityName(1), "The initial import did not seed the row");
+
+        // the ordinary editing path: the seed value changes, the .csvim stays byte-identical
+        write(CSV_PATH, "CITY_ID,CITY_NAME\n1,Varna\n2,Plovdiv");
+        synchronizationProcessor.forceProcessSynchronizers();
+
+        assertEquals("Varna", cityName(1), "Editing only the CSV must re-import the changed value");
+    }
+
+    /**
+     * Reads the seeded row's name.
+     *
+     * @param id the city id
+     * @return the city name
+     * @throws Exception the exception
+     */
+    private String cityName(int id) throws Exception {
+        try (Connection connection = dataSourceManager.getDefaultDataSource()
+                                                      .getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery("SELECT \"CITY_NAME\" FROM \"" + TABLE_NAME + "\" WHERE \"CITY_ID\" = " + id)) {
+            assertTrue(rs.next(), "Row with CITY_ID = " + id + " is missing");
+            return rs.getString(1);
+        }
+    }
+
+    /**
+     * Writes a fixture resource.
+     *
+     * @param path the path
+     * @param source the source
+     */
+    private void write(String path, String source) {
+        repository.createResource(path, source.getBytes(StandardCharsets.UTF_8), false, "text/plain", true);
+    }
+
+    /**
+     * Cleanup the fixture.
+     *
+     * @throws Exception the exception
+     */
+    @AfterEach
+    void cleanup() throws Exception {
+        boolean fixtureUsed = false;
+        for (String path : List.of(CSVIM_PATH, CSV_PATH, TABLE_PATH)) {
+            if (repository.hasResource(path)) {
+                repository.removeResource(path);
+                fixtureUsed = true;
+            }
+        }
+        if (fixtureUsed) {
+            synchronizationProcessor.forceProcessSynchronizers();
+            try (Connection connection = dataSourceManager.getDefaultDataSource()
+                                                          .getConnection();
+                    Statement statement = connection.createStatement()) {
+                statement.execute("DROP TABLE IF EXISTS \"" + TABLE_NAME + "\"");
+            }
+        }
+    }
 
     /**
      * A changed value in a CSV that carries fewer columns than its table must be applied on re-import.


### PR DESCRIPTION
Fixes #6686 — the sequel to #6676 / #6683: that one fixed the UPDATE binding so a re-import *can* apply a changed value; this one makes the re-import actually trigger when only a referenced `.csv` changes.

## The defect

`SynchronizationProcessor.checkAndCollect` computed the definition checksum from the `.csvim` file's own bytes alone. The referenced CSVs were opened only inside `importCsvim`, well after the MODIFIED decision — so editing only a CSV left the artefact `CREATED`, both inner switches fell through, and nothing was imported. No error, no warning. Since the `.csvim` is a stable pointer that stays byte-identical when a seed value changes, the ordinary editing path could never reach the re-import.

## The fix

- **`Synchronizer.checksumContent(location, content)`** — a new default hook returning the content whose checksum decides whether the definition is MODIFIED. Default: the file's own bytes (no behavior change for any other synchronizer).
- **`SynchronizationProcessor.checkAndCollect`** calls the hook and, when it extends the content, updates the definition checksum with the extended bytes. The definition's `content` (what `parse` receives) stays the `.csvim`'s own bytes.
- **`CsvimSynchronizer`** overrides the hook to append each referenced CSV's content to the `.csvim` bytes, so an edited CSV yields `MODIFIED` and the existing UPDATE path runs unchanged (which, with #6683 merged, now applies values correctly). A CSV that does not exist yet contributes nothing — its later appearance changes the checksum and triggers the import, closing a second silent gap for free. A parse failure falls back to the original bytes (the definition then breaks in `parse` as before).

## Test

`CsvimReimportIT.editingOnlyTheCsvTriggersReimport` drives the **full synchronizer path**: writes `.table` + `.csv` + `.csvim` registry fixtures, forces a sync, then rewrites **only the CSV** (the `.csvim` stays byte-identical — per the issue's warning, a fixture that also touches the `.csvim` passes while missing the bug) and asserts the row's **value** after the second sync.

- Verified **red** on unfixed code: `expected: <Varna> but was: <Sofia>`
- Green with the fix; the two pre-existing `CsvimReimportIT` tests stay green
- Unit tests of the three touched modules green; `formatter:validate` and the release-profile javadoc check pass

## Not touched (deliberately)

The `switch (flow)` fall-through in `CsvimSynchronizer.completeImpl` that the issue flags under "worth the implementer's attention" is left as-is — this fix rides the existing UPDATE/MODIFIED path and does not depend on the fall-through's behavior; changing lifecycle-transition semantics is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)