### PR TITLE
fix(templates): the DAO template no longer leaks its indentation into the output (#6754)

### DIFF
--- a/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
+++ b/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
@@ -17,13 +17,17 @@ package gen.${javaGenFolderName}.data.${javaPerspectiveName};
     #if($property.isCalculatedProperty && ($property.calculatedActionOnCreate || $property.calculatedActionOnUpdate))
         #set($haveCalculatedPropertyAction = "true")
     #end
-    ## System-owned columns a user update must never take from the payload (consumed by update()):
-    ## platform-managed read-only fields (an author's readOnly, roll-up targets, the document number
-    ## and uuid) and aggregate footer fields (an invoice's Net/Total/Paid). An aggregate that is
-    ## recomputed on update (an expressionUpdate such as Balance) is exempt here - update() reassigns
-    ## it AFTER recalculate(), from the resummed aggregates and the preserved values. A calculated
-    ## create-only field that stays user-editable (a defaulted Currency relation) carries neither
-    ## flag, so a user's edit of it is respected.
+## The comments below start at column 0 on purpose: Velocity gobbles the indentation of a line that
+## holds only a directive, but NOT of a line that holds only a ## comment - it emits the leading
+## whitespace and swallows the rest. Indented inside this loop they contributed 28 characters per
+## property to the output, which landed in front of the first import (#6754).
+## System-owned columns a user update must never take from the payload (consumed by update()):
+## platform-managed read-only fields (an author's readOnly, roll-up targets, the document number
+## and uuid) and aggregate footer fields (an invoice's Net/Total/Paid). An aggregate that is
+## recomputed on update (an expressionUpdate such as Balance) is exempt here - update() reassigns
+## it AFTER recalculate(), from the resummed aggregates and the preserved values. A calculated
+## create-only field that stays user-editable (a defaulted Currency relation) carries neither
+## flag, so a user's edit of it is respected.
     #if(!$property.dataPrimaryKey && ($property.isReadOnlyProperty || ($property.aggregate && !$property.calculatedPropertyExpressionUpdate && !$property.calculatedActionOnUpdate)))
         #set($ignore = $preservedOnUpdate.add($property))
     #end

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/template/ModelGenerationIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/template/ModelGenerationIT.java
@@ -103,6 +103,15 @@ class ModelGenerationIT extends IntegrationTest {
     private static final Pattern UNRESOLVED_REFERENCE = Pattern.compile("\\$\\{(?!JavaTask\\b)[A-Za-z]\\w*\\}?");
 
     /**
+     * An indented {@code package} or {@code import}, which Java never has. It is what template
+     * whitespace looks like once it reaches the output: Velocity gobbles the indentation of a line
+     * holding only a directive but not of a line holding only a {@code ##} comment, so an indented
+     * comment inside a loop emits its leading spaces once per iteration and they flush in front of the
+     * next literal the template renders - the first import (#6754).
+     */
+    private static final Pattern INDENTED_TOP_LEVEL_DECLARATION = Pattern.compile("^([ \\t]+)(package|import)[ \\t]", Pattern.MULTILINE);
+
+    /**
      * A member access whose member is missing - {@code parent. == null}, {@code target. = row.X} or
      * {@code derived.put("X", parent.)} - which is what an emitted-code helper produces when the field
      * name it interpolates is empty. Deliberately same-line only: generated code breaks a chained call
@@ -346,7 +355,10 @@ class ModelGenerationIT extends IntegrationTest {
      * the binder forgot to put in the context (it was {@code fromGenFolder}) becomes a syntax error
      * rather than a missing value;</li>
      * <li>a dangling {@code .} - what an emitted-code helper produces when a field name it interpolates
-     * is the empty string, which is what the intent glue writes for an unused optional field.</li>
+     * is the empty string, which is what the intent glue writes for an unused optional field;</li>
+     * <li>an indented {@code package} or {@code import} - template whitespace that leaked into the
+     * output. It still compiles, but {@code gen/} is committed so that template changes are diffable,
+     * and a leak puts a run of spaces into every generated file of every module.</li>
      * </ul>
      *
      * @param label the case label
@@ -368,6 +380,12 @@ class ModelGenerationIT extends IntegrationTest {
             problems.add("[" + label + "] " + path + " emitted a member access with no member, so an interpolated field name was"
                     + " empty: " + dangling.group()
                                            .trim());
+        }
+        Matcher indented = INDENTED_TOP_LEVEL_DECLARATION.matcher(content);
+        while (indented.find()) {
+            problems.add("[" + label + "] " + path + " preceded its " + indented.group(2) + " with " + indented.group(1)
+                                                                                                               .length()
+                    + " characters of whitespace, so a template leaked its indentation into the output");
         }
         return problems;
     }


### PR DESCRIPTION
Closes #6754.

### What was wrong

Every generated `<Entity>Repository.java` started like this:

```java
package gen.countries.data.settings;

                                    import org.eclipse.dirigible.components.data.store.java.repository.JavaRepository;
import org.eclipse.dirigible.sdk.component.Component;
```

28 characters of whitespace per entity property — 84 for a three-property entity, 140 for a five-property one.

### Why

Velocity gobbles the indentation of a line that holds only a **directive**, but *not* of a line that holds only a **`##` comment**: it emits the leading whitespace and swallows the rest of the line. The seven indented comment lines documenting the system-owned-fields block (arrived with #6688) sit inside the template's opening `#foreach ($property in $properties)`, so they contributed `7 x 4` characters per iteration, which flushed in front of the next literal the template rendered — the first `import`.

Confirmed by rendering the template head in isolation: 3 properties → exactly 84 spaces; unindenting the comments → 0.

The seven were the only indented `##` lines in any `.template` in the repository (`grep -rn "^[[:space:]]\+##" --include="*.template" components`), so the fix is those lines and nothing else. The `#if` / `#set` / `#end` lines around them keep their indentation — Velocity consumes theirs.

### The guard

`ModelGenerationIT` gains one check on rendered `.java` output: a top-level `package` or `import` may not be indented, which is what leaked template whitespace looks like once it reaches the file. Verified both ways — reinstalling the previous template makes it fail for every repository of every DAO-rendering case (`CityRepository.java preceded its import with 84 characters of whitespace`, `CustomerRepository.java ... 140 ...`, etc.), and it is green on this one with no other case flagged.

### Why it matters

Harmless to `javac`, but `gen/` is committed in intent-driven projects specifically so template changes are diffable, and this put a 100+ character whitespace prefix into every repository file of every module.

### Testing

- `mvn -P integration-tests verify -pl tests/tests-integrations -Dit.test=ModelGenerationIT` — green with the fix, red (108 problems, all this defect) with the template reverted.
- `mvn formatter:validate` on both touched modules — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)