### PR TITLE
perf(tests): one Dirigible boot per class for 22 more multi-method ITs

### DIFF
--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/ArtefactStatusEndpointIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/ArtefactStatusEndpointIT.java
@@ -23,12 +23,16 @@ import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * End-to-end test for {@code GET /services/core/artefacts}: publishes an artefact into the
  * registry, synchronizes, and asserts the endpoint reports it with the lifecycle the synchronizer
  * left behind.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself (or is read-only), so
+// the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class ArtefactStatusEndpointIT extends IntegrationTest {
 
     private static final String ENDPOINT = "/services/core/artefacts";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/BpmnModelApiIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/BpmnModelApiIT.java
@@ -16,6 +16,7 @@ import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.nio.charset.StandardCharsets;
 
@@ -38,6 +39,9 @@ import static org.hamcrest.Matchers.*;
  * Files are written directly into the repository at the workspace path the endpoint resolves to for
  * the {@code admin} user — no browser or synchronizer required.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself (or is read-only), so
+// the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class BpmnModelApiIT extends IntegrationTest {
 
     private static final String USERNAME = "admin";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/DocumentsApiIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/DocumentsApiIT.java
@@ -21,6 +21,7 @@ import org.eclipse.dirigible.tests.base.IntegrationTest;
 import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 import io.restassured.http.ContentType;
 
@@ -36,6 +37,9 @@ import io.restassured.http.ContentType;
  * child payload carries the {@code type} / {@code path} / {@code readable} fields the interfaces
  * render.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself (or is read-only), so
+// the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class DocumentsApiIT extends IntegrationTest {
 
     /**

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentCrossModelScheduleSourceIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentCrossModelScheduleSourceIT.java
@@ -10,7 +10,9 @@
 package org.eclipse.dirigible.integration.tests.api;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
@@ -30,6 +32,7 @@ import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * Cross-model schedule SOURCE coverage: a schedule owned by the CONSUMER model iterates a source
@@ -51,6 +54,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * {@code .model} absent, and a mistyped {@code where} field - both drop the schedule with a warning
  * in the generate response (never a job that cannot compile).
  */
+// One Dirigible boot for the whole class: each method cleans up after itself (or is read-only), so
+// the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class IntentCrossModelScheduleSourceIT extends IntegrationTest {
 
     private static final String WORKSPACE = "workspace";
@@ -315,10 +321,14 @@ class IntentCrossModelScheduleSourceIT extends IntegrationTest {
             restAssuredExecutor.execute(() -> given().when()
                                                      .delete("/services/ide/publisher/" + WORKSPACE + "/" + project)
                                                      .then()
-                                                     .statusCode(greaterThanOrEqualTo(200)));
+                                                     .statusCode(both(greaterThanOrEqualTo(200)).and(lessThan(300))));
             if (repository.hasCollection(projectPath(project))) {
                 repository.removeCollection(projectPath(project));
             }
         }
+        // The context (and its Quartz scheduler) now outlives the method: run the synchronizers so the
+        // JobSynchronizer's DELETE branch unschedules the published 5-second cron job - otherwise it
+        // keeps firing against unloaded gen classes for the rest of the class.
+        synchronizationProcessor.forceProcessSynchronizers();
     }
 }

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaBpmnIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaBpmnIT.java
@@ -23,6 +23,7 @@ import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 import io.restassured.http.ContentType;
 
@@ -43,6 +44,9 @@ import io.restassured.http.ContentType;
  * Each delegate writes a process variable; the test asserts both variables made it into the
  * historic record, proving end-to-end execution.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself (or is read-only), so
+// the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class JavaBpmnIT extends IntegrationTest {
 
     private static final String PROJECT = "java-bpmn-it";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaCamelIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaCamelIT.java
@@ -22,6 +22,7 @@ import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * End-to-end test for the Java Camel handler integration: drops a {@code .java} class implementing
@@ -35,6 +36,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * proves a recompiled handler is picked up without a server restart (the {@code .camel} route is
  * untouched between runs). Counterpart of {@code JavaBpmnIT} for the Camel engine.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself (or is read-only), so
+// the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class JavaCamelIT extends IntegrationTest {
 
     private static final String PROJECT = "java-camel-it";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaCompilationProblemsIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaCompilationProblemsIT.java
@@ -25,12 +25,16 @@ import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * Verifies that a client-Java compile failure surfaces as a Problems-view entry (category
  * {@code Compilation}, with the failing line) and that fixing or removing the source clears it.
  * HTTP-only against the Problems endpoint - no Selenide.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself (or is read-only), so
+// the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class JavaCompilationProblemsIT extends IntegrationTest {
 
     private static final String PROJECT = "java-problems-it";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/PerspectiveGroupAggregationIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/PerspectiveGroupAggregationIT.java
@@ -25,6 +25,7 @@ import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * End-to-end test for the perspective aggregator
@@ -37,6 +38,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * now declare itself the default of its extension point and adopt both the un-matched and the
  * un-grouped perspectives; the platform point keeps its 'undefined-group' catch-all.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself (or is read-only), so
+// the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class PerspectiveGroupAggregationIT extends IntegrationTest {
 
     private static final String SERVICE = "/services/js/platform-core/extension-services/perspectives.js?extensionPoints=";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/PrintRenderIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/PrintRenderIT.java
@@ -23,6 +23,7 @@ import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * End-to-end test for server-side print rendering ({@code sdk.print.Print} -> {@code PrintFacade}).
@@ -33,6 +34,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * SDK bean bridge + the render pipeline in the same tenant scope the generated snapshot delegate
  * will use.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself (or is read-only), so
+// the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class PrintRenderIT extends IntegrationTest {
 
     private static final String PROJECT = "print-render-it";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/RepositoryExportIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/RepositoryExportIT.java
@@ -31,12 +31,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * End-to-end test for the export representation of {@code GET /services/core/repository}: a
  * collection downloads as a zip of its content including its subfolders, a resource downloads as
  * the file itself, and the plain listing representation stays untouched.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself (or creates only
+// collision-free state), so the per-method context reset inherited from IntegrationTest would only
+// add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class RepositoryExportIT extends IntegrationTest {
 
     private static final String ENDPOINT = "/services/core/repository";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/SynchronizerCleanupRaceIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/SynchronizerCleanupRaceIT.java
@@ -28,6 +28,7 @@ import org.eclipse.dirigible.tests.base.IntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * A publish replaces a registry collection by deleting it and copying it back milliseconds later. A
@@ -39,6 +40,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * The pass must therefore defer its cleanup while the registry is being written, and still
  * reconcile a genuine deletion once the registry is quiet.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself (or is read-only), so
+// the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class SynchronizerCleanupRaceIT extends IntegrationTest {
 
     private static final String LOCATION = "/cleanup-race-it/Sample.java";
@@ -177,16 +181,15 @@ class SynchronizerCleanupRaceIT extends IntegrationTest {
 
     @AfterEach
     void removeSourcesFromRegistry() {
-        boolean removed = false;
         for (String path : List.of(REGISTRY_PATH, PROBE_REGISTRY_PATH,
                 IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PUBLISH_PROJECT + PUBLISH_SOURCE_PATH)) {
             if (repository.hasResource(path)) {
                 repository.removeResource(path);
-                removed = true;
             }
         }
-        if (removed) {
-            synchronizationProcessor.forceProcessSynchronizers();
-        }
+        // Unconditionally: the publish-bypass test unpublishes through the service without a sync, so
+        // no resource is left for the loop above to notice - but the registered JavaFile artefact for
+        // the vanished source still needs the cleanup pass, or every later rebuild bails and defers.
+        synchronizationProcessor.forceProcessSynchronizers();
     }
 }

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantConfigurationIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantConfigurationIT.java
@@ -24,12 +24,16 @@ import org.eclipse.dirigible.tests.base.IntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * End-to-end test for the tenant-aware configuration feature. Exercises the full chain in the
  * running application (per-tenant DIRIGIBLE_CONFIGURATION table -> store -> cache -> key policy ->
  * thread-scoped {@link Configuration} precedence) against the default tenant.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself (or is read-only), so
+// the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class TenantConfigurationIT extends IntegrationTest {
 
     /** A white-listed key (branding is the only injectable namespace for now). */

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/CsvProcessorIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/CsvProcessorIT.java
@@ -16,6 +16,7 @@ import org.eclipse.dirigible.components.data.sources.manager.DataSourcesManager;
 import org.eclipse.dirigible.tests.base.IntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -24,6 +25,10 @@ import java.sql.SQLException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+// One Dirigible boot for the whole class: each method cleans up after itself (or creates only
+// collision-free state), so the per-method context reset inherited from IntegrationTest would only
+// add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class CsvProcessorIT extends IntegrationTest {
 
     /** The default data source name. */

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/CsvimReimportIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/CsvimReimportIT.java
@@ -20,6 +20,7 @@ import org.eclipse.dirigible.tests.base.IntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
@@ -44,6 +45,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Also covers the other half of the same finding: the re-import must be TRIGGERED when only the
  * referenced CSV changes, since the .csvim itself is a stable pointer that stays byte-identical.
  */
+// One Dirigible boot for the whole class: each method cleans up after itself (or creates only
+// collision-free state), so the per-method context reset inherited from IntegrationTest would only
+// add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class CsvimReimportIT extends IntegrationTest {
 
     /** The project holding the synchronizer-path fixture. */

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/messaging/MessagingFacadeIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/messaging/MessagingFacadeIT.java
@@ -14,6 +14,7 @@ import org.eclipse.dirigible.components.api.messaging.MessagingFacade;
 import org.eclipse.dirigible.components.api.messaging.TimeoutException;
 import org.eclipse.dirigible.tests.base.IntegrationTest;
 import org.eclipse.dirigible.tests.framework.util.SleepUtil;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -21,7 +22,11 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import org.springframework.test.annotation.DirtiesContext;
 
+// One Dirigible boot for the whole class: each method cleans up after itself (or is read-only), so
+// the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class MessagingFacadeIT extends IntegrationTest {
 
     private static final String TEST_MESSAGE = "Test message";
@@ -32,6 +37,21 @@ public class MessagingFacadeIT extends IntegrationTest {
     class QueueTest {
         private static final String QUEUE = "my-test-queue";
         private static final long TIMEOUT_MILLIS = 500L;
+
+        /**
+         * The broker's JDBC store now outlives a test method, so a message a prior method left behind would
+         * break the FIFO and receive-timeout assertions - drain until the queue answers empty.
+         */
+        @BeforeEach
+        void drainQueue() {
+            while (true) {
+                try {
+                    MessagingFacade.receiveFromQueue(QUEUE, 50);
+                } catch (TimeoutException emptyQueue) {
+                    return;
+                }
+            }
+        }
 
         @Test
         void testSendReceiveOneMessage() {

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/rest/EnabledMultitenantModeIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/rest/EnabledMultitenantModeIT.java
@@ -13,11 +13,16 @@ import org.eclipse.dirigible.commons.config.DirigibleConfig;
 import org.eclipse.dirigible.tests.framework.tenant.DirigibleTestTenant;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * Multitenant mode must be enabled by default
  */
 
+// One Dirigible boot for the whole class: each method cleans up after itself (or creates only
+// collision-free state), so the per-method context reset inherited from IntegrationTest would only
+// add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class EnabledMultitenantModeIT extends TenantDeterminationIT {
 
     @BeforeAll

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DatabaseShellIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DatabaseShellIT.java
@@ -13,6 +13,7 @@ import org.eclipse.dirigible.tests.base.UserInterfaceIntegrationTest;
 import org.eclipse.dirigible.tests.framework.browser.HtmlAttribute;
 import org.eclipse.dirigible.tests.framework.browser.HtmlElementType;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * Smoke test for the Database shell. It asserts what only a real browser can: that the Harmonia +
@@ -25,6 +26,9 @@ import org.junit.jupiter.api.Test;
  * The page roots carry a stable id, so the assertions do not depend on what the instance happens to
  * have deployed. The one thing that IS depended on is DefaultDB, which every instance has.
  */
+// One Dirigible boot for the whole class: the methods are read-only or clean up after themselves,
+// so the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class DatabaseShellIT extends UserInterfaceIntegrationTest {
 
     private static final String DATABASE_PATH = "/services/web/database/index.html";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/IntentBuilderShellIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/IntentBuilderShellIT.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Selenide;
@@ -53,6 +54,9 @@ import com.sun.net.httpserver.HttpServer;
  * client-side re-validation, the auto-apply, the hidden persistence, and every step of the publish
  * pipeline (generate models, generate code, publish, verify against the Problems feed).
  */
+// One Dirigible boot for the whole class: the methods are read-only or clean up after themselves,
+// so the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class IntentBuilderShellIT extends UserInterfaceIntegrationTest {
 
     private static final String BUILDER_PATH = "/services/web/builder/index.html";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/MonitoringPerspectiveIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/MonitoringPerspectiveIT.java
@@ -18,6 +18,7 @@ import org.eclipse.dirigible.tests.framework.browser.HtmlElementType;
 import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * Smoke test for the Monitoring perspective. Verifies that:
@@ -35,6 +36,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * datasource set the runtime initializes by the time the click happens, so it is deliberately left
  * out.
  */
+// One Dirigible boot for the whole class: the methods are read-only or clean up after themselves,
+// so the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class MonitoringPerspectiveIT extends UserInterfaceIntegrationTest {
 
     private static final String PERSPECTIVE_ID = "perspective-monitoring";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/MonitoringShellIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/MonitoringShellIT.java
@@ -12,6 +12,7 @@ package org.eclipse.dirigible.integration.tests.ui.tests;
 import org.eclipse.dirigible.tests.base.UserInterfaceIntegrationTest;
 import org.eclipse.dirigible.tests.framework.browser.HtmlElementType;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * Smoke test for the Monitoring shell. It asserts what only a real browser can: that the Harmonia +
@@ -24,6 +25,9 @@ import org.junit.jupiter.api.Test;
  * The page roots carry a stable id, so the assertions hold whether or not the instance happens to
  * have processes, jobs or queues deployed.
  */
+// One Dirigible boot for the whole class: the methods are read-only or clean up after themselves,
+// so the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class MonitoringShellIT extends UserInterfaceIntegrationTest {
 
     private static final String MONITORING_PATH = "/services/web/monitoring/index.html";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/RestTransactionsIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/RestTransactionsIT.java
@@ -15,13 +15,16 @@ import org.eclipse.dirigible.components.tenants.domain.User;
 import org.eclipse.dirigible.components.tenants.service.UserService;
 import org.eclipse.dirigible.database.sql.DataType;
 import org.eclipse.dirigible.database.sql.ISqlDialect;
+import org.eclipse.dirigible.database.sql.SqlFactory;
 import org.eclipse.dirigible.database.sql.dialects.SqlDialectFactory;
 import org.eclipse.dirigible.tests.base.UserInterfaceIntegrationTest;
 import org.eclipse.dirigible.tests.framework.tenant.DirigibleTestTenant;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -33,6 +36,10 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
+// One Dirigible boot for the whole class: the database outlives a test method, so cleanupTestData
+// removes what a method commits (the TESTTABLE rows and the test user) instead of relying on the
+// per-method context reset inherited from IntegrationTest.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @Import(RestTransactionsITConfig.class)
 public class RestTransactionsIT extends UserInterfaceIntegrationTest {
 
@@ -41,6 +48,25 @@ public class RestTransactionsIT extends UserInterfaceIntegrationTest {
 
     @Autowired
     private DataSourcesManager dataSourcesManager;
+
+    @AfterEach
+    void cleanupTestData() throws SQLException {
+        DirigibleDataSource dataSource = dataSourcesManager.getDefaultDataSource();
+        ISqlDialect dialect = SqlDialectFactory.getDialect(dataSource);
+        try (Connection connection = dataSource.getConnection()) {
+            if (SqlFactory.getNative(connection)
+                          .existsTable(connection, RestTransactionsITConfig.TestRest.TEST_TABLE)) {
+                try (PreparedStatement dropStatement = connection.prepareStatement(dialect.drop()
+                                                                                          .table(RestTransactionsITConfig.TestRest.TEST_TABLE)
+                                                                                          .build())) {
+                    dropStatement.executeUpdate();
+                }
+            }
+        }
+        userService.findUserByUsernameAndTenantId(RestTransactionsITConfig.TestRest.TEST_USERNAME, DirigibleTestTenant.createDefaultTenant()
+                                                                                                                      .getId())
+                   .ifPresent(user -> userService.deleteUser(user.getId()));
+    }
 
     @Test
     void testCommitByDefaultForSystemDb() {

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/ShellSwitcherIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/ShellSwitcherIT.java
@@ -12,6 +12,7 @@ package org.eclipse.dirigible.integration.tests.ui.tests;
 import org.eclipse.dirigible.tests.base.UserInterfaceIntegrationTest;
 import org.eclipse.dirigible.tests.framework.browser.HtmlElementType;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * The shell switcher in every Harmonia shell's user menu: the other registered shells plus Home, so
@@ -21,6 +22,9 @@ import org.junit.jupiter.api.Test;
  * aggregation Home renders, so this exercises two different host shells to prove the block works
  * wherever it is embedded - and that each one leaves ITSELF out of its own list.
  */
+// One Dirigible boot for the whole class: the methods are read-only or clean up after themselves,
+// so the per-method context reset inherited from IntegrationTest would only add boot time per test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class ShellSwitcherIT extends UserInterfaceIntegrationTest {
 
     @Test


### PR DESCRIPTION
## What

Batch 2 of the `@DirtiesContext(AFTER_CLASS)` conversion (#6703 was batch 1): the remaining multi-method IT classes, audited class-by-class for shared-database honesty. **60 test methods now cost 22 Spring boots instead of 60**, trimming both the `api` and `ui` CI shards (the `ui` shard is the current wall-clock bottleneck).

## Scope

**Converted as-is (18)** — methods are read-only or already have honest per-method cleanup: `MonitoringPerspectiveIT`, `IntentBuilderShellIT`, `MonitoringShellIT`, `DatabaseShellIT`, `ShellSwitcherIT`, `EnabledMultitenantModeIT`, `CsvProcessorIT`, `RepositoryExportIT`, `CsvimReimportIT`, `DocumentsApiIT`, `JavaBpmnIT`, `JavaCamelIT`, `PerspectiveGroupAggregationIT`, `JavaCompilationProblemsIT`, `PrintRenderIT`, `ArtefactStatusEndpointIT`, `BpmnModelApiIT`, `TenantConfigurationIT`.

**Converted with a state-honesty fix (4):**
- `RestTransactionsIT` — new `@AfterEach` drops `TESTTABLE` and deletes the committed test user; two methods otherwise collide on both (one asserts the user exists after a commit, another asserts it's absent after a rollback).
- `IntentCrossModelScheduleSourceIT` — cleanup now force-syncs so the `JobSynchronizer` DELETE branch unschedules the published 5-second cron job (it otherwise keeps firing against unloaded gen classes for the rest of the class), and the unpublish cleanup asserts a strict 2xx instead of `>=200`.
- `SynchronizerCleanupRaceIT` — the cleanup sync runs unconditionally: the publish-bypass test unpublishes through the service without a sync, leaving a registered `JavaFile` whose source is gone, which makes every later client-Java rebuild defer.
- `MessagingFacadeIT` — the queue tests drain the broker (now persistent across methods, its JDBC store lives in SystemDB) before each method; the FIFO and receive-timeout assertions need an empty queue.

**Deliberately NOT converted, with cause:** `MultitenancyHarmoniaIT` (fixture asserts absolute row counts and empty CMIS listings — non-idempotent by construction), `LocalNativeAppLifecycleIT` (would leak live OS processes and duplicate default-package `Server` FQNs between methods), `SchemaExportImportIT` (whole-SystemDB export with an exclusion list tuned to a pristine database).

## Verification

Two consecutive full runs of all 22 classes (fresh `target/dirigible` each, isolated Maven repo): **62/62 green both times** (the 1 skip is the pre-existing `@Disabled` rollback test). `mvn formatter:validate` green.

With #6703 this closes out the low-risk portion of the boot-per-method cleanup; what remains for the IT-speed effort is consolidating the duplicated journeys (the 14 sample-project clones, the BPMN editor trio, `CreateNewFileIT`'s 431s single test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)