### PR TITLE
feat(intent): a declared payload for outward-facing messages (#6768)

### DIFF
--- a/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/core/Tenant.java
+++ b/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/core/Tenant.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.sdk.core;
+
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.eclipse.dirigible.sdk.component.Beans;
+
+/**
+ * The tenant the current execution belongs to. Requests carry it from the host they arrived on, and
+ * the platform re-establishes it around a listener dispatch or a scheduled job, so client code can
+ * read it anywhere it can read {@link org.eclipse.dirigible.sdk.security.User} — including from a
+ * message handler, where there is no request at all.
+ * <p>
+ * Use it to stamp outward-facing messages and audit records with who the sender is. Do NOT use it
+ * to scope queries: the platform already routes a tenant's data access to that tenant's schema, so
+ * a hand-rolled tenant filter is at best redundant and at worst a second, divergent rule.
+ * <p>
+ * Outside any tenant scope the id resolves to the default tenant, which is what a single-tenant
+ * deployment runs as.
+ */
+public final class Tenant {
+
+    private Tenant() {}
+
+    /**
+     * The current tenant's id.
+     *
+     * @return the tenant id, never {@code null}
+     */
+    public static String getId() {
+        return current().getId();
+    }
+
+    /**
+     * The current tenant's display name.
+     *
+     * @return the tenant name, never {@code null}
+     */
+    public static String getName() {
+        return current().getName();
+    }
+
+    private static org.eclipse.dirigible.components.base.tenant.Tenant current() {
+        TenantContext context = Beans.get(TenantContext.class);
+        return context.isInitialized() ? context.getCurrentTenant() : Beans.get(org.eclipse.dirigible.components.base.tenant.Tenant.class);
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -99,7 +99,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         List<Map<String, Object>> setters = buildSetters(model, settings);
         List<Map<String, Object>> notifications = buildNotifications(model, byName, compositionParents, settings, context);
         List<Map<String, Object>> schedules = buildSchedules(model, byName, compositionParents, settings, context);
-        List<Map<String, Object>> integrations = buildIntegrations(model, byName, compositionParents, settings);
+        List<Map<String, Object>> integrations = buildIntegrations(model, byName, compositionParents, settings, context);
         List<Map<String, Object>> inbound = buildInbound(model, byName, compositionParents, settings);
         List<Map<String, Object>> inboundMessages = buildInboundMessages(model, byName, compositionParents, settings);
         List<Map<String, Object>> inboundFiles = buildInboundFiles(model, byName, compositionParents, settings);
@@ -1200,7 +1200,8 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
 
     /** Test hook: build the {@code integrations} glue collection without a repository. */
     static List<Map<String, Object>> buildIntegrationsForTest(IntentModel model) {
-        return buildIntegrations(model, IntentEntities.byName(model), IntentEntities.compositionParents(model), IntentSettings.parse("{}"));
+        return buildIntegrations(model, IntentEntities.byName(model), IntentEntities.compositionParents(model), IntentSettings.parse("{}"),
+                null);
     }
 
     /** Test hook: build the {@code stepEvents} glue collection without a repository. */
@@ -2749,7 +2750,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
     }
 
     private static List<Map<String, Object>> buildIntegrations(IntentModel model, Map<String, EntityIntent> byName,
-            Map<String, String> compositionParents, IntentSettings settings) {
+            Map<String, String> compositionParents, IntentSettings settings, IntentGenerationContext context) {
         List<Map<String, Object>> integrations = new ArrayList<>();
         for (IntegrationIntent integration : model.getIntegrations()) {
             if (integration.getName() == null || integration.getName()
@@ -2765,6 +2766,18 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                 LOGGER.info("Settings opt-out: keeping existing listener for integration [{}] (not generated)", integration.getName());
                 continue;
             }
+            // The declared envelope, when there is one. A value that cannot be resolved (a cross-model
+            // relation.field the owner does not carry) drops the whole integration with the reason -
+            // sending the record instead would silently substitute a different contract.
+            PayloadSupport.Plan payload;
+            try {
+                payload = PayloadSupport.plan(integration.getPayload(), byName.get(entity), byName, compositionParents,
+                        crossModelLookup(model, context));
+            } catch (IllegalArgumentException ex) {
+                reportDroppedGlue(context,
+                        "Integration [" + integration.getName() + "]: " + ex.getMessage() + " - the integration was NOT generated");
+                continue;
+            }
             Map<String, Object> entry = new LinkedHashMap<>();
             entry.put("name", integration.getName());
             entry.put("className", IntentNaming.pascalCase(integration.getName()));
@@ -2774,6 +2787,8 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             entry.put("clientMethod", IntegrationSupport.clientMethod(integration.getMethod()));
             entry.put("hasBody", IntegrationSupport.hasBody(integration.getMethod()));
             entry.put("urlExpression", IntegrationSupport.urlExpression(integration.getUrl()));
+            entry.putAll(PayloadSupport.payloadFields(payload));
+            entry.put("relationLoads", relationLoads(payload == null ? List.of() : payload.loads()));
             integrations.add(entry);
         }
         return integrations;
@@ -3155,8 +3170,12 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
     }
 
     private static List<Map<String, Object>> relationLoads(NotificationSupport.Plan plan) {
+        return relationLoads(plan.loads());
+    }
+
+    private static List<Map<String, Object>> relationLoads(List<NotificationSupport.RelationLoad> resolved) {
         List<Map<String, Object>> loads = new ArrayList<>();
-        for (NotificationSupport.RelationLoad load : plan.loads()) {
+        for (NotificationSupport.RelationLoad load : resolved) {
             Map<String, Object> entry = new LinkedHashMap<>();
             entry.put("local", load.local());
             entry.put("targetEntity", load.targetEntity());

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/NotificationSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/NotificationSupport.java
@@ -291,7 +291,7 @@ public final class NotificationSupport {
         return quote(rhs);
     }
 
-    private static String quote(String value) {
+    static String quote(String value) {
         return "\"" + value.replace("\\", "\\\\")
                            .replace("\"", "\\\"")
                            .replace("\n", "\\n")
@@ -299,8 +299,25 @@ public final class NotificationSupport {
                 + "\"";
     }
 
+    /**
+     * A resolver over one entity, for a caller that needs the path vocabulary on its own terms - the
+     * declared {@code payload:} of an outward-facing entry ({@link PayloadSupport}), which classifies
+     * its own value forms but must resolve a field / one-hop {@code relation.field} exactly the way a
+     * notification does, and accumulate the same relation loads.
+     *
+     * @param entity the entity the paths resolve against
+     * @param byName all LOCAL entities by name
+     * @param compositionParents composition-parent map (to resolve a target's perspective)
+     * @param crossModel resolver for a cross-model relation's owner facts, or {@code null}
+     * @return a fresh resolver
+     */
+    static Resolver resolver(EntityIntent entity, Map<String, EntityIntent> byName, Map<String, String> compositionParents,
+            CrossModelLookup crossModel) {
+        return new Resolver(entity, null, byName, compositionParents, crossModel);
+    }
+
     /** Resolves values/text against the event entity, accumulating the relation loads they require. */
-    private static final class Resolver {
+    static final class Resolver {
 
         private final EntityIntent entity;
         private final EntityIntent anchor;
@@ -390,7 +407,7 @@ public final class NotificationSupport {
          * @param recordScope whether the {@code record.<field>} scope may address the fan-out's anchor here
          *        (placeholders yes, the recipient no)
          */
-        private String access(String path, boolean recordScope) {
+        String access(String path, boolean recordScope) {
             if (APP_URL_TOKEN.equals(path)) {
                 return APP_URL_EXPRESSION;
             }
@@ -457,7 +474,7 @@ public final class NotificationSupport {
             return "(" + relationName + " == null ? null : " + relationName + "." + pascalField + ")";
         }
 
-        private RelationIntent toOneRelation(String name) {
+        RelationIntent toOneRelation(String name) {
             for (RelationIntent relation : entity.getRelations()) {
                 boolean toOne = "manyToOne".equals(relation.getKind()) || "oneToOne".equals(relation.getKind());
                 if (toOne && name.equals(relation.getName())) {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/PayloadSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/PayloadSupport.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.eclipse.dirigible.components.intent.model.EntityIntent;
+import org.eclipse.dirigible.components.intent.model.FieldIntent;
+import org.eclipse.dirigible.components.intent.model.RelationIntent;
+
+/**
+ * The declared <b>payload</b> of an outward-facing entry - the message an application sends to
+ * another system, spelled out instead of being "the whole record, as stored".
+ *
+ * <p>
+ * Forwarding the entity JSON makes every column a public contract, so adding a field silently
+ * changes what the outside world receives; and a real integration contract is an <em>envelope</em>
+ * (a type, a version, a minted idempotency key, a timestamp, a tenant, a couple of record fields),
+ * which no arrangement of entity columns can produce. A {@code payload:} block declares that
+ * envelope in the model:
+ *
+ * <pre>
+ * payload:
+ *   type: "user.assignment.requested"     # literal
+ *   version: 1
+ *   messageId: "{uuid}"                   # minted per message
+ *   tenantId: "{tenant}"                  # execution context
+ *   appId: "&#64;config:APP_ID"                # configuration, as elsewhere
+ *   email: email                          # a field of the record
+ *   role: role.name                       # one hop off a to-one relation
+ *   requestedAt: "{now}"
+ * </pre>
+ *
+ * <p>
+ * <b>The value forms are borrowed from {@code notify}, not invented</b> - a value is a literal, a
+ * direct field, or a one-hop {@code relation.field} of a to-one relation, resolved by the very same
+ * {@link NotificationSupport.Resolver} (so the generated listener loads a related record once by FK
+ * id, exactly as a notification does). Multi-hop is rejected. {@code @config:KEY} resolves
+ * server-side, as in the integration's own {@code url:}. The context tokens are a <b>closed set</b>
+ * - uuid, now, tenant, user - and an unknown one is a parse error, never an empty string in a
+ * shipped message.
+ *
+ * <p>
+ * That cap is the point: three value forms and four tokens express a contract without the construct
+ * growing into a transformation language. A payload that needs more than this is an algorithm and
+ * belongs in a hand-written handler.
+ *
+ * <p>
+ * A bare word that is not a field or a to-one relation of the record is a <b>literal</b> - the only
+ * way a payload can carry a one-word constant, since YAML quoting does not survive the parse. Brace
+ * it ({@code "{email}"}) to have the reference checked.
+ */
+public final class PayloadSupport {
+
+    /** A per-message idempotency key. */
+    static final String TOKEN_UUID = "uuid";
+
+    /** The send time, as an ISO-8601 instant. */
+    static final String TOKEN_NOW = "now";
+
+    /** The id of the tenant the send runs for. */
+    static final String TOKEN_TENANT = "tenant";
+
+    /** The name of the user behind the write that raised the event. */
+    static final String TOKEN_USER = "user";
+
+    /** The closed set of context tokens, in the order the "valid: ..." message lists them. */
+    private static final Map<String, String> CONTEXT_TOKENS = contextTokens();
+
+    /** A dotted path of identifiers - one segment is a field, two a one-hop relation walk. */
+    private static final Pattern DOTTED_PATH = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*");
+
+    /** An explicitly braced reference: a context token, a field, or a one-hop relation walk. */
+    private static final Pattern BRACED = Pattern.compile("\\{([^{}]*)\\}");
+
+    private static final String CONFIG_PREFIX = "@config:";
+
+    private PayloadSupport() {}
+
+    /**
+     * One resolved payload entry: the JSON key and the Java expression that produces its value.
+     *
+     * @param key the payload key, as authored
+     * @param expression the Java expression evaluated against the loaded record
+     */
+    public record Entry(String key, String expression) {
+    }
+
+    /**
+     * A resolved payload: the entries in declaration order plus the one-hop relation loads the
+     * generated listener must perform before building them.
+     *
+     * @param entries the payload entries, in declaration order
+     * @param loads the one-hop relation loads the entries read from
+     */
+    public record Plan(List<Entry> entries, List<NotificationSupport.RelationLoad> loads) {
+    }
+
+    /**
+     * Validate a declared payload against the record it is built from, collecting every problem rather
+     * than stopping at the first. Cross-model {@code relation.field} paths are accepted here and
+     * resolved at generation time (the owner's model is not readable from the parser), which is the
+     * same division {@code notify} makes.
+     *
+     * @param payload the authored payload, may be empty
+     * @param entity the entity the event carries, or {@code null} when it could not be resolved
+     * @param byName all LOCAL entities by name
+     * @param subject how to name the owning entry in a message, e.g. {@code integration [pushOrder]}
+     * @param issues the collecting issue list
+     */
+    public static void validate(Map<String, Object> payload, EntityIntent entity, Map<String, EntityIntent> byName, String subject,
+            List<String> issues) {
+        if (payload == null || payload.isEmpty() || entity == null) {
+            return;
+        }
+        for (Map.Entry<String, Object> declared : payload.entrySet()) {
+            String key = declared.getKey();
+            Object value = declared.getValue();
+            if (value instanceof Map || value instanceof Iterable) {
+                issues.add(subject + " payload [" + key
+                        + "] must be a scalar - a nested object or list is not a payload value form (literal, field, relation.field,"
+                        + " @config:KEY or a context token)");
+                continue;
+            }
+            if (!(value instanceof String text)) {
+                continue; // a number / boolean / null literal needs no resolution
+            }
+            validateString(text.trim(), key, entity, byName, subject, issues);
+        }
+    }
+
+    /**
+     * Translate a declared payload into the entries and relation loads the generated listener renders.
+     *
+     * @param payload the authored payload
+     * @param entity the entity the event carries
+     * @param byName all LOCAL entities by name
+     * @param compositionParents composition-parent map (to resolve a load target's perspective)
+     * @param crossModel resolver for a cross-model relation's owner facts, or {@code null}
+     * @return the plan, or {@code null} when the payload is empty
+     * @throws IllegalArgumentException when a value cannot be resolved - the caller reports the drop
+     *         with the precise reason instead of sending a message with a hole in it
+     */
+    public static Plan plan(Map<String, Object> payload, EntityIntent entity, Map<String, EntityIntent> byName,
+            Map<String, String> compositionParents, NotificationSupport.CrossModelLookup crossModel) {
+        if (payload == null || payload.isEmpty() || entity == null) {
+            return null;
+        }
+        NotificationSupport.Resolver resolver = NotificationSupport.resolver(entity, byName, compositionParents, crossModel);
+        List<Entry> entries = new ArrayList<>();
+        for (Map.Entry<String, Object> declared : payload.entrySet()) {
+            entries.add(new Entry(declared.getKey(), expression(declared.getKey(), declared.getValue(), entity, resolver)));
+        }
+        return new Plan(entries, resolver.loads());
+    }
+
+    /**
+     * The glue keys a payload contributes, always present so the template can branch on them - an
+     * undefined Velocity variable renders as its own literal name, so a template must never depend on a
+     * key being absent.
+     *
+     * @param plan the resolved payload, or {@code null} when the entry declares none
+     * @return the {@code hasPayload} / {@code payloadFields} keys
+     */
+    public static Map<String, Object> payloadFields(Plan plan) {
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put("hasPayload", plan != null);
+        List<Map<String, Object>> rendered = new ArrayList<>();
+        if (plan != null) {
+            for (Entry entry : plan.entries()) {
+                Map<String, Object> field = new LinkedHashMap<>();
+                field.put("key", entry.key());
+                // The key is rendered pre-quoted: it goes into a Java string literal, and the template
+                // must not be the place that decides how a key is escaped.
+                field.put("keyLiteral", NotificationSupport.quote(entry.key()));
+                field.put("expression", entry.expression());
+                rendered.add(field);
+            }
+        }
+        fields.put("payloadFields", rendered);
+        return fields;
+    }
+
+    private static void validateString(String value, String key, EntityIntent entity, Map<String, EntityIntent> byName, String subject,
+            List<String> issues) {
+        if (value.startsWith(CONFIG_PREFIX)) {
+            if (value.substring(CONFIG_PREFIX.length())
+                     .isBlank()) {
+                issues.add(subject + " payload [" + key + "] has an empty @config: key");
+            }
+            return;
+        }
+        var braced = BRACED.matcher(value);
+        if (braced.matches()) {
+            String inner = braced.group(1)
+                                 .trim();
+            if (CONTEXT_TOKENS.containsKey(inner)) {
+                return;
+            }
+            if (DOTTED_PATH.matcher(inner)
+                           .matches()
+                    && inner.indexOf('.') >= 0) {
+                validatePath(inner, key, entity, byName, subject, issues, true);
+                return;
+            }
+            // A braced single word the author expected to be substituted: most likely a mistyped token,
+            // possibly a field that does not exist. The message offers both readings rather than guessing.
+            if (fieldOf(entity, inner) == null && toOneRelation(entity, inner) == null) {
+                issues.add(subject + " payload [" + key + "] references [" + inner + "], which is neither a context token (valid: "
+                        + tokenList() + ") nor a field or a to-one relation of [" + entity.getName() + "]");
+            }
+            return;
+        }
+        if (value.indexOf('{') >= 0 || value.indexOf('}') >= 0) {
+            issues.add(subject + " payload [" + key + "] value [" + value
+                    + "] mixes braces into text - a payload value is one whole value (a literal, a field, a one-hop relation.field,"
+                    + " @config:KEY or a context token), never an interpolated string");
+            return;
+        }
+        if (value.indexOf('.') >= 0 && DOTTED_PATH.matcher(value)
+                                                  .matches()) {
+            validatePath(value, key, entity, byName, subject, issues, false);
+        }
+        // Anything else is a literal - a URL, a one-word constant, a sentence.
+    }
+
+    /**
+     * Check a dotted path the author may have meant as a relation walk. When it was NOT braced, a head
+     * naming no to-one relation is simply a literal (a message type reads exactly like a path), so
+     * nothing is reported; once the head does name one, the author clearly meant a walk and a bad one
+     * is an error.
+     */
+    private static void validatePath(String path, String key, EntityIntent entity, Map<String, EntityIntent> byName, String subject,
+            List<String> issues, boolean braced) {
+        String[] segments = path.split("\\.");
+        String head = segments[0];
+        RelationIntent relation = toOneRelation(entity, head);
+        if (relation == null) {
+            if (braced) {
+                issues.add(subject + " payload [" + key + "] references [" + path + "], whose first segment [" + head
+                        + "] is not a to-one relation of [" + entity.getName() + "]");
+            }
+            return; // an unbraced dotted literal, e.g. a message type
+        }
+        if (segments.length > 2) {
+            issues.add(subject + " payload [" + key + "] references [" + path
+                    + "], which walks more than one relation - a payload value resolves at most one hop (relation.field)");
+            return;
+        }
+        if (relation.getModel() != null && !relation.getModel()
+                                                    .isBlank()) {
+            return; // cross-model: the owner's fields are resolved at generation time
+        }
+        EntityIntent target = byName.get(relation.getTo());
+        if (target != null && fieldOf(target, segments[1]) == null) {
+            issues.add(subject + " payload [" + key + "] references [" + path + "], but [" + segments[1] + "] is not a field of ["
+                    + relation.getTo() + "]");
+        }
+    }
+
+    private static String expression(String key, Object value, EntityIntent entity, NotificationSupport.Resolver resolver) {
+        if (value == null) {
+            return "null";
+        }
+        if (value instanceof Boolean flag) {
+            return flag.toString();
+        }
+        if (value instanceof Number number) {
+            return numberLiteral(number);
+        }
+        String text = value.toString()
+                           .trim();
+        if (text.startsWith(CONFIG_PREFIX)) {
+            return "Configurations.get(" + NotificationSupport.quote(text.substring(CONFIG_PREFIX.length())
+                                                                         .trim())
+                    + ")";
+        }
+        var braced = BRACED.matcher(text);
+        if (braced.matches()) {
+            String inner = braced.group(1)
+                                 .trim();
+            String token = CONTEXT_TOKENS.get(inner);
+            return token != null ? token : resolved(key, inner, entity, resolver);
+        }
+        if (isReference(text, entity)) {
+            return resolved(key, text, entity, resolver);
+        }
+        return NotificationSupport.quote(text);
+    }
+
+    /** An unbraced value is a reference only when its head actually names something on the record. */
+    private static boolean isReference(String text, EntityIntent entity) {
+        if (!DOTTED_PATH.matcher(text)
+                        .matches()) {
+            return false;
+        }
+        String head = text.split("\\.")[0];
+        return text.indexOf('.') < 0 ? fieldOf(entity, head) != null || toOneRelation(entity, head) != null
+                : toOneRelation(entity, head) != null;
+    }
+
+    private static String resolved(String key, String path, EntityIntent entity, NotificationSupport.Resolver resolver) {
+        String access = resolver.access(path, false);
+        if (access == null) {
+            throw new IllegalArgumentException(
+                    "payload [" + key + "] references [" + path + "], which cannot be resolved on [" + entity.getName() + "]");
+        }
+        return access;
+    }
+
+    /**
+     * An integral number becomes an {@code int} literal (a {@code long} one when it does not fit), a
+     * fractional one a {@code BigDecimal} so the authored precision survives into the JSON.
+     */
+    private static String numberLiteral(Number number) {
+        BigDecimal decimal = new BigDecimal(number.toString());
+        if (decimal.stripTrailingZeros()
+                   .scale() > 0) {
+            return "new java.math.BigDecimal(\"" + decimal.toPlainString() + "\")";
+        }
+        long value = decimal.longValue();
+        return value >= Integer.MIN_VALUE && value <= Integer.MAX_VALUE ? Long.toString(value) : value + "L";
+    }
+
+    private static FieldIntent fieldOf(EntityIntent entity, String name) {
+        for (FieldIntent field : entity.getFields()) {
+            if (name.equals(field.getName())) {
+                return field;
+            }
+        }
+        return null;
+    }
+
+    private static RelationIntent toOneRelation(EntityIntent entity, String name) {
+        for (RelationIntent relation : entity.getRelations()) {
+            boolean toOne = "manyToOne".equals(relation.getKind()) || "oneToOne".equals(relation.getKind());
+            if (toOne && name.equals(relation.getName())) {
+                return relation;
+            }
+        }
+        return null;
+    }
+
+    private static String tokenList() {
+        Set<String> names = new LinkedHashSet<>(CONTEXT_TOKENS.keySet());
+        return "{" + String.join("}, {", names) + "}";
+    }
+
+    private static Map<String, String> contextTokens() {
+        Map<String, String> tokens = new LinkedHashMap<>();
+        tokens.put(TOKEN_UUID, "java.util.UUID.randomUUID().toString()");
+        tokens.put(TOKEN_NOW, "java.time.Instant.now().toString()");
+        tokens.put(TOKEN_TENANT, "org.eclipse.dirigible.sdk.core.Tenant.getId()");
+        tokens.put(TOKEN_USER, "org.eclipse.dirigible.sdk.security.User.getName()");
+        return Collections.unmodifiableMap(tokens);
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/IntegrationIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/IntegrationIntent.java
@@ -18,9 +18,16 @@ import java.util.Map;
  *
  * <p>
  * {@link #event} is the same {@code onCreate}/{@code onUpdate}/{@code onDelete} binding the
- * notifications use. The generated {@code @Listener} forwards the entity JSON (the event payload)
- * to {@link #url} via {@link #method}. The URL is a literal or {@code @config:KEY} (read
- * server-side from the configuration). Custom body mapping and headers are a later increment.
+ * notifications use. The generated {@code @Listener} sends the request to {@link #url} via
+ * {@link #method}. The URL is a literal or {@code @config:KEY} (read server-side from the
+ * configuration). Custom headers are a later increment.
+ *
+ * <p>
+ * The request body is the entity JSON as stored, unless the entry declares a {@link #payload} - a
+ * key/value envelope built from literals, record fields, one-hop {@code relation.field} paths,
+ * {@code @config:KEY} lookups and the four context tokens (see
+ * {@link org.eclipse.dirigible.components.intent.generator.PayloadSupport}). Forwarding the raw
+ * record makes every column a public contract; a declared payload is the contract instead.
  */
 public class IntegrationIntent {
 
@@ -28,6 +35,7 @@ public class IntegrationIntent {
     private Map<String, Object> event = new LinkedHashMap<>();
     private String method = "POST";
     private String url;
+    private Map<String, Object> payload = new LinkedHashMap<>();
 
     public String getName() {
         return name;
@@ -59,5 +67,13 @@ public class IntegrationIntent {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public Map<String, Object> getPayload() {
+        return payload;
+    }
+
+    public void setPayload(Map<String, Object> payload) {
+        this.payload = payload == null ? new LinkedHashMap<>() : payload;
     }
 }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -19,8 +19,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.dirigible.components.intent.generator.IntegrationSupport;
 import org.eclipse.dirigible.components.intent.generator.IntentEntities;
 import org.eclipse.dirigible.components.intent.generator.NotifySupport;
+import org.eclipse.dirigible.components.intent.generator.PayloadSupport;
 import org.eclipse.dirigible.components.intent.generator.ProcessAssigneeSupport;
 import org.eclipse.dirigible.components.intent.generator.ProcessParallelSupport;
 import org.eclipse.dirigible.components.intent.generator.StepEventSupport;
@@ -1740,7 +1742,8 @@ public final class IntentParser {
             if (!names.add(name)) {
                 issues.add("duplicate integration [" + name + "]");
             }
-            validateEventBinding(integration.getEvent(), "integration [" + name + "]", entityNames, model, issues);
+            String subject = "integration [" + name + "]";
+            String eventEntity = validateEventBinding(integration.getEvent(), subject, entityNames, model, issues);
             String method = integration.getMethod();
             if (method != null && !method.isBlank() && !HTTP_METHODS.contains(method.trim()
                                                                                     .toUpperCase(Locale.ROOT))) {
@@ -1750,7 +1753,30 @@ public final class IntentParser {
                                                            .isBlank()) {
                 issues.add("integration [" + name + "] has no url");
             }
+            validateIntegrationPayload(integration, subject, eventEntity, model, issues);
         }
+    }
+
+    /**
+     * The declared {@code payload:} of an integration - the envelope it sends instead of the record as
+     * stored. The value forms and the closed context-token set are checked by {@link PayloadSupport};
+     * what belongs here is the transport rule: a method that carries no body has nowhere to put a
+     * payload, and accepting one there would generate a listener that resolves an envelope and throws
+     * it away.
+     */
+    private static void validateIntegrationPayload(IntegrationIntent integration, String subject, String eventEntity, IntentModel model,
+            List<String> issues) {
+        if (integration.getPayload()
+                       .isEmpty()) {
+            return;
+        }
+        if (!IntegrationSupport.hasBody(integration.getMethod())) {
+            issues.add(subject + " declares a payload, but its method [" + integration.getMethod()
+                    + "] sends no request body - a payload needs POST, PUT or PATCH");
+            return;
+        }
+        EntityIntent record = eventEntity == null ? null : entityByName(model, eventEntity);
+        PayloadSupport.validate(integration.getPayload(), record, IntentEntities.byName(model), subject, issues);
     }
 
     /**

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -2047,6 +2047,40 @@ integrations:
 
 **Rules:** exactly one event of the event axis; `method` from the allowed list; `url` required.
 
+**`payload:` - the declared envelope (use it whenever the receiver has a contract).** Without it the
+request body is the record as stored, which makes every column a public contract and cannot express
+an envelope (a type, a version, an idempotency key, a tenant). With it, the body is exactly what you
+declare:
+
+```yaml
+integrations:
+  - name: requestUserAssignment
+    event: { onCreate: UserInvitation }
+    method: POST                          # a payload needs POST / PUT / PATCH - the rest send no body
+    url: "@config:ASSIGNMENT_URL"
+    payload:
+      type: "user.assignment.requested"   # literal
+      version: 1
+      messageId: "{uuid}"                 # minted per message
+      tenantId: "{tenant}"                # execution context
+      appId: "@config:APP_ID"             # configuration, resolved server-side
+      email: email                        # a field of the record
+      role: role.name                     # one hop off a to-one relation
+      requestedAt: "{now}"
+```
+
+A value is a **literal**, a **direct field**, or a **one-hop `relation.field`** of a to-one relation -
+the same three forms `notify` resolves, and multi-hop (`a.b.c`) is rejected the same way. `@config:KEY`
+reads the configuration. The context tokens are a **closed set** - `{uuid}`, `{now}` (an ISO-8601
+instant), `{tenant}`, `{user}` - and an unknown one is a parse **error**, never an empty value in a
+shipped message. A payload value is one whole value: there is no interpolation (`"Order {id} placed"`
+is rejected) and no nested object or list. A bare word that names no field is a **literal**; brace it
+(`"{email}"`) when you mean a reference and want the parser to check it. Keys keep their authored
+order.
+
+If a contract needs more than this it is an algorithm, not a payload - say so and hand off to a
+hand-written handler rather than stretching the block.
+
 ### the event axis - what a notification / integration binds to
 
 **Both** `notifications` and `integrations` declare **exactly one** `event:`, either

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueIntegrationPayloadTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueIntegrationPayloadTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.parser.IntentParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The {@code integrations} glue entries a declared {@code payload:} contributes: the ordered
+ * key/expression list the template renders, plus the one-hop relation loads it needs - the same
+ * shape a notification carries, so the generated listener resolves a related record exactly once.
+ * An integration that declares no payload keeps forwarding the record and carries neither.
+ */
+class GlueIntegrationPayloadTest {
+
+    private static final String YAML = """
+            name: provisioning
+            entities:
+              - name: Role
+                kind: setting
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: UserInvitation
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: email, type: string }
+                relations:
+                  - { name: role, kind: manyToOne, to: Role }
+            integrations:
+              - name: requestUserAssignment
+                event: { onCreate: UserInvitation }
+                method: POST
+                url: "@config:ASSIGNMENT_URL"
+                payload:
+                  type: "user.assignment.requested"
+                  version: 1
+                  messageId: "{uuid}"
+                  tenantId: "{tenant}"
+                  email: email
+                  role: role.name
+              - name: pingCatalog
+                event: { onUpdate: UserInvitation }
+                method: POST
+                url: "https://hooks.example.com/invitations"
+            """;
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void aDeclaredPayloadBecomesAnOrderedKeyExpressionListWithItsRelationLoads() {
+        Map<String, Object> integration = integration("requestUserAssignment");
+
+        assertEquals(true, integration.get("hasPayload"));
+        List<Map<String, Object>> fields = (List<Map<String, Object>>) integration.get("payloadFields");
+        assertEquals(List.of("type", "version", "messageId", "tenantId", "email", "role"), fields.stream()
+                                                                                                 .map(field -> field.get("key"))
+                                                                                                 .toList(),
+                "the envelope keeps its authored order - a contract is read in the order it was written");
+        assertEquals("\"type\"", fields.get(0)
+                                       .get("keyLiteral"),
+                "the key is pre-quoted so the template never decides how it is escaped");
+        assertEquals("\"user.assignment.requested\"", fields.get(0)
+                                                            .get("expression"));
+        assertEquals("1", fields.get(1)
+                                .get("expression"));
+        assertEquals("java.util.UUID.randomUUID().toString()", fields.get(2)
+                                                                     .get("expression"));
+        assertEquals("org.eclipse.dirigible.sdk.core.Tenant.getId()", fields.get(3)
+                                                                            .get("expression"));
+        assertEquals("entity.Email", fields.get(4)
+                                           .get("expression"));
+        assertEquals("(role == null ? null : role.Name)", fields.get(5)
+                                                                .get("expression"));
+
+        List<Map<String, Object>> loads = (List<Map<String, Object>>) integration.get("relationLoads");
+        assertEquals(1, loads.size(), "loads: " + loads);
+        assertEquals("role", loads.get(0)
+                                  .get("local"));
+        assertEquals("Role", loads.get(0)
+                                  .get("targetEntity"));
+        assertEquals("Settings", loads.get(0)
+                                      .get("targetPerspective"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void anIntegrationWithoutAPayloadStillForwardsTheRecord() {
+        Map<String, Object> integration = integration("pingCatalog");
+
+        assertEquals(false, integration.get("hasPayload"));
+        assertTrue(((List<Map<String, Object>>) integration.get("payloadFields")).isEmpty());
+        assertTrue(((List<Map<String, Object>>) integration.get("relationLoads")).isEmpty());
+        assertEquals("\"https://hooks.example.com/invitations\"", integration.get("urlExpression"));
+    }
+
+    private static Map<String, Object> integration(String name) {
+        IntentModel model = IntentParser.parse(YAML);
+        for (Map<String, Object> entry : GlueIntentGenerator.buildIntegrationsForTest(model)) {
+            if (name.equals(entry.get("name"))) {
+                return entry;
+            }
+        }
+        throw new AssertionError("no integration [" + name + "] in the glue");
+    }
+}

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/PayloadSupportTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/PayloadSupportTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.intent.model.EntityIntent;
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.parser.IntentParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The value vocabulary of a declared payload: three value forms, four context tokens, and a hard
+ * stop at anything richer. These are pure translations, so they are asserted here rather than only
+ * through the generated Java.
+ */
+class PayloadSupportTest {
+
+    private static final String MODEL = """
+            name: provisioning
+            entities:
+              - name: Role
+                kind: setting
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: UserInvitation
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: email, type: string }
+                  - { name: seats, type: integer }
+                relations:
+                  - { name: role, kind: manyToOne, to: Role }
+            """;
+
+    @Test
+    void everyValueFormTranslatesToItsExpression() {
+        PayloadSupport.Plan plan = plan(payload("""
+                type=user.assignment.requested
+                messageId={uuid}
+                requestedAt={now}
+                tenantId={tenant}
+                requestedBy={user}
+                appId=@config:APP_ID
+                email=email
+                role=role.name
+                """));
+
+        Map<String, String> byKey = expressions(plan);
+        assertEquals("\"user.assignment.requested\"", byKey.get("type"), "a dotted word that names no relation is a literal");
+        assertEquals("java.util.UUID.randomUUID().toString()", byKey.get("messageId"));
+        assertEquals("java.time.Instant.now().toString()", byKey.get("requestedAt"));
+        assertEquals("org.eclipse.dirigible.sdk.core.Tenant.getId()", byKey.get("tenantId"));
+        assertEquals("org.eclipse.dirigible.sdk.security.User.getName()", byKey.get("requestedBy"));
+        assertEquals("Configurations.get(\"APP_ID\")", byKey.get("appId"));
+        assertEquals("entity.Email", byKey.get("email"));
+        assertEquals("(role == null ? null : role.Name)", byKey.get("role"), "one hop reads the related record the listener loads");
+
+        assertEquals(1, plan.loads()
+                            .size(),
+                "the one-hop value contributes exactly one relation load");
+        NotificationSupport.RelationLoad load = plan.loads()
+                                                    .get(0);
+        assertEquals("role", load.local());
+        assertEquals("Role", load.targetEntity());
+        assertEquals("Settings", load.targetPerspective(), "a setting target resolves to the global Settings perspective");
+    }
+
+    @Test
+    void nonStringScalarsStayLiterals() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("version", 1);
+        payload.put("rate", 1.50);
+        payload.put("draft", false);
+        payload.put("note", null);
+
+        Map<String, String> byKey = expressions(plan(payload));
+        assertEquals("1", byKey.get("version"));
+        assertEquals("new java.math.BigDecimal(\"1.5\")", byKey.get("rate"), "a fractional literal keeps its authored precision");
+        assertEquals("false", byKey.get("draft"));
+        assertEquals("null", byKey.get("note"));
+    }
+
+    @Test
+    void aBracedReferenceIsCheckedWhereABareWordIsALiteral() {
+        assertEquals("entity.Email", expressions(plan(payload("to={email}"))).get("to"));
+        // The same word unbraced also resolves - it IS a field. A word that is not stays a literal,
+        // which is the only way a payload can carry a one-word constant.
+        assertEquals("\"draft\"", expressions(plan(payload("state=draft"))).get("state"));
+    }
+
+    @Test
+    void anUnknownContextTokenIsRejectedNamingTheClosedSet() {
+        List<String> issues = validate(payload("stamp={today}"));
+        assertEquals(1, issues.size(), issues.toString());
+        assertTrue(issues.get(0)
+                         .contains("references [today], which is neither a context token")
+                && issues.get(0)
+                         .contains("{uuid}, {now}, {tenant}, {user}"),
+                issues.toString());
+    }
+
+    @Test
+    void aMultiHopReferenceIsRejected() {
+        List<String> issues = validate(payload("owner=role.owner.name"));
+        assertEquals(1, issues.size(), issues.toString());
+        assertTrue(issues.get(0)
+                         .contains("walks more than one relation"),
+                issues.toString());
+    }
+
+    @Test
+    void aOneHopOntoAFieldTheTargetDoesNotHaveIsRejected() {
+        List<String> issues = validate(payload("role=role.code"));
+        assertEquals(1, issues.size(), issues.toString());
+        assertTrue(issues.get(0)
+                         .contains("[code] is not a field of [Role]"),
+                issues.toString());
+    }
+
+    @Test
+    void aBracedNonReferenceIsRejectedRatherThanShippedEmpty() {
+        List<String> issues = validate(payload("who={requester}"));
+        assertEquals(1, issues.size(), issues.toString());
+        assertTrue(issues.get(0)
+                         .contains("nor a field or a to-one relation of [UserInvitation]"),
+                issues.toString());
+    }
+
+    @Test
+    void interpolatedTextAndNestedValuesAreRefused() {
+        List<String> mixed = validate(payload("subject=Order {id} shipped"));
+        assertEquals(1, mixed.size(), mixed.toString());
+        assertTrue(mixed.get(0)
+                        .contains("mixes braces into text"),
+                mixed.toString());
+
+        Map<String, Object> nested = new LinkedHashMap<>();
+        nested.put("actor", Map.of("id", "email"));
+        List<String> issues = validate(nested);
+        assertEquals(1, issues.size(), issues.toString());
+        assertTrue(issues.get(0)
+                         .contains("must be a scalar"),
+                issues.toString());
+    }
+
+    @Test
+    void anUnresolvableValueFailsGenerationRatherThanFallingBackToTheRecord() {
+        // Braced, so the parser would have caught it; the generator still refuses to build a payload
+        // with a hole in it, which is what makes the drop visible instead of the contract changing.
+        assertThrows(IllegalArgumentException.class, () -> plan(payload("who={role.code}")));
+    }
+
+    private static Map<String, String> expressions(PayloadSupport.Plan plan) {
+        Map<String, String> byKey = new LinkedHashMap<>();
+        for (PayloadSupport.Entry entry : plan.entries()) {
+            byKey.put(entry.key(), entry.expression());
+        }
+        return byKey;
+    }
+
+    private static PayloadSupport.Plan plan(Map<String, Object> payload) {
+        IntentModel model = IntentParser.parse(MODEL);
+        Map<String, EntityIntent> byName = IntentEntities.byName(model);
+        return PayloadSupport.plan(payload, byName.get("UserInvitation"), byName, IntentEntities.compositionParents(model), null);
+    }
+
+    private static List<String> validate(Map<String, Object> payload) {
+        IntentModel model = IntentParser.parse(MODEL);
+        Map<String, EntityIntent> byName = IntentEntities.byName(model);
+        List<String> issues = new ArrayList<>();
+        PayloadSupport.validate(payload, byName.get("UserInvitation"), byName, "integration [x]", issues);
+        return issues;
+    }
+
+    /**
+     * {@code key=value} lines into an ordered payload map - YAML would strip the quoting under test.
+     */
+    private static Map<String, Object> payload(String lines) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        for (String line : lines.split("\n")) {
+            if (!line.isBlank()) {
+                int split = line.indexOf('=');
+                payload.put(line.substring(0, split), line.substring(split + 1));
+            }
+        }
+        return payload;
+    }
+}

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/IntegrationPayloadIntentTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/IntegrationPayloadIntentTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The parse-time half of a declared {@code payload:} on an integration: the value forms are checked
+ * before anything is generated, and the transport rule (a payload needs a request body) is checked
+ * here rather than left to produce a listener that builds an envelope and discards it.
+ */
+class IntegrationPayloadIntentTest {
+
+    private static final String ENTITIES = """
+            name: provisioning
+            entities:
+              - name: Role
+                kind: setting
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: UserInvitation
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: email, type: string }
+                relations:
+                  - { name: role, kind: manyToOne, to: Role }
+            integrations:
+              - name: requestUserAssignment
+                event: { onCreate: UserInvitation }
+                method: %s
+                url: "@config:ASSIGNMENT_URL"
+                payload:
+            %s
+            """;
+
+    @Test
+    void aDeclaredPayloadParsesAndIsCarriedOnTheIntegration() {
+        IntentModel model = IntentParser.parse(intent("POST", """
+                      type: "user.assignment.requested"
+                      version: 1
+                      messageId: "{uuid}"
+                      tenantId: "{tenant}"
+                      appId: "@config:APP_ID"
+                      email: email
+                      role: role.name
+                      requestedAt: "{now}"
+                """));
+
+        var payload = model.getIntegrations()
+                           .get(0)
+                           .getPayload();
+        assertEquals(8, payload.size());
+        assertEquals("user.assignment.requested", payload.get("type"));
+        assertEquals(1L, payload.get("version"), "a YAML integer stays integral through the mapping");
+        assertEquals("role.name", payload.get("role"));
+    }
+
+    @Test
+    void aPayloadNeedsAMethodThatCarriesABody() {
+        IntentValidationException failure =
+                assertThrows(IntentValidationException.class, () -> IntentParser.parse(intent("GET", "      email: email\n")));
+        assertTrue(failure.getMessage()
+                          .contains("sends no request body"),
+                failure.getMessage());
+    }
+
+    @Test
+    void anUnknownContextTokenFailsTheParse() {
+        IntentValidationException failure =
+                assertThrows(IntentValidationException.class, () -> IntentParser.parse(intent("POST", "      stamp: \"{today}\"\n")));
+        assertTrue(failure.getMessage()
+                          .contains("neither a context token"),
+                failure.getMessage());
+    }
+
+    @Test
+    void aMultiHopValueFailsTheParse() {
+        IntentValidationException failure =
+                assertThrows(IntentValidationException.class, () -> IntentParser.parse(intent("POST", "      owner: role.owner.name\n")));
+        assertTrue(failure.getMessage()
+                          .contains("walks more than one relation"),
+                failure.getMessage());
+    }
+
+    private static String intent(String method, String payload) {
+        return ENTITIES.formatted(method, payload);
+    }
+}

--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/GlueGenerator.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/GlueGenerator.java
@@ -423,7 +423,12 @@ class GlueGenerator {
      * @param parameters the generation parameters
      */
     private static void bindIntegration(Map<String, Object> item, Map<String, Object> context, Map<String, Object> parameters) {
-        copy(context, item, "name", "className", "entity", "perspective", "topicSuffix", "clientMethod", "hasBody", "urlExpression");
+        copy(context, item, "name", "className", "entity", "perspective", "topicSuffix", "clientMethod", "hasBody", "urlExpression",
+                "hasPayload", "payloadFields");
+        // The declared payload reads the record and, for a one-hop value, a related record - the same
+        // loads a notification performs, so the same package resolution applies.
+        context.put("javaPerspective", sanitize(item, "perspective"));
+        context.put("relationLoads", relationLoads(item.get("relationLoads"), parameters));
     }
 
     /**

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Integration.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Integration.java.template
@@ -1,6 +1,9 @@
 package gen.events.${javaGenFolderName};
 
 import java.util.HashMap;
+#if($hasPayload)
+import java.util.LinkedHashMap;
+#end
 import java.util.Map;
 
 import org.eclipse.dirigible.sdk.component.Component;
@@ -9,13 +12,26 @@ import org.eclipse.dirigible.sdk.http.HttpClient;
 import org.eclipse.dirigible.sdk.messaging.ListenerKind;
 import org.eclipse.dirigible.sdk.messaging.MessageHandler;
 import org.eclipse.dirigible.sdk.utils.Json;
+#if($hasPayload)
+
+import gen.${javaGenFolderName}.data.${javaPerspective}.${entity}Entity;
+#foreach($load in $relationLoads)
+import gen.${load.javaGenFolder}.data.${load.javaTargetPerspective}.${load.targetEntity}Entity;
+import gen.${load.javaGenFolder}.data.${load.javaTargetPerspective}.${load.targetEntity}Repository;
+#end
+#end
 
 /**
  * Forwards a ${entity} event to an external endpoint via ${clientMethod}.
  *
  * Generated from the intent integrations block - do not edit; it is re-generated with the
- * application. The event payload (the entity JSON) is sent as the request body. The target URL comes
- * from the intent (a literal or a configuration value).
+ * application. The target URL comes from the intent (a literal or a configuration value).
+#if($hasPayload)
+ * The request body is the payload declared in the intent - the contract this application sends,
+ * built from literals, record fields, one-hop relation values and the context tokens.
+#else
+ * The event payload (the entity JSON) is sent as the request body.
+#end
  */
 @Component("${javaGenFolderName}_${className}Integration")
 public class ${className}Integration implements MessageHandler {
@@ -36,10 +52,26 @@ public class ${className}Integration implements MessageHandler {
         if (url == null || url.isBlank()) {
             return;
         }
+#if($hasPayload)
+        ${entity}Entity entity = Json.parse(message, ${entity}Entity.class);
+        if (entity == null) {
+            return;
+        }
+#foreach($load in $relationLoads)
+        ${load.targetEntity}Entity ${load.local} = entity.${load.fkProperty} == null ? null : new ${load.targetEntity}Repository().findById(entity.${load.fkProperty});
+#end
+        Map<String, Object> payload = new LinkedHashMap<>();
+#foreach($field in $payloadFields)
+        payload.put(${field.keyLiteral}, ${field.expression});
+#end
+        String body = Json.stringify(payload);
+#elseif($hasBody)
+        String body = message;
+#end
         try {
 #if($hasBody)
             Map<String, Object> options = new HashMap<>();
-            options.put("text", message);
+            options.put("text", body);
             options.put("contentType", "application/json");
             HttpClient.${clientMethod}(url, Json.stringify(options));
 #else

--- a/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/js/intent-diagrams.js
+++ b/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/js/intent-diagrams.js
@@ -366,6 +366,13 @@ window.IntentDiagrams = (() => {
         return 'POST ' + (ingest.path || '');
     };
 
+    // A declared payload is a contract, so the card says so - the alternative (the record as stored)
+    // is a different promise entirely and must not look the same on the diagram.
+    const integrationDetail = (integration) => {
+        const declared = Object.keys(integration.payload || {}).length;
+        return (integration.method || 'POST') + ' ' + eventVerb(integration.event) + (declared ? ' • payload' : '');
+    };
+
     // The roll-up's parent entity is the target of its `via` to-one relation on the counted child entity.
     const rollupParent = (model, rollup) => {
         const child = model.entities.find(e => e && e.name === rollup.entity);
@@ -388,7 +395,7 @@ window.IntentDiagrams = (() => {
             { list: model.reports, icon: ICON.report, color: COLOR.output, entity: r => r.source, detail: r => r.widget ? 'report • KPI ' + (r.widget.kind || (r.widget.value ? 'value' : 'count')) : 'report' },
             { list: model.notifications, icon: ICON.notification, color: COLOR.glue, entity: n => eventEntity(model, n.event), detail: n => eventVerb(n.event) + ' → email' },
             { list: model.schedules, icon: ICON.schedule, color: COLOR.glue, entity: s => s.model ? null : s.entity, detail: s => (s.model ? s.model + '.' + s.entity + ' • ' : '') + (s.cron || 'scheduled') },
-            { list: model.integrations, icon: ICON.integration, color: COLOR.glue, entity: i => eventEntity(model, i.event), detail: i => (i.method || 'POST') + ' ' + eventVerb(i.event) },
+            { list: model.integrations, icon: ICON.integration, color: COLOR.glue, entity: i => eventEntity(model, i.event), detail: integrationDetail },
             { list: model.inbound, icon: ICON.inbound, color: COLOR.glue, entity: w => w.create, detail: inboundDetail },
             { list: model.rollups, icon: ICON.rollup, color: COLOR.glue, entity: r => r.entity, detail: r => '→ ' + (rollupParent(model, r) || '?') + '.' + (r.field || '') }
         ];

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -271,6 +271,24 @@ class IntentEngineIT extends IntegrationTest {
                 method: POST
                 url: "@config:WAREHOUSE_URL"
 
+              # A declared payload: the envelope this application sends, instead of the record as
+              # stored. Literals, a minted key, the two context tokens, a configuration value, a field
+              # and a one-hop relation walk - the whole vocabulary in one contract.
+              - name: announceOrder
+                event: { onCreate: Order }
+                method: POST
+                url: "@config:ANNOUNCE_URL"
+                payload:
+                  type: "order.placed"
+                  version: 1
+                  messageId: "{uuid}"
+                  tenantId: "{tenant}"
+                  placedBy: "{user}"
+                  placedAt: "{now}"
+                  source: "@config:APP_ID"
+                  orderId: id
+                  customer: customer.name
+
             inbound:
               - name: ingestOrder
                 path: /ingest
@@ -725,9 +743,40 @@ class IntentEngineIT extends IntegrationTest {
         assertTrue(integration.contains("String url = Configurations.get(\"WAREHOUSE_URL\")"),
                 "an @config: URL should resolve through the configuration at run time");
         assertTrue(
-                integration.contains("HttpClient.post(url, Json.stringify(options))")
-                        && integration.contains("options.put(\"text\", message)"),
-                "a POST integration should forward the entity JSON as the request body");
+                integration.contains("HttpClient.post(url, Json.stringify(options))") && integration.contains("String body = message;")
+                        && integration.contains("options.put(\"text\", body)"),
+                "a POST integration without a declared payload should forward the entity JSON as the request body");
+
+        // A declared payload replaces that raw record with the envelope the intent spells out - every
+        // value form in one generated method, so a contract is expressible without a hand-written
+        // publisher (and adding an entity column no longer changes what the outside world receives).
+        String announce = contentOf("gen/events/orders/AnnounceOrderIntegration.java");
+        assertTrue(announce.contains("OrderEntity entity = Json.parse(message, OrderEntity.class)"),
+                "a payload-bearing integration should read the record the values resolve against");
+        assertTrue(
+                announce.contains(
+                        "CustomerEntity customer = entity.Customer == null ? null : new CustomerRepository().findById(entity.Customer)"),
+                "a one-hop value should load the related record once, exactly as a notification does");
+        assertTrue(announce.contains("payload.put(\"type\", \"order.placed\")") && announce.contains("payload.put(\"version\", 1)"),
+                "literals should land verbatim: " + announce);
+        assertTrue(
+                announce.contains("payload.put(\"messageId\", java.util.UUID.randomUUID().toString())")
+                        && announce.contains("payload.put(\"placedAt\", java.time.Instant.now().toString())")
+                        && announce.contains("payload.put(\"tenantId\", org.eclipse.dirigible.sdk.core.Tenant.getId())")
+                        && announce.contains("payload.put(\"placedBy\", org.eclipse.dirigible.sdk.security.User.getName())"),
+                "the four context tokens should each resolve to their run-time source");
+        assertTrue(announce.contains("payload.put(\"source\", Configurations.get(\"APP_ID\"))"),
+                "an @config: value should resolve through the configuration, as the URL does");
+        assertTrue(
+                announce.contains("payload.put(\"orderId\", entity.Id)")
+                        && announce.contains("payload.put(\"customer\", (customer == null ? null : customer.Name))"),
+                "a field and a one-hop relation.field should read the record and the loaded relation");
+        assertTrue(announce.contains("String body = Json.stringify(payload)") && announce.contains("options.put(\"text\", body)"),
+                "the declared payload, not the record, should be the request body");
+        assertTrue(
+                announce.indexOf("payload.put(\"type\"") < announce.indexOf("payload.put(\"version\"")
+                        && announce.indexOf("payload.put(\"version\"") < announce.indexOf("payload.put(\"messageId\""),
+                "the envelope should keep the order it was authored in");
 
         // The inbound webhook is a @Controller that ingests a posted JSON payload as the entity.
         String webhook = contentOf("gen/events/orders/IngestOrderWebhook.java");
@@ -2748,6 +2797,10 @@ class IntentEngineIT extends IntegrationTest {
                 && glue.contains("\"clientMethod\": \"post\""), "glue should carry the pushOrderToWarehouse integration as a POST");
         assertTrue(glue.contains("Configurations.get(\\\"WAREHOUSE_URL\\\")"),
                 "glue should carry the integration URL as a config lookup expression");
+        assertTrue(
+                glue.contains("\"name\": \"announceOrder\"") && glue.contains("\"hasPayload\": true")
+                        && glue.contains("\"key\": \"messageId\""),
+                "glue should carry the declared payload of the announceOrder integration");
         // Inbound: one per webhook, carrying the path + the entity to create.
         assertTrue(glue.contains("\"inbound\"") && glue.contains("\"name\": \"ingestOrder\"") && glue.contains("\"path\": \"/ingest\""),
                 "glue should carry the ingestOrder inbound webhook with its path");


### PR DESCRIPTION
Closes the `integrations:` half of #6768.

## The problem

Every outward-facing shape the intent could produce was "the whole record, as stored". That is only right when the receiver accepts the entity, and it costs something even then: every column becomes a public contract, so adding a field silently changes what the outside world receives. A real integration contract is usually an **envelope** — a type, a version, a minted idempotency key, a timestamp, the tenant — which no arrangement of entity columns can produce, so an application honouring one wrote the publisher by hand and the contract became invisible to the model.

## The construct

```yaml
integrations:
  - name: requestUserAssignment
    event: { onCreate: UserInvitation }
    method: POST
    url: "@config:ASSIGNMENT_URL"
    payload:
      type: "user.assignment.requested"     # literal
      version: 1
      messageId: "{uuid}"                   # minted per message
      tenantId: "{tenant}"                  # execution context
      appId: "@config:APP_ID"               # configuration
      email: email                          # a field of the record
      role: role.name                       # one hop off a to-one relation
      requestedAt: "{now}"
```

The generated handler reads the record, loads each referenced relation once, builds the map in the authored key order and posts `Json.stringify(payload)`.

**The vocabulary is `notify`'s, reused rather than rewritten.** The new `PayloadSupport` drives `NotificationSupport`'s own resolver, so a literal / a direct field / a one-hop `relation.field` mean exactly what they mean in a notify block, and the one-hop load is the same mechanism. `@config:KEY` reads the configuration, as `url:` already does. The context tokens are a closed set of four — `{uuid}`, `{now}`, `{tenant}`, `{user}`.

**The cap is the point**, so everything past it is a parse error rather than a run-time surprise: interpolated text (`"Order {id} placed"`), a nested object or list, a multi-hop path, an unknown token, and a payload on a method that carries no request body. Omitting `payload:` keeps today's behaviour byte for byte.

One authoring rule worth stating: a bare word naming no field and no to-one relation is a **literal** — the only way to carry a one-word constant, since YAML quoting does not survive the parse (it is also what makes `type: "user.assignment.requested"` in the issue's own example a literal and not a three-hop path). Brace it — `"{email}"` — when you mean a reference and want the parser to check it.

## Also here

`{tenant}` needed a client-facing accessor, so the SDK gains `org.eclipse.dirigible.sdk.core.Tenant` (id + name, falling back to the default tenant outside a scope) — readable from a message handler, where there is no request. The Intent Editor's glue card marks a payload-bearing integration, because "the declared envelope" and "the record as stored" are different promises and must not look the same on the diagram.

## Tests

- `PayloadSupportTest` — every value form, every token, and every refusal.
- `IntegrationPayloadIntentTest` — the parse-time half, including the transport rule.
- `GlueIntegrationPayloadTest` — the glue entries, their order, and the relation loads.
- `IntentEngineIT` — the outermost layer: the fixture gains a payload-bearing integration and the test asserts the **generated Java** (the record read, the one-hop `CustomerRepository().findById`, each token's run-time source, the authored key order, and that the declared payload — not the record — is the request body). 48/48 green locally.

## Scope

The `outbound:` half of #6768 waits on #6767; the vocabulary is designed once here so that construct and the arrival mapping (#6769) reuse it rather than inventing a second one.

## Docs

- IntentFile/intent-specification#31 (normative; left open for review)
- IntentFile/intentfile.github.io#26 (left open for review)
- dirigible-io/dirigible-io.github.io#192

🤖 Generated with [Claude Code](https://claude.com/claude-code)