### PR TITLE
test(monitoring): the build assertion names the configured product

### DIFF
--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/MonitoringShellIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/MonitoringShellIT.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.dirigible.integration.tests.ui.tests;
 
+import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.tests.base.UserInterfaceIntegrationTest;
 import org.eclipse.dirigible.tests.framework.browser.HtmlElementType;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,11 @@ import org.springframework.test.annotation.DirtiesContext;
 public class MonitoringShellIT extends UserInterfaceIntegrationTest {
 
     private static final String MONITORING_PATH = "/services/web/monitoring/index.html";
+
+    /**
+     * The configuration key the version endpoint - and therefore the sidebar - reports as the product.
+     */
+    private static final String DIRIGIBLE_PRODUCT_NAME = "DIRIGIBLE_PRODUCT_NAME";
 
     @Test
     void overviewRendersTheInstanceState() {
@@ -69,8 +75,11 @@ public class MonitoringShellIT extends UserInterfaceIntegrationTest {
         browser.clickOnElementById("monitoring-nav-system");
         browser.assertElementExistsByIdAndContainsText("monitoring-system-version", "Product");
         browser.assertElementExistsByIdAndContainsText("monitoring-system-version", "Version");
-        // The same figures condensed onto the sidebar, where every page shows them.
-        browser.assertElementExistsByIdAndContainsText("monitoring-build", "Eclipse Dirigible");
+        // The same figures condensed onto the sidebar, where every page shows them. The expected name is
+        // read from the configuration the sidebar itself renders, not hard-coded: this IT ships in
+        // dirigible-tests-integrations for downstream editions to reuse, and a rebranded assembly names
+        // its own build here - hard-coding "Eclipse Dirigible" made the test unpassable for them.
+        browser.assertElementExistsByIdAndContainsText("monitoring-build", Configuration.get(DIRIGIBLE_PRODUCT_NAME));
     }
 
     /**


### PR DESCRIPTION
## The problem

`MonitoringShellIT.systemNamesTheDeployedBuild` asserted a product-name **literal**:

```java
browser.assertElementExistsByIdAndContainsText("monitoring-build", "Eclipse Dirigible");
```

That element is rendered from `DIRIGIBLE_PRODUCT_NAME`, read through `/services/core/version`. A rebranded assembly therefore names *its own* build there — correctly — and the assertion can never hold for it.

This is not hypothetical. `tests/tests-integrations` lives in `src/main` specifically so the jar publishes to Maven Central and downstream editions can reuse these ITs, and they do: the codbex editions run `MonitoringShellIT` through a `@Suite` of ~26 upstream ITs. codbex-atlas sets `DIRIGIBLE_PRODUCT_NAME=${project.title}` → `codbex atlas`, so this single test has been red on its `main` since at least 14.24.0:

```
DirigibleCommonTestSuiteIT.systemNamesTheDeployedBuild
  Element by [By.id: monitoring-build] and conditions
  [[exist, match text "\QEclipse Dirigible\E"]] cannot be found in any iframe.
Tests run: 45, Failures: 1
```

The UI was already edition-aware — the `version` store resolves an unfiltered `${...}` placeholder to empty, and its own docstring cites a rebranded example ("BusinessIntents Suite 2.98.0"). Only the test wasn't.

## The change

Assert the configured product name rather than the literal:

```java
browser.assertElementExistsByIdAndContainsText("monitoring-build", Configuration.get(DIRIGIBLE_PRODUCT_NAME));
```

**Stock CI coverage is unchanged.** `project.title` is `Eclipse Dirigible` in the root pom and is filtered into `build/application/src/main/resources/dirigible.properties`, so `Configuration.get` returns exactly the literal that was hard-coded before — the same assertion, sourced from where the UI sources it. `Configuration` is already used by four other ITs in this module, so no new dependency.

The test's intent is "the System page names the deployed build", not "the build is Eclipse Dirigible".

## Verification

`MonitoringShellIT` run headless against a full local build of this branch:

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 34.91 s
  -- in org.eclipse.dirigible.integration.tests.ui.tests.MonitoringShellIT
BUILD SUCCESS
```

`formatter:validate` passes.

## Note for downstream editions

Separately, [codbex-atlas#431](https://github.com/codbex/codbex-atlas/pull/431) adapts that edition to #6735, which moved six Camel ITs from `...ui.tests.camel` to `...api.camel` and broke its release build at `testCompile`. Both cases are the same underlying point: this module is a published API for downstream editions, so an IT rename, move, or brand literal is a breaking change for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)