### PR TITLE
fix(templates): after create, land on the record page when it has detail children (#6693)

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
@@ -220,54 +220,7 @@ document.addEventListener('alpine:init', () => {
 #end
 
       if (this.isEdit || this.isPreview) {
-        this.state = 'loading';
-        try {
-          const record = await App.services.api.get(this.apiPath + '/' + encodeURIComponent(this.id));
-          // Copy only known form fields so server-only props don't leak into the body.
-          for (const key of Object.keys(this.form)) {
-            if (record[key] !== undefined) this.form[key] = record[key];
-          }
-          // Date/time widgets need the HTML input format, not the backend's serialized value.
-#foreach($property in $properties)
-#if($property.isDateType)
-          if (this.form.${property.name} != null) this.form.${property.name} = this.toDateInput(this.form.${property.name}, '${property.widgetType}');
-#end
-#end
-          // Relationship (dropdown) values must be STRINGS to match the option's data-value (an HTML
-          // attribute is always a string); a numeric FK from the record would otherwise match no
-          // option and the combobox would render empty on edit.
-#foreach($property in $properties)
-#if($property.widgetType == "DROPDOWN")
-          if (this.form.${property.name} != null) this.form.${property.name} = String(this.form.${property.name});
-#end
-#end
-#foreach($property in $properties)
-#if($property.widgetOptionsFilterBy && $property.widgetType == "DROPDOWN")
-          // Static option filter (intent `where:`): a value stored before/outside the filter is absent
-          // from the filtered chooser list, so its label would not resolve on edit. Splice in that one
-          // row by id - the filter still governs what may be newly picked (mirrors the items dialog,
-          // which keeps the full set for label resolution alongside the filtered chooser set).
-          await this.ensureFilteredCurrent('${property.name}', '${property.widgetDropdownControllerUrl}', '${property.widgetDropDownKey}', '${property.widgetDropDownValue}');
-#end
-#end
-#if($immutableStatusProperty || $immutableAlways)
-          try {
-            const m = await App.services.api.get(this.apiPath + '/' + encodeURIComponent(this.id) + '/mutable');
-            this.mutable = !m || m.mutable !== false;
-          } catch (e) {
-            console.error('[${name}FormPage] mutable pre-check failed', e);
-          }
-          // An immutable record opened on the /edit route renders as preview - the whole form is
-          // read-only, exactly as if Preview had been chosen (or the URL typed said /preview).
-          if (!this.mutable && this.isEdit) this.mode = 'preview';
-#end
-#if($history == "true")
-          await this.loadHistory();
-#end
-          this.state = 'ready';
-        } catch (e) {
-          this.applyLoadError(e, { fallbackMessage: 'Could not load the ${name} record.' });
-        }
+        await this.loadRecord();
       } else {
         // Prefill any form field whose name is supplied as a query param — used by
         // master-detail "Add" to preset the FK to the master (e.g. ?Customer=3).
@@ -298,6 +251,60 @@ document.addEventListener('alpine:init', () => {
       this.recalcCalculated();
 #end
       this.refreshIcons();
+    },
+
+    // Load the record behind the edit/preview route into the form. Also re-run after a create that
+    // lands on the record page, so server-assigned values (document numbers, defaults, calculated
+    // fields, the initial status) are the ones the user sees.
+    async loadRecord() {
+      this.state = 'loading';
+      try {
+        const record = await App.services.api.get(this.apiPath + '/' + encodeURIComponent(this.id));
+        // Copy only known form fields so server-only props don't leak into the body.
+        for (const key of Object.keys(this.form)) {
+          if (record[key] !== undefined) this.form[key] = record[key];
+        }
+        // Date/time widgets need the HTML input format, not the backend's serialized value.
+#foreach($property in $properties)
+#if($property.isDateType)
+        if (this.form.${property.name} != null) this.form.${property.name} = this.toDateInput(this.form.${property.name}, '${property.widgetType}');
+#end
+#end
+        // Relationship (dropdown) values must be STRINGS to match the option's data-value (an HTML
+        // attribute is always a string); a numeric FK from the record would otherwise match no
+        // option and the combobox would render empty on edit.
+#foreach($property in $properties)
+#if($property.widgetType == "DROPDOWN")
+        if (this.form.${property.name} != null) this.form.${property.name} = String(this.form.${property.name});
+#end
+#end
+#foreach($property in $properties)
+#if($property.widgetOptionsFilterBy && $property.widgetType == "DROPDOWN")
+        // Static option filter (intent `where:`): a value stored before/outside the filter is absent
+        // from the filtered chooser list, so its label would not resolve on edit. Splice in that one
+        // row by id - the filter still governs what may be newly picked (mirrors the items dialog,
+        // which keeps the full set for label resolution alongside the filtered chooser set).
+        await this.ensureFilteredCurrent('${property.name}', '${property.widgetDropdownControllerUrl}', '${property.widgetDropDownKey}', '${property.widgetDropDownValue}');
+#end
+#end
+#if($immutableStatusProperty || $immutableAlways)
+        try {
+          const m = await App.services.api.get(this.apiPath + '/' + encodeURIComponent(this.id) + '/mutable');
+          this.mutable = !m || m.mutable !== false;
+        } catch (e) {
+          console.error('[${name}FormPage] mutable pre-check failed', e);
+        }
+        // An immutable record opened on the /edit route renders as preview - the whole form is
+        // read-only, exactly as if Preview had been chosen (or the URL typed said /preview).
+        if (!this.mutable && this.isEdit) this.mode = 'preview';
+#end
+#if($history == "true")
+        await this.loadHistory();
+#end
+        this.state = 'ready';
+      } catch (e) {
+        this.applyLoadError(e, { fallbackMessage: 'Could not load the ${name} record.' });
+      }
     },
 
 #if($hasDropdowns)
@@ -537,10 +544,25 @@ document.addEventListener('alpine:init', () => {
           }
         } else {
           const created = await App.services.api.post(this.apiPath, payload);
+          const newId = created && (created.${primaryKeysString} != null ? created.${primaryKeysString} : created.id);
           // Only when opened as an FK "Add" iframe dialog: report the new record to the opener and stop
           // here (the parent closes the dialog and selects it). Otherwise fall through to the list.
           if (this.isDialog) {
-            this.emitCreated(created && (created.${primaryKeysString} != null ? created.${primaryKeysString} : created.id));
+            this.emitCreated(newId);
+            return;
+          }
+          // A record that owns detail collections is not done at create: its children are the natural
+          // next step of the same working session, and they can only be added from the record's own
+          // page. Land there rather than on the list, which would make the user hunt for the row they
+          // just created (the document layout already works this way). An explicit returnTo wins - the
+          // create was launched from somewhere that expects the user back - and a flat record has
+          // nothing left to do on its page, so it still goes to the list.
+          if (newId != null && !this.returnToParam() && App.detailsFor('${name}').length) {
+            this.id = newId;
+            this.mode = 'edit';
+            this.detailDefs = App.detailsFor('${name}');
+            window.PineconeRouter.navigate('/${name}/' + encodeURIComponent(newId) + '/edit');
+            await this.loadRecord();
             return;
           }
         }

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -1310,6 +1310,18 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertTrue(campaignMasterView.contains("statusVariant(lookupText('Status', row.Status))"),
                 "the master table must render the EntityStatus column as a resolved badge, not a raw id");
 
+        // #6693: a record that owns detail collections is not finished at create - its children are
+        // the next step of the same working session and can only be added from the record's own
+        // page, so the create lands there instead of on the list. A flat record has nothing left to
+        // do on its page and still returns to the list.
+        String campaignFormPage = contentOf("gen/emission/js/components/pages/Campaign/CampaignFormPage.js");
+        assertTrue(
+                campaignFormPage.contains("App.detailsFor('Campaign').length")
+                        && campaignFormPage.contains("window.PineconeRouter.navigate('/Campaign/' + encodeURIComponent(newId) + '/edit')"),
+                "a create on an entity with detail children must land on the record page, got: " + campaignFormPage);
+        assertTrue(campaignFormPage.contains("!this.returnToParam() && App.detailsFor"),
+                "an explicit returnTo must still win - the create was launched from somewhere expecting the user back");
+
         // Every list surface exports/prints its rows: the manage list and the master list emit the
         // column metadata + toolbar actions wired to the shared basePage CSV/print helpers, with
         // cells resolved like the table (FK labels, formatted dates - never raw ids).


### PR DESCRIPTION
Closes #6693.

## The problem

Saving a **New Project** returned to the list view — but a Project has two detail children (Project Tasks, Employee Project Assignments) that are the natural next step of the same working session. The user had to find the row they just created and reopen it to continue.

A document-typed entity (Sales Invoice) already lands on its own page after create — `…/SalesInvoice/1/edit` with the items section ready — which is the right flow.

## The change

`template-application-ui-harmonia-java` — the shared `<Entity>FormPage.js` create-success handler now navigates to `/<Entity>/{id}/edit` when the record has detail collections, instead of returning to the list.

The gate is `App.detailsFor('<Entity>').length` — the **runtime detail registry**, the same source the form already uses to decide whether to render its detail panels — not a generation-time layout flag, so it stays correct for any entity that gains or loses children (every detail registers itself with the shell at startup, so the answer is available on any page).

Two deliberate exclusions keep the existing flows intact:

- the FK **"Add" iframe dialog** (`?dialog=1`) still reports the new record to its opener and stops there;
- an explicit **`returnTo`** still wins — the create was launched from somewhere that expects the user back.

A flat record has nothing left to do on its page and still goes to the list.

The edit/preview load moves out of `init()` into a `loadRecord()` method (a pure move) so the create landing can reuse it: after navigating, the record is re-read, so server-assigned values — document numbers, defaults, calculated fields, the initial status — are the ones the user sees. This mirrors what the document layout has always done.

## Verification

`IntentEmissionCoverageIT` gains assertions on the generated `CampaignFormPage.js` (`Campaign` is the `MANAGE_MASTER` entity with a `CampaignNote` composition child), covering both the landing navigation and the `returnTo` precedence. The IT passes, and the generated page was `node --check`-parsed to confirm the template still renders valid JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)