### PR TITLE
fix(templates): a create-only calculated action no longer renders the field read-only

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -78,7 +78,10 @@
 ## read-only details block below the header form, not as editable inputs; they stay in the model for
 ## round-trip. Aggregate totals go in the totals footer; calculated fields stay inline (read-only).
 #if(!$property.dataAutoIncrement && $property.aggregate != "true" && !($property.widgetType == "DOCUMENT_NUMBER" && $property.numberSeries) && $property.widgetType != "DOCUMENT_STATUS" && $property.isReadOnlyProperty != "true" && !($property.auditType && $property.auditType != "NONE"))
-#set($readonly = ($property.isCalculatedProperty == "true"))
+## Read-only only when DERIVED - an expression, or an update-time recompute. A field whose only
+## calculated aspect is calculatedActionOnCreate is a server-side DEFAULT (Due, Currency, a tax
+## event date): pre-filled, but the user's pick is respected - it must stay editable (#6696).
+#set($readonly = ($property.isCalculatedProperty == "true" && ($property.calculatedPropertyExpressionCreate || $property.calculatedPropertyExpressionUpdate || $property.calculatedActionOnUpdate)))
 ## A non-setting association dropdown gets an inline "Add new / Refresh" control and spans the full row.
 #set($lookup = ($property.widgetType == "DROPDOWN" && $property.relationshipEntityName && $property.relationshipEntityPerspectiveName != "Settings" && !$readonly))
 #if($property.widgetLabel)#set($label = $property.widgetLabel)#else#set($label = $property.name)#end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
@@ -94,7 +94,10 @@
 ## master-detail surface (items dialog, detail tables). Offering the parent as a dropdown invites
 ## re-parenting by accident and is redundant inside the detail dialog.
 #if(!$property.dataAutoIncrement && $property.isReadOnlyProperty != "true" && $property.widgetType != "DOCUMENT_STATUS" && $property.relationshipType != "COMPOSITION" && !($property.auditType && $property.auditType != "NONE"))
-#set($readonly = ($property.isCalculatedProperty == "true"))
+## Read-only only when DERIVED - an expression, or an update-time recompute. A field whose only
+## calculated aspect is calculatedActionOnCreate is a server-side DEFAULT (Due, Currency, a tax
+## event date): pre-filled, but the user's pick is respected - it must stay editable (#6696).
+#set($readonly = ($property.isCalculatedProperty == "true" && ($property.calculatedPropertyExpressionCreate || $property.calculatedPropertyExpressionUpdate || $property.calculatedActionOnUpdate)))
 ## A non-setting association dropdown gets an inline "Add new / Refresh" control and spans the full row.
 #set($lookup = ($property.widgetType == "DROPDOWN" && $property.relationshipEntityName && $property.relationshipEntityPerspectiveName != "Settings" && !$readonly))
 #if($property.widgetLabel)#set($label = $property.widgetLabel)#else#set($label = $property.name)#end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/detail-register.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/detail-register.js.template
@@ -88,7 +88,10 @@ App.registerDetail('${masterEntity}', {
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement && $property.name != $masterEntityId && (!$property.auditType || $property.auditType == "NONE"))
 #if($property.widgetLabel)#set($elabel = $property.widgetLabel)#else#set($elabel = $property.name)#end
-#set($ereadonly = ($property.isCalculatedProperty == "true" || $property.isReadOnlyProperty == "true"))
+## Read-only only when DERIVED - an expression, or an update-time recompute. A field whose only
+## calculated aspect is calculatedActionOnCreate is a server-side DEFAULT (Due, Currency, a tax
+## event date): pre-filled, but the user's pick is respected - it must stay editable (#6696).
+#set($ereadonly = (($property.isCalculatedProperty == "true" && ($property.calculatedPropertyExpressionCreate || $property.calculatedPropertyExpressionUpdate || $property.calculatedActionOnUpdate)) || $property.isReadOnlyProperty == "true"))
 #if($property.widgetType == "DROPDOWN")
     { name: '${property.name}', label: '${elabel}', tkey: '$projectName:${tprefix}.t.${property.dataName}', widget: 'DROPDOWN', required: #if($property.isRequiredProperty == "true")true#{else}false#end, readonly: #if($ereadonly)true#{else}false#end, lookup: { url: '${property.widgetDropdownControllerUrl}', key: '${property.widgetDropDownKey}', text: '${property.widgetDropDownValue}', entity: '${property.relationshipEntityName}', creatable: #if($property.relationshipEntityName && $property.relationshipEntityPerspectiveName != "Settings")true#{else}false#end }#dependsOnMeta($property)#optionsFilterMeta($property)#hierMeta($property)#sensitiveMeta($property)#defaultMeta($property) },
 #else


### PR DESCRIPTION
Closes #6696.

`isCalculatedProperty` drove a hard `disabled` on the generated inputs. That is right for a DERIVED field (Balance recomputes on every write) but wrong for a field whose only calculated aspect is `calculatedActionOnCreate` — that is a server-side DEFAULT (Due from the customer's terms, Currency from the company, a document's tax event date, its bank account). The documented contract for those is "pre-filled AND editable — a value you pick is respected", and the actions implement exactly that (a non-null incoming value always wins); the REST layer honored a user value the form could no longer produce. Concretely: wiring a currency default (#6687) made the Currency picker un-editable — an invoice in another currency could no longer be created from the form.

Read-only now means DERIVED: an expression (create or update) or an update-time recompute action. A field that must stay locked despite a create-only action says `readOnly: true` explicitly — kept working, and it also enrolls the field in the generated `update()`'s system-owned preservation (#6689).

Emission sites: `document/document-view.html.template`, `manage/form-view.html.template`, `master/detail-register.js.template`.

Verified end-to-end on a local instance against the BusinessIntents suite: after regen, the defaulted Currency / Bank Account / Tax Event Date / Due inputs render `:disabled="isPreview"` (editable on create/edit), derived fields stay locked, and a REST create with no picks lands the defaults while explicit picks are respected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)