### PR TITLE
test(cms): close the acceptance list of the dynamic per-path access control

### DIFF
--- a/components/engine/engine-cms/pom.xml
+++ b/components/engine/engine-cms/pom.xml
@@ -22,12 +22,6 @@
 			<artifactId>dirigible-components-core-base</artifactId>
     	</dependency>
     	
-    	<!-- Engines -->
-    	<dependency>
-			<groupId>org.eclipse.dirigible</groupId>
-			<artifactId>dirigible-components-engine-security</artifactId>
-		</dependency>
-
     	<!-- Data - the per-tenant CMS access grants live in a tenant-routed table -->
     	<dependency>
 			<groupId>org.eclipse.dirigible</groupId>

--- a/components/engine/engine-cms/src/main/java/org/eclipse/dirigible/components/engine/cms/CmisSessionFactory.java
+++ b/components/engine/engine-cms/src/main/java/org/eclipse/dirigible/components/engine/cms/CmisSessionFactory.java
@@ -10,11 +10,9 @@
 package org.eclipse.dirigible.components.engine.cms;
 
 import org.eclipse.dirigible.commons.config.Configuration;
-import org.eclipse.dirigible.components.security.verifier.AccessVerifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.stereotype.Component;
@@ -49,19 +47,6 @@ public class CmisSessionFactory implements ApplicationContextAware, Initializing
     private static ApplicationContext applicationContext;
     /** The instance. */
     private static CmisSessionFactory INSTANCE;
-    /** The security access verifier. */
-    private final AccessVerifier securityAccessVerifier;
-
-    /**
-     * Instantiates a new cmis session factory.
-     *
-     * @param securityAccessVerifier the security access verifier
-     */
-    @Autowired
-    public CmisSessionFactory(AccessVerifier securityAccessVerifier) {
-        this.securityAccessVerifier = securityAccessVerifier;
-    }
-
 
     /**
      * After properties set.

--- a/components/engine/engine-cms/src/test/java/org/eclipse/dirigible/components/engine/cms/documents/DocumentAccessEvaluatorTest.java
+++ b/components/engine/engine-cms/src/test/java/org/eclipse/dirigible/components/engine/cms/documents/DocumentAccessEvaluatorTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.cms.documents;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.components.engine.cms.access.CmsAccessService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * The escapes that keep the platform working once a single grant exists.
+ * <p>
+ * Content seeding, a scheduled job, a workflow delegate minting a print snapshot and a message
+ * listener storing an attachment all write to the CMS with no user and no roles behind them.
+ * Denying them the moment an administrator restricts one folder would break seeding rather than
+ * secure it, so enforcement engages only for an actual request, never in anonymous mode, and never
+ * when it is switched off. Each is asserted here against a service that denies everything, so a
+ * passing case can only be the escape.
+ */
+class DocumentAccessEvaluatorTest {
+
+    private static final String CMS_ROLES_ENABLED = "DIRIGIBLE_CMS_ROLES_ENABLED";
+    private static final String PATH = "/reports/q1.pdf";
+
+    /** Denies every path, method and role - the most restrictive rule set there is. */
+    private final CmsAccessService denyingService = mock(CmsAccessService.class);
+
+    private final DocumentAccessEvaluator evaluator = new DocumentAccessEvaluator(denyingService);
+
+    private final HttpServletRequest request = mock(HttpServletRequest.class);
+
+    @BeforeEach
+    void denyEverything() {
+        when(denyingService.isAllowed(anyString(), anyString(), any())).thenReturn(false);
+    }
+
+    @AfterEach
+    void restoreTheKillSwitch() {
+        Configuration.remove(CMS_ROLES_ENABLED);
+    }
+
+    @Test
+    void aRestrictiveRuleAppliesToARequest() {
+        assertFalse(evaluator.isReadable(PATH, request), "a request is the one context enforcement applies to");
+        assertFalse(evaluator.isWritable(PATH, request));
+    }
+
+    @Test
+    void thereIsNothingToEnforceWithoutARequest() {
+        assertTrue(evaluator.isReadable(PATH, null), "seeding and delegates run with no request, no user and no roles");
+        assertTrue(evaluator.isWritable(PATH, null));
+    }
+
+    @Test
+    void anonymousModeSkipsEnforcementEntirely() {
+        try (MockedStatic<Configuration> configuration = mockStatic(Configuration.class, CALLS_REAL_METHODS)) {
+            // The mode is the only thing stubbed - every other configuration lookup stays real, so
+            // the enforcing case below proves the escape is what carries the assertion after it.
+            configuration.when(Configuration::isAnonymousModeEnabled)
+                         .thenReturn(false);
+            assertFalse(evaluator.isReadable(PATH, request));
+
+            configuration.when(Configuration::isAnonymousModeEnabled)
+                         .thenReturn(true);
+            assertTrue(evaluator.isReadable(PATH, request), "there is no caller to hold a role in anonymous mode");
+            assertTrue(evaluator.isWritable(PATH, request));
+        }
+    }
+
+    @Test
+    void theKillSwitchDisablesEnforcementWholesale() {
+        Configuration.set(CMS_ROLES_ENABLED, "false");
+
+        assertTrue(evaluator.isReadable(PATH, request));
+        assertTrue(evaluator.isWritable(PATH, request));
+    }
+
+    @Test
+    void theFlagsFollowTheSameDecision() {
+        assertFalse(evaluator.flags(PATH, request)
+                             .readable(),
+                "an unreadable path is not rendered at all");
+
+        DocumentAccessEvaluator.AccessFlags escaped = evaluator.flags(PATH, null);
+        assertTrue(escaped.readable());
+        assertFalse(escaped.readOnly(), "writing is allowed too, so nothing is marked read-only");
+    }
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/CmsAccessControlIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/CmsAccessControlIT.java
@@ -13,13 +13,20 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
+import java.util.function.Predicate;
 
+import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.components.base.http.roles.Roles;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.eclipse.dirigible.components.engine.cms.access.CmsAccessService;
 import org.eclipse.dirigible.tests.base.IntegrationTest;
 import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.eclipse.dirigible.tests.framework.security.SecurityUtil;
+import org.eclipse.dirigible.tests.framework.tenant.DirigibleTestTenant;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,17 +58,34 @@ class CmsAccessControlIT extends IntegrationTest {
     private static final String FOLDER = "cms-access-it";
     private static final String FOLDER_PATH = "/" + FOLDER;
     private static final String FILE_NAME = "secret.txt";
+    /** The kill-switch test uploads its own file - the class shares one database. */
+    private static final String SWITCH_FILE_NAME = "kill-switch.txt";
     private static final String GRANTED_ROLE = "cms-access-it-role";
+
+    /** A path only the second tenant ever writes a rule for. */
+    private static final String OTHER_TENANT_PATH = "/cms-access-it-other";
 
     private static final String ADMIN = "cms-access-it-admin";
     private static final String PLAIN = "cms-access-it-user";
     private static final String PASSWORD = "cms-access-it-password";
+
+    /** The kill switch, which must disable every surface at once. */
+    private static final String CMS_ROLES_ENABLED = "DIRIGIBLE_CMS_ROLES_ENABLED";
+
+    /** A caller holding nothing - restricted by any rule that covers the path. */
+    private static final Predicate<String> NO_ROLES = role -> false;
 
     @Autowired
     private RestAssuredExecutor restAssuredExecutor;
 
     @Autowired
     private SecurityUtil securityUtil;
+
+    @Autowired
+    private CmsAccessService cmsAccessService;
+
+    @Autowired
+    private TenantContext tenantContext;
 
     /**
      * The class shares one Spring context (and thus one database) across its methods, so the users are
@@ -180,7 +204,7 @@ class CmsAccessControlIT extends IntegrationTest {
     void a_read_grant_also_blocks_the_raw_cms_content_path() {
         restAssuredExecutor.execute(() -> {
             createFolder();
-            upload();
+            upload(FILE_NAME);
         }, ADMIN, PASSWORD);
 
         // open by default: both surfaces serve the file while no rule exists
@@ -216,6 +240,102 @@ class CmsAccessControlIT extends IntegrationTest {
                 ADMIN, PASSWORD);
     }
 
+    /**
+     * The kill switch carried over from the JavaScript implementation must still disable the whole
+     * mechanism, in every surface at once - it is what an operator reaches for when a rule locks the
+     * wrong people out of their own documents.
+     */
+    @Test
+    void the_kill_switch_disables_enforcement_wholesale() {
+        restAssuredExecutor.execute(() -> {
+            createFolder();
+            // Its own file: the class shares one database, so uploading the name another test
+            // already used would depend on the order the methods happen to run in.
+            upload(SWITCH_FILE_NAME);
+            grant(FOLDER_PATH, "READ", GRANTED_ROLE);
+        }, ADMIN, PASSWORD);
+
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get(DOCUMENTS + "?path=" + FOLDER_PATH)
+                                                 .then()
+                                                 .statusCode(403),
+                PLAIN, PASSWORD);
+
+        Configuration.set(CMS_ROLES_ENABLED, "false");
+        try {
+            // The rule is still stored - it is simply not consulted any more, in either surface.
+            restAssuredExecutor.execute(() -> {
+                given().when()
+                       .get(DOCUMENTS + "?path=" + FOLDER_PATH)
+                       .then()
+                       .statusCode(200);
+
+                given().when()
+                       .get(CMS + FOLDER_PATH + "/" + SWITCH_FILE_NAME)
+                       .then()
+                       .statusCode(200);
+
+                given().when()
+                       .get(DOCUMENTS)
+                       .then()
+                       .statusCode(200)
+                       .body("children.name", hasItem(FOLDER));
+            }, PLAIN, PASSWORD);
+        } finally {
+            Configuration.remove(CMS_ROLES_ENABLED);
+        }
+
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get(DOCUMENTS + "?path=" + FOLDER_PATH)
+                                                 .then()
+                                                 .statusCode(403),
+                PLAIN, PASSWORD);
+    }
+
+    /**
+     * Grants are tenant data. The mechanism this replaces kept them in the global
+     * {@code DIRIGIBLE_SECURITY_ACCESS} while every CMS path is tenant-resolved, so one tenant's rule
+     * governed every tenant's like-named folder - a tenant could restrict, or expose, a folder it
+     * cannot even see.
+     */
+    @Test
+    void a_grant_in_one_tenant_does_not_govern_another() throws Exception {
+        DirigibleTestTenant other = new DirigibleTestTenant("cms-access-it-tenant");
+        createTenants(other);
+        waitForTenantProvisioning(other);
+
+        restAssuredExecutor.execute(() -> {
+            createFolder();
+            grant(FOLDER_PATH, "READ", GRANTED_ROLE);
+        }, ADMIN, PASSWORD);
+
+        // Outside a tenant scope the store resolves against the default tenant's schema - the very
+        // rows the request above wrote. A caller holding no role is refused there ...
+        cmsAccessService.invalidate();
+        assertFalse(cmsAccessService.isAllowed(FOLDER_PATH, "READ", NO_ROLES), "the granting tenant's own rule applies to it");
+
+        // ... and the same path in the other tenant is untouched by it.
+        assertTrue(tenantContext.execute(other.getId(), () -> cmsAccessService.isAllowed(FOLDER_PATH, "READ", NO_ROLES)),
+                "a rule of one tenant must not reach another tenant's identically named path");
+
+        // The isolation holds in the other direction too: a grant written inside the other tenant
+        // lands in that tenant's schema only. It needs no cleanup, unlike the grants the other tests
+        // leave: it lives in a tenant this test creates and nothing else in the class ever enters.
+        tenantContext.execute(other.getId(), () -> {
+            cmsAccessService.grant(OTHER_TENANT_PATH, "READ", GRANTED_ROLE, "test");
+            return null;
+        });
+
+        assertFalse(tenantContext.execute(other.getId(), () -> cmsAccessService.isAllowed(OTHER_TENANT_PATH, "READ", NO_ROLES)),
+                "the other tenant's own rule applies to it");
+
+        // Re-read the default tenant's rows rather than trusting what is already cached, so this
+        // asserts an absent row and not a stale answer.
+        cmsAccessService.invalidate();
+        assertTrue(cmsAccessService.isAllowed(OTHER_TENANT_PATH, "READ", NO_ROLES),
+                "the default tenant never sees the row the other tenant wrote");
+    }
+
     private static void createFolder() {
         given().contentType(ContentType.JSON)
                .body("{\"parentFolder\":\"/\",\"name\":\"" + FOLDER + "\"}")
@@ -223,8 +343,8 @@ class CmsAccessControlIT extends IntegrationTest {
                .post(DOCUMENTS + "/folder");
     }
 
-    private static void upload() {
-        given().multiPart("file", FILE_NAME, "secret".getBytes(StandardCharsets.UTF_8))
+    private static void upload(String fileName) {
+        given().multiPart("file", fileName, "secret".getBytes(StandardCharsets.UTF_8))
                .when()
                .post(DOCUMENTS + "?path=" + FOLDER_PATH)
                .then()


### PR DESCRIPTION
Closes #6563.

## Why this issue is still open

Its design shipped in #6566 (the store, the resolver, the guard, the endpoint, the dialog in both
Documents surfaces) and #6571 (the raw content path). #6566's body named both this issue and #6562
in a single closing sentence — a form GitHub only reads for the first reference, so this one was
never linked and never closed.

What is genuinely missing is the part of the issue nobody ships by accident: the **acceptance list**
it names — *"Tests that must exist, because these are the failure modes of what is being replaced"*.
Three of the five were never written, and the two that guard the escapes and the kill switch guard
exactly the behaviour that keeps a restrictive rule from taking the platform down with it.

| The issue's list | Before | Now |
|---|---|---|
| a grant/revoke takes effect on the next request with no sleep | `CmsAccessControlIT` | unchanged |
| a restricted folder disappears from a listing and its children are unreachable by direct path | `CmsAccessControlIT` | unchanged |
| a rule in tenant A does not affect tenant B | **missing** | `CmsAccessControlIT.a_grant_in_one_tenant_does_not_govern_another` |
| each of the three system-context escapes still succeeds under a restrictive rule | **missing** | `DocumentAccessEvaluatorTest` |
| `DIRIGIBLE_CMS_ROLES_ENABLED=false` disables enforcement wholesale | **missing** | `DocumentAccessEvaluatorTest` + `CmsAccessControlIT.the_kill_switch_disables_enforcement_wholesale` |

## The three escapes

Content seeding, a scheduled job, a workflow delegate minting a print snapshot and a message
listener storing an attachment all write to the CMS with **no user and no roles behind them**.
Denying them the moment an administrator restricts one folder would break seeding rather than
secure it — so enforcement engages only for a request, never in anonymous mode, and never when the
kill switch is off. That is three branches of an `||` that no test touched; each is now asserted
against a service that **denies everything**, so a passing case can only be the escape. The
anonymous case additionally asserts the enforcing answer first, so the static-mock setup cannot
carry the assertion after it.

## Tenant isolation

The mechanism this replaced kept grants in the global `DIRIGIBLE_SECURITY_ACCESS` while every CMS
path is tenant-resolved, so one tenant's rule governed every tenant's like-named folder. The test
grants over HTTP in the default tenant, then asserts the same path is untouched inside a second,
provisioned tenant — and the reverse, a grant written inside that tenant that the default tenant
never sees, re-reading rather than trusting the cache so it asserts an absent row and not a stale
answer.

## The last residue of the replaced mechanism

`CmisSessionFactory` still injected `AccessVerifier` — the `.access`/`scope: CMIS` path that this
design removed — and never used it; it was `engine-cms`'s only reference to `engine-security`, so
the module dependency goes with it.

## Deliberately not included

**The legacy importer.** The issue asks for a one-shot import of `__internal/roles-access.json` and
of `scope: CMIS` rows on first start per tenant. #6566 left it out with the reason stated there: the
only writer of that file was `api/constraints.js`, which nothing called, so the loop maintained an
empty `{"constraints":[]}` — the issue says so itself. Adding an importer now would be a code path
reading a file the platform no longer writes, for rows that in practice do not exist. Say the word
if an installation is known to carry rules and it is a small addition.

**The `CMIS` option in the `.access` editor's scope dropdown.** Nothing consults that scope any
more, so the option authors a rule that silently does nothing — but removing it would leave an
existing file's scope unmatched by any option in the select, which is a worse failure than the one
it fixes. Worth its own change, not this one.

## Verification

- `DocumentAccessEvaluatorTest` 5/5, `CmsAccessResolutionTest` 11/11 green on `engine-cms`.
- `CmsAccessControlIT` 7/7 and `DocumentsApiIT` green, headless.
- Full reactor `mvn clean install -P quick-build` green after the dependency removal.
- `mvn formatter:validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
