### PR TITLE
ci(tests): shard the integration-test jobs into api / ui / samples slices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,11 +160,29 @@ jobs:
         if: runner.os == 'Linux'
         run: mvn test -P testcontainers
 
+  # The full IT suite is split ("sharded") into three disjoint slices selected by JUnit 5 tags, so
+  # the wall-clock time of a run is the slowest shard (~50 min) instead of the whole suite (~2h+):
+  #   api     - every HTTP-level IT (untagged, i.e. everything not tagged "ui")
+  #   ui      - the browser-driven ITs except the sample-project and camel families
+  #   samples - the sample-project clone/publish ITs ("sample") + the camel route ITs ("camel")
+  # The shards partition the suite: api + ui + samples = the complete IT set. A new untagged IT
+  # lands in "api"; a new UI IT (extends UserInterfaceIntegrationTest) lands in "ui" unless it is
+  # explicitly tagged "sample" or "camel".
   integration-tests-h2:
     runs-on: ubuntu-latest
-    # A green full IT run takes ~1h30m; a heap-exhausted JVM used to thrash for 4h+ before anyone
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - name: api
+            groups: "!ui"
+          - name: ui
+            groups: "ui & !sample & !camel"
+          - name: samples
+            groups: "sample | camel"
+    # A green shard takes ~50 min; a heap-exhausted JVM used to thrash for 4h+ before anyone
     # noticed. Cap the job well above the healthy time so hangs fail fast instead of burning runners.
-    timeout-minutes: 150
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
         with:
@@ -201,14 +219,14 @@ jobs:
         run: ttyd --version
 
       - name: Integration tests
-        run: mvn clean install -P integration-tests
+        run: mvn clean install -P integration-tests -Dit.groups='${{ matrix.shard.groups }}'
 
       - name: Generate a random artifact name
         if: always()
         id: generate_name
         run: |
           TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-          echo "ARTIFACT_NAME=selenide-screenshots-${TIMESTAMP}.zip" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=selenide-screenshots-h2-${{ matrix.shard.name }}-${TIMESTAMP}.zip" >> $GITHUB_ENV
 
       - name: Upload selenide screenshots
         uses: actions/upload-artifact@v4
@@ -220,8 +238,18 @@ jobs:
 
   integration-tests-postgresql:
     runs-on: ubuntu-latest
-    # Same rationale as integration-tests-h2: green run ~1h30m, cap runaway JVMs.
-    timeout-minutes: 150
+    # Same sharding + timeout rationale as integration-tests-h2.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - name: api
+            groups: "!ui"
+          - name: ui
+            groups: "ui & !sample & !camel"
+          - name: samples
+            groups: "sample | camel"
+    timeout-minutes: 90
     env:
       POSTGRES_DB: testdb
       POSTGRES_USER: testuser
@@ -276,7 +304,7 @@ jobs:
         run: ttyd --version
 
       - name: Integration tests
-        run: mvn clean install -P integration-tests
+        run: mvn clean install -P integration-tests -Dit.groups='${{ matrix.shard.groups }}'
         env:
           DIRIGIBLE_DATASOURCE_DEFAULT_DRIVER: org.postgresql.Driver
           DIRIGIBLE_DATASOURCE_DEFAULT_URL: jdbc:postgresql://localhost:5432/${{ env.POSTGRES_DB }}
@@ -288,7 +316,7 @@ jobs:
         id: generate_name
         run: |
           TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-          echo "ARTIFACT_NAME=selenide-screenshots-${TIMESTAMP}.zip" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=selenide-screenshots-postgresql-${{ matrix.shard.name }}-${TIMESTAMP}.zip" >> $GITHUB_ENV
 
       - name: Upload selenide screenshots
         uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,11 @@
 name: Nightly Integration Tests
 
 # The full Selenide UI integration suite (everything, incl. the sample-project clone/publish tests)
-# on both H2 and PostgreSQL. It is heavy (~1.5h per DB), so it does not run on every PR - PRs run the
-# fast "smoke-tests" job (see pull-request.yml). Runs on a nightly schedule and on demand; the same
-# full suite also runs on every push to master (see build.yml).
+# on both H2 and PostgreSQL. It is heavy (~2h of test time per DB), so it does not run on every PR -
+# PRs run the fast "smoke-tests" job (see pull-request.yml). Runs on a nightly schedule and on
+# demand; the same full suite also runs on every push to master (see build.yml). Like build.yml, the
+# suite is sharded into three tag-selected slices (api / ui / samples) that run in parallel, so the
+# wall-clock time is the slowest shard (~50 min), not the whole suite.
 on:
   schedule:
     - cron: '0 2 * * *'
@@ -16,6 +18,17 @@ concurrency:
 jobs:
   integration-tests-h2:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - name: api
+            groups: "!ui"
+          - name: ui
+            groups: "ui & !sample & !camel"
+          - name: samples
+            groups: "sample | camel"
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
         with:
@@ -52,14 +65,14 @@ jobs:
         run: ttyd --version
 
       - name: Integration tests
-        run: mvn clean install -P integration-tests
+        run: mvn clean install -P integration-tests -Dit.groups='${{ matrix.shard.groups }}'
 
       - name: Generate a random artifact name
         if: always()
         id: generate_name
         run: |
           TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-          echo "ARTIFACT_NAME=selenide-screenshots-h2-${TIMESTAMP}.zip" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=selenide-screenshots-h2-${{ matrix.shard.name }}-${TIMESTAMP}.zip" >> $GITHUB_ENV
 
       - name: Upload selenide screenshots
         uses: actions/upload-artifact@v4
@@ -71,6 +84,17 @@ jobs:
 
   integration-tests-postgresql:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - name: api
+            groups: "!ui"
+          - name: ui
+            groups: "ui & !sample & !camel"
+          - name: samples
+            groups: "sample | camel"
+    timeout-minutes: 90
     env:
       POSTGRES_DB: testdb
       POSTGRES_USER: testuser
@@ -125,7 +149,7 @@ jobs:
         run: ttyd --version
 
       - name: Integration tests
-        run: mvn clean install -P integration-tests
+        run: mvn clean install -P integration-tests -Dit.groups='${{ matrix.shard.groups }}'
         env:
           DIRIGIBLE_DATASOURCE_DEFAULT_DRIVER: org.postgresql.Driver
           DIRIGIBLE_DATASOURCE_DEFAULT_URL: jdbc:postgresql://localhost:5432/${{ env.POSTGRES_DB }}
@@ -137,7 +161,7 @@ jobs:
         id: generate_name
         run: |
           TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-          echo "ARTIFACT_NAME=selenide-screenshots-postgresql-${TIMESTAMP}.zip" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=selenide-screenshots-postgresql-${{ matrix.shard.name }}-${TIMESTAMP}.zip" >> $GITHUB_ENV
 
       - name: Upload selenide screenshots
         uses: actions/upload-artifact@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,7 +437,7 @@ Treat `modules/commons/commons-config/src/main/java/org/eclipse/dirigible/common
 
 - `code-style`: `mvn -T 1C formatter:validate`
 - `tests` (ubuntu + windows matrix): `mvn clean install -P unit-tests`
-- `integration-tests-h2` / `-postgresql`: the **full** Selenide IT suite, `mvn clean install -P integration-tests` with the matching `DIRIGIBLE_DATASOURCE_DEFAULT_*` env vars (MSSQL is no longer a CI leg — removed in #6150)
+- `integration-tests-h2` / `-postgresql`: the **full** Selenide IT suite, `mvn clean install -P integration-tests` with the matching `DIRIGIBLE_DATASOURCE_DEFAULT_*` env vars (MSSQL is no longer a CI leg — removed in #6150). Each DB leg is **sharded into three parallel matrix jobs** selected by tag expression — `api` (`!ui`), `ui` (`ui & !sample & !camel`), `samples` (`sample | camel`) — so the run's wall clock is the slowest shard (~50 min), not the whole ~2h suite. The shards partition the suite; keep them disjoint and complete when adding tags.
 - `build-deploy`: `mvn clean install -P quick-build` then Docker buildx multi-arch image push to `dirigiblelabs/dirigible`
 
 ### PR gate vs full suite (smoke / nightly split)
@@ -451,5 +451,6 @@ The full Selenide UI suite takes ~1.5h per DB, so it does **not** run on every P
 - Every browser-driven IT is `@Tag("ui")` - inherited from the `UserInterfaceIntegrationTest` base (and thus by `SampleProjectRepositoryIT` and all sample-project ITs). Do not tag these individually.
 - HTTP-level ITs (`extends IntegrationTest` directly) carry no tag, so they are always in the smoke set.
 - To force a specific UI IT to run on every PR, add `@Tag("smoke")` to that class (keep the list small - smoke must stay fast).
+- Shard-routing tags: `@Tag("sample")` sits on the `SampleProjectRepositoryIT` base (inherited by every sample-project IT); `@Tag("camel")` sits on each IT in `ui/tests/camel` (their `PredefinedProjectIT` base is shared with non-camel tests, so the base cannot carry it — tag new camel ITs individually). These route classes into the `samples` CI shard; everything else UI stays in the `ui` shard.
 
 `codeql.yml`, `release.yml` cover CodeQL and Maven Central release respectively.

--- a/tests/tests-integrations/pom.xml
+++ b/tests/tests-integrations/pom.xml
@@ -116,7 +116,9 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <!-- JUnit 5 tag selection lives here (not in the root pom) so only this module -
                      which has the JUnit 5 engine and the tagged ITs - applies it. Empty by default
-                     (full run); the PR smoke job passes -Dit.groups="!ui | smoke". Putting it in the
+                     (full run); the PR smoke job passes -Dit.groups="!ui | smoke", and the master/
+                     nightly IT jobs shard the suite via -Dit.groups="!ui" / "ui & !sample & !camel" /
+                     "sample | camel" (see .github/workflows/build.yml). Putting it in the
                      root failsafe config breaks other modules (e.g. dirigible-cli) that run failsafe
                      without a JUnit 5 engine, since non-empty groups require one on the classpath. -->
                 <configuration>

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelAsyncStepIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelAsyncStepIT.java
@@ -11,8 +11,10 @@ package org.eclipse.dirigible.integration.tests.ui.tests.camel;
 
 import org.eclipse.dirigible.tests.base.PredefinedProjectIT;
 import org.eclipse.dirigible.tests.base.TestProject;
+import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@Tag("camel")
 public class CamelAsyncStepIT extends PredefinedProjectIT {
 
     @Autowired

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelCronRouteStarterTemplateIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelCronRouteStarterTemplateIT.java
@@ -16,12 +16,14 @@ import org.eclipse.dirigible.tests.framework.ide.Workbench;
 import org.eclipse.dirigible.tests.framework.logging.LogsAsserter;
 import org.eclipse.dirigible.tests.framework.util.SynchronizationUtil;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.awaitility.Awaitility.await;
 
+@Tag("camel")
 public class CamelCronRouteStarterTemplateIT extends UserInterfaceIntegrationTest {
 
     private static final String TEMPLATE_TITLE = "Cron Route Project Starter";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelDirigibleJavaScriptComponentCronRouteIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelDirigibleJavaScriptComponentCronRouteIT.java
@@ -11,8 +11,10 @@ package org.eclipse.dirigible.integration.tests.ui.tests.camel;
 
 import org.eclipse.dirigible.tests.base.PredefinedProjectIT;
 import org.eclipse.dirigible.tests.base.TestProject;
+import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@Tag("camel")
 public class CamelDirigibleJavaScriptComponentCronRouteIT extends PredefinedProjectIT {
 
     @Autowired

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelDirigibleJavaScriptComponentHttpRouteIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelDirigibleJavaScriptComponentHttpRouteIT.java
@@ -11,8 +11,10 @@ package org.eclipse.dirigible.integration.tests.ui.tests.camel;
 
 import org.eclipse.dirigible.tests.base.PredefinedProjectIT;
 import org.eclipse.dirigible.tests.base.TestProject;
+import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@Tag("camel")
 public class CamelDirigibleJavaScriptComponentHttpRouteIT extends PredefinedProjectIT {
 
     @Autowired

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelDirigibleTwoStepsJSInvokerCronRouteIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelDirigibleTwoStepsJSInvokerCronRouteIT.java
@@ -11,8 +11,10 @@ package org.eclipse.dirigible.integration.tests.ui.tests.camel;
 
 import org.eclipse.dirigible.tests.base.PredefinedProjectIT;
 import org.eclipse.dirigible.tests.base.TestProject;
+import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@Tag("camel")
 public class CamelDirigibleTwoStepsJSInvokerCronRouteIT extends PredefinedProjectIT {
 
     @Autowired

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelDirigibleTwoStepsJSInvokerHttpRouteIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelDirigibleTwoStepsJSInvokerHttpRouteIT.java
@@ -11,8 +11,10 @@ package org.eclipse.dirigible.integration.tests.ui.tests.camel;
 
 import org.eclipse.dirigible.tests.base.PredefinedProjectIT;
 import org.eclipse.dirigible.tests.base.TestProject;
+import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@Tag("camel")
 public class CamelDirigibleTwoStepsJSInvokerHttpRouteIT extends PredefinedProjectIT {
 
     @Autowired

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelExtractTransformLoadJdbcIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelExtractTransformLoadJdbcIT.java
@@ -11,8 +11,10 @@ package org.eclipse.dirigible.integration.tests.ui.tests.camel;
 
 import org.eclipse.dirigible.tests.base.PredefinedProjectIT;
 import org.eclipse.dirigible.tests.base.TestProject;
+import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@Tag("camel")
 public class CamelExtractTransformLoadJdbcIT extends PredefinedProjectIT {
 
     @Autowired

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelExtractTransformLoadTypescriptIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelExtractTransformLoadTypescriptIT.java
@@ -11,8 +11,10 @@ package org.eclipse.dirigible.integration.tests.ui.tests.camel;
 
 import org.eclipse.dirigible.tests.base.PredefinedProjectIT;
 import org.eclipse.dirigible.tests.base.TestProject;
+import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@Tag("camel")
 public class CamelExtractTransformLoadTypescriptIT extends PredefinedProjectIT {
 
     @Autowired

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelHttpRouteStarterTemplateIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelHttpRouteStarterTemplateIT.java
@@ -14,12 +14,14 @@ import org.eclipse.dirigible.tests.framework.ide.WelcomeView;
 import org.eclipse.dirigible.tests.framework.ide.Workbench;
 import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.eclipse.dirigible.tests.framework.util.SynchronizationUtil;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 
+@Tag("camel")
 public class CamelHttpRouteStarterTemplateIT extends UserInterfaceIntegrationTest {
 
     private static final String TEMPLATE_TITLE = "HTTP Route Project Starter";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelTransactionsCommitIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelTransactionsCommitIT.java
@@ -11,8 +11,10 @@ package org.eclipse.dirigible.integration.tests.ui.tests.camel;
 
 import org.eclipse.dirigible.tests.base.PredefinedProjectIT;
 import org.eclipse.dirigible.tests.base.TestProject;
+import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@Tag("camel")
 public class CamelTransactionsCommitIT extends PredefinedProjectIT {
 
     @Autowired

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelTransactionsRollbackIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/camel/CamelTransactionsRollbackIT.java
@@ -12,9 +12,11 @@ package org.eclipse.dirigible.integration.tests.ui.tests.camel;
 import org.eclipse.dirigible.tests.base.PredefinedProjectIT;
 import org.eclipse.dirigible.tests.base.TestProject;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Disabled("Disabled until transaction logic is implemented")
+@Tag("camel")
 public class CamelTransactionsRollbackIT extends PredefinedProjectIT {
 
     @Autowired

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/sample/SampleProjectRepositoryIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/sample/SampleProjectRepositoryIT.java
@@ -16,9 +16,13 @@ import org.eclipse.dirigible.tests.framework.ide.GitPerspective;
 import org.eclipse.dirigible.tests.framework.ide.Workbench;
 import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.eclipse.dirigible.tests.framework.util.SynchronizationUtil;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+// "sample" (on top of the inherited "ui") routes the whole sample-project family into its own CI
+// shard - see the integration-tests matrix in .github/workflows/build.yml.
+@Tag("sample")
 abstract class SampleProjectRepositoryIT extends UserInterfaceIntegrationTest {
 
     @Autowired


### PR DESCRIPTION
## Problem

The full integration-test suite (116 IT classes, 275 test methods) runs strictly sequentially, so each DB leg of `build.yml` / `nightly.yml` takes **2h+ wall clock** (e.g. [run 31679871168](https://github.com/eclipse-dirigible/dirigible/actions/runs/31679871168): h2 leg 2h06m, postgresql leg 2h30m). The Maven build phase is only ~3 min — everything else is failsafe.

## Change

Split every DB leg into **three parallel matrix shards** selected by JUnit 5 tag expressions (the same mechanism the PR smoke job already uses):

| shard | selector | classes | measured time |
|---|---|---|---|
| `api` | `-Dit.groups='!ui'` | 57 | ~48 min |
| `ui` | `-Dit.groups='ui & !sample & !camel'` | 34 | ~48 min |
| `samples` | `-Dit.groups='sample \| camel'` | 25 | ~27 min |

The run's wall clock becomes the slowest shard (**~50 min**, meeting the ≤1h goal) instead of the whole suite, and a red shard immediately names the failing family. Total compute stays the same (+~3 min build phase per extra shard).

New tags:
- `@Tag("sample")` on the `SampleProjectRepositoryIT` base — inherited by all 14 sample-project ITs.
- `@Tag("camel")` on each of the 11 ITs in `ui/tests/camel` — their `PredefinedProjectIT` base is shared with non-camel tests, so the base cannot carry the tag.

Also: per-shard `timeout-minutes: 90` (was 150), per-shard screenshot artifact names, `fail-fast: false` so one red shard doesn't cancel the others, and doc updates (CLAUDE.md CI reference, tests-integrations pom comment).

## Verification

- Shard partition proven via JUnit Platform discovery over the compiled test classes: `57 + 34 + 25 = 116` classes — exactly the full-suite discovery count, with **zero classes selected by more than one shard**.
- `mvn compile -pl tests/tests-integrations` and `mvn formatter:validate -pl tests/tests-integrations` green; both workflow files YAML-validated.
- The timing figures come from the per-class failsafe timings of the linked run's h2 leg.

## Follow-ups (separate PRs, discussed in the analysis)

1. Relax `@DirtiesContext(AFTER_EACH_TEST_METHOD)` → `AFTER_CLASS` class-by-class (275 → ~116 Spring boots, ~25–35 min/leg of compute; `DatabaseFacadeIT` already proves the pattern: 18 tests in 0.9 s).
2. Consolidate duplicate journeys (the 14 sample-project ITs share one clone→publish→verify flow; the BPMN editor trio; `CreateNewFileIT` spends 431 s looping every file type through the UI).
3. Consider running the PG leg with the DB-sensitive shards only.

Note: the linked run's PG leg also **failed** functionally (`CsvProcessorIT`, `CsvimReimportIT` — `Table metadata was not found ... in schema [null]`, PostgreSQL-specific) — that is independent of this change and deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)