### PR TITLE
Dependency resolver component and 'maven' dependency type in project.json

### DIFF
--- a/build/application/Dockerfile
+++ b/build/application/Dockerfile
@@ -31,11 +31,15 @@ COPY target/dirigible-application-*-executable.jar dirigible.jar
 # META-INF/dirigible/<project>/.compiled marker and its registry payload). A downstream image COPYs
 # such jars here, or they are mounted at run time - the platform jar is consumed verbatim. Empty or
 # missing /modules is a no-op. Set LOADER_PATH to use other locations (comma-separated).
-RUN mkdir -p /modules
+#
+# /root/.dirigible/resolved-modules is where the platform links the maven dependencies declared in
+# project.json files (see DIRIGIBLE_DEPENDENCIES_DIR) - resolved at boot or on demand, they join
+# the classpath on the NEXT restart. Mount /root/.dirigible on a volume to keep them across runs.
+RUN mkdir -p /modules /root/.dirigible/resolved-modules
 
 # PropertiesLauncher (instead of the default JarLauncher) is what makes -Dloader.path work; it reads
 # the Start-Class from /dirigible.jar's manifest, so the application boots exactly as with -jar.
-ENTRYPOINT ["java", "--add-opens", "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED", "--add-opens", "java.base/java.nio=ALL-UNNAMED", "-cp", "/dirigible.jar", "-Dloader.path=/modules", "org.springframework.boot.loader.launch.PropertiesLauncher"]
+ENTRYPOINT ["java", "--add-opens", "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED", "--add-opens", "java.base/java.nio=ALL-UNNAMED", "-cp", "/dirigible.jar", "-Dloader.path=/modules,/root/.dirigible/resolved-modules", "org.springframework.boot.loader.launch.PropertiesLauncher"]
 
 # 8080 for the spring boot application,
 # 8081 for graalium debug port

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/ApplicationListenersOrder.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/ApplicationListenersOrder.java
@@ -39,6 +39,11 @@ public interface ApplicationListenersOrder {
         /** The synchronization intializer. */
         int SYNCHRONIZATION_INTIALIZER = 40;
 
+        /**
+         * The dependencies initializer - after synchronization, so project.json files are in the registry.
+         */
+        int DEPENDENCIES_INITIALIZER = 45;
+
         /** The jobs initializer. */
         int JOBS_INITIALIZER = 50;
 

--- a/components/core/core-dependencies/pom.xml
+++ b/components/core/core-dependencies/pom.xml
@@ -1,0 +1,85 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.dirigible</groupId>
+        <artifactId>dirigible-components-parent</artifactId>
+        <version>15.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <name>Components - Core - Dependencies</name>
+    <artifactId>dirigible-components-core-dependencies</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <!-- Base -->
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-core-base</artifactId>
+        </dependency>
+
+        <!-- Project - the project.json model carrying the maven dependency declarations -->
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-core-project</artifactId>
+        </dependency>
+
+        <!-- Repository - the registry the project.json files are collected from -->
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-core-repository</artifactId>
+        </dependency>
+
+        <!-- Maven Artifact Resolver - the supplier wires a complete RepositorySystem
+             (impl, basic connector, file/http transports, POM reading via maven-resolver-provider) -->
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-api</artifactId>
+            <version>${maven-resolver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-util</artifactId>
+            <version>${maven-resolver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-supplier</artifactId>
+            <version>${maven-resolver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-resolver-provider</artifactId>
+            <version>${maven-resolver-maven.version}</version>
+        </dependency>
+
+        <!-- Maven settings.xml support - mirrors and proxies of corporate setups are honored -->
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <version>${maven-resolver-maven.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings-builder</artifactId>
+            <version>${maven-resolver-maven.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.hakky54</groupId>
+            <artifactId>logcaptor</artifactId>
+            <version>${logcaptor.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <properties>
+        <license.header.location>../../../licensing-header.txt</license.header.location>
+        <parent.pom.folder>../../../</parent.pom.folder>
+    </properties>
+
+</project>

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DeclaredDependencies.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DeclaredDependencies.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The maven dependencies declared across all projects in the registry.
+ *
+ * @param dependencies the declared dependencies in registry order
+ * @param errors the declaration errors that never reached resolution (bad coordinate, version
+ *        range, unknown scope, ...), keyed by the declared id or the declaring project
+ */
+record DeclaredDependencies(Set<MavenDependency> dependencies, Map<String, String> errors) {
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesEndpoint.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesEndpoint.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import jakarta.annotation.security.RolesAllowed;
+import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * The maven dependency resolution surface - the current declared / resolved state and the on-demand
+ * union resolution. The resolved jars join the application classpath on the next restart.
+ */
+@RestController
+@RequestMapping(BaseEndpoint.PREFIX_ENDPOINT_CORE + "dependencies")
+class DependenciesEndpoint {
+
+    /** The dependencies service. */
+    private final DependenciesService dependenciesService;
+
+    /**
+     * Instantiates a new dependencies endpoint.
+     *
+     * @param dependenciesService the dependencies service
+     */
+    DependenciesEndpoint(DependenciesService dependenciesService) {
+        this.dependenciesService = dependenciesService;
+    }
+
+    /**
+     * The current declared / resolved state.
+     *
+     * @return the state
+     */
+    @GetMapping
+    @RolesAllowed({"ADMINISTRATOR", "OPERATOR", "DEVELOPER"})
+    ResponseEntity<DependenciesState> getState() {
+        return ResponseEntity.ok(dependenciesService.getState());
+    }
+
+    /**
+     * Runs the union resolution on demand.
+     *
+     * @return the resolved state
+     */
+    @PostMapping("resolve")
+    @RolesAllowed({"ADMINISTRATOR", "OPERATOR"})
+    ResponseEntity<DependenciesState> resolve() {
+        if (!dependenciesService.isDynamicEnabled()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Dynamic dependency resolution is disabled - set DIRIGIBLE_DEPENDENCIES_DYNAMIC=true to enable it");
+        }
+        return ResponseEntity.ok(dependenciesService.resolveAndActivate());
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesInitializer.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesInitializer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import org.eclipse.dirigible.components.base.ApplicationListenersOrder.ApplicationReadyEventListeners;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves the maven dependencies declared across the registry projects at startup - ordered after
+ * the synchronization initializer, so the project.json files are present in the registry. The
+ * resolved jars join the application classpath on the next restart.
+ */
+@Order(ApplicationReadyEventListeners.DEPENDENCIES_INITIALIZER)
+@Component
+class DependenciesInitializer implements ApplicationListener<ApplicationReadyEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DependenciesInitializer.class);
+
+    /** The dependencies service. */
+    private final DependenciesService dependenciesService;
+
+    /**
+     * Instantiates a new dependencies initializer.
+     *
+     * @param dependenciesService the dependencies service
+     */
+    DependenciesInitializer(DependenciesService dependenciesService) {
+        this.dependenciesService = dependenciesService;
+    }
+
+    /**
+     * On application event.
+     *
+     * @param event the event
+     */
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        if (!dependenciesService.isDynamicEnabled()) {
+            LOGGER.debug("Dynamic dependency resolution is disabled");
+            return;
+        }
+        try {
+            dependenciesService.resolveAndActivate();
+        } catch (RuntimeException e) {
+            // per-coordinate failures are reported in the result; whatever still escapes
+            // must never prevent the platform from booting
+            LOGGER.error("Maven dependency resolution failed", e);
+        }
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesService.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesService.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Orchestrates the declare - resolve - activate flow: collects the maven declarations of all
+ * registry projects, resolves their union into the local repository and links the resolved jars
+ * into the resolved-modules directory. The contract of this phase: declare, resolve (at boot or on
+ * demand), restart to activate.
+ */
+@Component
+class DependenciesService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DependenciesService.class);
+
+    /** The collector. */
+    private final ProjectDependenciesCollector collector;
+
+    /** The resolver. */
+    private final DependencyResolver resolver;
+
+    /** The linker. */
+    private final ResolvedModulesLinker linker;
+
+    /** The last resolved state, null before the first resolution. */
+    private final AtomicReference<DependenciesState> lastState = new AtomicReference<>();
+
+    /**
+     * Instantiates a new dependencies service.
+     *
+     * @param collector the collector
+     * @param resolver the resolver
+     * @param linker the linker
+     */
+    DependenciesService(ProjectDependenciesCollector collector, DependencyResolver resolver, ResolvedModulesLinker linker) {
+        this.collector = collector;
+        this.resolver = resolver;
+        this.linker = linker;
+    }
+
+    /**
+     * Whether dynamic dependency resolution is enabled on this instance.
+     *
+     * @return true when enabled
+     */
+    boolean isDynamicEnabled() {
+        return DirigibleConfig.DEPENDENCIES_DYNAMIC_ENABLED.getBooleanValue();
+    }
+
+    /**
+     * Runs the union resolution and links the resolved jars into the resolved-modules directory.
+     *
+     * @return the resolved state
+     */
+    synchronized DependenciesState resolveAndActivate() {
+        DeclaredDependencies declared = collector.collect();
+        ResolutionResult result = resolver.resolve(declared.dependencies());
+        Map<String, String> failures = new LinkedHashMap<>(declared.errors());
+        failures.putAll(result.failures());
+        Path localRepository = MavenResolverConfig.fromConfiguration()
+                                                  .localRepository();
+        linker.sync(localRepository, result.artifacts(), failures.isEmpty());
+        DependenciesState state = new DependenciesState(isDynamicEnabled(), declared.dependencies()
+                                                                                    .stream()
+                                                                                    .map(MavenDependency::coordinate)
+                                                                                    .toList(),
+                result.artifacts()
+                      .stream()
+                      .map(Path::toString)
+                      .toList(),
+                result.mediated(), failures, localRepository.toString(), linker.directory()
+                                                                               .toString(),
+                Instant.now());
+        lastState.set(state);
+        LOGGER.info(
+                "Maven dependency resolution completed: [{}] declared, [{}] jar(s) activated for the next restart, [{}] mediated, [{}] failure(s)",
+                state.declared()
+                     .size(),
+                state.artifacts()
+                     .size(),
+                state.mediated()
+                     .size(),
+                state.failures()
+                     .size());
+        return state;
+    }
+
+    /**
+     * The current declared / resolved state.
+     *
+     * @return the state
+     */
+    DependenciesState getState() {
+        DependenciesState state = lastState.get();
+        if (state == null) {
+            return DependenciesState.empty(isDynamicEnabled(), linker.directory()
+                                                                     .toString());
+        }
+        return state.withEnabled(isDynamicEnabled());
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesState.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesState.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The declared / resolved dependency state the endpoint reports.
+ *
+ * @param enabled whether dynamic dependency resolution is enabled on this instance
+ * @param declared the declared coordinates
+ * @param artifacts the resolved jar paths inside the local repository
+ * @param mediated the versions chosen where more than one was requested, keyed by
+ *        groupId:artifactId
+ * @param failures the per-coordinate failure messages
+ * @param localRepository the local repository, null before the first resolution
+ * @param resolvedModulesDirectory the directory the resolved jars are linked into
+ * @param resolvedAt when the state was resolved, null before the first resolution
+ */
+record DependenciesState(boolean enabled, List<String> declared, List<String> artifacts, Map<String, String> mediated,
+        Map<String, String> failures, String localRepository, String resolvedModulesDirectory, Instant resolvedAt) {
+
+    /**
+     * The state before the first resolution.
+     *
+     * @param enabled whether dynamic dependency resolution is enabled
+     * @param resolvedModulesDirectory the resolved-modules directory
+     * @return the empty state
+     */
+    static DependenciesState empty(boolean enabled, String resolvedModulesDirectory) {
+        return new DependenciesState(enabled, List.of(), List.of(), Map.of(), Map.of(), null, resolvedModulesDirectory, null);
+    }
+
+    /**
+     * The same state with the enabled flag re-read.
+     *
+     * @param value the current flag value
+     * @return the state
+     */
+    DependenciesState withEnabled(boolean value) {
+        return new DependenciesState(value, declared, artifacts, mediated, failures, localRepository, resolvedModulesDirectory, resolvedAt);
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependencyResolver.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependencyResolver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import java.util.Set;
+
+/**
+ * Resolves Maven coordinates into the instance-global local repository.
+ *
+ * <p>
+ * The input is the union of all projects' declarations, resolved in a single collect request, so
+ * Maven's standard version mediation applies globally - one flat classpath means one mediation.
+ * Failures are per-coordinate and never thrown: an unresolvable dependency surfaces in the result
+ * and must never prevent the platform from booting.
+ *
+ * <p>
+ * Example:
+ *
+ * <pre>{@code
+ * ResolutionResult r =
+ *         resolver.resolve(Set.of(new MavenDependency("software.amazon.awssdk:s3:2.32.4", MavenDependency.Scope.MODULE, List.of())));
+ * r.artifacts(); // jar paths inside the local repo (immutable, versioned)
+ * r.mediated(); // versions chosen where the graph requested more than one
+ * r.failures(); // per-coordinate failure messages (unresolvable, bad checksum, ...)
+ * }</pre>
+ */
+public interface DependencyResolver {
+
+    /**
+     * Resolves the declared dependencies and their transitive graph into the local repository.
+     *
+     * @param declared the union of all declared dependencies
+     * @return the resolution result - resolved jar paths, mediated versions and per-coordinate failures
+     */
+    ResolutionResult resolve(Set<MavenDependency> declared);
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/MavenDependency.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/MavenDependency.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A Maven dependency declared by a project - the exact coordinate to resolve, the scope it is
+ * resolved for and the transitive exclusions to apply.
+ *
+ * @param coordinate the coordinate as a single {@code groupId:artifactId:version} string; exact
+ *        versions only, version ranges are rejected
+ * @param scope the scope the dependency is resolved for
+ * @param exclusions the transitive exclusions as {@code groupId:artifactId} entries where the
+ *        artifactId may be the {@code *} wildcard; never null, may be empty
+ */
+public record MavenDependency(String coordinate, Scope scope, List<String> exclusions) {
+
+    /**
+     * The scope a declared dependency is resolved for.
+     */
+    public enum Scope {
+
+        /** The dependency joins the module classpath - the only scope supported in this phase. */
+        MODULE,
+
+        /** Reserved for a later phase - parsed, but rejected as unsupported. */
+        PLATFORM;
+
+        /**
+         * Parses a scope as declared in {@code project.json} - blank means {@link #MODULE}.
+         *
+         * @param value the declared scope, may be null
+         * @return the scope
+         * @throws IllegalArgumentException when the value is neither {@code module} nor {@code platform}
+         */
+        public static Scope parse(String value) {
+            if (value == null || value.isBlank()) {
+                return MODULE;
+            }
+            return switch (value.trim()
+                                .toLowerCase()) {
+                case "module" -> MODULE;
+                case "platform" -> PLATFORM;
+                default -> throw new IllegalArgumentException("Unknown scope [" + value + "] - use module or platform");
+            };
+        }
+    }
+
+    /**
+     * Validates the declaration.
+     *
+     * @param coordinate the coordinate as {@code groupId:artifactId:version}
+     * @param scope the scope
+     * @param exclusions the exclusions, null is treated as empty
+     */
+    public MavenDependency {
+        Objects.requireNonNull(scope, "scope must not be null");
+        exclusions = exclusions == null ? List.of() : List.copyOf(exclusions);
+        validateCoordinate(coordinate);
+        exclusions.forEach(MavenDependency::validateExclusion);
+    }
+
+    /**
+     * Validate coordinate.
+     *
+     * @param coordinate the coordinate
+     */
+    private static void validateCoordinate(String coordinate) {
+        Objects.requireNonNull(coordinate, "coordinate must not be null");
+        String[] parts = coordinate.split(":", -1);
+        if (parts.length != 3 || parts[0].isBlank() || parts[1].isBlank() || parts[2].isBlank()) {
+            throw new IllegalArgumentException("Invalid maven coordinate [" + coordinate + "] - expected groupId:artifactId:version");
+        }
+        String version = parts[2];
+        if (version.chars()
+                   .anyMatch(c -> c == '[' || c == ']' || c == '(' || c == ')' || c == ',')) {
+            throw new IllegalArgumentException(
+                    "Version ranges are not supported [" + coordinate + "] - declare an exact version, e.g. 1.4.0");
+        }
+    }
+
+    /**
+     * Validate exclusion.
+     *
+     * @param exclusion the exclusion
+     */
+    private static void validateExclusion(String exclusion) {
+        String[] parts = exclusion.split(":", -1);
+        if (parts.length != 2 || parts[0].isBlank() || "*".equals(parts[0]) || parts[1].isBlank()) {
+            throw new IllegalArgumentException(
+                    "Invalid exclusion [" + exclusion + "] - expected groupId:artifactId, artifactId may be the * wildcard");
+        }
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/MavenDependencyResolver.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/MavenDependencyResolver.java
@@ -1,0 +1,506 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import jakarta.annotation.PreDestroy;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.apache.maven.settings.Mirror;
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.building.DefaultSettingsBuilderFactory;
+import org.apache.maven.settings.building.DefaultSettingsBuildingRequest;
+import org.apache.maven.settings.building.SettingsBuildingException;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.collection.CollectResult;
+import org.eclipse.aether.collection.DependencyCollectionException;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.graph.Exclusion;
+import org.eclipse.aether.repository.Authentication;
+import org.eclipse.aether.repository.AuthenticationSelector;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.MirrorSelector;
+import org.eclipse.aether.repository.Proxy;
+import org.eclipse.aether.repository.ProxySelector;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.supplier.RepositorySystemSupplier;
+import org.eclipse.aether.util.artifact.JavaScopes;
+import org.eclipse.aether.util.graph.transformer.ConflictResolver;
+import org.eclipse.aether.util.repository.AuthenticationBuilder;
+import org.eclipse.aether.util.repository.DefaultAuthenticationSelector;
+import org.eclipse.aether.util.repository.DefaultMirrorSelector;
+import org.eclipse.aether.util.repository.DefaultProxySelector;
+import org.eclipse.dirigible.components.dependencies.MavenResolverConfig.MavenRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * The {@link DependencyResolver} over the Apache Maven Artifact Resolver - coordinates are taken
+ * programmatically (no POM generation, no external mvn binary) and resolved in one union collect
+ * request so Maven's standard version mediation applies globally.
+ */
+@Component
+class MavenDependencyResolver implements DependencyResolver {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MavenDependencyResolver.class);
+
+    /** The configuration source - read on every resolution so runtime changes take effect. */
+    private final Supplier<MavenResolverConfig> configSupplier;
+
+    /** The repository system - thread-safe and configuration-independent, created once. */
+    private final RepositorySystem repositorySystem;
+
+    /**
+     * Instantiates the resolver reading its configuration from the environment.
+     */
+    MavenDependencyResolver() {
+        this(MavenResolverConfig::fromConfiguration);
+    }
+
+    /**
+     * Instantiates the resolver with an explicit configuration source - the constructor the unit tests
+     * use to point at file-based fixture repositories.
+     *
+     * @param configSupplier the configuration source
+     */
+    MavenDependencyResolver(Supplier<MavenResolverConfig> configSupplier) {
+        this.configSupplier = configSupplier;
+        this.repositorySystem = new RepositorySystemSupplier().get();
+    }
+
+    /**
+     * Shuts the repository system down.
+     */
+    @PreDestroy
+    void shutdown() {
+        repositorySystem.shutdown();
+    }
+
+    /**
+     * Resolve.
+     *
+     * @param declared the union of all declared dependencies
+     * @return the resolution result
+     */
+    @Override
+    public ResolutionResult resolve(Set<MavenDependency> declared) {
+        Map<String, String> failures = new LinkedHashMap<>();
+        List<MavenDependency> resolvable = new ArrayList<>();
+        for (MavenDependency dependency : declared) {
+            if (dependency.scope() == MavenDependency.Scope.PLATFORM) {
+                failures.put(dependency.coordinate(), "Scope [platform] is reserved for a later phase and is not supported yet");
+                LOGGER.error("Cannot resolve maven dependency [{}]: scope [platform] is reserved for a later phase",
+                        dependency.coordinate());
+            } else {
+                resolvable.add(dependency);
+            }
+        }
+        if (resolvable.isEmpty()) {
+            return new ResolutionResult(List.of(), Map.of(), failures);
+        }
+
+        // the collect request merges duplicate groupId:artifactId root dependencies before conflict
+        // resolution ever sees them, so direct conflicts are mediated here - first declaration wins -
+        // and every declared version is seeded into the mediation report
+        Map<String, Set<String>> requestedVersions = new LinkedHashMap<>();
+        Map<String, MavenDependency> roots = new LinkedHashMap<>();
+        for (MavenDependency dependency : resolvable) {
+            String[] parts = dependency.coordinate()
+                                       .split(":", -1);
+            requestedVersions.computeIfAbsent(parts[0] + ":" + parts[1], key -> new LinkedHashSet<>())
+                             .add(parts[2]);
+            roots.putIfAbsent(parts[0] + ":" + parts[1], dependency);
+        }
+
+        MavenResolverConfig config = configSupplier.get();
+        DefaultRepositorySystemSession session = newSession(config);
+        List<RemoteRepository> repositories = remoteRepositories(session, config);
+        String repositoriesDescription = describe(repositories);
+        LOGGER.info("Resolving [{}] declared maven dependency(ies) from repositories [{}] into local repository [{}]", resolvable.size(),
+                repositoriesDescription, config.localRepository());
+
+        List<MavenDependency> rootDependencies = List.copyOf(roots.values());
+        CollectResult collectResult;
+        try {
+            collectResult = repositorySystem.collectDependencies(session, collectRequest(rootDependencies, repositories));
+        } catch (DependencyCollectionException e) {
+            LOGGER.error("Maven dependency graph collection failed for [{}] from repositories [{}]", coordinates(rootDependencies),
+                    repositoriesDescription, e);
+            resolvable.forEach(
+                    dependency -> failures.putIfAbsent(dependency.coordinate(), "Dependency graph collection failed: " + e.getMessage()));
+            return new ResolutionResult(List.of(), Map.of(), failures);
+        }
+
+        Map<String, String> winnerVersions = new LinkedHashMap<>();
+        List<DependencyNode> winners = new ArrayList<>();
+        walk(collectResult.getRoot(), requestedVersions, winnerVersions, winners);
+
+        List<Path> artifacts = resolveArtifacts(session, winners, failures, repositoriesDescription);
+        Map<String, String> mediated = mediated(requestedVersions, winnerVersions);
+        mediated.forEach((ga, version) -> LOGGER.info("Version mediation chose [{}:{}] out of the requested versions {}", ga, version,
+                requestedVersions.get(ga)));
+        return new ResolutionResult(artifacts, mediated, failures);
+    }
+
+    /**
+     * Creates the session - local repository, offline mode, verbose conflict resolution (so version
+     * mediation is reportable) and the settings.xml mirror / proxy / server selectors.
+     *
+     * @param config the configuration
+     * @return the session
+     */
+    private DefaultRepositorySystemSession newSession(MavenResolverConfig config) {
+        DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
+        session.setLocalRepositoryManager(repositorySystem.newLocalRepositoryManager(session, new LocalRepository(config.localRepository()
+                                                                                                                        .toFile())));
+        session.setOffline(config.offline());
+        session.setSystemProperties(System.getProperties());
+        // keep conflict losers in the graph so the mediation report can name the requested versions
+        session.setConfigProperty(ConflictResolver.CONFIG_PROP_VERBOSE, Boolean.TRUE);
+        // remote repositories are instance-level operator configuration - a repository declared
+        // inside a dependency's POM must not redirect where artifacts are downloaded from
+        session.setIgnoreArtifactDescriptorRepositories(true);
+        Settings settings = readSettings(config.settingsXml());
+        if (settings != null) {
+            session.setMirrorSelector(mirrorSelector(settings));
+            session.setProxySelector(proxySelector(settings));
+            session.setAuthenticationSelector(authenticationSelector(settings));
+        }
+        return session;
+    }
+
+    /**
+     * Builds the union collect request - every declared dependency becomes a root dependency of one
+     * request, so one mediation covers the whole flat classpath.
+     *
+     * @param resolvable the declared dependencies
+     * @param repositories the remote repositories
+     * @return the collect request
+     */
+    private CollectRequest collectRequest(List<MavenDependency> resolvable, List<RemoteRepository> repositories) {
+        CollectRequest collectRequest = new CollectRequest();
+        collectRequest.setRepositories(repositories);
+        for (MavenDependency dependency : resolvable) {
+            List<Exclusion> exclusions = dependency.exclusions()
+                                                   .stream()
+                                                   .map(exclusion -> {
+                                                       String[] parts = exclusion.split(":", -1);
+                                                       return new Exclusion(parts[0], parts[1], "*", "*");
+                                                   })
+                                                   .toList();
+            collectRequest.addDependency(
+                    new Dependency(new DefaultArtifact(dependency.coordinate()), JavaScopes.RUNTIME, false, exclusions));
+        }
+        return collectRequest;
+    }
+
+    /**
+     * Walks the verbose dependency graph - conflict losers are retained as leaves carrying the winner
+     * reference, so both the winners (the classpath) and every requested version (the mediation report)
+     * come out of one walk.
+     *
+     * @param node the node whose children are walked
+     * @param requestedVersions all requested versions per groupId:artifactId
+     * @param winnerVersions the winning version per groupId:artifactId
+     * @param winners the winner nodes in graph order
+     */
+    private void walk(DependencyNode node, Map<String, Set<String>> requestedVersions, Map<String, String> winnerVersions,
+            List<DependencyNode> winners) {
+        for (DependencyNode child : node.getChildren()) {
+            Artifact artifact = child.getArtifact();
+            if (artifact == null) {
+                continue;
+            }
+            String ga = artifact.getGroupId() + ":" + artifact.getArtifactId();
+            requestedVersions.computeIfAbsent(ga, key -> new LinkedHashSet<>())
+                             .add(artifact.getVersion());
+            if (child.getData()
+                     .get(ConflictResolver.NODE_DATA_WINNER) != null) {
+                continue; // a conflict loser - a leaf by definition of the verbose graph
+            }
+            if (winnerVersions.putIfAbsent(ga, artifact.getVersion()) == null && isClasspathScope(child)) {
+                winners.add(child);
+            }
+            walk(child, requestedVersions, winnerVersions, winners);
+        }
+    }
+
+    /**
+     * Checks if is classpath scope.
+     *
+     * @param node the node
+     * @return true, if is classpath scope
+     */
+    private boolean isClasspathScope(DependencyNode node) {
+        String scope = node.getDependency()
+                           .getScope();
+        return scope == null || scope.isEmpty() || JavaScopes.COMPILE.equals(scope) || JavaScopes.RUNTIME.equals(scope);
+    }
+
+    /**
+     * Resolves the winner nodes' artifacts into the local repository - a failing artifact is reported
+     * per coordinate and never fails the rest.
+     *
+     * @param session the session
+     * @param winners the winner nodes
+     * @param failures the per-coordinate failures to add to
+     * @param repositoriesDescription the repositories, for the error log
+     * @return the resolved jar paths
+     */
+    private List<Path> resolveArtifacts(RepositorySystemSession session, List<DependencyNode> winners, Map<String, String> failures,
+            String repositoriesDescription) {
+        List<ArtifactRequest> requests = winners.stream()
+                                                .map(ArtifactRequest::new)
+                                                .toList();
+        List<ArtifactResult> results;
+        try {
+            results = repositorySystem.resolveArtifacts(session, requests);
+        } catch (ArtifactResolutionException e) {
+            results = e.getResults();
+        }
+        List<Path> artifacts = new ArrayList<>();
+        for (ArtifactResult result : results) {
+            if (result.isResolved()) {
+                artifacts.add(result.getArtifact()
+                                    .getFile()
+                                    .toPath());
+            } else {
+                Artifact artifact = result.getRequest()
+                                          .getArtifact();
+                String coordinate = artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + artifact.getVersion();
+                String message = result.getExceptions()
+                                       .stream()
+                                       .map(Throwable::getMessage)
+                                       .filter(m -> m != null && !m.isBlank())
+                                       .collect(Collectors.joining("; "));
+                if (message.isEmpty()) {
+                    message = "Could not resolve the artifact";
+                }
+                failures.put(coordinate, message);
+                Exception cause = result.getExceptions()
+                                        .isEmpty() ? null
+                                                : result.getExceptions()
+                                                        .get(0);
+                LOGGER.error("Could not resolve maven dependency [{}] from repositories [{}]: {}", coordinate, repositoriesDescription,
+                        message, cause);
+            }
+        }
+        return artifacts;
+    }
+
+    /**
+     * The mediation report - the groupId:artifactId entries the graph requested in more than one
+     * version, mapped to the version mediation chose.
+     *
+     * @param requestedVersions all requested versions per groupId:artifactId
+     * @param winnerVersions the winning version per groupId:artifactId
+     * @return the mediated versions
+     */
+    private Map<String, String> mediated(Map<String, Set<String>> requestedVersions, Map<String, String> winnerVersions) {
+        Map<String, String> mediated = new LinkedHashMap<>();
+        requestedVersions.forEach((ga, versions) -> {
+            String winner = winnerVersions.get(ga);
+            if (versions.size() > 1 && winner != null) {
+                mediated.put(ga, winner);
+            }
+        });
+        return mediated;
+    }
+
+    /**
+     * Builds the remote repositories - the configured credentials are applied first, then the session's
+     * settings.xml mirror / proxy / server selectors, so corporate setups work unmodified.
+     *
+     * @param session the session
+     * @param config the configuration
+     * @return the remote repositories
+     */
+    private List<RemoteRepository> remoteRepositories(RepositorySystemSession session, MavenResolverConfig config) {
+        List<RemoteRepository> repositories = new ArrayList<>();
+        for (MavenRepository definition : config.repositories()) {
+            RemoteRepository.Builder builder = new RemoteRepository.Builder(definition.id(), "default", definition.url());
+            if (definition.username() != null && !definition.username()
+                                                            .isBlank()) {
+                builder.setAuthentication(new AuthenticationBuilder().addUsername(definition.username())
+                                                                     .addPassword(definition.password())
+                                                                     .build());
+            }
+            repositories.add(applySessionSelectors(session, builder.build()));
+        }
+        return repositories;
+    }
+
+    /**
+     * Applies the session's mirror, proxy and authentication selectors to an explicitly configured
+     * repository - the resolver only applies them to repositories discovered during collection, so the
+     * top-level ones have to be processed here.
+     *
+     * @param session the session
+     * @param repository the repository
+     * @return the effective repository
+     */
+    private RemoteRepository applySessionSelectors(RepositorySystemSession session, RemoteRepository repository) {
+        RemoteRepository effective = repository;
+        MirrorSelector mirrorSelector = session.getMirrorSelector();
+        if (mirrorSelector != null) {
+            RemoteRepository mirror = mirrorSelector.getMirror(effective);
+            if (mirror != null) {
+                effective = mirror;
+            }
+        }
+        RemoteRepository.Builder builder = new RemoteRepository.Builder(effective);
+        boolean changed = false;
+        ProxySelector proxySelector = session.getProxySelector();
+        if (effective.getProxy() == null && proxySelector != null) {
+            Proxy proxy = proxySelector.getProxy(effective);
+            if (proxy != null) {
+                builder.setProxy(proxy);
+                changed = true;
+            }
+        }
+        AuthenticationSelector authenticationSelector = session.getAuthenticationSelector();
+        if (effective.getAuthentication() == null && authenticationSelector != null) {
+            Authentication authentication = authenticationSelector.getAuthentication(effective);
+            if (authentication != null) {
+                builder.setAuthentication(authentication);
+                changed = true;
+            }
+        }
+        return changed ? builder.build() : effective;
+    }
+
+    /**
+     * Reads the effective settings.
+     *
+     * @param settingsXml the settings.xml path, null when absent
+     * @return the settings, null when absent or unreadable
+     */
+    private Settings readSettings(Path settingsXml) {
+        if (settingsXml == null) {
+            return null;
+        }
+        try {
+            DefaultSettingsBuildingRequest request = new DefaultSettingsBuildingRequest();
+            request.setUserSettingsFile(settingsXml.toFile());
+            return new DefaultSettingsBuilderFactory().newInstance()
+                                                      .build(request)
+                                                      .getEffectiveSettings();
+        } catch (SettingsBuildingException e) {
+            LOGGER.warn("Ignoring the unreadable maven settings [{}]", settingsXml, e);
+            return null;
+        }
+    }
+
+    /**
+     * Mirror selector from the settings.
+     *
+     * @param settings the settings
+     * @return the mirror selector
+     */
+    private MirrorSelector mirrorSelector(Settings settings) {
+        DefaultMirrorSelector selector = new DefaultMirrorSelector();
+        for (Mirror mirror : settings.getMirrors()) {
+            selector.add(mirror.getId(), mirror.getUrl(), mirror.getLayout(), false, mirror.isBlocked(), mirror.getMirrorOf(),
+                    mirror.getMirrorOfLayouts());
+        }
+        return selector;
+    }
+
+    /**
+     * Proxy selector from the settings.
+     *
+     * @param settings the settings
+     * @return the proxy selector
+     */
+    private ProxySelector proxySelector(Settings settings) {
+        DefaultProxySelector selector = new DefaultProxySelector();
+        for (org.apache.maven.settings.Proxy proxy : settings.getProxies()) {
+            if (!proxy.isActive()) {
+                continue;
+            }
+            Authentication authentication = null;
+            if (proxy.getUsername() != null && !proxy.getUsername()
+                                                     .isBlank()) {
+                authentication = new AuthenticationBuilder().addUsername(proxy.getUsername())
+                                                            .addPassword(proxy.getPassword())
+                                                            .build();
+            }
+            selector.add(new Proxy(proxy.getProtocol(), proxy.getHost(), proxy.getPort(), authentication), proxy.getNonProxyHosts());
+        }
+        return selector;
+    }
+
+    /**
+     * Authentication selector from the settings' servers, so a mirrored corporate repository
+     * authenticates with the credentials its settings.xml already carries.
+     *
+     * @param settings the settings
+     * @return the authentication selector
+     */
+    private AuthenticationSelector authenticationSelector(Settings settings) {
+        DefaultAuthenticationSelector selector = new DefaultAuthenticationSelector();
+        for (Server server : settings.getServers()) {
+            if (server.getUsername() == null && server.getPrivateKey() == null) {
+                continue;
+            }
+            AuthenticationBuilder builder = new AuthenticationBuilder().addUsername(server.getUsername())
+                                                                       .addPassword(server.getPassword());
+            if (server.getPrivateKey() != null) {
+                builder.addPrivateKey(server.getPrivateKey(), server.getPassphrase());
+            }
+            selector.add(server.getId(), builder.build());
+        }
+        return selector;
+    }
+
+    /**
+     * Describes the repositories for logging - ids and URLs, never credentials.
+     *
+     * @param repositories the repositories
+     * @return the description
+     */
+    private String describe(List<RemoteRepository> repositories) {
+        return repositories.stream()
+                           .map(repository -> repository.getId() + " (" + repository.getUrl() + ")")
+                           .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Coordinates.
+     *
+     * @param dependencies the dependencies
+     * @return the string
+     */
+    private String coordinates(List<MavenDependency> dependencies) {
+        return dependencies.stream()
+                           .map(MavenDependency::coordinate)
+                           .collect(Collectors.joining(", "));
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/MavenResolverConfig.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/MavenResolverConfig.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * The instance-level configuration of the Maven dependency resolution - repositories and their
+ * credentials are operator configuration and deliberately never part of project.json.
+ *
+ * @param localRepository the local repository the artifacts are resolved into
+ * @param repositories the remote repositories to resolve from, in configuration order
+ * @param offline whether resolution runs offline (local repository only)
+ * @param settingsXml the user's Maven settings.xml whose mirrors and proxies are honored, null when
+ *        absent
+ */
+record MavenResolverConfig(Path localRepository, List<MavenRepository> repositories, boolean offline, Path settingsXml) {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MavenResolverConfig.class);
+
+    /**
+     * The id of the default Maven Central entry - a configured entry with this id overrides its URL.
+     */
+    private static final String CENTRAL_ID = "central";
+
+    /** The default Maven Central URL. */
+    private static final String CENTRAL_URL = "https://repo1.maven.org/maven2";
+
+    /**
+     * A remote repository definition.
+     *
+     * @param id the repository id
+     * @param url the repository URL
+     * @param username the username, null when the repository needs no authentication
+     * @param password the password, null when the repository needs no authentication
+     */
+    record MavenRepository(String id, String url, String username, String password) {
+    }
+
+    /**
+     * Reads the configuration from the environment - evaluated on every resolution so runtime
+     * configuration changes take effect without a restart.
+     *
+     * @return the configuration
+     */
+    static MavenResolverConfig fromConfiguration() {
+        Path userHome = Path.of(System.getProperty("user.home"));
+        return new MavenResolverConfig(localRepository(userHome), configuredRepositories(), DirigibleConfig.MAVEN_OFFLINE.getBooleanValue(),
+                settingsXml(userHome));
+    }
+
+    /**
+     * The local repository - the configured location, else the developer's own local repository when
+     * one exists (cache parity with local builds), else a platform-owned directory.
+     *
+     * @param userHome the user home
+     * @return the local repository path
+     */
+    private static Path localRepository(Path userHome) {
+        String configured = DirigibleConfig.MAVEN_LOCAL_REPO.getStringValue();
+        if (configured != null && !configured.isBlank()) {
+            return Path.of(configured);
+        }
+        Path m2Repository = userHome.resolve(".m2")
+                                    .resolve("repository");
+        if (Files.isDirectory(m2Repository)) {
+            return m2Repository;
+        }
+        return userHome.resolve(".dirigible")
+                       .resolve("m2");
+    }
+
+    /**
+     * The remote repositories - Maven Central by default plus the operator-configured entries. An entry
+     * with the id central overrides the default Central URL.
+     *
+     * @return the repositories in configuration order
+     */
+    private static List<MavenRepository> configuredRepositories() {
+        Map<String, String> urls = new LinkedHashMap<>();
+        urls.put(CENTRAL_ID, CENTRAL_URL);
+        String configured = DirigibleConfig.MAVEN_REPOSITORIES.getStringValue();
+        if (configured != null && !configured.isBlank()) {
+            for (String entry : configured.split(",")) {
+                String trimmed = entry.trim();
+                if (trimmed.isEmpty()) {
+                    continue;
+                }
+                int separator = trimmed.indexOf('=');
+                if (separator <= 0 || separator == trimmed.length() - 1) {
+                    LOGGER.warn("Ignoring the malformed maven repository entry [{}] - expected id=url", trimmed);
+                    continue;
+                }
+                urls.put(trimmed.substring(0, separator)
+                                .trim(),
+                        trimmed.substring(separator + 1)
+                               .trim());
+            }
+        }
+        List<MavenRepository> repositories = new ArrayList<>();
+        urls.forEach((id, url) -> repositories.add(new MavenRepository(id, url, credential(id, "USERNAME"), credential(id, "PASSWORD"))));
+        return repositories;
+    }
+
+    /**
+     * A repository credential from the DIRIGIBLE_MAVEN_[ID]_USERNAME / DIRIGIBLE_MAVEN_[ID]_PASSWORD
+     * pair - the id is uppercased and every non-alphanumeric character becomes an underscore.
+     *
+     * @param repositoryId the repository id
+     * @param suffix USERNAME or PASSWORD
+     * @return the credential, null when not configured
+     */
+    private static String credential(String repositoryId, String suffix) {
+        String normalizedId = repositoryId.toUpperCase(Locale.ROOT)
+                                          .replaceAll("[^A-Z0-9]", "_");
+        return Configuration.get("DIRIGIBLE_MAVEN_" + normalizedId + "_" + suffix);
+    }
+
+    /**
+     * The user's Maven settings.xml when it exists.
+     *
+     * @param userHome the user home
+     * @return the settings.xml path, null when absent
+     */
+    private static Path settingsXml(Path userHome) {
+        Path settings = userHome.resolve(".m2")
+                                .resolve("settings.xml");
+        return Files.isRegularFile(settings) ? settings : null;
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ProjectDependenciesCollector.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ProjectDependenciesCollector.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import org.eclipse.dirigible.components.project.ProjectMetadata;
+import org.eclipse.dirigible.components.project.ProjectMetadataDependency;
+import org.eclipse.dirigible.components.project.ProjectMetadataUtils;
+import org.eclipse.dirigible.repository.api.ICollection;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.repository.api.IResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Collects the maven dependency declarations from the project.json files of all projects in the
+ * registry.
+ */
+@Component
+class ProjectDependenciesCollector {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProjectDependenciesCollector.class);
+
+    /** The repository. */
+    private final IRepository repository;
+
+    /**
+     * Instantiates a new collector.
+     *
+     * @param repository the repository
+     */
+    ProjectDependenciesCollector(IRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * Collects the declarations of all registry projects.
+     *
+     * @return the declared dependencies and the declaration errors
+     */
+    DeclaredDependencies collect() {
+        Set<MavenDependency> dependencies = new LinkedHashSet<>();
+        Map<String, String> errors = new LinkedHashMap<>();
+        ICollection registry = repository.getCollection(IRepositoryStructure.PATH_REGISTRY_PUBLIC);
+        if (!registry.exists()) {
+            return new DeclaredDependencies(dependencies, errors);
+        }
+        for (ICollection project : registry.getCollections()) {
+            IResource descriptor = project.getResource(ProjectMetadata.PROJECT_METADATA_FILE_NAME);
+            if (!descriptor.exists()) {
+                continue;
+            }
+            ProjectMetadata metadata;
+            try {
+                metadata = ProjectMetadataUtils.fromJson(new String(descriptor.getContent(), StandardCharsets.UTF_8));
+            } catch (RuntimeException e) {
+                LOGGER.warn("Ignoring the unparseable [{}] of project [{}]", ProjectMetadata.PROJECT_METADATA_FILE_NAME, project.getName(),
+                        e);
+                continue;
+            }
+            if (metadata != null) {
+                collectDeclared(project.getName(), metadata, dependencies, errors);
+            }
+        }
+        return new DeclaredDependencies(dependencies, errors);
+    }
+
+    /**
+     * Collects one project's maven declarations - git entries keep their meaning elsewhere, and unknown
+     * types are tolerated with a warning so an older platform accepts a newer descriptor.
+     *
+     * @param project the project name
+     * @param metadata the parsed project.json
+     * @param dependencies the collected dependencies to add to
+     * @param errors the declaration errors to add to
+     */
+    static void collectDeclared(String project, ProjectMetadata metadata, Set<MavenDependency> dependencies, Map<String, String> errors) {
+        for (ProjectMetadataDependency declared : metadata.getDependencies()) {
+            String type = declared.getType();
+            if (ProjectMetadataDependency.TYPE_GIT.equalsIgnoreCase(type)) {
+                continue; // consumed by the IDE workspace
+            }
+            if (!ProjectMetadataDependency.TYPE_MAVEN.equalsIgnoreCase(type)) {
+                LOGGER.warn("Ignoring the dependency of unknown type [{}] declared by project [{}]", type, project);
+                continue;
+            }
+            String id = declared.getId();
+            if (id == null || id.isBlank()) {
+                errors.put(project, "Project [" + project + "] declares a maven dependency without an id (groupId:artifactId:version)");
+                LOGGER.error("Project [{}] declares a maven dependency without an id (groupId:artifactId:version)", project);
+                continue;
+            }
+            try {
+                MavenDependency.Scope scope = MavenDependency.Scope.parse(declared.getScope());
+                List<String> exclusions = declared.getExclusions();
+                dependencies.add(new MavenDependency(id, scope, exclusions == null ? List.of() : exclusions));
+            } catch (IllegalArgumentException e) {
+                errors.put(id, "Project [" + project + "]: " + e.getMessage());
+                LOGGER.error("Invalid maven dependency [{}] declared by project [{}]", id, project, e);
+            }
+        }
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ResolutionResult.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ResolutionResult.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The outcome of a {@link DependencyResolver#resolve(java.util.Set)} call.
+ *
+ * @param artifacts the resolved jar paths inside the local repository - immutable, versioned
+ *        locations that are never copied out or overwritten in place
+ * @param mediated the versions chosen where the dependency graph requested more than one, keyed by
+ *        {@code groupId:artifactId}
+ * @param failures the per-coordinate failure messages (unresolvable, bad checksum, unsupported
+ *        scope, ...), keyed by the failing coordinate
+ */
+public record ResolutionResult(List<Path> artifacts, Map<String, String> mediated, Map<String, String> failures) {
+
+    /**
+     * Copies the collections defensively, keeping their order.
+     *
+     * @param artifacts the resolved jar paths
+     * @param mediated the mediated versions
+     * @param failures the per-coordinate failures
+     */
+    public ResolutionResult {
+        artifacts = List.copyOf(artifacts);
+        mediated = Collections.unmodifiableMap(new LinkedHashMap<>(mediated));
+        failures = Collections.unmodifiableMap(new LinkedHashMap<>(failures));
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ResolvedModulesLinker.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ResolvedModulesLinker.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * Maintains the resolved-modules directory - the stable directory the launch classpath includes
+ * (see the loader.path entry in the application's Dockerfile). Resolved jars are linked in at their
+ * mediated versions; they join the application classpath on the next restart.
+ */
+@Component
+class ResolvedModulesLinker {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResolvedModulesLinker.class);
+
+    /**
+     * The resolved-modules directory - the configured location or the platform-owned default.
+     *
+     * @return the directory
+     */
+    Path directory() {
+        String configured = DirigibleConfig.DEPENDENCIES_DIR.getStringValue();
+        if (configured != null && !configured.isBlank()) {
+            return Path.of(configured);
+        }
+        return Path.of(System.getProperty("user.home"), ".dirigible", "resolved-modules");
+    }
+
+    /**
+     * Synchronizes the directory with the resolved artifacts - new jars are linked in (symlink, copy
+     * where symlinks are unavailable) and, when the resolution was complete, jars no longer resolved
+     * are removed. After a partial resolution nothing is removed, so a transient repository outage
+     * never strips previously activated jars from the next launch's classpath.
+     *
+     * @param localRepository the local repository the artifacts live in
+     * @param artifacts the resolved jar paths
+     * @param removeStale whether jars no longer resolved are removed
+     */
+    void sync(Path localRepository, List<Path> artifacts, boolean removeStale) {
+        Path directory = directory();
+        try {
+            Files.createDirectories(directory);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create the resolved-modules directory [" + directory + "]", e);
+        }
+        Map<String, Path> desired = new LinkedHashMap<>();
+        artifacts.forEach(artifact -> desired.putIfAbsent(linkName(localRepository, artifact), artifact));
+        if (removeStale) {
+            removeStaleEntries(directory, desired.keySet());
+        }
+        desired.forEach((name, target) -> place(directory.resolve(name), target));
+        LOGGER.info("Resolved-modules directory [{}] holds [{}] jar(s) - they join the application classpath on the next restart",
+                directory, desired.size());
+    }
+
+    /**
+     * The link name - the groupId prefixes the artifact file name so equally named artifacts of
+     * different groups never collide.
+     *
+     * @param localRepository the local repository
+     * @param artifact the artifact path inside it
+     * @return the link name
+     */
+    private String linkName(Path localRepository, Path artifact) {
+        Path fileName = artifact.getFileName();
+        Path versionDirectory = artifact.getParent();
+        Path artifactDirectory = versionDirectory != null ? versionDirectory.getParent() : null;
+        Path groupDirectory = artifactDirectory != null ? artifactDirectory.getParent() : null;
+        if (groupDirectory == null || !artifact.startsWith(localRepository)) {
+            return fileName.toString();
+        }
+        String groupId = localRepository.relativize(groupDirectory)
+                                        .toString()
+                                        .replace(localRepository.getFileSystem()
+                                                                .getSeparator(),
+                                                ".");
+        return groupId + "-" + fileName;
+    }
+
+    /**
+     * Removes the jars no longer resolved.
+     *
+     * @param directory the resolved-modules directory
+     * @param desired the link names that stay
+     */
+    private void removeStaleEntries(Path directory, Set<String> desired) {
+        try (Stream<Path> entries = Files.list(directory)) {
+            entries.filter(entry -> entry.getFileName()
+                                         .toString()
+                                         .endsWith(".jar"))
+                   .filter(entry -> !desired.contains(entry.getFileName()
+                                                           .toString()))
+                   .forEach(entry -> {
+                       try {
+                           Files.delete(entry);
+                           LOGGER.info("Removed the no longer resolved dependency jar [{}] from [{}]", entry.getFileName(), directory);
+                       } catch (IOException e) {
+                           LOGGER.warn("Could not remove the stale dependency jar [{}]", entry, e);
+                       }
+                   });
+        } catch (IOException e) {
+            LOGGER.warn("Could not list the resolved-modules directory [{}]", directory, e);
+        }
+    }
+
+    /**
+     * Places one artifact - an existing correct symlink is kept, an existing regular file is kept
+     * (versioned artifact paths are immutable, so the same name means the same content), anything else
+     * is (re)created.
+     *
+     * @param link the link path in the resolved-modules directory
+     * @param target the artifact path in the local repository
+     */
+    private void place(Path link, Path target) {
+        try {
+            if (Files.isSymbolicLink(link)) {
+                if (target.equals(Files.readSymbolicLink(link))) {
+                    return;
+                }
+                Files.delete(link);
+            } else if (Files.exists(link)) {
+                return;
+            }
+            try {
+                Files.createSymbolicLink(link, target);
+            } catch (IOException | UnsupportedOperationException e) {
+                LOGGER.debug("Symbolic links are unavailable for [{}]; copying instead", link, e);
+                Files.copy(target, link, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to place the resolved dependency [" + target + "] as [" + link + "]", e);
+        }
+    }
+
+}

--- a/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/DependencyResolverTest.java
+++ b/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/DependencyResolverTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import org.eclipse.dirigible.components.dependencies.MavenDependency.Scope;
+import org.eclipse.dirigible.components.dependencies.MavenResolverConfig.MavenRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Resolves fixture artifacts from a file: repository laid out in a temporary directory - no test
+ * touches the network.
+ */
+class DependencyResolverTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Path repositoryDir;
+    private Path localRepository;
+    private MavenDependencyResolver resolver;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        repositoryDir = Files.createDirectories(tempDir.resolve("fixture-repo"));
+        localRepository = tempDir.resolve("local-repo");
+        MavenResolverConfig config = new MavenResolverConfig(localRepository, List.of(new MavenRepository("fixture", repositoryDir.toUri()
+                                                                                                                                  .toString(),
+                null, null)), false, null);
+        resolver = new MavenDependencyResolver(() -> config);
+    }
+
+    @AfterEach
+    void tearDown() {
+        resolver.shutdown();
+    }
+
+    @Test
+    void resolves_the_transitive_graph_into_the_local_repository() throws IOException {
+        deploy("leaf", "1.0.0", "");
+        deploy("mid", "1.0.0", dependencyOn("leaf", "1.0.0"));
+
+        ResolutionResult result = resolver.resolve(declared(module("com.example:mid:1.0.0")));
+
+        assertThat(result.failures()).isEmpty();
+        assertThat(result.mediated()).isEmpty();
+        assertThat(result.artifacts()).containsExactlyInAnyOrder(localRepository.resolve("com/example/mid/1.0.0/mid-1.0.0.jar"),
+                localRepository.resolve("com/example/leaf/1.0.0/leaf-1.0.0.jar"));
+        assertThat(result.artifacts()).allSatisfy(artifact -> assertThat(artifact).exists());
+    }
+
+    @Test
+    void applies_the_declared_exclusions() throws IOException {
+        deploy("leaf", "1.0.0", "");
+        deploy("mid", "1.0.0", dependencyOn("leaf", "1.0.0"));
+
+        ResolutionResult exact =
+                resolver.resolve(declared(new MavenDependency("com.example:mid:1.0.0", Scope.MODULE, List.of("com.example:leaf"))));
+        assertThat(exact.failures()).isEmpty();
+        assertThat(exact.artifacts()).containsExactly(localRepository.resolve("com/example/mid/1.0.0/mid-1.0.0.jar"));
+
+        ResolutionResult wildcard =
+                resolver.resolve(declared(new MavenDependency("com.example:mid:1.0.0", Scope.MODULE, List.of("com.example:*"))));
+        assertThat(wildcard.failures()).isEmpty();
+        assertThat(wildcard.artifacts()).containsExactly(localRepository.resolve("com/example/mid/1.0.0/mid-1.0.0.jar"));
+    }
+
+    @Test
+    void reports_the_mediated_version_when_conflicting_versions_are_requested() throws IOException {
+        deploy("leaf", "1.0.0", "");
+        deploy("leaf", "1.1.0", "");
+
+        ResolutionResult result = resolver.resolve(declared(module("com.example:leaf:1.0.0"), module("com.example:leaf:1.1.0")));
+
+        assertThat(result.failures()).isEmpty();
+        // directly declared conflicts are mediated first-declaration-wins
+        assertThat(result.mediated()).containsEntry("com.example:leaf", "1.0.0");
+        assertThat(result.artifacts()).containsExactly(localRepository.resolve("com/example/leaf/1.0.0/leaf-1.0.0.jar"));
+    }
+
+    @Test
+    void reports_the_mediated_version_of_a_transitive_conflict() throws IOException {
+        deploy("leaf", "1.0.0", "");
+        deploy("leaf", "1.1.0", "");
+        deploy("mid", "1.0.0", dependencyOn("leaf", "1.1.0"));
+
+        // the direct declaration is nearer than mid's transitive request, so 1.0.0 wins
+        ResolutionResult result = resolver.resolve(declared(module("com.example:leaf:1.0.0"), module("com.example:mid:1.0.0")));
+
+        assertThat(result.failures()).isEmpty();
+        assertThat(result.mediated()).containsEntry("com.example:leaf", "1.0.0");
+        assertThat(result.artifacts()).containsExactlyInAnyOrder(localRepository.resolve("com/example/leaf/1.0.0/leaf-1.0.0.jar"),
+                localRepository.resolve("com/example/mid/1.0.0/mid-1.0.0.jar"));
+    }
+
+    @Test
+    void reports_an_unresolvable_coordinate_without_failing_the_rest() throws IOException {
+        deploy("leaf", "1.0.0", "");
+        deploy("mid", "1.0.0", dependencyOn("leaf", "1.0.0"));
+
+        ResolutionResult result = resolver.resolve(declared(module("com.example:mid:1.0.0"), module("com.example:missing:9.9.9")));
+
+        assertThat(result.artifacts()).containsExactlyInAnyOrder(localRepository.resolve("com/example/mid/1.0.0/mid-1.0.0.jar"),
+                localRepository.resolve("com/example/leaf/1.0.0/leaf-1.0.0.jar"));
+        assertThat(result.failures()).containsKey("com.example:missing:9.9.9");
+        assertThat(result.failures()
+                         .get("com.example:missing:9.9.9")).contains("missing")
+                                                           .contains("fixture");
+    }
+
+    @Test
+    void rejects_the_platform_scope_as_unsupported() throws IOException {
+        deploy("leaf", "1.0.0", "");
+
+        ResolutionResult result = resolver.resolve(declared(new MavenDependency("com.example:leaf:1.0.0", Scope.PLATFORM, List.of())));
+
+        assertThat(result.artifacts()).isEmpty();
+        assertThat(result.failures()).containsKey("com.example:leaf:1.0.0");
+        assertThat(result.failures()
+                         .get("com.example:leaf:1.0.0")).contains("platform");
+    }
+
+    private static MavenDependency module(String coordinate) {
+        return new MavenDependency(coordinate, Scope.MODULE, List.of());
+    }
+
+    private static Set<MavenDependency> declared(MavenDependency... dependencies) {
+        return new LinkedHashSet<>(Arrays.asList(dependencies));
+    }
+
+    private void deploy(String artifactId, String version, String dependenciesXml) throws IOException {
+        Path directory = repositoryDir.resolve("com/example")
+                                      .resolve(artifactId)
+                                      .resolve(version);
+        Files.createDirectories(directory);
+        Files.writeString(directory.resolve(artifactId + "-" + version + ".pom"), pom(artifactId, version, dependenciesXml));
+        writeJar(directory.resolve(artifactId + "-" + version + ".jar"));
+    }
+
+    private static String pom(String artifactId, String version, String dependenciesXml) {
+        return """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>%s</artifactId>
+                    <version>%s</version>
+                    %s
+                </project>
+                """.formatted(artifactId, version, dependenciesXml);
+    }
+
+    private static String dependencyOn(String artifactId, String version) {
+        return """
+                <dependencies>
+                    <dependency>
+                        <groupId>com.example</groupId>
+                        <artifactId>%s</artifactId>
+                        <version>%s</version>
+                    </dependency>
+                </dependencies>
+                """.formatted(artifactId, version);
+    }
+
+    private static void writeJar(Path path) throws IOException {
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(path))) {
+            out.putNextEntry(new JarEntry("fixture.txt"));
+            out.write("fixture".getBytes(StandardCharsets.UTF_8));
+            out.closeEntry();
+        }
+    }
+
+}

--- a/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/MavenDependencyTest.java
+++ b/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/MavenDependencyTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import org.eclipse.dirigible.components.dependencies.MavenDependency.Scope;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MavenDependencyTest {
+
+    @Test
+    void accepts_an_exact_coordinate_and_normalizes_null_exclusions() {
+        MavenDependency dependency = new MavenDependency("com.example:widget:2.1.0", Scope.MODULE, null);
+
+        assertThat(dependency.coordinate()).isEqualTo("com.example:widget:2.1.0");
+        assertThat(dependency.exclusions()).isEmpty();
+    }
+
+    @Test
+    void rejects_a_version_range_with_a_clear_error() {
+        assertThatThrownBy(() -> new MavenDependency("com.example:widget:[1.0,2.0)", Scope.MODULE, List.of())).isInstanceOf(
+                IllegalArgumentException.class)
+                                                                                                              .hasMessageContaining(
+                                                                                                                      "exact version");
+    }
+
+    @Test
+    void rejects_a_malformed_coordinate() {
+        assertThatThrownBy(() -> new MavenDependency("com.example:widget", Scope.MODULE, List.of()))
+                                                                                                    .isInstanceOf(
+                                                                                                            IllegalArgumentException.class)
+                                                                                                    .hasMessageContaining(
+                                                                                                            "groupId:artifactId:version");
+    }
+
+    @Test
+    void rejects_a_malformed_exclusion() {
+        assertThatThrownBy(() -> new MavenDependency("com.example:widget:2.1.0", Scope.MODULE, List.of("com.example"))).isInstanceOf(
+                IllegalArgumentException.class);
+        assertThatThrownBy(() -> new MavenDependency("com.example:widget:2.1.0", Scope.MODULE, List.of("*:widget"))).isInstanceOf(
+                IllegalArgumentException.class);
+    }
+
+    @Test
+    void parses_the_scope_leniently() {
+        assertThat(Scope.parse(null)).isEqualTo(Scope.MODULE);
+        assertThat(Scope.parse("")).isEqualTo(Scope.MODULE);
+        assertThat(Scope.parse("module")).isEqualTo(Scope.MODULE);
+        assertThat(Scope.parse("PLATFORM")).isEqualTo(Scope.PLATFORM);
+        assertThatThrownBy(() -> Scope.parse("global")).isInstanceOf(IllegalArgumentException.class)
+                                                       .hasMessageContaining("global");
+    }
+
+}

--- a/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/ProjectMetadataParsingTest.java
+++ b/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/ProjectMetadataParsingTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import nl.altindag.log.LogCaptor;
+import org.eclipse.dirigible.components.dependencies.MavenDependency.Scope;
+import org.eclipse.dirigible.components.project.ProjectMetadata;
+import org.eclipse.dirigible.components.project.ProjectMetadataDependency;
+import org.eclipse.dirigible.components.project.ProjectMetadataUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The project.json parsing contract of the maven dependency type - maven entries parse, git entries
+ * keep their exact current meaning, and unknown types are tolerated with a warning so an older
+ * platform accepts a newer descriptor.
+ */
+class ProjectMetadataParsingTest {
+
+    private static final String PROJECT_JSON = """
+            {
+                "guid": "my-project",
+                "dependencies": [
+                    { "type": "git", "guid": "employees",
+                      "url": "https://github.com/example/employees.git", "branch": "main" },
+                    { "type": "maven", "id": "com.businessintents:employees:1.4.0" },
+                    { "type": "maven", "id": "com.example:widget:2.1.0",
+                      "scope": "module",
+                      "exclusions": ["com.fasterxml.jackson.core:*"] }
+                ],
+                "actions": []
+            }
+            """;
+
+    @Test
+    void maven_entries_parse() {
+        ProjectMetadata metadata = ProjectMetadataUtils.fromJson(PROJECT_JSON);
+
+        ProjectMetadataDependency[] dependencies = metadata.getDependencies();
+        assertThat(dependencies).hasSize(3);
+        assertThat(dependencies[1].getType()).isEqualTo(ProjectMetadataDependency.TYPE_MAVEN);
+        assertThat(dependencies[1].getId()).isEqualTo("com.businessintents:employees:1.4.0");
+        assertThat(dependencies[1].getScope()).isNull();
+        assertThat(dependencies[1].getExclusions()).isNull();
+        assertThat(dependencies[2].getScope()).isEqualTo("module");
+        assertThat(dependencies[2].getExclusions()).containsExactly("com.fasterxml.jackson.core:*");
+    }
+
+    @Test
+    void git_entries_are_unaffected() {
+        ProjectMetadata metadata = ProjectMetadataUtils.fromJson(PROJECT_JSON);
+
+        ProjectMetadataDependency git = metadata.getDependencies()[0];
+        assertThat(git.getType()).isEqualTo(ProjectMetadataDependency.TYPE_GIT);
+        assertThat(git.getGuid()).isEqualTo("employees");
+        assertThat(git.getUrl()).isEqualTo("https://github.com/example/employees.git");
+        assertThat(git.getBranch()).isEqualTo("main");
+    }
+
+    @Test
+    void collects_the_maven_declarations_and_skips_the_git_ones() {
+        Set<MavenDependency> dependencies = new LinkedHashSet<>();
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(PROJECT_JSON), dependencies, errors);
+
+        assertThat(errors).isEmpty();
+        assertThat(dependencies).containsExactly(new MavenDependency("com.businessintents:employees:1.4.0", Scope.MODULE, List.of()),
+                new MavenDependency("com.example:widget:2.1.0", Scope.MODULE, List.of("com.fasterxml.jackson.core:*")));
+    }
+
+    @Test
+    void an_unknown_dependency_type_warns_and_is_ignored() {
+        String json = """
+                {
+                    "guid": "my-project",
+                    "dependencies": [
+                        { "type": "npm", "id": "left-pad@1.3.0" }
+                    ]
+                }
+                """;
+        Set<MavenDependency> dependencies = new LinkedHashSet<>();
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        try (LogCaptor logCaptor = LogCaptor.forClass(ProjectDependenciesCollector.class)) {
+            ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies, errors);
+
+            assertThat(logCaptor.getWarnLogs()).anySatisfy(message -> assertThat(message).contains("npm")
+                                                                                         .contains("my-project"));
+        }
+        assertThat(dependencies).isEmpty();
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    void a_version_range_becomes_a_declaration_error() {
+        String json = """
+                {
+                    "guid": "my-project",
+                    "dependencies": [
+                        { "type": "maven", "id": "com.example:widget:[1.0,2.0)" }
+                    ]
+                }
+                """;
+        Set<MavenDependency> dependencies = new LinkedHashSet<>();
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies, errors);
+
+        assertThat(dependencies).isEmpty();
+        assertThat(errors).containsKey("com.example:widget:[1.0,2.0)");
+        assertThat(errors.get("com.example:widget:[1.0,2.0)")).contains("exact version");
+    }
+
+    @Test
+    void a_maven_entry_without_an_id_becomes_a_declaration_error() {
+        String json = """
+                {
+                    "guid": "my-project",
+                    "dependencies": [
+                        { "type": "maven" }
+                    ]
+                }
+                """;
+        Set<MavenDependency> dependencies = new LinkedHashSet<>();
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies, errors);
+
+        assertThat(dependencies).isEmpty();
+        assertThat(errors).containsKey("my-project");
+    }
+
+    @Test
+    void the_platform_scope_is_parsed() {
+        String json = """
+                {
+                    "guid": "my-project",
+                    "dependencies": [
+                        { "type": "maven", "id": "com.example:widget:2.1.0", "scope": "platform" }
+                    ]
+                }
+                """;
+        Set<MavenDependency> dependencies = new LinkedHashSet<>();
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies, errors);
+
+        // parsed here - rejected as unsupported by the resolver until phase 3
+        assertThat(errors).isEmpty();
+        assertThat(dependencies).containsExactly(new MavenDependency("com.example:widget:2.1.0", Scope.PLATFORM, List.of()));
+    }
+
+}

--- a/components/core/core-project/src/main/java/org/eclipse/dirigible/components/project/ProjectMetadataDependency.java
+++ b/components/core/core-project/src/main/java/org/eclipse/dirigible/components/project/ProjectMetadataDependency.java
@@ -9,10 +9,18 @@
  */
 package org.eclipse.dirigible.components.project;
 
+import java.util.List;
+
 /**
  * The ProjectMetadataDependency serialization object.
  */
 public class ProjectMetadataDependency {
+
+    /** Dependency type of a sibling git repository, consumed by the IDE workspace. */
+    public static final String TYPE_GIT = "git";
+
+    /** Dependency type of a Maven artifact, resolved by the platform's dependency resolver. */
+    public static final String TYPE_MAVEN = "maven";
 
     /** The guid. */
     private String guid;
@@ -25,6 +33,17 @@ public class ProjectMetadataDependency {
 
     /** The branch. */
     private String branch;
+
+    /** The Maven coordinate as a single groupId:artifactId:version string (maven type only). */
+    private String id;
+
+    /** The scope - module (default) or platform (maven type only). */
+    private String scope;
+
+    /**
+     * The exclusions as groupId:artifactId entries, artifactId may be the * wildcard (maven type only).
+     */
+    private List<String> exclusions;
 
     /**
      * Gets the guid.
@@ -96,6 +115,60 @@ public class ProjectMetadataDependency {
      */
     public void setBranch(String branch) {
         this.branch = branch;
+    }
+
+    /**
+     * Gets the Maven coordinate.
+     *
+     * @return the coordinate as groupId:artifactId:version
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the Maven coordinate.
+     *
+     * @param id the coordinate as groupId:artifactId:version
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the scope.
+     *
+     * @return the scope
+     */
+    public String getScope() {
+        return scope;
+    }
+
+    /**
+     * Sets the scope.
+     *
+     * @param scope the new scope
+     */
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    /**
+     * Gets the exclusions.
+     *
+     * @return the exclusions as groupId:artifactId entries
+     */
+    public List<String> getExclusions() {
+        return exclusions;
+    }
+
+    /**
+     * Sets the exclusions.
+     *
+     * @param exclusions the exclusions as groupId:artifactId entries
+     */
+    public void setExclusions(List<String> exclusions) {
+        this.exclusions = exclusions;
     }
 
 }

--- a/components/group/group-core/pom.xml
+++ b/components/group/group-core/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-core-dependencies</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
             <artifactId>dirigible-components-core-configurations</artifactId>
         </dependency>
         <dependency>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -31,6 +31,7 @@
         <module>core/core-tracing</module>
         <module>core/core-java</module>
         <module>core/core-liquibase</module>
+        <module>core/core-dependencies</module>
 
         <!-- Security -->
         <module>security/security-basic</module>
@@ -661,6 +662,11 @@
             <dependency>
                 <groupId>org.eclipse.dirigible</groupId>
                 <artifactId>dirigible-components-core-project</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.dirigible</groupId>
+                <artifactId>dirigible-components-core-dependencies</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -51,6 +51,36 @@
                 <version>${activemq.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-api</artifactId>
+                <version>${maven-resolver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-util</artifactId>
+                <version>${maven-resolver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-supplier</artifactId>
+                <version>${maven-resolver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-resolver-provider</artifactId>
+                <version>${maven-resolver-maven.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-settings</artifactId>
+                <version>${maven-resolver-maven.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-settings-builder</artifactId>
+                <version>${maven-resolver-maven.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.sap.cloud.db.jdbc</groupId>
                 <artifactId>ngdbc</artifactId>
                 <version>${ngdbc.version}</version>

--- a/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
+++ b/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
@@ -149,6 +149,31 @@ public enum DirigibleConfig {
     /** Default JDWP port the Java debug adapter attaches to. */
     JAVA_DEBUG_JDWP_PORT("DIRIGIBLE_JAVA_DEBUG_JDWP_PORT", "8000"),
 
+    /** Whether dynamic dependency resolution of project.json maven declarations is enabled. */
+    DEPENDENCIES_DYNAMIC_ENABLED("DIRIGIBLE_DEPENDENCIES_DYNAMIC", Boolean.TRUE.toString()),
+
+    /**
+     * Directory the resolved dependency JARs are linked into; blank means [user
+     * home]/.dirigible/resolved-modules.
+     */
+    DEPENDENCIES_DIR("DIRIGIBLE_DEPENDENCIES_DIR", null),
+
+    /**
+     * Maven local repository; blank means [user home]/.m2/repository when it exists, else [user
+     * home]/.dirigible/m2.
+     */
+    MAVEN_LOCAL_REPO("DIRIGIBLE_MAVEN_LOCAL_REPO", null),
+
+    /**
+     * Remote Maven repositories as comma-separated id=url pairs. An entry with id central overrides the
+     * default Maven Central URL; other entries are added to it. Credentials go in the
+     * DIRIGIBLE_MAVEN_[ID]_USERNAME / DIRIGIBLE_MAVEN_[ID]_PASSWORD pair for the entry's uppercased id.
+     */
+    MAVEN_REPOSITORIES("DIRIGIBLE_MAVEN_REPOSITORIES", null),
+
+    /** Whether Maven dependency resolution runs offline (local repository only). */
+    MAVEN_OFFLINE("DIRIGIBLE_MAVEN_OFFLINE", Boolean.FALSE.toString()),
+
     /** Milliseconds the platform waits for a started native-app process to start accepting TCP. */
     NATIVE_APP_READY_TIMEOUT_MS("DIRIGIBLE_NATIVE_APP_READY_TIMEOUT_MS", "30000"),
 

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,11 @@
         <!-- ActiveMQ -->
         <activemq.version>6.1.0</activemq.version>
 
+        <!-- Maven Artifact Resolver (embedded for dynamic dependency resolution);
+             maven-resolver-maven.version is the Maven line the resolver release pairs with -->
+        <maven-resolver.version>1.9.27</maven-resolver.version>
+        <maven-resolver-maven.version>3.9.12</maven-resolver-maven.version>
+
         <!-- Camel -->
         <camel.version>4.22.0</camel.version>
 

--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/base/IntegrationTest.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/base/IntegrationTest.java
@@ -48,6 +48,14 @@ public abstract class IntegrationTest {
     }
 
     @BeforeAll
+    static void useIsolatedDependenciesFolders() {
+        // keep the boot-time maven dependency resolution off the developer's real ~/.dirigible
+        // and ~/.m2 - both land under the dirigible folder the cleaner wipes
+        Configuration.set("DIRIGIBLE_DEPENDENCIES_DIR", "target/dirigible/resolved-modules");
+        Configuration.set("DIRIGIBLE_MAVEN_LOCAL_REPO", "target/dirigible/m2");
+    }
+
+    @BeforeAll
     static void cleanBeforeTestClassExecution() {
         DirigibleCleaner.deleteDirigibleFolder();
     }

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/DependencyResolutionIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/DependencyResolutionIT.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import ch.qos.logback.classic.Level;
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.logging.LogsAsserter;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * End-to-end test for the maven dependency type in project.json: a fixture coordinate served from a
+ * file: repository is declared, resolved through the REST surface into the local repository and
+ * linked into the resolved-modules directory, and the state endpoint reports it. No test touches
+ * the network - the fixture repository replaces Maven Central.
+ */
+// One Dirigible boot for the whole class: each method cleans up the declaring project after itself.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class DependencyResolutionIT extends IntegrationTest {
+
+    /** The project declaring the maven dependencies. */
+    private static final String PROJECT = "dependency-resolution-it";
+
+    /** The project.json path under the registry root. */
+    private static final String PROJECT_JSON_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/project.json";
+
+    /** The resolver's logger - package-private class, so the name is spelled out. */
+    private static final String RESOLVER_LOGGER = "org.eclipse.dirigible.components.dependencies.MavenDependencyResolver";
+
+    @TempDir
+    static Path tempDir;
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    private Path localRepository;
+    private Path resolvedModulesDir;
+    private LogsAsserter resolverLogs;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        Path fixtureRepo = Files.createDirectories(tempDir.resolve("fixture-repo"));
+        deploy(fixtureRepo, "leaf", "1.0.0", "");
+        deploy(fixtureRepo, "mid", "1.0.0", dependencyOn("leaf", "1.0.0"));
+        localRepository = tempDir.resolve("local-repo");
+        resolvedModulesDir = tempDir.resolve("resolved-modules");
+        // the fixture repository REPLACES Maven Central, so no request can leave the machine
+        Configuration.set("DIRIGIBLE_MAVEN_REPOSITORIES", "central=" + fixtureRepo.toUri());
+        Configuration.set("DIRIGIBLE_MAVEN_LOCAL_REPO", localRepository.toString());
+        Configuration.set("DIRIGIBLE_DEPENDENCIES_DIR", resolvedModulesDir.toString());
+        resolverLogs = new LogsAsserter(RESOLVER_LOGGER, Level.ERROR);
+    }
+
+    @AfterEach
+    void removeProjectFromRegistry() {
+        if (repository.hasResource(PROJECT_JSON_PATH)) {
+            repository.removeResource(PROJECT_JSON_PATH);
+        }
+    }
+
+    @Test
+    void a_declared_maven_dependency_is_resolved_and_activated() {
+        writeProjectJson("""
+                {
+                    "guid": "%s",
+                    "dependencies": [
+                        { "type": "maven", "id": "com.example:mid:1.0.0" }
+                    ]
+                }
+                """.formatted(PROJECT));
+
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .post("/services/core/dependencies/resolve")
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body("failures", anEmptyMap())
+                                                 .body("declared", hasItem("com.example:mid:1.0.0"))
+                                                 .body("artifacts", hasSize(2)));
+
+        // the artifacts landed in the local repository at their immutable versioned paths
+        assertThat(localRepository.resolve("com/example/mid/1.0.0/mid-1.0.0.jar")).exists();
+        assertThat(localRepository.resolve("com/example/leaf/1.0.0/leaf-1.0.0.jar")).exists();
+
+        // and are linked into the resolved-modules directory the next launch's classpath includes
+        assertThat(resolvedModulesDir.resolve("com.example-mid-1.0.0.jar")).exists();
+        assertThat(resolvedModulesDir.resolve("com.example-leaf-1.0.0.jar")).exists();
+
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get("/services/core/dependencies")
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body("enabled", is(true))
+                                                 .body("declared", hasItem("com.example:mid:1.0.0"))
+                                                 .body("artifacts", hasSize(2))
+                                                 .body("failures", anEmptyMap()));
+    }
+
+    @Test
+    void an_unresolvable_coordinate_is_reported_without_failing_the_platform() {
+        writeProjectJson("""
+                {
+                    "guid": "%s",
+                    "dependencies": [
+                        { "type": "maven", "id": "com.example:mid:1.0.0" },
+                        { "type": "maven", "id": "com.example:missing:9.9.9" }
+                    ]
+                }
+                """.formatted(PROJECT));
+
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .post("/services/core/dependencies/resolve")
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body("failures", hasKey("com.example:missing:9.9.9"))
+                                                 // the resolvable declaration still made it
+                                                 .body("artifacts", hasSize(2)));
+
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get("/services/core/dependencies")
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body("failures", hasKey("com.example:missing:9.9.9")));
+
+        // the error log names the coordinate and the repositories tried
+        assertThat(resolverLogs.containsMessage("Could not resolve maven dependency [com.example:missing:9.9.9] from repositories [central",
+                Level.ERROR)).isTrue();
+    }
+
+    private void writeProjectJson(String content) {
+        repository.createResource(PROJECT_JSON_PATH, content.getBytes(StandardCharsets.UTF_8), false, "application/json", true);
+    }
+
+    private static void deploy(Path repositoryDir, String artifactId, String version, String dependenciesXml) throws IOException {
+        Path directory = repositoryDir.resolve("com/example")
+                                      .resolve(artifactId)
+                                      .resolve(version);
+        Files.createDirectories(directory);
+        Files.writeString(directory.resolve(artifactId + "-" + version + ".pom"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>%s</artifactId>
+                    <version>%s</version>
+                    %s
+                </project>
+                """.formatted(artifactId, version, dependenciesXml));
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(directory.resolve(artifactId + "-" + version + ".jar")))) {
+            out.putNextEntry(new JarEntry("fixture.txt"));
+            out.write("fixture".getBytes(StandardCharsets.UTF_8));
+            out.closeEntry();
+        }
+    }
+
+    private static String dependencyOn(String artifactId, String version) {
+        return """
+                <dependencies>
+                    <dependency>
+                        <groupId>com.example</groupId>
+                        <artifactId>%s</artifactId>
+                        <version>%s</version>
+                    </dependency>
+                </dependencies>
+                """.formatted(artifactId, version);
+    }
+
+}


### PR DESCRIPTION
## Overview

A project can now declare a Maven dependency in its `project.json` and have the platform resolve it (with its transitive graph) into the instance-global local repository and activate it after a restart - no image rebuild, no hand-written POMs. Resolution runs at boot and on demand, one union request across all projects so one mediation produces one flat classpath; failures are per-coordinate and never prevent boot.

## New environment variables

| Variable | Default | Purpose |
| --- | --- | --- |
| `DIRIGIBLE_DEPENDENCIES_DYNAMIC` | `true` | Enables the whole feature (boot-time resolution + the REST surface). **Disable it for `prod` runs** - see below. |
| `DIRIGIBLE_DEPENDENCIES_DIR` | `~/.dirigible/resolved-modules` | Directory the resolved jars are linked into; part of the image's launch classpath. |
| `DIRIGIBLE_MAVEN_LOCAL_REPO` | `~/.m2/repository` if present, else `~/.dirigible/m2` | The local repository artifacts are resolved into. |
| `DIRIGIBLE_MAVEN_REPOSITORIES` | Maven Central | Comma-separated `id=url` pairs; an entry with id `central` overrides the Central URL, others are added. |
| `DIRIGIBLE_MAVEN_<ID>_USERNAME` / `DIRIGIBLE_MAVEN_<ID>_PASSWORD` | - | Credentials per repository id (uppercased). Operator configuration - never in `project.json`, never logged. |
| `DIRIGIBLE_MAVEN_OFFLINE` | `false` | Resolve from the local repository only. |

`~/.m2/settings.xml` mirrors/proxies/server credentials are honored, so corporate Nexus setups work unmodified.

**Production note:** dynamic resolution is a development/staging convenience. For `prod` runs set `DIRIGIBLE_DEPENDENCIES_DYNAMIC=false` and bake the required jars into the image (the `/modules` drop-in or a pre-populated resolved-modules directory on a volume), so the runtime classpath is immutable and never depends on remote repository availability.

Custom repository example (GitHub Packages Maven registry):

```
DIRIGIBLE_MAVEN_REPOSITORIES=central=https://repo1.maven.org/maven2,acme=https://maven.pkg.github.com/acme/artefacts
DIRIGIBLE_MAVEN_ACME_USERNAME=ci-bot
DIRIGIBLE_MAVEN_ACME_PASSWORD=<token>
```

## Worked example

```jsonc
{
    "guid": "my-project",
    "dependencies": [
        { "type": "git", "guid": "employees",
          "url": "https://github.com/example/employees.git", "branch": "main" },

        { "type": "maven", "id": "com.businessintents:employees:1.4.0" },
        { "type": "maven", "id": "software.amazon.awssdk:s3:2.32.4" },

        { "type": "maven", "id": "com.example:widget:2.1.0",
          "scope": "module",
          "exclusions": ["com.fasterxml.jackson.core:*"] }
    ],
    "actions": []
}
```

A successful resolution (from the integration test run):

```
o.e.d.c.d.MavenDependencyResolver - Resolving [1] declared maven dependency(ies) from repositories [central (file:///...)] into local repository [/.../local-repo]
o.e.d.c.d.ResolvedModulesLinker - Resolved-modules directory [/.../resolved-modules] holds [2] jar(s) - they join the application classpath on the next restart
o.e.d.c.d.DependenciesService - Maven dependency resolution completed: [1] declared, [2] jar(s) activated for the next restart, [0] mediated, [0] failure(s)
```

`GET /services/core/dependencies`:

```json
{
    "enabled": true,
    "declared": ["com.example:mid:1.0.0"],
    "artifacts": [
        "/.../local-repo/com/example/mid/1.0.0/mid-1.0.0.jar",
        "/.../local-repo/com/example/leaf/1.0.0/leaf-1.0.0.jar"
    ],
    "mediated": {},
    "failures": {},
    "localRepository": "/.../local-repo",
    "resolvedModulesDirectory": "/.../resolved-modules",
    "resolvedAt": "2026-08-17T13:16:52.337536Z"
}
```

Fixes: #6777.