### PR TITLE
perf(tests): one Dirigible boot per class for eight multi-method HTTP ITs

### DIFF
--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/security/SecurityUtil.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/security/SecurityUtil.java
@@ -18,6 +18,8 @@ import org.eclipse.dirigible.components.tenants.service.UserService;
 import org.eclipse.dirigible.tests.framework.tenant.DirigibleTestTenant;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @Component
 public class SecurityUtil {
 
@@ -36,6 +38,33 @@ public class SecurityUtil {
 
         Role role = roleService.findByName(roleName);
         userService.assignUserRoles(user, role);
+    }
+
+    /**
+     * Creates the user (with the role) on first call and is a no-op afterwards. For tests whose class
+     * shares one Spring context across methods ({@code @DirtiesContext(AFTER_CLASS)}): the database
+     * outlives a test method there, so a repeated plain create would violate the unique user
+     * constraint.
+     */
+    public void ensureUserInDefaultTenant(String username, String password, String roleName) {
+        if (findUserInDefaultTenant(username).isEmpty()) {
+            createUserInDefaultTenant(username, password, roleName);
+        }
+    }
+
+    /** The role-less variant of {@link #ensureUserInDefaultTenant(String, String, String)}. */
+    public void ensureUserInDefaultTenant(String username, String password) {
+        if (findUserInDefaultTenant(username).isEmpty()) {
+            createUserInDefaultTenant(username, password);
+        }
+    }
+
+    private Optional<User> findUserInDefaultTenant(String username) {
+        DirigibleTestTenant defaultTenant = DirigibleTestTenant.createDefaultTenant();
+        String defaultTenantId = tenantService.findBySubdomain(defaultTenant.getSubdomain())
+                                              .get()
+                                              .getId();
+        return userService.findUserByUsernameAndTenantId(username, defaultTenantId);
     }
 
     public User createUserInDefaultTenant(String username, String password) {

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/CmsAccessControlIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/CmsAccessControlIT.java
@@ -20,9 +20,11 @@ import org.eclipse.dirigible.components.base.http.roles.Roles;
 import org.eclipse.dirigible.tests.base.IntegrationTest;
 import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.eclipse.dirigible.tests.framework.security.SecurityUtil;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 import io.restassured.http.ContentType;
 
@@ -35,6 +37,9 @@ import io.restassured.http.ContentType;
  * listing (the resolver it used matched an exact path only); and grants lived in a global table
  * while the content they guard is per tenant.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself, so the per-method
+// context reset inherited from IntegrationTest would only add ~10s of boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class CmsAccessControlIT extends IntegrationTest {
 
     private static final String DOCUMENTS = "/services/documents";
@@ -59,13 +64,23 @@ class CmsAccessControlIT extends IntegrationTest {
     private SecurityUtil securityUtil;
 
     /**
-     * The base class dirties the Spring context after every test method, so each test starts from a
-     * clean database - the users are created per test and nothing needs tearing down.
+     * The class shares one Spring context (and thus one database) across its methods, so the users are
+     * created once and the grants each test leaves behind are revoked in {@link #revokeGrants()}.
      */
     @BeforeEach
     void createUsers() {
-        securityUtil.createUserInDefaultTenant(ADMIN, PASSWORD, Roles.RoleNames.ADMINISTRATOR);
-        securityUtil.createUserInDefaultTenant(PLAIN, PASSWORD);
+        securityUtil.ensureUserInDefaultTenant(ADMIN, PASSWORD, Roles.RoleNames.ADMINISTRATOR);
+        securityUtil.ensureUserInDefaultTenant(PLAIN, PASSWORD);
+    }
+
+    /**
+     * A leaked grant would break the "open by default - no rule exists" premise the other tests start
+     * from. {@code revoke} is best-effort (it asserts no status), so this is a no-op when the test
+     * already revoked or never granted.
+     */
+    @AfterEach
+    void revokeGrants() {
+        restAssuredExecutor.execute(() -> revoke(FOLDER_PATH, "READ", GRANTED_ROLE), ADMIN, PASSWORD);
     }
 
     @Test

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/EndpointAuthorizationIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/EndpointAuthorizationIT.java
@@ -18,6 +18,7 @@ import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.eclipse.dirigible.tests.framework.security.SecurityUtil;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * End-to-end proof that the {@code @RolesAllowed} annotations guarding the platform's endpoints are
@@ -30,6 +31,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * the annotations silently stopped guarding anything - the administrative surfaces below were open
  * to any authenticated user, with no error anywhere. This test locks the enforcement in place.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself, so the per-method
+// context reset inherited from IntegrationTest would only add ~10s of boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class EndpointAuthorizationIT extends IntegrationTest {
 
     private static final String PLAIN_USER = "endpoint-authz-it-user";
@@ -59,7 +63,7 @@ class EndpointAuthorizationIT extends IntegrationTest {
 
     @Test
     void privileged_endpoints_reject_an_authenticated_user_without_a_platform_role() {
-        securityUtil.createUserInDefaultTenant(PLAIN_USER, PASSWORD);
+        securityUtil.ensureUserInDefaultTenant(PLAIN_USER, PASSWORD);
 
         for (String endpoint : PRIVILEGED_ENDPOINTS) {
             restAssuredExecutor.execute(() -> given().when()
@@ -72,7 +76,7 @@ class EndpointAuthorizationIT extends IntegrationTest {
 
     @Test
     void privileged_endpoints_admit_an_administrator() {
-        securityUtil.createUserInDefaultTenant(ADMIN_USER, PASSWORD, Roles.RoleNames.ADMINISTRATOR);
+        securityUtil.ensureUserInDefaultTenant(ADMIN_USER, PASSWORD, Roles.RoleNames.ADMINISTRATOR);
 
         restAssuredExecutor.execute(() -> given().when()
                                                  .get("/services/core/configurations")
@@ -88,7 +92,7 @@ class EndpointAuthorizationIT extends IntegrationTest {
      */
     @Test
     void database_exports_are_not_readable_without_an_administrative_role() {
-        securityUtil.createUserInDefaultTenant(PLAIN_USER, PASSWORD);
+        securityUtil.ensureUserInDefaultTenant(PLAIN_USER, PASSWORD);
 
         // the anonymous CMS mapping is gone entirely, so the path resolves to no handler at all
         given().when()
@@ -104,7 +108,7 @@ class EndpointAuthorizationIT extends IntegrationTest {
 
         // ... and the roles that MAY read an export still get past the guard (the export download in
         // the IDE shell must keep working - this request only fails later, on the missing document)
-        securityUtil.createUserInDefaultTenant(ADMIN_USER, PASSWORD, Roles.RoleNames.ADMINISTRATOR);
+        securityUtil.ensureUserInDefaultTenant(ADMIN_USER, PASSWORD, Roles.RoleNames.ADMINISTRATOR);
         restAssuredExecutor.execute(() -> given().when()
                                                  .get("/services/cms/__EXPORTS/dump.zip")
                                                  .then()
@@ -120,7 +124,7 @@ class EndpointAuthorizationIT extends IntegrationTest {
      */
     @Test
     void data_transfer_is_not_drivable_without_a_platform_role() {
-        securityUtil.createUserInDefaultTenant(PLAIN_USER, PASSWORD);
+        securityUtil.ensureUserInDefaultTenant(PLAIN_USER, PASSWORD);
 
         restAssuredExecutor.execute(() -> given().when()
                                                  .get("/websockets/data/transfer")
@@ -135,7 +139,7 @@ class EndpointAuthorizationIT extends IntegrationTest {
      */
     @Test
     void task_variables_are_not_readable_for_a_foreign_task() {
-        securityUtil.createUserInDefaultTenant(PLAIN_USER, PASSWORD);
+        securityUtil.ensureUserInDefaultTenant(PLAIN_USER, PASSWORD);
 
         restAssuredExecutor.execute(() -> given().when()
                                                  .get("/services/inbox/tasks/1234567890/variables")

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentConversationIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentConversationIT.java
@@ -37,6 +37,7 @@ import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * End-to-end test for the persisted AI conversations behind the Builder and the Intent Editor -
@@ -49,6 +50,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * each surface keeps its own, every message carries its author and its time, and one tenant's
  * history is unreachable from another. HTTP-only, no Chrome, no synchronization cycles.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself, so the per-method
+// context reset inherited from IntegrationTest would only add ~10s of boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class IntentConversationIT extends IntegrationTest {
 
     private static final String BASE_URL = "/services/ide/intent/conversations";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -30,6 +30,7 @@ import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * End-to-end test for the intent editor services: {@code POST /services/ide/intent/parse} (the
@@ -42,6 +43,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * workspace, exactly as the editor's Generate button does it. HTTP-only - no Selenide, no Chrome,
  * no synchronization cycles.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself, so the per-method
+// context reset inherited from IntegrationTest would only add ~10s of boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class IntentEngineIT extends IntegrationTest {
 
     private static final String PROJECT = "intent-test";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaEngineIT.java
@@ -22,6 +22,7 @@ import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * End-to-end test for the engine-java module: drops {@code .java} sources directly under
@@ -33,6 +34,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * delete → compile-error. Each case verifies the synchronizer's CREATE/UPDATE/DELETE/FAILED
  * handling end-to-end through the HTTP boundary.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself, so the per-method
+// context reset inherited from IntegrationTest would only add ~10s of boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class JavaEngineIT extends IntegrationTest {
 
     /** Project segment used for all sources in this IT. */

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/NumberingSdkIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/NumberingSdkIT.java
@@ -35,6 +35,7 @@ import org.eclipse.dirigible.tests.framework.tenant.DirigibleTestTenant;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * End-to-end test for first-class document numbering: the {@code .numbers} artefact synchronizer
@@ -44,6 +45,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * SHAPE lives in the {@code .numbers} declaration and the per-tenant settings - application code
  * only ever references the series by name.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself, so the per-method
+// context reset inherited from IntegrationTest would only add ~10s of boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class NumberingSdkIT extends IntegrationTest {
 
     private static final String PROJECT = "numbering-it";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/SecurityIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/SecurityIT.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -29,6 +30,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+// One Dirigible boot for the whole class: each method cleans up after itself, so the per-method
+// context reset inherited from IntegrationTest would only add ~10s of boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class SecurityIT extends IntegrationTest {
 
     /** Public static paths served by the framework rather than by an application endpoint. */

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/db/DataStoreIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/db/DataStoreIT.java
@@ -25,7 +25,11 @@ import org.eclipse.dirigible.tests.base.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
+// One Dirigible boot for the whole class: each method cleans up after itself, so the per-method
+// context reset inherited from IntegrationTest would only add ~10s of boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class DataStoreIT extends IntegrationTest {
 
     @Autowired


### PR DESCRIPTION
## Problem

`IntegrationTest` carries `@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)`, so a class with N test methods boots the full Dirigible runtime N times. Across the suite that is 275 boots for 116 classes — ~41 minutes of pure Spring startup per CI leg (measured on [run 31679871168](https://github.com/eclipse-dirigible/dirigible/actions/runs/31679871168)). Follow-up to #6702, which sharded the jobs; this shrinks the biggest shard's actual compute.

## Change

Override to `@DirtiesContext(AFTER_CLASS)` on the eight multi-method HTTP-level ITs whose methods already clean up after themselves — the pattern `DatabaseFacadeIT` has proven for a while (18 tests in 0.9s):

| Class | Methods | CI baseline | Local after (2 runs) |
|---|---|---|---|
| `IntentEngineIT` | 42 | 337s | 37s |
| `NumberingSdkIT` | 8 | 131s | 69s |
| `SecurityIT` | 7 | 82s | 21s |
| `DataStoreIT` | 7 | 79s | 20s |
| `JavaEngineIT` | 5 | 77s | 32s |
| `CmsAccessControlIT` | 5 | 69s | 23s |
| `IntentConversationIT` | 5 | 67s | 21s |
| `EndpointAuthorizationIT` | 5 | 65s | 21s |

84 methods now cost 8 boots instead of 84 (~10 min off the `api` shard).

Where sharing the database across methods needed honesty, it was added rather than assumed:

- **`SecurityUtil`** gains idempotent `ensureUserInDefaultTenant` variants — once the context survives the method, a repeated plain create violates the unique user constraint.
- **`CmsAccessControlIT`** revokes its READ grant in a new `@AfterEach` — a leaked grant breaks the "open by default — no rule exists" premise the other tests start from — and its user setup becomes idempotent.
- **`EndpointAuthorizationIT`** switches its repeated per-method user creation to the idempotent variant.

The remaining six classes keep only the annotation: `IntentEngineIT`, `JavaEngineIT`, `IntentConversationIT` and `NumberingSdkIT` already have honest `@AfterEach` cleanup; `DataStoreIT` recreates its tables in `@BeforeEach`; `SecurityIT` is read-only (MockMvc + `@WithMockUser`). `NumberingSdkIT`'s assertions were audited for counter persistence: they are all relative (`b == a+1`), explicitly seeded, or use partition names unique to their method — consistent with the engine's own "counters are never reset" contract.

Deliberately NOT converted (candidates for a later batch, each needs its own analysis): `LocalNativeAppLifecycleIT` (OS process lifecycle), `EnabledMultitenantModeIT` (tenant provisioning), and the UI classes.

## Verification

- Two consecutive full runs of the converted batch (fresh `target/dirigible` each): **84/84 green, ~4:20 per run** (the repeatability check the `SecurityIT`/#6661 lesson calls for — leaked state shows up on the second run).
- `mvn formatter:validate` green on both modules; `mvn -P release` javadoc check green on `tests-framework` (new public methods carry Javadoc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)