### PR TITLE
fix(generation): the glue templates get every reference they render

### DIFF
--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/GlueGenerator.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/GlueGenerator.java
@@ -443,6 +443,12 @@ class GlueGenerator {
                 "itemLines", "fromItemEntity", "toItemEntity", "srcFkProperty", "toFkProperty", "itemFieldAssignments", "fromPerspective",
                 "sourceStatusProperty", "sourceStatusValue");
         context.put("fromJavaPerspective", sanitize(item, "fromPerspective"));
+        // The SOURCE's gen folder / owning project: this project unless the source belongs to another
+        // model (intent `fromUses:`). That is what lets a create-from be authored on the module owning
+        // the TARGET and keeps the two modules' generated Java acyclic - only one side references the
+        // other.
+        context.put("fromGenFolder", truthy(item, "crossModelSource") ? sanitize(item, "fromModel") : str(parameters, "javaGenFolderName"));
+        context.put("fromProjectName", truthy(item, "crossModelSource") ? str(item, "fromProject") : str(parameters, "projectName"));
         context.put("toGenFolder", truthy(item, "crossModel") ? sanitize(item, "toModel") : str(parameters, "javaGenFolderName"));
         context.put("toJavaPerspective", sanitize(item, "toPerspective"));
         // A primary source item that is not a composition child lives outside the source document's

--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/RollupAggregates.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/RollupAggregates.java
@@ -107,9 +107,14 @@ final class RollupAggregates {
      */
     private static String renderSum(Map<String, Object> rollup, String countField) {
         String sumField = str(rollup, "sumField");
-        String capacityField = str(rollup, "capacityField");
-        String balanceField = str(rollup, "balanceField");
-        String statusField = str(rollup, "statusField");
+        // Emptiness, not nullness: the intent glue writes "" for an unused optional field
+        // (GlueIntentGenerator), and the JavaScript this was ported from tested truthiness - so a null
+        // check let "" through and emitted `parent. == null ? ...`, which does not compile. That broke
+        // the WHOLE client-Java batch (one javac task per generation), so every controller in the app
+        // 404-ed, not just the roll-up.
+        String capacityField = strOrEmpty(rollup, "capacityField");
+        String balanceField = strOrEmpty(rollup, "balanceField");
+        String statusField = strOrEmpty(rollup, "statusField");
         StringBuilder out = new StringBuilder(512);
         out.append("        {\n");
         out.append("            java.math.BigDecimal sum = java.math.BigDecimal.ZERO;\n");
@@ -135,13 +140,13 @@ final class RollupAggregates {
            .append("\", parent.")
            .append(countField)
            .append(");\n");
-        if (capacityField != null) {
+        if (!capacityField.isEmpty()) {
             out.append("                java.math.BigDecimal capacity = parent.")
                .append(capacityField)
                .append(" == null ? java.math.BigDecimal.ZERO : parent.")
                .append(capacityField)
                .append(";\n");
-            if (balanceField != null) {
+            if (!balanceField.isEmpty()) {
                 out.append("                parent.")
                    .append(balanceField)
                    .append(" = capacity.subtract(sum);\n");
@@ -151,7 +156,7 @@ final class RollupAggregates {
                    .append(balanceField)
                    .append(");\n");
             }
-            if (statusField != null) {
+            if (!statusField.isEmpty()) {
                 out.append("                if (sum.signum() > 0) {\n");
                 out.append("                    parent.")
                    .append(statusField)

--- a/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/RollupAggregatesTest.java
+++ b/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/RollupAggregatesTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.ide.template.service.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the emitted roll-up compute blocks, whose optional fields the intent layer writes as the
+ * EMPTY STRING rather than leaving out.
+ *
+ * <p>
+ * That distinction is the whole point of these tests. The JavaScript this was ported from tested
+ * truthiness ({@code if (ru.capacityField)}), which is false for {@code ""}; a null check is not,
+ * so an unused capacity emitted {@code parent. == null} - a member access with no member. It does
+ * not compile, and because the client-Java runtime compiles the whole registry in one javac task,
+ * it took every controller in the generated application down with it (a 404 on endpoints that had
+ * nothing to do with roll-ups).
+ */
+class RollupAggregatesTest {
+
+    /**
+     * A roll-up whose optional capacity, balance and status are unset the way the intent writes them.
+     */
+    private static Map<String, Object> sumRollup(String capacityField, String balanceField, String statusField) {
+        Map<String, Object> rollup = new LinkedHashMap<>();
+        rollup.put("op", "sum");
+        rollup.put("childEntity", "SalesOrderItem");
+        rollup.put("countField", "Total");
+        rollup.put("sumField", "Amount");
+        rollup.put("capacityField", capacityField);
+        rollup.put("balanceField", balanceField);
+        rollup.put("statusField", statusField);
+        rollup.put("statusWhenFull", "");
+        rollup.put("statusWhenPartial", "");
+        return rollup;
+    }
+
+    @Test
+    void emptyOptionalsEmitNoCapacityBlockAtAll() {
+        String rendered = RollupAggregates.render(sumRollup("", "", ""));
+
+        assertThat(rendered).as("the sum itself is always emitted")
+                            .contains("parent.Total = sum;");
+        assertThat(rendered).as("an unset capacity must not emit a capacity block")
+                            .doesNotContain("capacity");
+        assertThat(rendered).as("no member access may be left without its member")
+                            .doesNotContain("parent. ")
+                            .doesNotContain("parent.;")
+                            .doesNotContain("parent.)");
+    }
+
+    @Test
+    void populatedOptionalsEmitTheCapacityBalanceAndStatusBlock() {
+        Map<String, Object> rollup = sumRollup("Capacity", "Available", "Status");
+        rollup.put("statusWhenFull", "3");
+        rollup.put("statusWhenPartial", "2");
+
+        String rendered = RollupAggregates.render(rollup);
+
+        assertThat(rendered).contains("parent.Capacity")
+                            .contains("parent.Available = capacity.subtract(sum);")
+                            .contains("parent.Status = sum.compareTo(capacity) >= 0 ? 3 : 2;");
+    }
+
+    @Test
+    void absentOptionalsBehaveLikeEmptyOnes() {
+        Map<String, Object> rollup = new LinkedHashMap<>();
+        rollup.put("op", "sum");
+        rollup.put("childEntity", "SalesOrderItem");
+        rollup.put("countField", "Total");
+        rollup.put("sumField", "Amount");
+
+        String rendered = RollupAggregates.render(rollup);
+
+        assertThat(rendered).doesNotContain("capacity")
+                            .doesNotContain("parent. ");
+    }
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/template/ModelGenerationIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/template/ModelGenerationIT.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -94,6 +95,20 @@ class ModelGenerationIT extends IntegrationTest {
      * Mustache engine names its indexed collection twins by suffixing an underscore.
      */
     private static final Pattern ENGINE_ADDED_KEY = Pattern.compile("\"[A-Za-z0-9]+_\"\\s*:");
+
+    /**
+     * A Velocity reference that survived rendering. {@code ${JavaTask}} is excluded: it is a literal
+     * Flowable delegate expression that generated code carries on purpose.
+     */
+    private static final Pattern UNRESOLVED_REFERENCE = Pattern.compile("\\$\\{(?!JavaTask\\b)[A-Za-z]\\w*\\}?");
+
+    /**
+     * A member access whose member is missing - {@code parent. == null}, {@code target. = row.X} or
+     * {@code derived.put("X", parent.)} - which is what an emitted-code helper produces when the field
+     * name it interpolates is empty. Deliberately same-line only: generated code breaks a chained call
+     * after the dot, so a dot at end of line is normal and its member is on the next one.
+     */
+    private static final Pattern DANGLING_MEMBER_ACCESS = Pattern.compile("\\w\\.[ \\t]*[=;),!]");
 
     /** The workspace service. */
     @Autowired
@@ -191,6 +206,7 @@ class ModelGenerationIT extends IntegrationTest {
                     .contains("{{")) {
                 problems.add("[" + label + "] a rendered path kept its placeholder: " + file.getKey());
             }
+            problems.addAll(unresolvedReferences(label, file.getKey(), file.getValue()));
         }
         String descriptorPath = baseName(fixture) + DESCRIPTOR_EXTENSION;
         String descriptor = rendered.get(descriptorPath);
@@ -314,6 +330,46 @@ class ModelGenerationIT extends IntegrationTest {
     private static String baseName(String fixture) {
         int dot = fixture.indexOf('.');
         return dot > 0 ? fixture.substring(0, dot) : fixture;
+    }
+
+    /**
+     * Collects what would not compile in a rendered {@code .java} file.
+     *
+     * <p>
+     * Generated Java is the one output whose validity can be judged without running it, and it is the
+     * output where a rendering gap is most expensive: the client-Java runtime compiles the whole
+     * registry in ONE javac task, so a single broken generated file unregisters every controller in the
+     * application - the symptom is a 404 on an endpoint that has nothing to do with the defect. Both
+     * checks below are here because both defects reached master:
+     * <ul>
+     * <li>a surviving {@code ${reference}} - Velocity renders an undefined reference verbatim, so a key
+     * the binder forgot to put in the context (it was {@code fromGenFolder}) becomes a syntax error
+     * rather than a missing value;</li>
+     * <li>a dangling {@code .} - what an emitted-code helper produces when a field name it interpolates
+     * is the empty string, which is what the intent glue writes for an unused optional field.</li>
+     * </ul>
+     *
+     * @param label the case label
+     * @param path the rendered file path
+     * @param content the rendered content
+     * @return the problems found, empty when the file is sound
+     */
+    private static List<String> unresolvedReferences(String label, String path, String content) {
+        if (!path.endsWith(".java") || content == null) {
+            return List.of();
+        }
+        List<String> problems = new ArrayList<>();
+        Matcher reference = UNRESOLVED_REFERENCE.matcher(content);
+        while (reference.find()) {
+            problems.add("[" + label + "] " + path + " kept an unresolved template reference: " + reference.group());
+        }
+        Matcher dangling = DANGLING_MEMBER_ACCESS.matcher(content);
+        while (dangling.find()) {
+            problems.add("[" + label + "] " + path + " emitted a member access with no member, so an interpolated field name was"
+                    + " empty: " + dangling.group()
+                                           .trim());
+        }
+        return problems;
     }
 
 }

--- a/tests/tests-integrations/src/main/resources/ModelGenerationIT/orders.glue
+++ b/tests/tests-integrations/src/main/resources/ModelGenerationIT/orders.glue
@@ -23,7 +23,8 @@
                     "targetEntity": "Currency",
                     "targetPerspective": "Currencies"
                 }
-            ]
+            ],
+            "businessKeyProperty": "Id"
         }
     ],
     "notifications": [
@@ -52,7 +53,17 @@
                     "targetEntity": "Currency",
                     "targetPerspective": "Currencies"
                 }
-            ]
+            ],
+            "attach": "",
+            "attachEntity": "",
+            "attachLanguageExpression": "",
+            "attachFileNameExpression": "",
+            "attachLanguageFkProperty": "",
+            "attachLanguageTargetEntity": "",
+            "attachLanguageTargetPerspective": "",
+            "attachLanguageCrossModel": false,
+            "attachLanguageTargetModel": "",
+            "attachKeyProperty": ""
         }
     ],
     "rollups": [
@@ -66,7 +77,15 @@
             "topicSuffix": "",
             "op": "sum",
             "sumField": "Amount",
-            "countField": "Total"
+            "countField": "Total",
+            "capacityField": "",
+            "balanceField": "",
+            "statusField": "",
+            "statusWhenFull": "",
+            "statusWhenPartial": "",
+            "parentModel": "",
+            "parentCrossModel": false,
+            "criteriaExpression": "Criteria.create().eq(\"SalesOrder\", entity.SalesOrder)"
         },
         {
             "className": "SalesOrderItemRollup",
@@ -77,7 +96,10 @@
             "fkProperty": "SalesOrder",
             "topicSuffix": "",
             "op": "count",
-            "countField": "LineCount"
+            "countField": "LineCount",
+            "parentModel": "",
+            "parentCrossModel": false,
+            "criteriaExpression": "Criteria.create().eq(\"SalesOrder\", entity.SalesOrder)"
         },
         {
             "className": "SalesOrderItemRollup",
@@ -89,7 +111,35 @@
             "topicSuffix": "-deleted",
             "op": "sum",
             "sumField": "Amount",
-            "countField": "Total"
+            "countField": "Total",
+            "capacityField": "",
+            "balanceField": "",
+            "statusField": "",
+            "statusWhenFull": "",
+            "statusWhenPartial": "",
+            "parentModel": "",
+            "parentCrossModel": false,
+            "criteriaExpression": "Criteria.create().eq(\"SalesOrder\", entity.SalesOrder)"
+        },
+        {
+            "className": "SalesOrderItemRollup",
+            "childEntity": "SalesOrderItem",
+            "childPerspective": "Sales Orders",
+            "parentEntity": "SalesOrder",
+            "parentPerspective": "Sales Orders",
+            "parentModel": "",
+            "parentCrossModel": false,
+            "fkProperty": "SalesOrder",
+            "topicSuffix": "-capacity",
+            "op": "sum",
+            "sumField": "Amount",
+            "countField": "Reserved",
+            "capacityField": "Capacity",
+            "balanceField": "Available",
+            "statusField": "Status",
+            "statusWhenFull": "3",
+            "statusWhenPartial": "2",
+            "criteriaExpression": "Criteria.create().eq(\"SalesOrder\", entity.SalesOrder)"
         }
     ],
     "aggregates": [
@@ -123,6 +173,46 @@
             "keyAccessor": "getId",
             "field": "Status",
             "value": "APPROVED"
+        }
+    ],
+    "generates": [
+        {
+            "name": "invoiceFromOrder",
+            "className": "InvoiceFromOrder",
+            "crossModel": false,
+            "fromEntity": "SalesOrder",
+            "fromPerspective": "Sales Orders",
+            "crossModelSource": false,
+            "fromModel": "",
+            "fromProject": "",
+            "toEntity": "SalesInvoice",
+            "toModel": "",
+            "toPerspective": "Sales Invoices",
+            "toPk": "Id",
+            "fieldAssignments": "        target.Customer = source.Customer;\n",
+            "sourceStatusProperty": "",
+            "sourceStatusValue": "",
+            "hasItems": false,
+            "hasItemLines": false
+        },
+        {
+            "name": "orderFromQuote",
+            "className": "OrderFromQuote",
+            "crossModel": false,
+            "fromEntity": "Quote",
+            "fromPerspective": "Quotes",
+            "crossModelSource": true,
+            "fromModel": "sales-quotes",
+            "fromProject": "codbex-quotes",
+            "toEntity": "SalesOrder",
+            "toModel": "",
+            "toPerspective": "Sales Orders",
+            "toPk": "Id",
+            "fieldAssignments": "        target.Customer = source.Customer;\n",
+            "sourceStatusProperty": "Status",
+            "sourceStatusValue": "4",
+            "hasItems": false,
+            "hasItemLines": false
         }
     ]
 }


### PR DESCRIPTION
Master is red: `IntentEmissionCoverageIT` fails on both DB legs since #6707 ([run 31720936125](https://github.com/eclipse-dirigible/dirigible/actions/runs/31720936125), and every run after it). The reported failure is a `ConditionTimeout` on `GET /services/java/emission-test/gen/emission/api/account/AccountController` answering **404** - which is nowhere near the cause.

### What actually broke

Two defects in the Java generation pipeline, both in generated *glue* code:

1. **`GlueGenerator.bindGenerate` never bound `fromGenFolder` / `fromProjectName`.** Velocity renders an undefined reference *verbatim*, so `Generate.java.template` emitted a literal `gen.${fromGenFolder}.data...`. The JavaScript this replaced computed both (`generateUtils.js`: `crossModelSource ? the source model's folder : this project's`).
2. **`RollupAggregates` tested `capacityField != null` where the JavaScript tested truthiness.** `GlueIntentGenerator` writes `""` for an unused optional field, and `""` is not `null`, so an unused capacity emitted `parent. == null ? … : parent. ;` - a member access with no member.

**Why that 404s an unrelated controller:** client Java compiles the whole registry in **one javac task**. A single unparseable generated file unregisters every controller in the application, so the symptom lands on an endpoint that has nothing to do with roll-ups or create-from. Worth remembering the next time a generated app 404s for no reason.

### Why the tests let it through

`ModelGenerationIT` replaced the parity oracle when the JavaScript pipeline was deleted, and it checked rendered **paths** for surviving placeholders - never rendered **content**. And its `orders.glue` fixture declared no `generates` block at all, and *omitted* the optional roll-up keys rather than carrying them as `""` the way the intent really writes them. The fixture exercised a descriptor shape no generation produces.

### Changes

- the two fixes above;
- `ModelGenerationIT` rejects an unresolved `${reference}` and a dangling member access in any generated `.java`. `${JavaTask}` is excluded - that Flowable delegate expression is a deliberate literal. **Verified red on the unfixed code**, naming `${fromGenFolder}` and `${fromProjectName}`;
- `orders.glue` made faithful to the intent's output: `generates` with a local **and** a cross-model source, the attachment family, `businessKeyProperty`, `criteriaExpression`, roll-ups carrying `""` optionals, plus one populated capacity/balance/status roll-up. Completing it surfaced three more unresolved references immediately (all fixture gaps, now closed);
- `RollupAggregatesTest` pins empty vs populated vs absent optionals - red without the fix, 0.06s.

### Verification

```
IntentEmissionCoverageIT   Tests run: 1, Failures: 0, Errors: 0   73.3 s   (was failing)
ModelGenerationIT          Tests run: 1, Failures: 0, Errors: 0   24.6 s
ide-template unit tests    Tests run: 72, Failures: 0, Errors: 0
```
formatter:validate and the release-profile javadoc check are clean.

### Follow-up worth considering (not in this PR)

Velocity renders an undefined reference verbatim, which is how a forgotten context key becomes a Java syntax error instead of a missing value. Turning on `runtime.references.strict` for the model pipeline would make that fail loudly at generation time. It needs a sweep first - some templates may rely on an absent optional rendering as nothing - so it does not belong in a master-red fix.
