### PR TITLE
fix(jobs): a trigger sets only the job's own parameters, thread-scoped (#6729)

### DIFF
--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/job/scheduler.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/job/scheduler.ts
@@ -90,6 +90,9 @@ export class Scheduler {
     /**
      * Triggers the immediate execution of a job.
      *
+     * Only the parameters the job artefact declares may be passed - anything else is rejected.
+     * The values are visible as configurations to the job body for the duration of the run only.
+     *
      * @param name The name of the job to trigger.
      * @param parameters Optional key-value object of parameters to pass to the job execution.
      */
@@ -289,6 +292,9 @@ class Job {
 
     /**
      * Triggers the immediate execution of this job instance.
+     *
+     * Only the parameters the job artefact declares may be passed - anything else is rejected.
+     * The values are visible as configurations to the job body for the duration of the run only.
      *
      * @param parameters Optional key-value object of parameters to pass to the job execution.
      */

--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/endpoint/JobEndpoint.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/endpoint/JobEndpoint.java
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,6 +40,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import io.swagger.v3.oas.annotations.Parameter;
 
@@ -171,7 +173,8 @@ public class JobEndpoint extends BaseEndpoint {
     }
 
     /**
-     * Trigger job.
+     * Trigger job. Only the parameters the job artefact declares may be passed - anything else is
+     * rejected as a bad request rather than applied to the platform configuration (dirigible #6729).
      *
      * @param job the job
      * @param parameters the parameters
@@ -186,7 +189,12 @@ public class JobEndpoint extends BaseEndpoint {
         for (NameValuePair pair : parameters) {
             parametersMap.put(pair.getName(), pair.getValue());
         }
-        return ResponseEntity.ok(jobService.trigger(job, parametersMap));
+        try {
+            return ResponseEntity.ok(jobService.trigger(job, parametersMap));
+        } catch (IllegalArgumentException ex) {
+            // An unknown job name or an undeclared parameter - the caller's mistake, not the server's.
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        }
     }
 
     /**

--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/service/JobService.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/service/JobService.java
@@ -9,12 +9,16 @@
  */
 package org.eclipse.dirigible.components.jobs.service;
 
-import static java.text.MessageFormat.format;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.components.base.artefact.BaseArtefactService;
 import org.eclipse.dirigible.components.jobs.domain.Job;
+import org.eclipse.dirigible.components.jobs.domain.JobParameter;
 import org.eclipse.dirigible.components.jobs.email.JobEmailProcessor;
 import org.eclipse.dirigible.components.jobs.handler.JobHandlerRunner;
 import org.eclipse.dirigible.components.jobs.manager.JobsManager;
@@ -125,36 +129,74 @@ public class JobService extends BaseArtefactService<Job, Long> {
     }
 
     /**
-     * Trigger.
+     * Trigger a job now with the given parameters.
+     *
+     * <p>
+     * A job body reads a parameter as a configuration value ({@code job.getParameter(name)} in the
+     * JavaScript SDK, {@code Configurations.get(name)} in the Java one), so the parameters have to be
+     * visible through {@link Configuration} while the handler runs. Two things bound what that costs
+     * (dirigible #6729):
+     *
+     * <ul>
+     * <li><b>Only the job's own declared parameters may be set.</b> The trigger is exposed over REST
+     * and to user scripts, so an unbounded key space would let any caller who may trigger a job
+     * transiently redefine any configuration key the platform reads. The {@code .job} artefact already
+     * declares its parameters, so this is a check against data the platform owns.</li>
+     * <li><b>The values are thread-scoped, not global.</b> They go into the thread configuration
+     * introduced for tenant overrides (#6205) rather than the process-global RUNTIME layer, so a
+     * trigger cannot change what a concurrent request - or another tenant - reads. The previous memento
+     * over {@code Configuration.set} also permanently pinned the resolved value of every key it touched
+     * into the RUNTIME layer; nothing is written outside this thread now.</li>
+     * </ul>
      *
      * @param name the name
-     * @param parametersMap the parameters map
+     * @param parametersMap the parameters, keyed by the declared parameter name
      * @return true, if successful
+     * @throws IllegalArgumentException if the job does not exist, or a parameter it does not declare
+     *         was passed
      * @throws Exception the exception
      */
     public boolean trigger(String name, Map<String, String> parametersMap) throws Exception {
         Job job = findByName(name);
-        if (job == null) {
-            String error = format("Job with name {0} does not exist, hence cannot be triggered", name);
-            throw new Exception(error);
-        }
-        Map<String, String> memento = new HashMap<String, String>();
-        try {
-            for (Map.Entry<String, String> entry : parametersMap.entrySet()) {
-                memento.put(entry.getKey(), Configuration.get(entry.getKey()));
-                Configuration.set(entry.getKey(), entry.getValue());
-            }
+        Map<String, String> parameters = (parametersMap != null) ? parametersMap : Collections.emptyMap();
+        assertDeclaredParameters(job, parameters);
 
+        Map<String, String> outerConfiguration = Configuration.getThreadConfiguration();
+        Map<String, String> jobConfiguration = new HashMap<>(outerConfiguration);
+        jobConfiguration.putAll(parameters);
+        Configuration.setThreadConfiguration(jobConfiguration);
+        try {
             // Run it on the engine the job declares - the same dispatch the scheduled fire uses. A
             // client-Java job's handler is a class name, not a JavaScript path (dirigible #6305).
             jobHandlerRunner.run(job.getHandler(), job.getEngine());
         } finally {
-            for (Map.Entry<String, String> entry : memento.entrySet()) {
-                Configuration.set(entry.getKey(), entry.getValue());
-            }
+            Configuration.setThreadConfiguration(outerConfiguration);
         }
 
         return true;
+    }
+
+    /**
+     * Rejects any parameter the job artefact does not declare.
+     *
+     * @param job the job being triggered
+     * @param parameters the parameters supplied by the caller
+     */
+    private static void assertDeclaredParameters(Job job, Map<String, String> parameters) {
+        List<JobParameter> declaredParameters = job.getParameters();
+        Set<String> declared = (declaredParameters != null) ? declaredParameters.stream()
+                                                                                .map(JobParameter::getName)
+                                                                                .collect(Collectors.toSet())
+                : Collections.emptySet();
+        List<String> undeclared = parameters.keySet()
+                                            .stream()
+                                            .filter(key -> !declared.contains(key))
+                                            .sorted()
+                                            .toList();
+        if (!undeclared.isEmpty()) {
+            throw new IllegalArgumentException("Job [" + job.getName() + "] does not declare the parameter(s) " + undeclared
+                    + ". A trigger may set only the parameters declared by the job artefact: " + declared);
+        }
     }
 
 }

--- a/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/endpoint/JobEndpointTest.java
+++ b/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/endpoint/JobEndpointTest.java
@@ -11,9 +11,11 @@ package org.eclipse.dirigible.components.jobs.endpoint;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -24,6 +26,7 @@ import java.util.Set;
 
 import jakarta.persistence.EntityManager;
 
+import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
 import org.eclipse.dirigible.components.jobs.domain.Job;
 import org.eclipse.dirigible.components.jobs.domain.JobEmail;
@@ -43,6 +46,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -201,6 +205,27 @@ public class JobEndpointTest {
 
         assertEquals(0, jobEmailService.findAllByJobName(testJob.getName())
                                        .size());
+    }
+
+    /**
+     * A trigger may set only the parameters the job artefact declares. Anything else is the caller's
+     * mistake, answered as a bad request, and it never reaches the platform configuration (dirigible
+     * #6729). The test job declares none, so any parameter is undeclared.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void triggerRejectsAnUndeclaredParameter() throws Exception {
+        String key = "DIRIGIBLE_TEST_UNDECLARED_JOB_PARAMETER";
+
+        mockMvc.perform(post("/services/jobs/trigger/{name}", testJob.getName()).with(csrf())
+                                                                                .contentType(MediaType.APPLICATION_JSON)
+                                                                                .content("[{\"name\":\"" + key
+                                                                                        + "\",\"value\":\"http://attacker.example.com\"}]"))
+               .andDo(print())
+               .andExpect(status().isBadRequest());
+
+        assertNull(Configuration.get(key));
     }
 
     /**

--- a/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/service/JobTriggerParametersTest.java
+++ b/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/service/JobTriggerParametersTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.jobs.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.components.jobs.domain.Job;
+import org.eclipse.dirigible.components.jobs.domain.JobParameter;
+import org.eclipse.dirigible.components.jobs.email.JobEmailProcessor;
+import org.eclipse.dirigible.components.jobs.handler.JobHandlerRunner;
+import org.eclipse.dirigible.components.jobs.manager.JobsManager;
+import org.eclipse.dirigible.components.jobs.repository.JobRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What a trigger-now may do to the platform configuration (dirigible #6729). The parameters reach
+ * the job body as configuration values, but only the ones the artefact declares, and only for the
+ * thread that runs the handler.
+ */
+class JobTriggerParametersTest {
+
+    /** The job's name as the repository holds it - the trigger path carries a leading separator. */
+    private static final String JOB_NAME = "project/report.job";
+
+    /** The path the Jobs perspective posts to. */
+    private static final String TRIGGER_PATH = "/" + JOB_NAME;
+
+    /** A key the caller must never be able to redefine through a trigger. */
+    private static final String INFRASTRUCTURE_KEY = "DIRIGIBLE_TEST_INFRASTRUCTURE_KEY";
+
+    private final JobRepository jobRepository = mock(JobRepository.class);
+
+    private final JobHandlerRunner jobHandlerRunner = mock(JobHandlerRunner.class);
+
+    private final JobService jobService =
+            new JobService(jobRepository, mock(JobEmailProcessor.class), mock(JobsManager.class), jobHandlerRunner);
+
+    @AfterEach
+    void cleanUpConfiguration() {
+        Configuration.removeThreadConfiguration();
+        Configuration.remove(INFRASTRUCTURE_KEY);
+    }
+
+    @Test
+    void aDeclaredParameterIsVisibleToTheHandlerAndGoneAfterwards() throws Exception {
+        registerJob(job(JOB_NAME, "REPORT_DATE"));
+        doAnswer(invocation -> {
+            assertEquals("2026-08-14", Configuration.get("REPORT_DATE"), "the job body reads its parameter as a configuration value");
+            return null;
+        }).when(jobHandlerRunner)
+          .run("/project/report.mjs", null);
+
+        jobService.trigger(TRIGGER_PATH, Map.of("REPORT_DATE", "2026-08-14"));
+
+        verify(jobHandlerRunner).run("/project/report.mjs", null);
+        assertNull(Configuration.get("REPORT_DATE"), "the parameter must not outlive the run");
+    }
+
+    @Test
+    void anUndeclaredParameterIsRejectedAndTheJobNeverRuns() {
+        registerJob(job(JOB_NAME, "REPORT_DATE"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> jobService.trigger(TRIGGER_PATH, Map.of(INFRASTRUCTURE_KEY, "http://attacker.example.com")));
+
+        assertNull(Configuration.get(INFRASTRUCTURE_KEY), "an undeclared key must never reach the configuration");
+        verifyNoInteractions(jobHandlerRunner);
+    }
+
+    /**
+     * The values used to go into the RUNTIME layer, which is process-global and outranks everything
+     * else - so a trigger changed what every concurrent request read. They are thread-scoped now.
+     */
+    @Test
+    void theParametersDoNotLeakOutOfTheTriggeringThread() throws Exception {
+        registerJob(job(JOB_NAME, "REPORT_DATE"));
+        AtomicReference<String> seenByAnotherThread = new AtomicReference<>("not read");
+        doAnswer(invocation -> {
+            Thread reader = new Thread(() -> seenByAnotherThread.set(Configuration.get("REPORT_DATE")));
+            reader.start();
+            reader.join();
+            return null;
+        }).when(jobHandlerRunner)
+          .run("/project/report.mjs", null);
+
+        jobService.trigger(TRIGGER_PATH, Map.of("REPORT_DATE", "2026-08-14"));
+
+        assertNull(seenByAnotherThread.get(), "a concurrent request must not see the parameter");
+    }
+
+    /**
+     * The thread configuration also carries the tenant's own overrides for the duration of the request,
+     * so the trigger has to add to it rather than replace it.
+     */
+    @Test
+    void theSurroundingThreadConfigurationSurvivesTheRun() throws Exception {
+        registerJob(job(JOB_NAME, "REPORT_DATE"));
+        Configuration.setThreadConfiguration(Map.of("DIRIGIBLE_BRANDING_NAME", "Tenant One"));
+        doAnswer(invocation -> {
+            assertEquals("Tenant One", Configuration.get("DIRIGIBLE_BRANDING_NAME"));
+            return null;
+        }).when(jobHandlerRunner)
+          .run("/project/report.mjs", null);
+
+        jobService.trigger(TRIGGER_PATH, Map.of("REPORT_DATE", "2026-08-14"));
+
+        assertEquals(Map.of("DIRIGIBLE_BRANDING_NAME", "Tenant One"), Configuration.getThreadConfiguration());
+    }
+
+    private void registerJob(Job job) {
+        when(jobRepository.findByName(job.getName())).thenReturn(Optional.of(job));
+    }
+
+    private static Job job(String name, String... declaredParameters) {
+        Job job = new Job();
+        job.setName(name);
+        job.setHandler("/project/report.mjs");
+        job.setParameters(Arrays.stream(declaredParameters)
+                                .map(parameterName -> new JobParameter(parameterName, "string", "", "", null, job))
+                                .toList());
+        return job;
+    }
+}


### PR DESCRIPTION
Closes #6729.

## The problem

`JobService.trigger(name, parametersMap)` copied **every** entry of the caller-supplied map into `Configuration.set(...)` — the **RUNTIME** layer, the highest precedence in `Configuration.get`: above the tenant thread map, above the environment, above the `.properties` files, and process-global rather than scoped to the triggered job.

The map comes straight off the request body of `POST /services/jobs/trigger/{*job}` (and off the JS `Scheduler.trigger`). So anyone who may trigger a job could transiently redefine **any** configuration key the platform reads — an outbound base URL and whatever credential the platform attaches to it, a datasource, a mail host — for every request in flight, in every tenant, for as long as the job ran. It is gated on `ADMINISTRATOR`/`OPERATOR`/`DEVELOPER`, so this is privilege *widening*, not an unauthenticated hole; in a multi-tenant deployment DEVELOPER is not an infrastructure role.

CodeQL sees the same thing from the other end: the endpoint is the taint source behind a share of the open `java/ssrf` / `java/log-injection` alerts, whose sinks are just code reading a `DIRIGIBLE_*` value and acting on it.

## The fix

Setting parameters *is* how jobs read them, so this keeps the contract and bounds the two things that were unbounded — options 1 + 2 from the issue.

**1. The key space is the job's own declared parameters.** The `.job` artefact already declares them, so this is a check against data the platform owns rather than a new allow-list to maintain — and the sanctioned reader, `job.getParameter(name)`, only ever looks at declared names anyway. An undeclared key is refused and the job does not run: `400` from the endpoint, `IllegalArgumentException` from the facade.

**2. The values are thread-scoped.** They go into the thread configuration introduced for tenant overrides (#6205) instead of the global RUNTIME layer, so a trigger cannot change what a concurrent request — or another tenant — reads. Both SDKs resolve a parameter through `Configuration.get`, which consults that map, so job bodies are unaffected. The surrounding thread configuration (the tenant's own overrides for the request) is merged, not replaced, and restored in a `finally`.

This also retires the memento, which was its own small leak: it restored the **resolved** value of every key it touched by writing it back through `Configuration.set`, permanently pinning an environment value into the RUNTIME layer. Nothing is written outside the triggering thread now.

## Compatibility

Both UIs that trigger a job — the Jobs perspective dialog and the Monitoring shell — already post only the parameters they read from `GET /services/jobs/parameters/{*job}`, so neither changes. A script calling `Scheduler.trigger(name, {...})` with a key the job does not declare now fails loudly instead of writing to the platform configuration; that key was never readable through `job.getParameter` in the first place.

## Tests

- `JobTriggerParametersTest` (new) — a declared parameter reaches the handler and is gone afterwards; an undeclared one is refused *before* the handler runs; a concurrent thread never sees either; the tenant's own thread configuration survives the run. Verified red on the old code (2 of 4 fail), green with the fix.
- `JobEndpointTest.triggerRejectsAnUndeclaredParameter` (new) — the `400`, and that the key never reaches the configuration. Verified red on the old code (the job ran instead).
- Whole `engine-jobs` unit suite green (30 tests); `formatter:validate` and the `release`-profile javadoc clean on the module.