### PR TITLE
fix(messaging): the client-Java listener path subscribes per tenant (#6765)

### DIFF
--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumer.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumer.java
@@ -12,7 +12,9 @@ package org.eclipse.dirigible.engine.java.listener;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -20,8 +22,10 @@ import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.components.base.tenant.DefaultTenant;
 import org.eclipse.dirigible.components.base.tenant.Tenant;
 import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.eclipse.dirigible.components.base.tenant.TenantPostProvisioningStep;
 import org.eclipse.dirigible.components.configurations.tenant.TenantConfigurationService;
 import org.eclipse.dirigible.components.listeners.config.ActiveMQConnectionArtifactsFactory;
+import org.eclipse.dirigible.components.listeners.service.DestinationNameManager;
 import org.eclipse.dirigible.components.listeners.service.TenantPropertyManager;
 import org.eclipse.dirigible.engine.java.component.ComponentContainer;
 import org.eclipse.dirigible.engine.java.spi.JavaClassConsumer;
@@ -56,10 +60,27 @@ import jakarta.jms.TextMessage;
  * </ul>
  * The bean is built (with constructor + field injection) by the {@link ComponentContainer}; this
  * consumer fetches it and opens a JMS connection per subscription, tearing them down on unload.
+ *
+ * <p>
+ * <b>One subscription per provisioned tenant.</b> A destination name a client class declares is
+ * logical; its physical name on the broker is tenant-scoped, exactly as the producer computes it at
+ * send time (see {@link DestinationNameManager} for the shared contract). Class loading, though,
+ * happens once per generation on a thread with no tenant of its own — so this consumer fans out
+ * explicitly over {@link TenantContext#executeForEachTenant}, the same way the sibling
+ * {@code ScheduledClassConsumer} registers a client-Java job per tenant. Without that fan-out the
+ * subscription sat on the unprefixed name while every non-default tenant published to a prefixed
+ * one, and nothing a generated application's glue layer subscribes to ever fired outside the
+ * default tenant.
+ *
+ * <p>
+ * Tenants also outlive a generation: this consumer is a {@link TenantPostProvisioningStep}, so a
+ * tenant provisioned after the last client-Java rebuild is topped up without disturbing the
+ * subscriptions already open. A tenant that goes away leaves its subscriptions behind until the
+ * next rebuild — inert, because nothing publishes to a removed tenant's destinations.
  */
 @Component
 @Order(500)
-public class ListenerClassConsumer implements JavaClassConsumer {
+public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvisioningStep {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ListenerClassConsumer.class);
 
@@ -69,20 +90,22 @@ public class ListenerClassConsumer implements JavaClassConsumer {
     private final TenantPropertyManager tenantPropertyManager;
     private final Tenant defaultTenant;
     private final TenantConfigurationService tenantConfigurationService;
+    private final DestinationNameManager destinationNameManager;
 
-    /** fqn → open JMS Connections (one per subscription) for teardown. */
-    private final ConcurrentMap<String, List<Connection>> connections = new ConcurrentHashMap<>();
+    /** fqn → what the loaded class declared, and the connections open for it per tenant. */
+    private final ConcurrentMap<String, Registration> registrations = new ConcurrentHashMap<>();
 
     @Autowired
     public ListenerClassConsumer(ComponentContainer componentContainer, ActiveMQConnectionArtifactsFactory connectionFactory,
             TenantContext tenantContext, TenantPropertyManager tenantPropertyManager, @DefaultTenant Tenant defaultTenant,
-            TenantConfigurationService tenantConfigurationService) {
+            TenantConfigurationService tenantConfigurationService, DestinationNameManager destinationNameManager) {
         this.componentContainer = componentContainer;
         this.connectionFactory = connectionFactory;
         this.tenantContext = tenantContext;
         this.tenantPropertyManager = tenantPropertyManager;
         this.defaultTenant = defaultTenant;
         this.tenantConfigurationService = tenantConfigurationService;
+        this.destinationNameManager = destinationNameManager;
     }
 
     @Override
@@ -109,12 +132,11 @@ public class ListenerClassConsumer implements JavaClassConsumer {
             return;
         }
 
-        stopExisting(info.fqn());
-        List<Connection> opened = new ArrayList<>();
+        List<Subscription> subscriptions = new ArrayList<>();
 
         if (messageHandler) {
             MessageHandler handler = (MessageHandler) instance;
-            subscribe(opened, handler.destination(), handler.kind(), new TypedDispatcher(handler), info.fqn());
+            subscriptions.add(new Subscription(handler.destination(), handler.kind(), new TypedDispatcher(handler), info.fqn()));
         } else {
             for (Method method : type.getDeclaredMethods()) {
                 Listener annotation = method.getAnnotation(Listener.class);
@@ -128,15 +150,16 @@ public class ListenerClassConsumer implements JavaClassConsumer {
                 }
                 method.setAccessible(true);
                 String label = info.fqn() + "#" + method.getName();
-                subscribe(opened, annotation.name(), annotation.kind(), new MethodDispatcher(instance, method), label);
+                subscriptions.add(new Subscription(annotation.name(), annotation.kind(), new MethodDispatcher(instance, method), label));
             }
         }
 
-        if (opened.isEmpty()) {
+        if (subscriptions.isEmpty()) {
+            stopExisting(info.fqn());
             LOGGER.warn("Listener [{}] produced no subscription.", info.fqn());
             return;
         }
-        connections.put(info.fqn(), opened);
+        register(info.fqn(), subscriptions);
     }
 
     @Override
@@ -145,31 +168,101 @@ public class ListenerClassConsumer implements JavaClassConsumer {
         LOGGER.info("Java @Listener [{}] disconnected.", info.fqn());
     }
 
-    private void subscribe(List<Connection> opened, String destinationName, ListenerKind kind, Dispatcher dispatcher, String label) {
+    /**
+     * Top up the tenants that have no subscription yet for the classes already loaded. Called once a
+     * tenant provisioning round completes: the client-Java generation is JVM-wide and is only rebuilt
+     * on publish, so a tenant created afterwards would otherwise stay unsubscribed until the next
+     * rebuild.
+     */
+    @Override
+    public void execute() {
+        registrations.forEach(this::subscribeMissingTenants);
+    }
+
+    /** Replace whatever this class had subscribed with the subscriptions it declares now. */
+    private synchronized void register(String fqn, List<Subscription> subscriptions) {
+        stopExisting(fqn);
+        Registration registration = new Registration(subscriptions);
+        registrations.put(fqn, registration);
+        subscribeMissingTenants(fqn, registration);
+    }
+
+    /**
+     * Open this class's subscriptions in every provisioned tenant that does not have them yet. Additive
+     * on purpose — an already-subscribed tenant is left alone, so topping up after a provisioning round
+     * never drops a message in flight.
+     */
+    private synchronized void subscribeMissingTenants(String fqn, Registration registration) {
+        try {
+            tenantContext.executeForEachTenant(() -> {
+                String tenantId = tenantContext.getCurrentTenant()
+                                               .getId();
+                if (registration.isSubscribed(tenantId)) {
+                    return null;
+                }
+                List<Connection> opened = new ArrayList<>();
+                boolean complete = true;
+                for (Subscription subscription : registration.subscriptions()) {
+                    Connection connection = subscribe(subscription, tenantId);
+                    if (connection == null) {
+                        complete = false;
+                    } else {
+                        opened.add(connection);
+                    }
+                }
+                if (complete) {
+                    registration.subscribed(tenantId, opened);
+                } else {
+                    // All or nothing per tenant: leave the tenant unrecorded so the next load or
+                    // provisioning round retries it cleanly, and close what did open so that retry
+                    // cannot end up with two consumers competing on the same destination.
+                    closeAll(fqn, opened);
+                }
+                return null;
+            });
+        } catch (Exception e) {
+            LOGGER.error("Failed to subscribe listener [{}] for the provisioned tenants: {}", fqn, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Open one subscription. Runs inside the target tenant's context, so the physical destination is
+     * the very name a producer in that tenant computes for the same logical one.
+     *
+     * @return the connection it opened, or {@code null} if the broker refused the subscription
+     */
+    private Connection subscribe(Subscription subscription, String tenantId) {
+        String label = subscription.label();
+        String destinationName = destinationNameManager.toTenantName(subscription.destination());
         try {
             Connection connection = connectionFactory.createConnection(
                     ex -> LOGGER.error("[java-listener] JMS error for [{}]: {}", label, ex.getMessage(), ex));
             Session session = connectionFactory.createSession(connection);
             Destination destination =
-                    kind == ListenerKind.TOPIC ? session.createTopic(destinationName) : session.createQueue(destinationName);
+                    subscription.kind() == ListenerKind.TOPIC ? session.createTopic(destinationName) : session.createQueue(destinationName);
             MessageConsumer consumer = session.createConsumer(destination);
-            consumer.setMessageListener(msg -> dispatch(msg, dispatcher, label));
-            opened.add(connection);
-            LOGGER.info("Java @Listener [{}] connected to {} '{}'.", label, kind, destinationName);
+            consumer.setMessageListener(msg -> dispatch(msg, subscription.dispatcher(), label));
+            LOGGER.info("Java @Listener [{}] connected to {} '{}' for tenant [{}].", label, subscription.kind(), destinationName, tenantId);
+            return connection;
         } catch (JMSException e) {
-            LOGGER.error("Failed to start listener for [{}]: {}", label, e.getMessage(), e);
+            LOGGER.error("Failed to start listener for [{}] in tenant [{}]: {}", label, tenantId, e.getMessage(), e);
+            return null;
         }
     }
 
-    private void stopExisting(String fqn) {
-        List<Connection> old = connections.remove(fqn);
+    private synchronized void stopExisting(String fqn) {
+        Registration old = registrations.remove(fqn);
         if (old != null) {
-            for (Connection connection : old) {
-                try {
-                    connection.close();
-                } catch (JMSException e) {
-                    LOGGER.warn("Failed to close JMS connection for [{}]: {}", fqn, e.getMessage(), e);
-                }
+            closeAll(fqn, old.openConnections());
+        }
+    }
+
+    private static void closeAll(String fqn, List<Connection> connections) {
+        for (Connection connection : connections) {
+            try {
+                connection.close();
+            } catch (JMSException e) {
+                LOGGER.warn("Failed to close JMS connection for [{}]: {}", fqn, e.getMessage(), e);
             }
         }
     }
@@ -233,6 +326,45 @@ public class ListenerClassConsumer implements JavaClassConsumer {
         } catch (Exception e) {
             Throwable cause = e.getCause() != null ? e.getCause() : e;
             dispatcher.onError(cause.getMessage(), label);
+        }
+    }
+
+    /**
+     * One subscription a loaded class asks for: the <em>logical</em> destination, its kind, and how a
+     * message on it is dispatched. Tenant-independent — the same spec is opened once per tenant.
+     */
+    private record Subscription(String destination, ListenerKind kind, Dispatcher dispatcher, String label) {
+    }
+
+    /** What one loaded class declared, plus the connections open for it in each tenant. */
+    private static final class Registration {
+
+        private final List<Subscription> subscriptions;
+
+        /** tenant id → the JMS connections open for this class in that tenant. */
+        private final Map<String, List<Connection>> connectionsByTenant = new HashMap<>();
+
+        Registration(List<Subscription> subscriptions) {
+            this.subscriptions = List.copyOf(subscriptions);
+        }
+
+        List<Subscription> subscriptions() {
+            return subscriptions;
+        }
+
+        boolean isSubscribed(String tenantId) {
+            return connectionsByTenant.containsKey(tenantId);
+        }
+
+        void subscribed(String tenantId, List<Connection> connections) {
+            connectionsByTenant.put(tenantId, connections);
+        }
+
+        List<Connection> openConnections() {
+            List<Connection> all = new ArrayList<>();
+            connectionsByTenant.values()
+                               .forEach(all::addAll);
+            return all;
         }
     }
 

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumerTenantSubscriptionTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumerTenantSubscriptionTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.java.listener;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.dirigible.components.base.callable.CallableResultAndException;
+import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.eclipse.dirigible.components.configurations.tenant.TenantConfigurationService;
+import org.eclipse.dirigible.components.listeners.config.ActiveMQConnectionArtifactsFactory;
+import org.eclipse.dirigible.components.listeners.service.DestinationNameManager;
+import org.eclipse.dirigible.components.listeners.service.TenantPropertyManager;
+import org.eclipse.dirigible.engine.java.component.ComponentContainer;
+import org.eclipse.dirigible.engine.java.spi.LoadedClass;
+import org.eclipse.dirigible.sdk.messaging.MessageHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.jms.Connection;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.Queue;
+import jakarta.jms.Session;
+
+/**
+ * A client-Java listener must subscribe to the SAME physical destination the producer publishes to.
+ * The producer prefixes a non-default tenant's destination name; this consumer used to subscribe to
+ * the raw name once, JVM-wide, so a generated application's whole glue layer — triggers,
+ * notifications, roll-ups, transitions — was silently dead in every non-default tenant while
+ * looking perfectly healthy on the default one.
+ */
+class ListenerClassConsumerTenantSubscriptionTest {
+
+    /** A typed listener on a queue, so the assertions can read {@code createQueue} arguments. */
+    static class OrdersHandler implements MessageHandler {
+
+        @Override
+        public String destination() {
+            return "orders";
+        }
+
+        @Override
+        public void onMessage(String message) {
+            // The subscription, not the dispatch, is what this test is about.
+        }
+    }
+
+    private static final String DEFAULT_TENANT_ID = "default-tenant";
+
+    /** The tenants {@code executeForEachTenant} fans out over; mutable, so a test can add one. */
+    private final Map<String, Tenant> provisionedTenants = new LinkedHashMap<>();
+
+    /** The tenant whose context the fan-out is currently simulating. */
+    private final AtomicReference<String> currentTenantId = new AtomicReference<>();
+
+    private Session session;
+    private ListenerClassConsumer consumer;
+
+    @BeforeEach
+    @SuppressWarnings("rawtypes")
+    void setUp() throws Exception {
+        addTenant(DEFAULT_TENANT_ID);
+        addTenant("acme");
+
+        ComponentContainer componentContainer = mock(ComponentContainer.class);
+        when(componentContainer.instanceOf(OrdersHandler.class)).thenReturn(Optional.of(new OrdersHandler()));
+
+        ActiveMQConnectionArtifactsFactory connectionFactory = mock(ActiveMQConnectionArtifactsFactory.class);
+        Connection connection = mock(Connection.class);
+        session = mock(Session.class);
+        when(connectionFactory.createConnection(any())).thenReturn(connection);
+        when(connectionFactory.createSession(connection)).thenReturn(session);
+        when(session.createQueue(anyString())).thenReturn(mock(Queue.class));
+        when(session.createConsumer(any())).thenReturn(mock(MessageConsumer.class));
+
+        TenantContext tenantContext = mock(TenantContext.class);
+        when(tenantContext.getCurrentTenant()).thenAnswer(invocation -> provisionedTenants.get(currentTenantId.get()));
+        // Run the callable once per provisioned tenant, inline, with that tenant current — the contract
+        // the real TenantContext offers and the sibling ScheduledClassConsumerTest relies on too.
+        when(tenantContext.executeForEachTenant(any())).thenAnswer(invocation -> {
+            for (String tenantId : new ArrayList<>(provisionedTenants.keySet())) {
+                currentTenantId.set(tenantId);
+                ((CallableResultAndException) invocation.getArgument(0)).call();
+            }
+            currentTenantId.set(null);
+            return List.of();
+        });
+
+        // Stands in for the real rule: the default tenant keeps the logical name, everyone else is
+        // prefixed. DestinationNameManagerTest owns that rule; here it only has to be applied.
+        DestinationNameManager destinationNameManager = mock(DestinationNameManager.class);
+        when(destinationNameManager.toTenantName(anyString())).thenAnswer(invocation -> {
+            String logicalName = invocation.getArgument(0);
+            String tenantId = currentTenantId.get();
+            return DEFAULT_TENANT_ID.equals(tenantId) ? logicalName : tenantId + "###" + logicalName;
+        });
+
+        TenantConfigurationService tenantConfigurationService = mock(TenantConfigurationService.class);
+        when(tenantConfigurationService.resolveInjectableForCurrentTenant()).thenReturn(new HashMap<>());
+
+        consumer = new ListenerClassConsumer(componentContainer, connectionFactory, tenantContext, mock(TenantPropertyManager.class),
+                mock(Tenant.class), tenantConfigurationService, destinationNameManager);
+    }
+
+    @Test
+    void aLoadedListenerSubscribesInEveryProvisionedTenantUnderThatTenantsDestinationName() throws Exception {
+        loadListener();
+
+        verify(session).createQueue("orders");
+        verify(session).createQueue("acme###orders");
+    }
+
+    @Test
+    void aTenantProvisionedAfterTheClassWasLoadedIsSubscribedByThePostProvisioningStep() throws Exception {
+        loadListener();
+
+        addTenant("beta");
+        consumer.execute();
+
+        verify(session).createQueue("beta###orders");
+    }
+
+    @Test
+    void toppingUpDoesNotReSubscribeATenantThatIsAlreadyConnected() throws Exception {
+        loadListener();
+
+        consumer.execute();
+
+        // Re-subscribing would close nothing and duplicate everything: two consumers on one queue in
+        // the same tenant means a message reaches the handler once at random and the other consumer
+        // competes for the next one.
+        verify(session, times(1)).createQueue("orders");
+        verify(session, times(1)).createQueue("acme###orders");
+    }
+
+    private void addTenant(String tenantId) {
+        Tenant tenant = mock(Tenant.class);
+        when(tenant.getId()).thenReturn(tenantId);
+        when(tenant.isDefault()).thenReturn(DEFAULT_TENANT_ID.equals(tenantId));
+        provisionedTenants.put(tenantId, tenant);
+    }
+
+    private void loadListener() {
+        consumer.onClassLoaded(
+                new LoadedClass("sample", OrdersHandler.class.getName(), OrdersHandler.class, OrdersHandler.class.getClassLoader()));
+    }
+}

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumerTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -26,6 +27,7 @@ import org.eclipse.dirigible.components.base.tenant.Tenant;
 import org.eclipse.dirigible.components.base.tenant.TenantContext;
 import org.eclipse.dirigible.components.configurations.tenant.TenantConfigurationService;
 import org.eclipse.dirigible.components.listeners.config.ActiveMQConnectionArtifactsFactory;
+import org.eclipse.dirigible.components.listeners.service.DestinationNameManager;
 import org.eclipse.dirigible.components.listeners.service.TenantPropertyManager;
 import org.eclipse.dirigible.engine.java.component.ComponentContainer;
 import org.eclipse.dirigible.engine.java.spi.LoadedClass;
@@ -97,9 +99,20 @@ class ListenerClassConsumerTest {
         // ScheduledClassConsumerTest relies on for TenantContext.executeForEachTenant.
         when(tenantContext.execute(any(String.class), any())).thenAnswer(
                 invocation -> ((CallableResultAndException) invocation.getArgument(1)).call());
+        // The subscription fan-out: one (default) tenant is all this test needs, so the logical name
+        // is also the physical one. ListenerClassConsumerTenantSubscriptionTest covers the fan-out.
+        Tenant currentTenant = mock(Tenant.class);
+        when(currentTenant.getId()).thenReturn("default-tenant");
+        when(tenantContext.getCurrentTenant()).thenReturn(currentTenant);
+        when(tenantContext.executeForEachTenant(any())).thenAnswer(invocation -> {
+            ((CallableResultAndException) invocation.getArgument(0)).call();
+            return List.of();
+        });
+        DestinationNameManager destinationNameManager = mock(DestinationNameManager.class);
+        when(destinationNameManager.toTenantName("notifications")).thenReturn("notifications");
 
         ListenerClassConsumer listenerConsumer = new ListenerClassConsumer(componentContainer, connectionFactory, tenantContext,
-                tenantPropertyManager, defaultTenant, tenantConfigurationService);
+                tenantPropertyManager, defaultTenant, tenantConfigurationService, destinationNameManager);
         listenerConsumer.onClassLoaded(new LoadedClass("sample", RecordingHandler.class.getName(), RecordingHandler.class,
                 RecordingHandler.class.getClassLoader()));
 

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/DestinationNameManager.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/DestinationNameManager.java
@@ -16,10 +16,38 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /**
- * The Class DestinationNameManager.
+ * The single owner of the physical JMS destination name — and therefore the home of the contract
+ * that every messaging call site shares.
+ *
+ * <p>
+ * A destination name that a project authors — a {@code .listener} artefact's name, a client-Java
+ * {@code MessageHandler.destination()}, the argument to {@code Producer.sendToTopic} — is
+ * <em>logical</em>. Its physical name on the broker is always tenant-scoped:
+ * {@code <tenantId>###<name>} outside the default tenant, and the bare name inside it, so a
+ * single-tenant deployment never sees a prefix at all. Three consequences, which only work if all
+ * sides hold them together:
+ * <ul>
+ * <li>a <b>producer</b> resolves the name from the tenant that is current at send time —
+ * {@link MessageProducer};</li>
+ * <li>a <b>synchronous consumer</b> resolves it the same way, so it can only ever draw its own
+ * tenant's messages — {@link MessageConsumer};</li>
+ * <li>a <b>subscriber</b> is not bound to a single tenant, so it opens <b>one subscription per
+ * provisioned tenant</b>. The {@code .listener} path gets that for free from its multitenant
+ * synchronizer ({@link ListenerCreator} is called once per tenant); the client-Java
+ * {@code MessageHandler} / {@code @Listener} path, whose class loading happens off any tenant
+ * thread, fans out explicitly ({@code ListenerClassConsumer} in {@code engine-java}).</li>
+ * </ul>
+ *
+ * <p>
+ * The {@code tenant_id} message property ({@link TenantPropertyManager}) remains the authority for
+ * <em>dispatch</em>: it is what re-establishes the tenant context on the broker thread, and it also
+ * covers a message that was published with no tenant scope at all. It does not replace the prefix —
+ * the prefix is what keeps one tenant's messages out of another tenant's consumers in the first
+ * place, which the property alone cannot do for a queue (competing consumers) or for a synchronous
+ * receive.
  */
 @Component
-class DestinationNameManager {
+public class DestinationNameManager {
 
     /** The Constant LOGGER. */
     private static final Logger LOGGER = LoggerFactory.getLogger(DestinationNameManager.class);
@@ -37,12 +65,14 @@ class DestinationNameManager {
     }
 
     /**
-     * To tenant name.
+     * The physical destination name for a logical one, scoped to the tenant that is current on this
+     * thread. Outside any tenant context (a platform thread that never entered one) the name is
+     * returned unchanged.
      *
-     * @param destinationName the destination name
-     * @return the string
+     * @param destinationName the logical destination name
+     * @return the physical destination name to create on the broker
      */
-    String toTenantName(String destinationName) {
+    public String toTenantName(String destinationName) {
         if (tenantContext.isNotInitialized()) {
             LOGGER.debug("Tenant context is NOT initialized. Will return destination name as it is. Destination name [{}]",
                     destinationName);

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenerCreator.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenerCreator.java
@@ -13,7 +13,10 @@ import org.eclipse.dirigible.components.listeners.domain.ListenerKind;
 import org.springframework.stereotype.Component;
 
 /**
- * The Class ListenerCreator.
+ * Turns a {@code .listener} artefact into the descriptor its subscription is started from. Called
+ * from the multitenant listener synchronizer, i.e. once per provisioned tenant, which is how this
+ * path satisfies the "one subscription per tenant" half of the contract documented on
+ * {@link DestinationNameManager}.
  */
 @Component
 class ListenerCreator {

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/MessageConsumer.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/MessageConsumer.java
@@ -19,7 +19,10 @@ import org.springframework.stereotype.Component;
 import java.lang.IllegalStateException;
 
 /**
- * The Class MessageConsumer.
+ * Draws a single message synchronously from a queue or a topic. The physical destination is
+ * resolved from the tenant that is current on the calling thread, so a caller can only ever receive
+ * its own tenant's messages — see {@link DestinationNameManager} for the naming contract this
+ * shares with {@link MessageProducer} and with the subscribing sides.
  */
 @Component
 public class MessageConsumer {

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/MessageProducer.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/MessageProducer.java
@@ -17,7 +17,10 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /**
- * The Class MessageProducer.
+ * Sends a message to a queue or a topic, resolving the physical destination from the tenant that is
+ * current at send time and stamping that tenant onto the message. See
+ * {@link DestinationNameManager} for the destination-naming contract this shares with
+ * {@link MessageConsumer} and with the subscribing sides.
  */
 @Component
 public class MessageProducer {

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/DestinationNameManagerTest.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/DestinationNameManagerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.listeners.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The physical-name rule that every messaging call site depends on. It had no direct test, which is
+ * how the client-Java subscriber came to bypass it altogether while the producer applied it.
+ */
+class DestinationNameManagerTest {
+
+    private static final String LOGICAL_NAME = "orders";
+
+    @Test
+    void outsideAnyTenantContextTheNameIsUnchanged() {
+        TenantContext tenantContext = mock(TenantContext.class);
+        when(tenantContext.isNotInitialized()).thenReturn(true);
+
+        assertEquals(LOGICAL_NAME, new DestinationNameManager(tenantContext).toTenantName(LOGICAL_NAME));
+    }
+
+    @Test
+    void theDefaultTenantIsNotPrefixed() {
+        assertEquals(LOGICAL_NAME, toTenantName("default-tenant", true),
+                "a single-tenant deployment must see the logical name on the broker");
+    }
+
+    @Test
+    void anyOtherTenantIsPrefixedWithItsId() {
+        assertEquals("acme###" + LOGICAL_NAME, toTenantName("acme", false));
+    }
+
+    private static String toTenantName(String tenantId, boolean defaultTenant) {
+        Tenant tenant = mock(Tenant.class);
+        when(tenant.isDefault()).thenReturn(defaultTenant);
+        if (!defaultTenant) {
+            when(tenant.getId()).thenReturn(tenantId);
+        }
+        TenantContext tenantContext = mock(TenantContext.class);
+        when(tenantContext.getCurrentTenant()).thenReturn(tenant);
+
+        return new DestinationNameManager(tenantContext).toTenantName(LOGICAL_NAME);
+    }
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaListenerTenantIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaListenerTenantIT.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.eclipse.dirigible.components.api.messaging.MessagingFacade;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.tenant.DirigibleTestTenant;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
+/**
+ * The producer and the client-Java subscriber must meet on the same physical destination in a
+ * NON-DEFAULT tenant.
+ *
+ * <p>
+ * This is the symmetry the whole glue layer of a generated intent application rests on: the
+ * generated repository publishes through {@code Producer.sendToTopic}, and every process trigger,
+ * notification, roll-up, transition and posting subscribes on the client-Java
+ * {@code MessageHandler} / {@code @Listener} path. The producer resolves a tenant-prefixed
+ * destination per call while the subscriber used to bind the raw name once for the whole JVM, so
+ * outside the default tenant the two never met and no reaction ever fired — invisible in
+ * single-tenant deployments, in ordinary development, and in every other IT, all of which run on
+ * the default tenant.
+ *
+ * <p>
+ * Both phases round-trip a real message: a client listener on a topic echoes onto a queue, and the
+ * test draws that echo back inside the tenant's context. Both legs go through the platform's own
+ * naming, so neither would pass on a prefix that the producer and the consumer merely agreed to
+ * spell the same wrong way. They differ only in the order of the two events whose interleaving is
+ * the actual hazard — a tenant appearing before the class is loaded, and a tenant appearing after —
+ * and they run in that order against one shared tenant, because provisioning a tenant is by far the
+ * most expensive thing here.
+ */
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class JavaListenerTenantIT extends IntegrationTest {
+
+    private static final String PROJECT = "java-listener-tenant-it";
+
+    /** The tenant both phases use; provisioned by the first one that needs it. */
+    private static DirigibleTestTenant tenant;
+
+    /** How long a round trip may take, covering the compile + subscribe lag after a forced sync. */
+    private static final int ROUND_TRIP_TIMEOUT_SECONDS = 90;
+
+    /** Per attempt — short, because a failed attempt is retried with a fresh publish. */
+    private static final long RECEIVE_TIMEOUT_MILLIS = 2000;
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    @Autowired
+    private TenantContext tenantContext;
+
+    @Autowired
+    private Scheduler scheduler;
+
+    @Test
+    @Order(1)
+    void aTenantProvisionedAfterTheClassWasLoadedGetsSubscribedToo() throws SchedulerException {
+        // The class is loaded while only the default tenant exists...
+        publishEcho("OnProvision", "on-provision");
+
+        // ...and the tenant appears afterwards. A client-Java generation is JVM-wide and is only
+        // rebuilt on publish, so nothing re-runs the load-time fan-out here — only the
+        // post-provisioning top-up can make this round trip succeed.
+        provisionTenant();
+
+        assertRoundTrip("on-provision");
+    }
+
+    @Test
+    @Order(2)
+    void aMessagePublishedInANonDefaultTenantReachesItsClientJavaListener() throws SchedulerException {
+        // Reverse order: the tenant is already there when the class is loaded, so this is the
+        // load-time fan-out's job.
+        provisionTenant();
+
+        publishEcho("OnLoad", "on-load");
+
+        assertRoundTrip("on-load");
+    }
+
+    /**
+     * Provision the shared tenant, once per class.
+     *
+     * <p>
+     * The provisioning job is triggered explicitly rather than waited for: its schedule is
+     * {@code DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS} wide (15 minutes by default) and the
+     * only prompt firing is the one at startup, so a test that merely waited would be racing that boot
+     * firing — which is exactly how a second tenant in the same class silently timed out.
+     */
+    private void provisionTenant() throws SchedulerException {
+        if (tenant != null) {
+            return;
+        }
+        DirigibleTestTenant created = new DirigibleTestTenant("java-listener-tenant-it");
+        createTenants(created);
+        scheduler.triggerJob(JobKey.jobKey("TenantsProvisioningJob", "system"));
+        waitForTenantProvisioning(created);
+        tenant = created;
+    }
+
+    /**
+     * Publish into the tenant's topic and draw the listener's echo back off its queue, retrying the
+     * whole exchange: a topic does not retain messages, so a send that lands before the subscription is
+     * open is simply lost and has to be repeated.
+     */
+    private void assertRoundTrip(String destinationSuffix) {
+        String topic = PROJECT + "-in-" + destinationSuffix;
+        String queue = PROJECT + "-out-" + destinationSuffix;
+        String message = "ping-" + destinationSuffix;
+
+        String[] received = new String[1];
+        Awaitility.await()
+                  .pollInterval(1, TimeUnit.SECONDS)
+                  .atMost(ROUND_TRIP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                  .until(() -> tenantContext.execute(tenant.getId(), () -> {
+                      MessagingFacade.sendToTopic(topic, message);
+                      try {
+                          received[0] = MessagingFacade.receiveFromQueue(queue, RECEIVE_TIMEOUT_MILLIS);
+                          return true;
+                      } catch (RuntimeException notYet) {
+                          return false;
+                      }
+                  }));
+
+        assertEquals("echo:" + message, received[0],
+                "the listener must receive what a producer in the same tenant published, and its own publish must come back to that tenant");
+    }
+
+    /** Write a client listener source into the registry and reconcile it. */
+    private void publishEcho(String className, String destinationSuffix) {
+        String source = """
+                package demo;
+
+                import org.eclipse.dirigible.sdk.component.Component;
+                import org.eclipse.dirigible.sdk.messaging.ListenerKind;
+                import org.eclipse.dirigible.sdk.messaging.MessageHandler;
+                import org.eclipse.dirigible.sdk.messaging.Producer;
+
+                @Component
+                public class %s implements MessageHandler {
+
+                    @Override
+                    public String destination() {
+                        return "%s-in-%s";
+                    }
+
+                    @Override
+                    public ListenerKind kind() {
+                        return ListenerKind.TOPIC;
+                    }
+
+                    @Override
+                    public void onMessage(String message) {
+                        Producer.sendToQueue("%s-out-%s", "echo:" + message);
+                    }
+                }
+                """.formatted(className, PROJECT, destinationSuffix, PROJECT, destinationSuffix);
+
+        repository.createResource(sourcePath(className), source.getBytes(StandardCharsets.UTF_8), false, "text/x-java", true);
+        synchronizationProcessor.forceProcessSynchronizers();
+    }
+
+    private static String sourcePath(String className) {
+        return IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/demo/" + className + ".java";
+    }
+}


### PR DESCRIPTION
Closes #6765.

## 1. Reproduced first — and it is the worse of the two outcomes

Confirmed at runtime against unmodified `master`, not only read in the code. The new IT's two phases both error with `ConditionTimeoutException`: the glue never fires. The subscription line from that run says it all:

```
Java @Listener [demo.OnProvision] connected to TOPIC 'java-listener-tenant-it-in-on-provision'
```

One subscription, raw name, no tenant — while `MessageProducer` in a non-default tenant publishes to `<tenantId>###java-listener-tenant-it-in-on-provision`. So: **the generated glue layer is silently dead for every non-default tenant.** Triggers, notifications, roll-ups, aggregates, waits, transitions, posts, and the inbound consumers from #6743 all subscribe on this path, and the generated repository publishes through `Producer`. On the default tenant `toTenantName` is the identity, which is why development, single-tenant deployments and the whole IT suite never saw it.

With the fix, the same run produces one subscription per tenant, and the top-up lands exactly inside post-provisioning:

```
1362  [demo.OnProvision] connected to TOPIC 'java-listener-tenant-it-in-on-provision' for tenant [default-tenant]
1385  Tenant [...] has been provisioned successfully
1386  Starting post provisioning process...
1387  [demo.OnProvision] connected to TOPIC '<tenant>###java-listener-tenant-it-in-on-provision' for tenant [<tenant>]
```

Both phases pass in 29s, against 184s of timeouts before.

## 2. Which of the two designs, and why not the other one

The issue offered per-tenant subscription or a tenant-neutral destination scoped by the `tenant_id` property, and leaned to the second as cheaper. **I went with the first**, because the second is unsafe in a way that is not visible from the listener path alone.

The `tenant_id` property re-establishes the tenant for an *async dispatch*, so it is sufficient there. But the same logical names are also resolved by `MessageConsumer.receiveMessageFromQueue` — the SDK `Consumer.receiveFromQueue`. A **synchronous** receive has no dispatch to scope: on a neutral destination, tenant A's code would draw tenant B's message straight into tenant A's request. Same hazard for a queue with competing consumers. That trades a dead glue layer for a cross-tenant leak, so the prefix has to stay and the subscriber has to meet it.

It is also the convention already: **`ScheduledClassConsumer`, the sibling consumer in the same module, already registers client-Java jobs per tenant** via `executeForEachTenant`, with a comment giving this exact reasoning. Listeners were the odd one out, not the precedent.

## 3. The change

- **`ListenerClassConsumer` subscribes once per provisioned tenant**, fanning out over `TenantContext#executeForEachTenant` and resolving each destination through `DestinationNameManager` *inside* that tenant's context — so the physical name is literally the one a producer in that tenant computes. Per-fqn bookkeeping moves from `fqn → List<Connection>` to `fqn → Registration` (declared subscriptions + connections per tenant). All-or-nothing per tenant: a tenant whose subscriptions did not all open is left unrecorded and its partial connections closed, so a retry cannot end up with two consumers competing on one destination.
- **Tenants outlive a generation.** A client-Java generation is JVM-wide and only rebuilt on publish (`JavaSynchronizer.finishing()` is `dirty`-gated), so the consumer is now also a `TenantPostProvisioningStep`: a tenant provisioned later is topped up **additively**, leaving open subscriptions untouched. A removed tenant leaves inert subscriptions until the next rebuild — documented, since nothing publishes to a gone tenant's destinations.
- **One contract, documented once.** `DestinationNameManager` (now `public`, as `engine-java` resolves through it) carries it: authored names are logical, the physical name is tenant-scoped, a producer resolves it at send time, a synchronous consumer the same way, and a subscriber opens one per tenant — with the `tenant_id` property named as the authority for *dispatch* and explicitly **not** a substitute for the prefix. `MessageProducer`, `MessageConsumer` and `ListenerCreator` each point at it.

## 4. Tests

- `DestinationNameManagerTest` — the prefixing rule had **no direct test at all**, which is how a third call site came to bypass it.
- `ListenerClassConsumerTenantSubscriptionTest` — per-tenant fan-out onto the prefixed name, the post-provisioning top-up subscribing a late tenant, and that topping up does **not** double-subscribe an already-connected one.
- `JavaListenerTenantIT` — the missing symmetry test: a real producer/consumer round trip on the client-Java path under a non-default tenant. A client listener on a topic echoes onto a queue and the test draws that echo back inside the tenant's context, so both legs go through the platform's own naming; neither would pass on a prefix the two sides merely agreed to spell the same wrong way. Two ordered phases cover both interleavings (tenant before the class load, tenant after).

Verified: unit tests for both modules, the `release` profile javadoc build on both (no `error:`), and repo-wide `formatter:validate`.

## Notes for follow-ups

- **The `global:` marker** mentioned in the issue is now a one-line addition per site: all three resolve names through `DestinationNameManager`, so a marker only has to suppress the prefix there and switch the subscriber from per-tenant to single.
- **Client-Java jobs have the same late-tenant blind spot** this PR closes for listeners: `ScheduledClassConsumer` fans out at class-load time only, and `JavaSynchronizer` is not multitenant, so a tenant provisioned after the last publish gets no client-Java job rows until the next rebuild. Not touched here.
- **`IntegrationTest.waitForTenantProvisioning` is a race, not a wait**, and this is worth its own issue. `DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS` defaults to **900** and the only prompt firing is the one at boot, while the helper caps at 35s — so a tenant created after that firing can only be provisioned 15 minutes later. It passes today because the ITs that use it provision at most one tenant per class and happen to win the race; a second tenant in one class times out silently. The new IT triggers `TenantsProvisioningJob` explicitly instead of racing it. The shared helper is left alone deliberately (downstream editions reuse it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
