### PR TITLE
test(csvim): quote identifiers so CSVIM ITs pass on PostgreSQL

### DIFF
--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/CsvProcessorIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/CsvProcessorIT.java
@@ -49,14 +49,14 @@ public class CsvProcessorIT extends IntegrationTest {
         try (Connection connection = dataSourceManager.getDefaultDataSource()
                                                       .getConnection()) {
             connection.createStatement()
-                      .execute("CREATE TABLE CSV_A (A1 INT PRIMARY KEY, A2 VARCHAR(20), A3 VARCHAR(20))");
+                      .execute("CREATE TABLE \"CSV_A\" (\"A1\" INT PRIMARY KEY, \"A2\" VARCHAR(20), \"A3\" VARCHAR(20))");
             try {
                 csvimProcessor.setStrictMode(true);
                 byte[] content = "A1,A2,A3\n1,a2_1,a3_1\n2,a2_2,a3_2".getBytes();
                 CsvFile csvFile = new CsvFile(null, "CSV_A", null, "import", true, true, ",", "\"", null, false, null);
                 csvimProcessor.process(csvFile, content, defaultDataSourceName);
                 ResultSet rs = connection.createStatement()
-                                         .executeQuery("SELECT COUNT(*) FROM CSV_A");
+                                         .executeQuery("SELECT COUNT(*) FROM \"CSV_A\"");
                 if (rs.next()) {
                     int c = rs.getInt(1);
                     assertEquals(2, c, "No data has been imported from CSV file CSV_A.csv");
@@ -67,7 +67,7 @@ public class CsvProcessorIT extends IntegrationTest {
                 fail(e.getMessage(), e);
             } finally {
                 connection.createStatement()
-                          .execute("DROP TABLE CSV_A");
+                          .execute("DROP TABLE \"CSV_A\"");
             }
 
         }
@@ -83,7 +83,7 @@ public class CsvProcessorIT extends IntegrationTest {
         try (Connection connection = dataSourceManager.getDefaultDataSource()
                                                       .getConnection()) {
             connection.createStatement()
-                      .execute("CREATE TABLE CSV_A (A1 INT PRIMARY KEY, A2 VARCHAR(20), A3 VARCHAR(20))");
+                      .execute("CREATE TABLE \"CSV_A\" (\"A1\" INT PRIMARY KEY, \"A2\" VARCHAR(20), \"A3\" VARCHAR(20))");
             try {
                 csvimProcessor.setStrictMode(true);
                 byte[] content = "A1,A2\n1,a2_1\n2,a2_2".getBytes();
@@ -94,7 +94,7 @@ public class CsvProcessorIT extends IntegrationTest {
                     //
                 }
                 ResultSet rs = connection.createStatement()
-                                         .executeQuery("SELECT COUNT(*) FROM CSV_A");
+                                         .executeQuery("SELECT COUNT(*) FROM \"CSV_A\"");
                 if (rs.next()) {
                     int c = rs.getInt(1);
                     assertEquals(0, c, "Data has been imported from CSV file CSV_A.csv in a strict mode and wrong CSV file");
@@ -103,7 +103,7 @@ public class CsvProcessorIT extends IntegrationTest {
                 fail(e.getMessage(), e);
             } finally {
                 connection.createStatement()
-                          .execute("DROP TABLE CSV_A");
+                          .execute("DROP TABLE \"CSV_A\"");
             }
 
         }
@@ -119,7 +119,7 @@ public class CsvProcessorIT extends IntegrationTest {
         try (Connection connection = dataSourceManager.getDefaultDataSource()
                                                       .getConnection()) {
             connection.createStatement()
-                      .execute("CREATE TABLE CSV_A (A1 INT PRIMARY KEY, A2 VARCHAR(20), A3 VARCHAR(20))");
+                      .execute("CREATE TABLE \"CSV_A\" (\"A1\" INT PRIMARY KEY, \"A2\" VARCHAR(20), \"A3\" VARCHAR(20))");
             try {
                 csvimProcessor.setStrictMode(false);
                 byte[] content = "A1,A2\n1,a2_1\n2,a2_2".getBytes();
@@ -130,7 +130,7 @@ public class CsvProcessorIT extends IntegrationTest {
                     //
                 }
                 ResultSet rs = connection.createStatement()
-                                         .executeQuery("SELECT COUNT(*) FROM CSV_A");
+                                         .executeQuery("SELECT COUNT(*) FROM \"CSV_A\"");
                 if (rs.next()) {
                     int c = rs.getInt(1);
                     assertEquals(2, c, "No data has been imported from CSV file CSV_A.csv");
@@ -141,7 +141,7 @@ public class CsvProcessorIT extends IntegrationTest {
                 fail(e.getMessage(), e);
             } finally {
                 connection.createStatement()
-                          .execute("DROP TABLE CSV_A");
+                          .execute("DROP TABLE \"CSV_A\"");
             }
 
         }
@@ -157,7 +157,7 @@ public class CsvProcessorIT extends IntegrationTest {
         try (Connection connection = dataSourceManager.getDefaultDataSource()
                                                       .getConnection()) {
             connection.createStatement()
-                      .execute("CREATE TABLE CSV_A (A1 INT PRIMARY KEY, A2 VARCHAR(20), A3 VARCHAR(20))");
+                      .execute("CREATE TABLE \"CSV_A\" (\"A1\" INT PRIMARY KEY, \"A2\" VARCHAR(20), \"A3\" VARCHAR(20))");
             try {
                 csvimProcessor.setStrictMode(false);
                 byte[] content = "A1,A3,A2,A4\n1,a3_1,a2_1,a4_1\n2,a3_2,a2_3,a4_1".getBytes();
@@ -168,13 +168,13 @@ public class CsvProcessorIT extends IntegrationTest {
                     //
                 }
                 ResultSet rs = connection.createStatement()
-                                         .executeQuery("SELECT COUNT(*) FROM CSV_A");
+                                         .executeQuery("SELECT COUNT(*) FROM \"CSV_A\"");
                 if (rs.next()) {
                     int c = rs.getInt(1);
                     assertEquals(2, c, "No data has been imported from CSV file CSV_A.csv");
 
                     rs = connection.createStatement()
-                                   .executeQuery("SELECT * FROM CSV_A");
+                                   .executeQuery("SELECT * FROM \"CSV_A\"");
                     if (rs.next()) {
                         assertEquals("a2_1", rs.getString("A2"));
                         assertEquals("a3_1", rs.getString("A3"));
@@ -186,7 +186,7 @@ public class CsvProcessorIT extends IntegrationTest {
                 fail(e.getMessage(), e);
             } finally {
                 connection.createStatement()
-                          .execute("DROP TABLE CSV_A");
+                          .execute("DROP TABLE \"CSV_A\"");
             }
 
         }

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/CsvimReimportIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/CsvimReimportIT.java
@@ -207,7 +207,7 @@ class CsvimReimportIT extends IntegrationTest {
         try (Connection connection = dataSourceManager.getDefaultDataSource()
                                                       .getConnection()) {
             connection.createStatement()
-                      .execute("CREATE TABLE CSV_REIMPORT (R1 INT PRIMARY KEY, R2 VARCHAR(20), R3 VARCHAR(20))");
+                      .execute("CREATE TABLE \"CSV_REIMPORT\" (\"R1\" INT PRIMARY KEY, \"R2\" VARCHAR(20), \"R3\" VARCHAR(20))");
             try {
                 csvimProcessor.setStrictMode(false);
                 CsvFile csvFile = new CsvFile(null, "CSV_REIMPORT", null, "import", true, true, ",", "\"", null, false, null);
@@ -218,18 +218,18 @@ class CsvimReimportIT extends IntegrationTest {
                 csvimProcessor.process(csvFile, "R1,R2\n1,r2_1_changed\n2,r2_2".getBytes(), defaultDataSourceName);
 
                 ResultSet rs = connection.createStatement()
-                                         .executeQuery("SELECT R2, R3 FROM CSV_REIMPORT WHERE R1 = 1");
+                                         .executeQuery("SELECT \"R2\", \"R3\" FROM \"CSV_REIMPORT\" WHERE \"R1\" = 1");
                 assertTrue(rs.next(), "Row with R1 = 1 is missing after the re-import");
                 assertEquals("r2_1_changed", rs.getString("R2"), "The changed value did not reach the row");
                 assertNull(rs.getString("R3"), "A column the CSV does not carry must be set to null, not to the record's id");
 
                 rs = connection.createStatement()
-                               .executeQuery("SELECT COUNT(*) FROM CSV_REIMPORT");
+                               .executeQuery("SELECT COUNT(*) FROM \"CSV_REIMPORT\"");
                 assertTrue(rs.next());
                 assertEquals(2, rs.getInt(1), "The re-import must update the existing rows, not add new ones");
             } finally {
                 connection.createStatement()
-                          .execute("DROP TABLE CSV_REIMPORT");
+                          .execute("DROP TABLE \"CSV_REIMPORT\"");
             }
         }
     }
@@ -244,7 +244,7 @@ class CsvimReimportIT extends IntegrationTest {
         try (Connection connection = dataSourceManager.getDefaultDataSource()
                                                       .getConnection()) {
             connection.createStatement()
-                      .execute("CREATE TABLE CSV_REIMPORT_NH (N1 INT PRIMARY KEY, N2 VARCHAR(20), N3 VARCHAR(20))");
+                      .execute("CREATE TABLE \"CSV_REIMPORT_NH\" (\"N1\" INT PRIMARY KEY, \"N2\" VARCHAR(20), \"N3\" VARCHAR(20))");
             try {
                 csvimProcessor.setStrictMode(false);
                 CsvFile csvFile = new CsvFile(null, "CSV_REIMPORT_NH", null, "import", false, false, ",", "\"", null, false, null);
@@ -254,18 +254,18 @@ class CsvimReimportIT extends IntegrationTest {
                 csvimProcessor.process(csvFile, "1,n2_1_changed\n2,n2_2".getBytes(), defaultDataSourceName);
 
                 ResultSet rs = connection.createStatement()
-                                         .executeQuery("SELECT N2, N3 FROM CSV_REIMPORT_NH WHERE N1 = 1");
+                                         .executeQuery("SELECT \"N2\", \"N3\" FROM \"CSV_REIMPORT_NH\" WHERE \"N1\" = 1");
                 assertTrue(rs.next(), "Row with N1 = 1 is missing after the re-import");
                 assertEquals("n2_1_changed", rs.getString("N2"), "The changed value did not reach the row");
                 assertNull(rs.getString("N3"), "A column the record does not reach must be bound as null");
 
                 rs = connection.createStatement()
-                               .executeQuery("SELECT COUNT(*) FROM CSV_REIMPORT_NH");
+                               .executeQuery("SELECT COUNT(*) FROM \"CSV_REIMPORT_NH\"");
                 assertTrue(rs.next());
                 assertEquals(2, rs.getInt(1), "The re-import must update the existing rows, not add new ones");
             } finally {
                 connection.createStatement()
-                          .execute("DROP TABLE CSV_REIMPORT_NH");
+                          .execute("DROP TABLE \"CSV_REIMPORT_NH\"");
             }
         }
     }


### PR DESCRIPTION
## Problem

`master` is red on the `integration-tests-postgresql` leg: 5 failures in `CsvProcessorIT` and `CsvimReimportIT`, e.g.

```
Table metadata was not found for table [CSV_A] in schema [null]
CsvProcessorIT.importNonStrictMode:136  expected: <2> but was: <0>
```

These two ITs were compiled but never actually executed until #6684 wired them into the suite, which exposed a pre-existing H2-only assumption on the PostgreSQL leg.

## Root cause

Both tests create their fixture tables with **unquoted** DDL (`CREATE TABLE CSV_A ...`) and then look them up by the literal uppercase name with a null schema. Unquoted identifiers fold to **UPPERCASE** on H2 but to **lowercase** on PostgreSQL, and `DatabaseNameNormalizer.normalizeTableName` only strips quotes — it does not fold case. So on PostgreSQL the metadata lookup in `CsvimProcessor.process` (via `CsvimUtils.getTableMetadata` → `DatabaseMetadataHelper.describeTable`) misses the lowercase-stored table and throws. The `expected: <2> but was: <0>` variants are the non-strict form of the same miss (0 rows imported).

## Fix

Quote the table and column identifiers in the DDL/DML so both databases store them in the same case, matching the uppercase name passed to `CsvFile` and the uppercase CSV headers. This mirrors how the real `.table` synchronizer path stores identifiers and the convention already used by every other JDBC-style IT in the suite (`DatabaseCrudNullValuesIT`, `SchemaRepublishTypeToleranceIT`, `NumberingSdkIT`, and the passing sibling test in `CsvimReimportIT` itself).

Test-only change; no production code touched.

## Verification

Analysis-verified. I could not run the PostgreSQL leg locally (no Docker), so it has not yet been run-verified against PostgreSQL 16.

Note: the `integration-tests-h2` leg on the same failing run hit the 2h30m max-execution-time cap (a hang), which is a separate issue this PR does not address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)