### PR TITLE
Swappable modules classloader — restartless add/upgrade/remove of dependency JARs

### DIFF
--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/dependencies/DependenciesChangedEvent.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/dependencies/DependenciesChangedEvent.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.dependencies;
+
+import org.springframework.context.ApplicationEvent;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Published after the maven dependency layer swapped to a new modules-classloader generation.
+ * Listeners react to the change - the Java engine rediscovers AOT compiled modules, invalidates its
+ * compile classpath and rebuilds the client sources; the monitoring surface records the change.
+ * Published synchronously on the swapping thread, so a listener's reaction completes before the
+ * swap pipeline reports success.
+ */
+public class DependenciesChangedEvent extends ApplicationEvent {
+
+    /** The added coordinates. */
+    private final Set<String> added;
+
+    /** The removed coordinates. */
+    private final Set<String> removed;
+
+    /** The mediated versions, groupId:artifactId to the chosen version. */
+    private final Map<String, String> mediated;
+
+    /** The installed modules-classloader generation number. */
+    private final int generation;
+
+    /**
+     * Instantiates a new event.
+     *
+     * @param source the publisher
+     * @param added the added coordinates
+     * @param removed the removed coordinates
+     * @param mediated the mediated versions
+     * @param generation the installed generation number
+     */
+    public DependenciesChangedEvent(Object source, Set<String> added, Set<String> removed, Map<String, String> mediated, int generation) {
+        super(source);
+        this.added = Collections.unmodifiableSet(new LinkedHashSet<>(added));
+        this.removed = Collections.unmodifiableSet(new LinkedHashSet<>(removed));
+        this.mediated = Collections.unmodifiableMap(new LinkedHashMap<>(mediated));
+        this.generation = generation;
+    }
+
+    /**
+     * Gets the added coordinates.
+     *
+     * @return the added coordinates
+     */
+    public Set<String> getAdded() {
+        return added;
+    }
+
+    /**
+     * Gets the removed coordinates.
+     *
+     * @return the removed coordinates
+     */
+    public Set<String> getRemoved() {
+        return removed;
+    }
+
+    /**
+     * Gets the mediated versions.
+     *
+     * @return the mediated versions, groupId:artifactId to the chosen version
+     */
+    public Map<String, String> getMediated() {
+        return mediated;
+    }
+
+    /**
+     * Gets the installed modules-classloader generation number.
+     *
+     * @return the generation number
+     */
+    public int getGeneration() {
+        return generation;
+    }
+
+}

--- a/components/core/core-dependencies/pom.xml
+++ b/components/core/core-dependencies/pom.xml
@@ -33,6 +33,18 @@
             <artifactId>dirigible-components-core-repository</artifactId>
         </dependency>
 
+        <!-- Java runtime - the swappable modules classloader layer -->
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-core-java</artifactId>
+        </dependency>
+
+        <!-- Initializers - the per-jar registry payload expander -->
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-core-initializers</artifactId>
+        </dependency>
+
         <!-- Maven Artifact Resolver - the supplier wires a complete RepositorySystem
              (impl, basic connector, file/http transports, POM reading via maven-resolver-provider) -->
         <dependency>

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DeclaredDependencies.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DeclaredDependencies.java
@@ -11,6 +11,8 @@ package org.eclipse.dirigible.components.dependencies;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 /**
  * The maven dependencies declared across all projects in the registry.
@@ -20,4 +22,24 @@ import java.util.Set;
  *        range, unknown scope, ...), keyed by the declared id or the declaring project
  */
 record DeclaredDependencies(Set<MavenDependency> dependencies, Map<String, String> errors) {
+
+    /**
+     * A change-detection fingerprint of the declarations - stable across collection order, different
+     * for any semantic change (coordinate, scope, exclusions, or a declaration error).
+     *
+     * @return the fingerprint
+     */
+    String fingerprint() {
+        String declared = dependencies.stream()
+                                      .map(dependency -> dependency.coordinate() + "|" + dependency.scope() + "|"
+                                              + new TreeSet<>(dependency.exclusions()))
+                                      .sorted()
+                                      .collect(Collectors.joining(";"));
+        String failed = errors.entrySet()
+                              .stream()
+                              .map(entry -> entry.getKey() + "=" + entry.getValue())
+                              .sorted()
+                              .collect(Collectors.joining(";"));
+        return declared + "||" + failed;
+    }
 }

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesEndpoint.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesEndpoint.java
@@ -21,7 +21,8 @@ import org.springframework.web.server.ResponseStatusException;
 
 /**
  * The maven dependency resolution surface - the current declared / resolved state and the on-demand
- * union resolution. The resolved jars join the application classpath on the next restart.
+ * union resolution. The resolved jars take effect immediately through the swappable modules
+ * classloader; no restart is required.
  */
 @RestController
 @RequestMapping(BaseEndpoint.PREFIX_ENDPOINT_CORE + "dependencies")

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesInitializer.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesInitializer.java
@@ -20,7 +20,8 @@ import org.springframework.stereotype.Component;
 /**
  * Resolves the maven dependencies declared across the registry projects at startup - ordered after
  * the synchronization initializer, so the project.json files are present in the registry. The
- * resolved jars join the application classpath on the next restart.
+ * resolved jars are activated through the modules classloader immediately; the run also arms the
+ * declaration watcher by recording the first fingerprint.
  */
 @Order(ApplicationReadyEventListeners.DEPENDENCIES_INITIALIZER)
 @Component

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesService.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesService.java
@@ -10,6 +10,8 @@
 package org.eclipse.dirigible.components.dependencies;
 
 import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.components.dependencies.DependencySynchronizer.SwapOutcome;
+import org.eclipse.dirigible.engine.java.runtime.ModulesClassLoaderHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -22,14 +24,18 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Orchestrates the declare - resolve - activate flow: collects the maven declarations of all
- * registry projects, resolves their union into the local repository and links the resolved jars
- * into the resolved-modules directory. The contract of this phase: declare, resolve (at boot or on
- * demand), restart to activate.
+ * registry projects, resolves their union into the local repository and reconciles the resolved
+ * JARs into the running system through the {@link DependencySynchronizer} - a dependency change
+ * takes effect without restarting the platform. The resolved-modules directory is still maintained
+ * as the launch-time seed.
  */
 @Component
 class DependenciesService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DependenciesService.class);
+
+    /** The failures key carrying a swap abort. */
+    private static final String SWAP_FAILURE_KEY = "modules-swap";
 
     /** The collector. */
     private final ProjectDependenciesCollector collector;
@@ -40,8 +46,17 @@ class DependenciesService {
     /** The linker. */
     private final ResolvedModulesLinker linker;
 
+    /** The dependency synchronizer. */
+    private final DependencySynchronizer dependencySynchronizer;
+
+    /** The loader holder. */
+    private final ModulesClassLoaderHolder loaderHolder;
+
     /** The last resolved state, null before the first resolution. */
     private final AtomicReference<DependenciesState> lastState = new AtomicReference<>();
+
+    /** The fingerprint of the declarations the last resolution processed, null before it. */
+    private volatile String lastDeclaredFingerprint;
 
     /**
      * Instantiates a new dependencies service.
@@ -49,11 +64,16 @@ class DependenciesService {
      * @param collector the collector
      * @param resolver the resolver
      * @param linker the linker
+     * @param dependencySynchronizer the dependency synchronizer
+     * @param loaderHolder the loader holder
      */
-    DependenciesService(ProjectDependenciesCollector collector, DependencyResolver resolver, ResolvedModulesLinker linker) {
+    DependenciesService(ProjectDependenciesCollector collector, DependencyResolver resolver, ResolvedModulesLinker linker,
+            DependencySynchronizer dependencySynchronizer, ModulesClassLoaderHolder loaderHolder) {
         this.collector = collector;
         this.resolver = resolver;
         this.linker = linker;
+        this.dependencySynchronizer = dependencySynchronizer;
+        this.loaderHolder = loaderHolder;
     }
 
     /**
@@ -66,18 +86,46 @@ class DependenciesService {
     }
 
     /**
-     * Runs the union resolution and links the resolved jars into the resolved-modules directory.
+     * The fingerprint of the declarations the last resolution processed - the watcher compares the
+     * registry against it.
+     *
+     * @return the fingerprint, null before the first resolution
+     */
+    String lastDeclaredFingerprint() {
+        return lastDeclaredFingerprint;
+    }
+
+    /**
+     * Runs the union resolution and reconciles the result into the running system. On any failure -
+     * declaration, resolution or swap validation - the installed modules-classloader generation keeps
+     * serving and the failure is reported in the returned state.
      *
      * @return the resolved state
      */
     synchronized DependenciesState resolveAndActivate() {
         DeclaredDependencies declared = collector.collect();
+        lastDeclaredFingerprint = declared.fingerprint();
         ResolutionResult result = resolver.resolve(declared.dependencies());
         Map<String, String> failures = new LinkedHashMap<>(declared.errors());
         failures.putAll(result.failures());
         Path localRepository = MavenResolverConfig.fromConfiguration()
                                                   .localRepository();
+
+        SwapOutcome outcome;
+        if (failures.isEmpty()) {
+            outcome = dependencySynchronizer.swap(localRepository, result.artifacts(), result.mediated());
+        } else {
+            outcome = SwapOutcome.kept(null);
+            LOGGER.error("Not swapping the dependency layer: [{}] declaration/resolution failure(s) - the installed generation keeps "
+                    + "serving. Failures: {}", failures.size(), failures);
+        }
+        if (outcome.error() != null) {
+            failures.put(SWAP_FAILURE_KEY, outcome.error());
+        }
+        // the resolved-modules directory stays maintained as the seed of the next launch's
+        // classpath; stale links are removed only after a fully clean pass
         linker.sync(localRepository, result.artifacts(), failures.isEmpty());
+
         DependenciesState state = new DependenciesState(isDynamicEnabled(), declared.dependencies()
                                                                                     .stream()
                                                                                     .map(MavenDependency::coordinate)
@@ -88,18 +136,20 @@ class DependenciesService {
                       .toList(),
                 result.mediated(), failures, localRepository.toString(), linker.directory()
                                                                                .toString(),
-                Instant.now());
+                loaderHolder.generation(), loaderHolder.retiredGenerationsLive(), Instant.now());
         lastState.set(state);
         LOGGER.info(
-                "Maven dependency resolution completed: [{}] declared, [{}] jar(s) activated for the next restart, [{}] mediated, [{}] failure(s)",
+                "Maven dependency resolution completed: [{}] declared, [{}] jar(s) {}, [{}] mediated, [{}] failure(s), "
+                        + "classloader generation [{}]",
                 state.declared()
                      .size(),
                 state.artifacts()
                      .size(),
-                state.mediated()
-                     .size(),
+                outcome.swapped() ? "active" : "resolved (generation kept)", state.mediated()
+                                                                                  .size(),
                 state.failures()
-                     .size());
+                     .size(),
+                state.classLoaderGeneration());
         return state;
     }
 
@@ -114,7 +164,7 @@ class DependenciesService {
             return DependenciesState.empty(isDynamicEnabled(), linker.directory()
                                                                      .toString());
         }
-        return state.withEnabled(isDynamicEnabled());
+        return state.refreshed(isDynamicEnabled(), loaderHolder.generation(), loaderHolder.retiredGenerationsLive());
     }
 
 }

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesState.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesState.java
@@ -23,11 +23,15 @@ import java.util.Map;
  *        groupId:artifactId
  * @param failures the per-coordinate failure messages
  * @param localRepository the local repository, null before the first resolution
- * @param resolvedModulesDirectory the directory the resolved jars are linked into
+ * @param resolvedModulesDirectory the directory the resolved jars are linked into (the launch-time
+ *        seed; at runtime the jars are served by the modules classloader directly)
+ * @param classLoaderGeneration the installed modules-classloader generation number
+ * @param retiredClassLoaders how many retired generations are still pinned by live references
  * @param resolvedAt when the state was resolved, null before the first resolution
  */
 record DependenciesState(boolean enabled, List<String> declared, List<String> artifacts, Map<String, String> mediated,
-        Map<String, String> failures, String localRepository, String resolvedModulesDirectory, Instant resolvedAt) {
+        Map<String, String> failures, String localRepository, String resolvedModulesDirectory, int classLoaderGeneration,
+        int retiredClassLoaders, Instant resolvedAt) {
 
     /**
      * The state before the first resolution.
@@ -37,17 +41,20 @@ record DependenciesState(boolean enabled, List<String> declared, List<String> ar
      * @return the empty state
      */
     static DependenciesState empty(boolean enabled, String resolvedModulesDirectory) {
-        return new DependenciesState(enabled, List.of(), List.of(), Map.of(), Map.of(), null, resolvedModulesDirectory, null);
+        return new DependenciesState(enabled, List.of(), List.of(), Map.of(), Map.of(), null, resolvedModulesDirectory, 0, 0, null);
     }
 
     /**
-     * The same state with the enabled flag re-read.
+     * The same state with the enabled flag and the classloader counters re-read.
      *
-     * @param value the current flag value
+     * @param enabled the current flag value
+     * @param classLoaderGeneration the current generation number
+     * @param retiredClassLoaders the current pinned retired-generation count
      * @return the state
      */
-    DependenciesState withEnabled(boolean value) {
-        return new DependenciesState(value, declared, artifacts, mediated, failures, localRepository, resolvedModulesDirectory, resolvedAt);
+    DependenciesState refreshed(boolean enabled, int classLoaderGeneration, int retiredClassLoaders) {
+        return new DependenciesState(enabled, declared, artifacts, mediated, failures, localRepository, resolvedModulesDirectory,
+                classLoaderGeneration, retiredClassLoaders, resolvedAt);
     }
 
 }

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesWatcher.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesWatcher.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Watches the registry's project.json maven declarations and runs the swap pipeline when they
+ * change - so a published dependency change takes effect without a restart and without a manual
+ * resolve call. The check is a cheap fingerprint comparison over the collected declarations; the
+ * pipeline runs only on an actual change, so a persistently failing declaration is retried only
+ * when it changes again.
+ */
+@Component
+class DependenciesWatcher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DependenciesWatcher.class);
+
+    /** The dependencies service. */
+    private final DependenciesService dependenciesService;
+
+    /** The collector. */
+    private final ProjectDependenciesCollector collector;
+
+    /**
+     * Instantiates a new dependencies watcher.
+     *
+     * @param dependenciesService the dependencies service
+     * @param collector the collector
+     */
+    DependenciesWatcher(DependenciesService dependenciesService, ProjectDependenciesCollector collector) {
+        this.dependenciesService = dependenciesService;
+        this.collector = collector;
+    }
+
+    /**
+     * One watch tick. Armed only after the boot-time resolution recorded the first fingerprint, so the
+     * watcher never races the startup sequence.
+     */
+    @Scheduled(initialDelay = 10_000, fixedDelay = 5_000)
+    void watch() {
+        if (!dependenciesService.isDynamicEnabled()) {
+            return;
+        }
+        String last = dependenciesService.lastDeclaredFingerprint();
+        if (last == null) {
+            return;
+        }
+        String current = collector.collect()
+                                  .fingerprint();
+        if (current.equals(last)) {
+            return;
+        }
+        LOGGER.info("The registry's maven dependency declarations changed - running the swap pipeline");
+        try {
+            dependenciesService.resolveAndActivate();
+        } catch (RuntimeException e) {
+            // the installed generation keeps serving; the next declaration change retries
+            LOGGER.error("The dependency swap pipeline failed", e);
+        }
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependencySynchronizer.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependencySynchronizer.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import org.eclipse.dirigible.components.base.dependencies.DependenciesChangedEvent;
+import org.eclipse.dirigible.components.dependencies.ModuleJarInspector.Inspection;
+import org.eclipse.dirigible.components.initializers.classpath.ClasspathExpander;
+import org.eclipse.dirigible.engine.java.runtime.ModulesClassLoader;
+import org.eclipse.dirigible.engine.java.runtime.ModulesClassLoaderHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The restartless dependency swap - reconciles the resolved JAR set into the running system as one
+ * pipeline:
+ *
+ * <ol>
+ * <li>Union resolution ran upstream (see {@code DependenciesService}) - the input here is its
+ * resolved JAR set; a resolution with failures never reaches this point, so a broken declaration
+ * leaves the installed generation serving (no partial swap).</li>
+ * <li>Validate every arriving JAR before anything is touched: it must be a readable archive and
+ * must not carry native libraries - the JVM binds a native library to exactly one classloader, so a
+ * swappable loader would break on the first upgrade; such a dependency belongs to
+ * {@code scope: "platform"} (a later phase).</li>
+ * <li>Registry payload: the {@code META-INF/dirigible/&lt;project&gt;/**} content of removed JARs
+ * leaves the registry, arriving JARs lay theirs in - the per-artefact synchronizers reconcile the
+ * runtime state of those files on their next pass.</li>
+ * <li>Swap the {@link ModulesClassLoaderHolder} to a fresh {@link ModulesClassLoader} generation
+ * over the launch-classpath JARs plus the resolved set.</li>
+ * <li>Publish a {@link DependenciesChangedEvent} - the Java engine reacts synchronously by
+ * rediscovering AOT compiled modules through the new generation, invalidating its compile classpath
+ * and rebuilding the client sources; other listeners (monitoring) observe the change.</li>
+ * </ol>
+ *
+ * One swap runs at a time; the Java engine's own lock discipline serializes the triggered rebuild
+ * with regular synchronization passes. A parent-first shadowed artifact (also present on the
+ * platform classpath) is reported with a WARN - detection stays best-effort until the shadowing
+ * report of a later phase.
+ */
+@Component
+class DependencySynchronizer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DependencySynchronizer.class);
+
+    /** The loader holder. */
+    private final ModulesClassLoaderHolder loaderHolder;
+
+    /** The classpath expander. */
+    private final ClasspathExpander classpathExpander;
+
+    /** The event publisher. */
+    private final ApplicationEventPublisher eventPublisher;
+
+    /** The launch-classpath jars (loader.path / LOADER_PATH) - constant for the process lifetime. */
+    private final List<Path> launchClasspathJars;
+
+    /**
+     * Instantiates a new dependency synchronizer.
+     *
+     * @param loaderHolder the loader holder
+     * @param classpathExpander the classpath expander
+     * @param eventPublisher the event publisher
+     */
+    DependencySynchronizer(ModulesClassLoaderHolder loaderHolder, ClasspathExpander classpathExpander,
+            ApplicationEventPublisher eventPublisher) {
+        this.loaderHolder = loaderHolder;
+        this.classpathExpander = classpathExpander;
+        this.eventPublisher = eventPublisher;
+        this.launchClasspathJars = launchClasspathJars();
+    }
+
+    /**
+     * The outcome of a swap attempt.
+     *
+     * @param swapped whether a new generation was installed
+     * @param error the abort reason, null when the swap succeeded or nothing changed
+     * @param added the arrived coordinates
+     * @param removed the left coordinates
+     */
+    record SwapOutcome(boolean swapped, String error, Set<String> added, Set<String> removed) {
+
+        /**
+         * Kept the current generation.
+         *
+         * @param error the reason, null when nothing changed
+         * @return the outcome
+         */
+        static SwapOutcome kept(String error) {
+            return new SwapOutcome(false, error, Set.of(), Set.of());
+        }
+    }
+
+    /**
+     * Reconciles the resolved JAR set into a new modules-classloader generation.
+     *
+     * @param localRepository the local repository the artifacts live in, for coordinate derivation
+     * @param resolvedJars the resolved JAR set
+     * @param mediated the mediated versions, forwarded to the change event
+     * @return the outcome
+     */
+    synchronized SwapOutcome swap(Path localRepository, List<Path> resolvedJars, Map<String, String> mediated) {
+        List<Path> target = new ArrayList<>(launchClasspathJars);
+        for (Path jar : resolvedJars) {
+            if (!target.contains(jar)) {
+                target.add(jar);
+            }
+        }
+
+        ModulesClassLoader current = loaderHolder.current();
+        Set<Path> currentJars = new LinkedHashSet<>(current.jars());
+        if (loaderHolder.generation() > 0 && currentJars.equals(new LinkedHashSet<>(target))) {
+            return SwapOutcome.kept(null);
+        }
+
+        List<Path> added = target.stream()
+                                 .filter(jar -> !currentJars.contains(jar))
+                                 .toList();
+        List<Path> removed = currentJars.stream()
+                                        .filter(jar -> !target.contains(jar))
+                                        .toList();
+
+        // validate everything BEFORE the first side effect - an aborted swap leaves generation N
+        // installed and serving, with no partial state anywhere
+        Map<Path, Inspection> inspections = new LinkedHashMap<>();
+        for (Path jar : added) {
+            Inspection inspection;
+            try {
+                inspection = ModuleJarInspector.inspect(jar);
+            } catch (IOException e) {
+                String error = "Jar [" + jar + "] is not a readable archive - keeping the installed generation. Cause: " + e.getMessage();
+                LOGGER.error("Dependency swap aborted: {}", error, e);
+                return SwapOutcome.kept(error);
+            }
+            if (!inspection.nativeLibraries()
+                           .isEmpty()) {
+                String error = "Jar [" + jar.getFileName() + "] contains native libraries " + inspection.nativeLibraries()
+                        + " which the swappable module tier cannot host (a native library binds to exactly one classloader)."
+                        + " Declare it with scope \"platform\" once supported, or bake it into the image.";
+                LOGGER.error("Dependency swap aborted: {}", error);
+                return SwapOutcome.kept(error);
+            }
+            inspections.put(jar, inspection);
+        }
+
+        warnOnPlatformShadowing(inspections);
+        reconcileRegistryPayload(added, removed, inspections);
+
+        ModulesClassLoader next = loaderHolder.swap(target);
+        int generation = loaderHolder.generation();
+
+        Set<String> addedCoordinates = coordinates(localRepository, added);
+        Set<String> removedCoordinates = coordinates(localRepository, removed);
+        if (!addedCoordinates.isEmpty() || !removedCoordinates.isEmpty()) {
+            LOGGER.info("Dependency layer swapped to generation [{}]: added {}, removed {}", generation, addedCoordinates,
+                    removedCoordinates);
+            eventPublisher.publishEvent(new DependenciesChangedEvent(this, addedCoordinates, removedCoordinates, mediated, generation));
+        }
+        return new SwapOutcome(true, null, addedCoordinates, removedCoordinates);
+    }
+
+    /**
+     * Removes the registry payload of leaving JARs and lays the payload of arriving ones. A project
+     * carried by a JAR that stays is never removed, and an upgraded module's project is removed and
+     * immediately re-laid from the new JAR.
+     *
+     * @param added the arriving jars
+     * @param removed the leaving jars
+     * @param inspections the arriving jars' inspections
+     */
+    private void reconcileRegistryPayload(List<Path> added, List<Path> removed, Map<Path, Inspection> inspections) {
+        Set<String> removedProjects = new LinkedHashSet<>();
+        for (Path jar : removed) {
+            try {
+                removedProjects.addAll(ModuleJarInspector.inspect(jar)
+                                                         .projects());
+            } catch (IOException e) {
+                // the immutable local-repo file was deleted externally - its payload cannot be
+                // attributed any more; the per-artefact synchronizers will reap orphans over time
+                LOGGER.warn("Cannot inspect the removed jar [{}] for its registry payload", jar, e);
+            }
+        }
+        if (!removedProjects.isEmpty()) {
+            // a project is only removed when NO remaining jar still carries it
+            ModulesClassLoader current = loaderHolder.current();
+            for (Path staying : current.jars()) {
+                if (removed.contains(staying) || !Files.isRegularFile(staying)) {
+                    continue;
+                }
+                try {
+                    removedProjects.removeAll(ModuleJarInspector.inspect(staying)
+                                                                .projects());
+                } catch (IOException e) {
+                    LOGGER.warn("Cannot inspect the staying jar [{}] while removing registry payload", staying, e);
+                }
+            }
+            removedProjects.forEach(classpathExpander::remove);
+        }
+        for (Path jar : added) {
+            if (!inspections.get(jar)
+                            .projects()
+                            .isEmpty()) {
+                classpathExpander.expand(jar);
+            }
+        }
+    }
+
+    /**
+     * WARN when an arriving artifact is also present on the platform classpath - parent-first
+     * delegation resolves such classes to the platform's version, so the declared version is inert.
+     *
+     * @param inspections the arriving jars' inspections
+     */
+    private void warnOnPlatformShadowing(Map<Path, Inspection> inspections) {
+        ClassLoader platform = getClass().getClassLoader();
+        inspections.forEach((jar, inspection) -> {
+            String probe = inspection.representativeClassResource();
+            if (probe != null && platform.getResource(probe) != null) {
+                LOGGER.warn("The resolved artifact [{}] is also present on the platform classpath - parent-first delegation serves "
+                        + "the platform's version, not the declared one", jar.getFileName());
+            }
+        });
+    }
+
+    /**
+     * Derives {@code groupId:artifactId:version} coordinates from local-repository paths; a path
+     * outside the local repository (a launch-classpath jar) reports its file name.
+     *
+     * @param localRepository the local repository
+     * @param jars the jars
+     * @return the coordinates
+     */
+    private static Set<String> coordinates(Path localRepository, List<Path> jars) {
+        Set<String> coordinates = new LinkedHashSet<>();
+        for (Path jar : jars) {
+            coordinates.add(coordinate(localRepository, jar));
+        }
+        return coordinates;
+    }
+
+    /**
+     * Coordinate of one jar.
+     *
+     * @param localRepository the local repository
+     * @param jar the jar
+     * @return the coordinate, or the file name when the jar is not a local-repository artifact
+     */
+    private static String coordinate(Path localRepository, Path jar) {
+        if (!jar.startsWith(localRepository)) {
+            return String.valueOf(jar.getFileName());
+        }
+        Path relative = localRepository.relativize(jar);
+        int segments = relative.getNameCount();
+        if (segments < 4) {
+            return String.valueOf(jar.getFileName());
+        }
+        String version = relative.getName(segments - 2)
+                                 .toString();
+        String artifactId = relative.getName(segments - 3)
+                                    .toString();
+        String groupId = relative.subpath(0, segments - 3)
+                                 .toString()
+                                 .replace(relative.getFileSystem()
+                                                  .getSeparator(),
+                                         ".");
+        return groupId + ":" + artifactId + ":" + version;
+    }
+
+    /**
+     * The jars already on the launch classpath via {@code loader.path} / {@code LOADER_PATH} - they
+     * seed every generation, so the drop-in {@code /modules} behavior stays intact (their classes
+     * resolve parent-first from the application classloader anyway).
+     *
+     * @return the launch-classpath jars
+     */
+    private static List<Path> launchClasspathJars() {
+        String property = System.getProperty("loader.path");
+        String raw = property != null ? property : System.getenv("LOADER_PATH");
+        if (raw == null || raw.isBlank()) {
+            return List.of();
+        }
+        List<Path> jars = new ArrayList<>();
+        for (String segment : raw.split(",")) {
+            String trimmed = segment.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            Path path = Path.of(trimmed);
+            if (Files.isDirectory(path)) {
+                try (var stream = Files.list(path)) {
+                    stream.filter(candidate -> candidate.toString()
+                                                        .endsWith(".jar"))
+                          .sorted()
+                          .forEach(jars::add);
+                } catch (IOException e) {
+                    LOGGER.warn("Could not list the loader.path directory [{}]", path, e);
+                }
+            } else if (Files.isRegularFile(path) && trimmed.endsWith(".jar")) {
+                jars.add(path);
+            }
+        }
+        return List.copyOf(jars);
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependencySynchronizer.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependencySynchronizer.java
@@ -164,7 +164,7 @@ class DependencySynchronizer {
         warnOnPlatformShadowing(inspections);
         reconcileRegistryPayload(added, removed, inspections);
 
-        ModulesClassLoader next = loaderHolder.swap(target);
+        loaderHolder.swap(target);
         int generation = loaderHolder.generation();
 
         Set<String> addedCoordinates = coordinates(localRepository, added);

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ModuleJarInspector.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ModuleJarInspector.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * A one-pass inspection of a module jar, feeding the swap pipeline's pre-swap validation and
+ * payload bookkeeping: which registry projects the jar carries, whether it contains native
+ * libraries (rejected on the module tier), and a representative class resource for the
+ * platform-shadowing warning.
+ */
+final class ModuleJarInspector {
+
+    /**
+     * The inspection result.
+     *
+     * @param projects the projects carried under META-INF/dirigible
+     * @param nativeLibraries the native library entries (.so / .dylib / .dll), empty for a loadable
+     *        module jar
+     * @param representativeClassResource a class entry usable to probe whether the parent classpath
+     *        already carries this artifact, null when the jar has no classes
+     */
+    record Inspection(Set<String> projects, List<String> nativeLibraries, String representativeClassResource) {
+    }
+
+    /** The registry payload root inside a jar. */
+    private static final String DIRIGIBLE_ROOT = "META-INF/dirigible/";
+
+    /**
+     * Instantiates a new module jar inspector.
+     */
+    private ModuleJarInspector() {
+        // utility
+    }
+
+    /**
+     * Inspects the jar in one pass over its entries.
+     *
+     * @param jarPath the jar
+     * @return the inspection
+     * @throws IOException when the jar is not a readable archive
+     */
+    static Inspection inspect(Path jarPath) throws IOException {
+        Set<String> projects = new LinkedHashSet<>();
+        List<String> nativeLibraries = new ArrayList<>();
+        String representativeClassResource = null;
+        try (JarFile jar = new JarFile(jarPath.toFile())) {
+            Enumeration<JarEntry> entries = jar.entries();
+            while (entries.hasMoreElements()) {
+                JarEntry entry = entries.nextElement();
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                String name = entry.getName();
+                if (name.startsWith(DIRIGIBLE_ROOT)) {
+                    String rest = name.substring(DIRIGIBLE_ROOT.length());
+                    int slash = rest.indexOf('/');
+                    if (slash > 0) {
+                        projects.add(rest.substring(0, slash));
+                    }
+                } else if (name.endsWith(".so") || name.endsWith(".dylib") || name.endsWith(".dll")) {
+                    nativeLibraries.add(name);
+                } else if (representativeClassResource == null && name.endsWith(".class") && !name.startsWith("META-INF/")
+                        && !"module-info.class".equals(name)) {
+                    representativeClassResource = name;
+                }
+            }
+        }
+        return new Inspection(projects, nativeLibraries, representativeClassResource);
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ResolvedModulesLinker.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ResolvedModulesLinker.java
@@ -72,7 +72,12 @@ class ResolvedModulesLinker {
             removeStaleEntries(directory, desired.keySet());
         }
         desired.forEach((name, target) -> place(directory.resolve(name), target));
-        LOGGER.info("Resolved-modules directory [{}] holds [{}] jar(s) - the seed of the next launch's classpath", directory,
+        // the directory is operator configuration - strip line breaks so a crafted value cannot
+        // forge log entries
+        LOGGER.info("Resolved-modules directory [{}] holds [{}] jar(s) - the seed of the next launch's classpath", directory.toString()
+                                                                                                                            .replaceAll(
+                                                                                                                                    "[\\r\\n]",
+                                                                                                                                    "_"),
                 desired.size());
     }
 

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ResolvedModulesLinker.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ResolvedModulesLinker.java
@@ -75,9 +75,10 @@ class ResolvedModulesLinker {
         // the directory is operator configuration - strip line breaks so a crafted value cannot
         // forge log entries
         LOGGER.info("Resolved-modules directory [{}] holds [{}] jar(s) - the seed of the next launch's classpath", directory.toString()
-                                                                                                                            .replaceAll(
-                                                                                                                                    "[\\r\\n]",
-                                                                                                                                    "_"),
+                                                                                                                            .replace('\r',
+                                                                                                                                    '_')
+                                                                                                                            .replace('\n',
+                                                                                                                                    '_'),
                 desired.size());
     }
 

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ResolvedModulesLinker.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ResolvedModulesLinker.java
@@ -27,8 +27,9 @@ import java.util.stream.Stream;
 
 /**
  * Maintains the resolved-modules directory - the stable directory the launch classpath includes
- * (see the loader.path entry in the application's Dockerfile). Resolved jars are linked in at their
- * mediated versions; they join the application classpath on the next restart.
+ * (see the loader.path entry in the application's Dockerfile). At runtime the resolved jars are
+ * served by the swappable modules classloader; this directory is the seed that keeps them on the
+ * classpath from the first moment of the next launch.
  */
 @Component
 class ResolvedModulesLinker {
@@ -71,8 +72,8 @@ class ResolvedModulesLinker {
             removeStaleEntries(directory, desired.keySet());
         }
         desired.forEach((name, target) -> place(directory.resolve(name), target));
-        LOGGER.info("Resolved-modules directory [{}] holds [{}] jar(s) - they join the application classpath on the next restart",
-                directory, desired.size());
+        LOGGER.info("Resolved-modules directory [{}] holds [{}] jar(s) - the seed of the next launch's classpath", directory,
+                desired.size());
     }
 
     /**

--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/classpath/ClasspathExpander.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/classpath/ClasspathExpander.java
@@ -167,13 +167,45 @@ public class ClasspathExpander {
             if (entry.getName()
                      .startsWith(jarRoot)) {
                 if (!entry.isDirectory()) {
-                    byte[] content = IOUtils.toByteArray(jar.getInputStream(entry));
                     String registryPath = entry.getName()
                                                .substring(jarRoot.length());
+                    if (!isSafeRegistryPath(registryPath)) {
+                        LOGGER.warn("Skipping the jar entry [{}] - its path would escape the registry root", entry.getName()
+                                                                                                                  .replaceAll("[\\r\\n]",
+                                                                                                                          "_"));
+                        continue;
+                    }
+                    byte[] content = IOUtils.toByteArray(jar.getInputStream(entry));
                     repository.createResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepository.SEPARATOR + registryPath, content);
                 }
             }
         }
+    }
+
+    /**
+     * Guards against Zip Slip: an archive entry may only map to a path strictly below the registry root
+     * - no '.' or '..' segments, no blank segments, no backslashes.
+     *
+     * @param registryPath the entry's registry-relative path
+     * @return true when the path is safe to create
+     */
+    private static boolean isSafeRegistryPath(String registryPath) {
+        if (registryPath.indexOf('\\') >= 0) {
+            return false;
+        }
+        String[] segments = registryPath.split("/");
+        boolean hasContent = false;
+        for (int i = 0; i < segments.length; i++) {
+            String segment = segments[i];
+            if (i == 0 && segment.isEmpty()) {
+                continue; // the leading separator
+            }
+            if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment)) {
+                return false;
+            }
+            hasContent = true;
+        }
+        return hasContent;
     }
 
     /**

--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/classpath/ClasspathExpander.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/classpath/ClasspathExpander.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.JarURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -104,7 +105,6 @@ public class ClasspathExpander {
      * @throws IOException Signals that an I/O exception has occurred.
      */
     private void handleJarURLConnection(String root, URLConnection urlConnection) throws IOException {
-        String jarRoot = "META-INF/" + root;
         JarURLConnection jarUrlConnection = (JarURLConnection) urlConnection;
         // A cached JarURLConnection hands out the JVM-wide shared JarFile - the very instance the
         // application class loader reads resources from. Closing it breaks every read of that JAR
@@ -113,22 +113,64 @@ public class ClasspathExpander {
         // Opting out of the cache yields a handle this method exclusively owns and may close.
         jarUrlConnection.setUseCaches(false);
         try (JarFile jar = jarUrlConnection.getJarFile()) {
-            Enumeration<JarEntry> entries = jar.entries();
-            JarEntry maybeSkip = jar.getJarEntry("META-INF/dirigible/.skip");
-            if (maybeSkip != null) {
-                return;
-            }
-            while (entries.hasMoreElements()) {
-                JarEntry entry = entries.nextElement();
-                if (entry.getName()
-                         .startsWith(jarRoot)) {
-                    if (!entry.isDirectory()) {
-                        byte[] content = IOUtils.toByteArray(jar.getInputStream(entry));
-                        String registryPath = entry.getName()
-                                                   .substring(jarRoot.length());
-                        repository.createResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepository.SEPARATOR + registryPath,
-                                content);
-                    }
+            copyRegistryContent(root, jar);
+        }
+    }
+
+    /**
+     * Lays a single jar's {@code META-INF/dirigible/**} payload into the registry - the per-jar
+     * counterpart of the startup sweep, used when a module jar joins the running system without a
+     * restart. The {@code .skip} marker is honored exactly as at startup.
+     *
+     * @param jarPath the jar to expand
+     */
+    public void expand(Path jarPath) {
+        try (JarFile jar = new JarFile(jarPath.toFile())) {
+            copyRegistryContent("dirigible", jar);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to expand the registry content of [" + jarPath + "]", e);
+        }
+    }
+
+    /**
+     * Removes a project's content from the registry - the inverse of {@link #expand(Path)}, used when
+     * the module jar carrying the project leaves the running system. The per-artefact synchronizers
+     * clean up the runtime state of the removed files on their next pass.
+     *
+     * @param project the project name directly under the registry root
+     */
+    public void remove(String project) {
+        String path = IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepository.SEPARATOR + project;
+        if (repository.hasCollection(path)) {
+            repository.removeCollection(path);
+            LOGGER.info("Removed the registry content of project [{}]", project);
+        }
+    }
+
+    /**
+     * Copies every entry under {@code META-INF/<root>/} into the registry, honoring the {@code .skip}
+     * marker.
+     *
+     * @param root the root under META-INF, e.g. dirigible
+     * @param jar the open jar
+     * @throws IOException on a read failure
+     */
+    private void copyRegistryContent(String root, JarFile jar) throws IOException {
+        String jarRoot = "META-INF/" + root;
+        Enumeration<JarEntry> entries = jar.entries();
+        JarEntry maybeSkip = jar.getJarEntry("META-INF/dirigible/.skip");
+        if (maybeSkip != null) {
+            return;
+        }
+        while (entries.hasMoreElements()) {
+            JarEntry entry = entries.nextElement();
+            if (entry.getName()
+                     .startsWith(jarRoot)) {
+                if (!entry.isDirectory()) {
+                    byte[] content = IOUtils.toByteArray(jar.getInputStream(entry));
+                    String registryPath = entry.getName()
+                                               .substring(jarRoot.length());
+                    repository.createResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepository.SEPARATOR + registryPath, content);
                 }
             }
         }

--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/classpath/ClasspathExpander.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/classpath/ClasspathExpander.java
@@ -162,50 +162,36 @@ public class ClasspathExpander {
         if (maybeSkip != null) {
             return;
         }
+        Path registryRoot = Path.of(IRepositoryStructure.PATH_REGISTRY_PUBLIC);
         while (entries.hasMoreElements()) {
             JarEntry entry = entries.nextElement();
             if (entry.getName()
                      .startsWith(jarRoot)) {
                 if (!entry.isDirectory()) {
-                    String registryPath = entry.getName()
-                                               .substring(jarRoot.length());
-                    if (!isSafeRegistryPath(registryPath)) {
+                    // Zip Slip guard: resolve the entry against the registry root, normalize, and
+                    // require the result to stay strictly below the root - a crafted '..' entry is
+                    // skipped and lands nowhere
+                    String relative = entry.getName()
+                                           .substring(jarRoot.length());
+                    while (relative.startsWith("/")) {
+                        relative = relative.substring(1);
+                    }
+                    Path target = relative.isEmpty() || relative.indexOf('\\') >= 0 ? null
+                            : registryRoot.resolve(relative)
+                                          .normalize();
+                    if (target == null || !target.startsWith(registryRoot) || target.equals(registryRoot)) {
                         LOGGER.warn("Skipping the jar entry [{}] - its path would escape the registry root", entry.getName()
-                                                                                                                  .replaceAll("[\\r\\n]",
-                                                                                                                          "_"));
+                                                                                                                  .replace('\r', '_')
+                                                                                                                  .replace('\n', '_'));
                         continue;
                     }
                     byte[] content = IOUtils.toByteArray(jar.getInputStream(entry));
-                    repository.createResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepository.SEPARATOR + registryPath, content);
+                    repository.createResource(target.toString()
+                                                    .replace(File.separatorChar, IRepository.SEPARATOR.charAt(0)),
+                            content);
                 }
             }
         }
-    }
-
-    /**
-     * Guards against Zip Slip: an archive entry may only map to a path strictly below the registry root
-     * - no '.' or '..' segments, no blank segments, no backslashes.
-     *
-     * @param registryPath the entry's registry-relative path
-     * @return true when the path is safe to create
-     */
-    private static boolean isSafeRegistryPath(String registryPath) {
-        if (registryPath.indexOf('\\') >= 0) {
-            return false;
-        }
-        String[] segments = registryPath.split("/");
-        boolean hasContent = false;
-        for (int i = 0; i < segments.length; i++) {
-            String segment = segments[i];
-            if (i == 0 && segment.isEmpty()) {
-                continue; // the leading separator
-            }
-            if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment)) {
-                return false;
-            }
-            hasContent = true;
-        }
-        return hasContent;
     }
 
     /**

--- a/components/core/core-initializers/src/test/java/org/eclipse/dirigible/components/initializers/classpath/ClasspathExpanderTest.java
+++ b/components/core/core-initializers/src/test/java/org/eclipse/dirigible/components/initializers/classpath/ClasspathExpanderTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.initializers.classpath;
+
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.repository.local.LocalRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The per-jar expand / remove round-trip of {@link ClasspathExpander} - the runtime counterpart of
+ * the startup sweep - including the {@code .skip} marker.
+ */
+class ClasspathExpanderTest {
+
+    @TempDir
+    Path tempDir;
+
+    private IRepository repository;
+    private ClasspathExpander expander;
+
+    @BeforeEach
+    void setUp() {
+        repository = new LocalRepository(tempDir.resolve("repository")
+                                                .toString(),
+                true);
+        expander = new ClasspathExpander(repository);
+    }
+
+    @Test
+    void expands_a_single_jar_into_the_registry_and_removes_its_project() throws IOException {
+        Path jar = jarWithEntries("module.jar",
+                Map.of("META-INF/dirigible/my-module/hello.txt", "payload", "META-INF/dirigible/my-module/sub/nested.txt", "nested"));
+
+        expander.expand(jar);
+
+        assertThat(resourceContent("/my-module/hello.txt")).isEqualTo("payload");
+        assertThat(resourceContent("/my-module/sub/nested.txt")).isEqualTo("nested");
+
+        expander.remove("my-module");
+
+        assertThat(repository.hasCollection(IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/my-module")).isFalse();
+        // removing an absent project is a no-op, not an error
+        expander.remove("my-module");
+    }
+
+    @Test
+    void honors_the_skip_marker() throws IOException {
+        Path jar = jarWithEntries("skipped.jar",
+                Map.of("META-INF/dirigible/.skip", "", "META-INF/dirigible/skipped-module/hello.txt", "payload"));
+
+        expander.expand(jar);
+
+        assertThat(repository.hasCollection(IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/skipped-module")).isFalse();
+    }
+
+    private String resourceContent(String registryRelativePath) {
+        return new String(repository.getResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + registryRelativePath)
+                                    .getContent(),
+                StandardCharsets.UTF_8);
+    }
+
+    private Path jarWithEntries(String name, Map<String, String> entries) throws IOException {
+        Path jar = tempDir.resolve(name);
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jar))) {
+            for (Map.Entry<String, String> entry : entries.entrySet()) {
+                out.putNextEntry(new JarEntry(entry.getKey()));
+                out.write(entry.getValue()
+                               .getBytes(StandardCharsets.UTF_8));
+                out.closeEntry();
+            }
+        }
+        return jar;
+    }
+
+}

--- a/components/core/core-initializers/src/test/java/org/eclipse/dirigible/components/initializers/classpath/ClasspathExpanderTest.java
+++ b/components/core/core-initializers/src/test/java/org/eclipse/dirigible/components/initializers/classpath/ClasspathExpanderTest.java
@@ -64,6 +64,22 @@ class ClasspathExpanderTest {
     }
 
     @Test
+    void rejects_entries_that_would_escape_the_registry_root() throws IOException {
+        Path jar = jarWithEntries("zip-slip.jar", Map.of("META-INF/dirigible/../../../evil.txt", "escape",
+                "META-INF/dirigible/mod/../../evil2.txt", "escape", "META-INF/dirigible/mod/safe.txt", "kept"));
+
+        expander.expand(jar);
+
+        // the safe sibling entry is laid down; the traversal entries are skipped and land nowhere
+        assertThat(resourceContent("/mod/safe.txt")).isEqualTo("kept");
+        try (var files = Files.walk(tempDir)) {
+            assertThat(files.filter(file -> file.getFileName()
+                                                .toString()
+                                                .startsWith("evil"))).isEmpty();
+        }
+    }
+
+    @Test
     void honors_the_skip_marker() throws IOException {
         Path jar = jarWithEntries("skipped.jar",
                 Map.of("META-INF/dirigible/.skip", "", "META-INF/dirigible/skipped-module/hello.txt", "payload"));

--- a/components/core/core-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/ModulesClassLoader.java
+++ b/components/core/core-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/ModulesClassLoader.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.java.runtime;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * The swappable classpath layer for the maven dependency JARs projects declare in
+ * {@code project.json}. Sits between the application classloader (its parent) and the
+ * {@link ClientClassLoader} generations (whose parent it becomes), so a dependency change takes
+ * effect without restarting the platform.
+ *
+ * <p>
+ * <b>Generation lifecycle.</b> A single instance is active at a time, owned by
+ * {@link ModulesClassLoaderHolder}. A dependency change never mutates the active instance - the
+ * swap pipeline builds a <em>fresh</em> loader over the new JAR set and swaps it in, exactly like a
+ * {@code ClientClassLoader} rebuild:
+ *
+ * <pre>
+ * generation N   modules loader over [a-1.0.jar, b-2.0.jar]   (serving)
+ *   - project.json changes b to 2.1
+ * generation N+1 modules loader over [a-1.0.jar, b-2.1.jar]   (built, validated, swapped in)
+ *   - generation N drains: it stays reachable only while in-flight requests hold classes
+ *     loaded from it; once those return, GC reclaims the loader and its Metaspace
+ * </pre>
+ *
+ * The retired generation is intentionally never {@link #close() closed} while it may still serve
+ * in-flight code - see the holder's javadoc.
+ *
+ * <p>
+ * <b>Immutable-path rule.</b> The JARs are the resolver's outputs at their versioned Maven local
+ * repository paths - immutable by Maven's contract. They are never copied to a mutable directory
+ * and never overwritten in place, so an open loader of a retired generation always reads consistent
+ * bytes. An upgrade is a <em>different path</em>, never a rewritten file.
+ *
+ * <p>
+ * <b>Parent-first delegation</b> (the {@link URLClassLoader} default - deliberately no child-first
+ * tricks): a class also present on the platform classpath resolves to the platform's version, which
+ * keeps exactly one definition of shared libraries in the JVM.
+ */
+public final class ModulesClassLoader extends URLClassLoader {
+
+    /** The loader name - stable, so heap dumps and logs identify the layer at a glance. */
+    public static final String NAME = "dirigible-modules";
+
+    /** The jars. */
+    private final List<Path> jars;
+
+    /**
+     * Instantiates a new generation over the given JAR set.
+     *
+     * @param parent the parent classloader - the application classloader
+     * @param jars the JAR paths inside the Maven local repository, in classpath order
+     */
+    public ModulesClassLoader(ClassLoader parent, List<Path> jars) {
+        super(NAME, toUrls(jars), parent);
+        this.jars = List.copyOf(jars);
+    }
+
+    /**
+     * The JAR set this generation serves, in classpath order.
+     *
+     * @return the jar paths
+     */
+    public List<Path> jars() {
+        return jars;
+    }
+
+    /**
+     * To urls.
+     *
+     * @param jars the jars
+     * @return the urls
+     */
+    private static URL[] toUrls(List<Path> jars) {
+        URL[] urls = new URL[jars.size()];
+        for (int i = 0; i < jars.size(); i++) {
+            try {
+                urls[i] = jars.get(i)
+                              .toUri()
+                              .toURL();
+            } catch (MalformedURLException e) {
+                throw new IllegalArgumentException("Not a loadable jar path: " + jars.get(i), e);
+            }
+        }
+        return urls;
+    }
+
+}

--- a/components/core/core-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/ModulesClassLoaderHolder.java
+++ b/components/core/core-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/ModulesClassLoaderHolder.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.java.runtime;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.lang.ref.WeakReference;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Singleton owner of the current {@link ModulesClassLoader} - the swap-point for the maven
+ * dependency layer, mirroring {@link ClientClassLoaderHolder} for client code.
+ *
+ * <p>
+ * Reads happen on every classloading path that goes through a {@link ClientClassLoader} parent
+ * chain; writes happen only in the dependency swap pipeline, one at a time. {@link AtomicReference}
+ * gives lock-free reads and linearizable swaps. The retired loader is intentionally not closed -
+ * in-flight requests may still hold classes loaded from it; once those references drop, GC reclaims
+ * it. Retired generations are tracked with {@link WeakReference}s so monitoring can report how many
+ * are still pinned by live references.
+ *
+ * <p>
+ * Before the first {@link #swap(List)} the holder serves an empty generation over no JARs - plain
+ * parent-first delegation to the application classloader, byte-for-byte the pre-dynamic behavior.
+ */
+@Component
+public class ModulesClassLoaderHolder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ModulesClassLoaderHolder.class);
+
+    /** The current loader. */
+    private final AtomicReference<ModulesClassLoader> ref = new AtomicReference<>();
+
+    /** The generation counter - 0 until the first swap. */
+    private final AtomicInteger generation = new AtomicInteger();
+
+    /** Weak references to retired generations, for the monitoring counters. */
+    private final List<WeakReference<ModulesClassLoader>> retired = new CopyOnWriteArrayList<>();
+
+    /**
+     * The currently-active modules classloader. Never null - before the first swap an empty generation
+     * over the application classloader is created on demand.
+     *
+     * @return the current loader
+     */
+    public ModulesClassLoader current() {
+        ModulesClassLoader current = ref.get();
+        if (current != null) {
+            return current;
+        }
+        ModulesClassLoader initial = new ModulesClassLoader(parentClassLoader(), List.of());
+        return ref.compareAndSet(null, initial) ? initial : ref.get();
+    }
+
+    /**
+     * Builds a fresh generation over the given JAR set and installs it. The previous generation is
+     * retired (weakly tracked, never closed).
+     *
+     * @param jars the JAR paths of the new generation, in classpath order
+     * @return the installed loader
+     */
+    public synchronized ModulesClassLoader swap(List<Path> jars) {
+        ModulesClassLoader next = new ModulesClassLoader(parentClassLoader(), jars);
+        ModulesClassLoader previous = ref.getAndSet(next);
+        int number = generation.incrementAndGet();
+        if (previous != null) {
+            retired.add(new WeakReference<>(previous));
+        }
+        LOGGER.info("Modules classloader generation [{}] installed over [{}] jar(s)", number, jars.size());
+        return next;
+    }
+
+    /**
+     * The number of installed generations - 0 until the first swap.
+     *
+     * @return the generation number
+     */
+    public int generation() {
+        return generation.get();
+    }
+
+    /**
+     * How many retired generations are still pinned by live references - the heap-dump observability
+     * counter. A steadily growing value indicates a loader leak in a consumer.
+     *
+     * @return the live retired-generation count
+     */
+    public int retiredGenerationsLive() {
+        retired.removeIf(reference -> reference.get() == null);
+        return retired.size();
+    }
+
+    /**
+     * Parent class loader.
+     *
+     * @return the class loader
+     */
+    private static ClassLoader parentClassLoader() {
+        return ModulesClassLoaderHolder.class.getClassLoader();
+    }
+
+}

--- a/components/core/core-java/src/test/java/org/eclipse/dirigible/engine/java/runtime/ModulesClassLoaderTest.java
+++ b/components/core/core-java/src/test/java/org/eclipse/dirigible/engine/java/runtime/ModulesClassLoaderTest.java
@@ -97,11 +97,16 @@ class ModulesClassLoaderTest {
 
         Path jar = jarWithClass("swap-lib", "com.example.Swapped", "v1");
         ModulesClassLoader swapped = holder.swap(List.of(jar));
-
-        assertThat(holder.generation()).isEqualTo(1);
-        assertThat(holder.current()).isSameAs(swapped);
-        assertThat(value(holder.current()
-                               .loadClass("com.example.Swapped"))).isEqualTo("v1");
+        try {
+            assertThat(holder.generation()).isEqualTo(1);
+            assertThat(holder.current()).isSameAs(swapped);
+            assertThat(value(holder.current()
+                                   .loadClass("com.example.Swapped"))).isEqualTo("v1");
+        } finally {
+            // the holder deliberately never closes loaders; the test must, or the open jar handle
+            // blocks the @TempDir cleanup on Windows
+            swapped.close();
+        }
     }
 
     private static String value(Class<?> type) throws Exception {

--- a/components/core/core-java/src/test/java/org/eclipse/dirigible/engine/java/runtime/ModulesClassLoaderTest.java
+++ b/components/core/core-java/src/test/java/org/eclipse/dirigible/engine/java/runtime/ModulesClassLoaderTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.java.runtime;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+import java.io.IOException;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The modules layer contract: parent-first delegation, visibility from child
+ * {@link ClientClassLoader} generations, and independence of two generations over different JAR
+ * sets.
+ */
+class ModulesClassLoaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void delegates_parent_first() throws Exception {
+        Path parentJar = jarWithClass("parent-lib", "com.example.Dup", "parent");
+        Path childJar = jarWithClass("child-lib", "com.example.Dup", "child");
+
+        try (URLClassLoader parent = new URLClassLoader(new java.net.URL[] {parentJar.toUri()
+                                                                                     .toURL()},
+                getClass().getClassLoader()); ModulesClassLoader modules = new ModulesClassLoader(parent, List.of(childJar))) {
+
+            Class<?> resolved = modules.loadClass("com.example.Dup");
+
+            assertThat(value(resolved)).isEqualTo("parent");
+            assertThat(resolved.getClassLoader()).isSameAs(parent);
+        }
+    }
+
+    @Test
+    void loads_a_module_only_class_and_is_visible_from_a_client_generation() throws Exception {
+        Path moduleJar = jarWithClass("module-lib", "com.example.ModuleOnly", "from-module");
+
+        try (ModulesClassLoader modules = new ModulesClassLoader(getClass().getClassLoader(), List.of(moduleJar))) {
+            ClientClassLoader clientGeneration = new ClientClassLoader(modules, Map.of());
+
+            Class<?> resolved = clientGeneration.loadClass("com.example.ModuleOnly");
+
+            assertThat(value(resolved)).isEqualTo("from-module");
+            assertThat(resolved.getClassLoader()).isSameAs(modules);
+            assertThat(modules.getName()).isEqualTo(ModulesClassLoader.NAME);
+        }
+    }
+
+    @Test
+    void two_generations_over_different_jar_sets_are_independent() throws Exception {
+        Path jarA = jarWithClass("lib-a", "com.example.OnlyA", "a");
+        Path jarB = jarWithClass("lib-b", "com.example.OnlyB", "b");
+
+        try (ModulesClassLoader generationOne = new ModulesClassLoader(getClass().getClassLoader(), List.of(jarA));
+                ModulesClassLoader generationTwo = new ModulesClassLoader(getClass().getClassLoader(), List.of(jarB))) {
+
+            assertThat(value(generationOne.loadClass("com.example.OnlyA"))).isEqualTo("a");
+            assertThat(value(generationTwo.loadClass("com.example.OnlyB"))).isEqualTo("b");
+            assertThatThrownBy(() -> generationTwo.loadClass("com.example.OnlyA")).isInstanceOf(ClassNotFoundException.class);
+            assertThat(generationOne.jars()).containsExactly(jarA);
+            assertThat(generationTwo.jars()).containsExactly(jarB);
+        }
+    }
+
+    @Test
+    void holder_serves_an_empty_generation_until_the_first_swap_and_counts_generations() throws Exception {
+        ModulesClassLoaderHolder holder = new ModulesClassLoaderHolder();
+
+        assertThat(holder.generation()).isZero();
+        assertThat(holder.current()
+                         .jars()).isEmpty();
+        // the pre-swap generation behaves as plain delegation to the application classloader
+        assertThat(holder.current()
+                         .loadClass(ModulesClassLoaderTest.class.getName())).isSameAs(ModulesClassLoaderTest.class);
+
+        Path jar = jarWithClass("swap-lib", "com.example.Swapped", "v1");
+        ModulesClassLoader swapped = holder.swap(List.of(jar));
+
+        assertThat(holder.generation()).isEqualTo(1);
+        assertThat(holder.current()).isSameAs(swapped);
+        assertThat(value(holder.current()
+                               .loadClass("com.example.Swapped"))).isEqualTo("v1");
+    }
+
+    private static String value(Class<?> type) throws Exception {
+        return (String) type.getMethod("value")
+                            .invoke(type.getDeclaredConstructor()
+                                        .newInstance());
+    }
+
+    /**
+     * Compiles a single class whose {@code value()} answers the given literal and packs it in a jar.
+     */
+    private Path jarWithClass(String jarName, String fqn, String value) throws IOException {
+        int lastDot = fqn.lastIndexOf('.');
+        String packageName = fqn.substring(0, lastDot);
+        String className = fqn.substring(lastDot + 1);
+        Path sourceDir = Files.createDirectories(tempDir.resolve(jarName + "-src")
+                                                        .resolve(packageName.replace('.', '/')));
+        Path source = sourceDir.resolve(className + ".java");
+        Files.writeString(source, """
+                package %s;
+                public class %s {
+                    public String value() {
+                        return "%s";
+                    }
+                }
+                """.formatted(packageName, className, value));
+        Path classesDir = Files.createDirectories(tempDir.resolve(jarName + "-classes"));
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        int exitCode = compiler.run(null, null, null, "-d", classesDir.toString(), source.toString());
+        assertThat(exitCode).isZero();
+
+        Path jar = tempDir.resolve(jarName + ".jar");
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jar)); Stream<Path> files = Files.walk(classesDir)) {
+            for (Path file : files.filter(Files::isRegularFile)
+                                  .toList()) {
+                out.putNextEntry(new JarEntry(classesDir.relativize(file)
+                                                        .toString()
+                                                        .replace('\\', '/')));
+                out.write(Files.readAllBytes(file));
+                out.closeEntry();
+            }
+        }
+        return jar;
+    }
+
+}

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/ClassPathIndex.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/ClassPathIndex.java
@@ -65,7 +65,10 @@ import org.springframework.stereotype.Component;
  * Either way the entries of {@code loader.path} / {@code LOADER_PATH} are appended — the runtime
  * image's drop-in directory for AOT compiled module jars (see
  * {@code build/application/Dockerfile}). Those jars are on the application classpath, so client
- * sources must be able to compile against them.
+ * sources must be able to compile against them. The jars of the current
+ * {@link ModulesClassLoaderHolder modules classloader} generation are appended as well, and a
+ * dependency swap {@link #invalidate() invalidates} the cache, so client sources compile against
+ * the project-declared maven dependencies without a restart.
  */
 @Component
 public class ClassPathIndex {
@@ -79,6 +82,12 @@ public class ClassPathIndex {
     private static final String STAMP_FILENAME = "extracted.stamp";
 
     private final AtomicReference<List<Path>> entriesRef = new AtomicReference<>();
+
+    private final ModulesClassLoaderHolder modulesLoaderHolder;
+
+    public ClassPathIndex(ModulesClassLoaderHolder modulesLoaderHolder) {
+        this.modulesLoaderHolder = modulesLoaderHolder;
+    }
 
     /** Disk paths that should be passed to {@code javac} via {@code --class-path}. */
     public List<Path> classPathEntries() {
@@ -100,9 +109,25 @@ public class ClassPathIndex {
         }
     }
 
-    private static List<Path> build() {
+    /**
+     * Drops the cached classpath so the next {@link #classPathEntries()} rebuilds it - called by the
+     * dependency swap pipeline after the modules classloader generation changed. The expensive platform
+     * half (the one-time fat-jar extraction) is disk-cached and stamp-checked, so a rebuild after an
+     * invalidation is cheap.
+     */
+    public void invalidate() {
+        entriesRef.set(null);
+    }
+
+    private List<Path> build() {
         List<Path> entries = new ArrayList<>(buildPlatformEntries());
         entries.addAll(loaderPathEntries(rawLoaderPath()));
+        for (Path jar : modulesLoaderHolder.current()
+                                           .jars()) {
+            if (!entries.contains(jar)) {
+                entries.add(jar);
+            }
+        }
         return Collections.unmodifiableList(entries);
     }
 

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/CompiledModuleClassProvider.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/CompiledModuleClassProvider.java
@@ -11,10 +11,17 @@ package org.eclipse.dirigible.engine.java.runtime;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
 import org.eclipse.dirigible.engine.java.spi.LoadedClass;
 import org.slf4j.Logger;
@@ -41,9 +48,12 @@ import org.springframework.stereotype.Component;
  * <p>
  * Discovery reads the markers directly from the classpath (so it does not depend on the
  * {@code ClasspathExpander} having laid the module's registry payload down first) and loads each
- * listed class through the <em>application</em> classloader - the same one that already holds the
- * compiled module jar. It runs once, on {@link ApplicationReadyEvent}; a later registry rebuild
- * unions its classes back in (see {@link JavaLoader}).
+ * listed class through the given classloader - by default the current
+ * {@link ModulesClassLoaderHolder modules classloader} generation, whose parent chain includes the
+ * application classloader holding the {@code /modules} drop-in jars. It runs on
+ * {@link ApplicationReadyEvent} and again via {@link #rediscover(ClassLoader)} whenever the
+ * dependency layer swaps to a new generation; each pass replaces the compiled set (see
+ * {@link JavaLoader#installCompiledModules(List)}).
  */
 @Component
 public class CompiledModuleClassProvider {
@@ -58,50 +68,153 @@ public class CompiledModuleClassProvider {
     private static final String DIRIGIBLE_ROOT = "META-INF/dirigible/";
 
     private final JavaLoader javaLoader;
+    private final ModulesClassLoaderHolder modulesLoaderHolder;
 
     @Autowired
-    public CompiledModuleClassProvider(JavaLoader javaLoader) {
+    public CompiledModuleClassProvider(JavaLoader javaLoader, ModulesClassLoaderHolder modulesLoaderHolder) {
         this.javaLoader = javaLoader;
+        this.modulesLoaderHolder = modulesLoaderHolder;
     }
 
     /** Discover and register the compiled modules once the application context is ready. */
     @EventListener(ApplicationReadyEvent.class)
     public void registerCompiledModules() {
-        List<LoadedClass> classes = discover();
-        if (classes.isEmpty()) {
+        rediscover(modulesLoaderHolder.current());
+    }
+
+    /**
+     * Set once a non-empty compiled set was installed; an empty discovery must still be installed then,
+     * so classes of a removed module jar unregister. Before that, an empty discovery is a no-op - the
+     * pre-dynamic boot behavior.
+     */
+    private volatile boolean installedBefore = false;
+
+    /**
+     * Re-runs compiled-module discovery through the given classloader and installs the result as the
+     * compiled sub-generation - the dependency swap pipeline calls this with the freshly-installed
+     * modules classloader so AOT module jars that arrived, changed or left with the dependency change
+     * register and unregister without a restart.
+     *
+     * @param classLoader the classloader to scan and load through
+     */
+    public synchronized void rediscover(ClassLoader classLoader) {
+        List<LoadedClass> classes = discover(classLoader);
+        if (classes.isEmpty() && !installedBefore) {
             return;
         }
+        installedBefore = !classes.isEmpty();
         javaLoader.installCompiledModules(classes);
         LOGGER.info("Registered [{}] class(es) from AOT compiled module(s) on the classpath", classes.size());
     }
 
     /**
-     * Scan the classpath for {@code .compiled} markers and load every listed class through the
-     * application classloader. Package-visible for testing. Never throws: an unreadable marker or an
-     * unloadable class is logged and skipped so one bad module cannot block the rest.
+     * Scan the classpath of the given classloader for {@code .compiled} markers and load every listed
+     * class through it. The Spring resource scan covers the application classpath (including the fat
+     * jar's nested {@code BOOT-INF/lib} entries); a {@link ModulesClassLoader}'s own jars are
+     * additionally scanned entry-by-entry, because a resource scan only sees a jar's directories when
+     * the packaging tool emitted directory entries - a guarantee third-party module jars do not give.
+     * Package-visible for testing. Never throws: an unreadable marker or an unloadable class is logged
+     * and skipped so one bad module cannot block the rest.
      */
-    List<LoadedClass> discover() {
-        List<LoadedClass> result = new ArrayList<>();
-        ClassLoader classLoader = getClass().getClassLoader();
+    List<LoadedClass> discover(ClassLoader classLoader) {
+        Map<String, LoadedClass> result = new LinkedHashMap<>();
+        scanWithResolver(classLoader, result);
+        if (classLoader instanceof ModulesClassLoader modulesClassLoader) {
+            scanModuleJars(modulesClassLoader, result);
+        }
+        return new ArrayList<>(result.values());
+    }
+
+    /**
+     * Scan with the Spring pattern resolver.
+     *
+     * @param classLoader the class loader to scan and load through
+     * @param result the discovered classes, keyed by FQN
+     */
+    private void scanWithResolver(ClassLoader classLoader, Map<String, LoadedClass> result) {
         Resource[] markers;
         try {
             markers = new PathMatchingResourcePatternResolver(classLoader).getResources(MARKER_PATTERN);
         } catch (IOException e) {
             LOGGER.error("Failed to scan the classpath for AOT compiled-module markers", e);
-            return result;
+            return;
         }
         for (Resource marker : markers) {
             String project = projectOf(marker);
-            for (String fqn : readClassNames(marker)) {
-                try {
-                    Class<?> type = Class.forName(fqn, true, classLoader);
-                    result.add(new LoadedClass(project, fqn, type, classLoader));
-                } catch (ClassNotFoundException | LinkageError e) {
-                    LOGGER.error("Compiled-module class [{}] (project [{}]) could not be loaded: {}", fqn, project, e.getMessage(), e);
+            List<String> classNames;
+            try {
+                classNames = readClassNames(marker.getInputStream());
+            } catch (IOException e) {
+                LOGGER.error("Failed to read compiled-module marker [{}]: {}", marker, e.getMessage(), e);
+                continue;
+            }
+            load(project, classNames, classLoader, result);
+        }
+    }
+
+    /**
+     * Scan the modules classloader's own jars entry-by-entry.
+     *
+     * @param classLoader the modules class loader
+     * @param result the discovered classes, keyed by FQN
+     */
+    private void scanModuleJars(ModulesClassLoader classLoader, Map<String, LoadedClass> result) {
+        for (Path jarPath : classLoader.jars()) {
+            try (JarFile jar = new JarFile(jarPath.toFile())) {
+                Enumeration<JarEntry> entries = jar.entries();
+                while (entries.hasMoreElements()) {
+                    JarEntry entry = entries.nextElement();
+                    String project = markerProject(entry.getName());
+                    if (project == null) {
+                        continue;
+                    }
+                    List<String> classNames;
+                    try (var in = jar.getInputStream(entry)) {
+                        classNames = readClassNames(in);
+                    }
+                    load(project, classNames, classLoader, result);
                 }
+            } catch (IOException e) {
+                LOGGER.error("Failed to scan the module jar [{}] for AOT compiled-module markers: {}", jarPath, e.getMessage(), e);
             }
         }
-        return result;
+    }
+
+    /**
+     * Load the listed classes through the given classloader. A class discovered by an earlier scan
+     * wins.
+     *
+     * @param project the owning project
+     * @param classNames the listed class names
+     * @param classLoader the class loader to load through
+     * @param result the discovered classes, keyed by FQN
+     */
+    private void load(String project, List<String> classNames, ClassLoader classLoader, Map<String, LoadedClass> result) {
+        for (String fqn : classNames) {
+            if (result.containsKey(fqn)) {
+                continue;
+            }
+            try {
+                Class<?> type = Class.forName(fqn, true, classLoader);
+                result.put(fqn, new LoadedClass(project, fqn, type, type.getClassLoader()));
+            } catch (ClassNotFoundException | LinkageError e) {
+                LOGGER.error("Compiled-module class [{}] (project [{}]) could not be loaded: {}", fqn, project, e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * The project of a jar entry that is a compiled-module marker, null for any other entry.
+     *
+     * @param entryName the jar entry name
+     * @return the project, or null when the entry is not a marker
+     */
+    private static String markerProject(String entryName) {
+        if (!entryName.startsWith(DIRIGIBLE_ROOT) || !entryName.endsWith("/.compiled")) {
+            return null;
+        }
+        String project = entryName.substring(DIRIGIBLE_ROOT.length(), entryName.length() - "/.compiled".length());
+        return project.isEmpty() || project.indexOf('/') >= 0 ? null : project;
     }
 
     /**
@@ -126,9 +239,9 @@ public class CompiledModuleClassProvider {
     }
 
     /** Non-blank, non-comment lines of a marker, trimmed. */
-    private static List<String> readClassNames(Resource marker) {
+    private static List<String> readClassNames(InputStream markerContent) throws IOException {
         List<String> names = new ArrayList<>();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(marker.getInputStream(), StandardCharsets.UTF_8))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(markerContent, StandardCharsets.UTF_8))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 String trimmed = line.trim();
@@ -136,8 +249,6 @@ public class CompiledModuleClassProvider {
                     names.add(trimmed);
                 }
             }
-        } catch (IOException e) {
-            LOGGER.error("Failed to read compiled-module marker [{}]: {}", marker, e.getMessage(), e);
         }
         return names;
     }

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/JavaLoader.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/JavaLoader.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.dirigible.engine.java.component.ComponentContainer;
-import org.eclipse.dirigible.engine.java.handler.JavaHandler;
 import org.eclipse.dirigible.engine.java.spi.JavaClassConsumer;
 import org.eclipse.dirigible.engine.java.spi.LoadedClass;
 import org.slf4j.Logger;
@@ -60,6 +59,7 @@ public class JavaLoader {
 
     private final JavaSourceCompiler compiler;
     private final ClientClassLoaderHolder loaderHolder;
+    private final ModulesClassLoaderHolder modulesLoaderHolder;
     private final ComponentContainer componentContainer;
     private final List<JavaClassConsumer> consumers;
     private final JavaCompiledOutputDirectory outputDirectory;
@@ -86,10 +86,12 @@ public class JavaLoader {
     private final Map<String, byte[]> currentBytecode = new HashMap<>();
 
     @Autowired
-    public JavaLoader(JavaSourceCompiler compiler, ClientClassLoaderHolder loaderHolder, ComponentContainer componentContainer,
-            List<JavaClassConsumer> consumers, JavaCompiledOutputDirectory outputDirectory, ApplicationEventPublisher eventPublisher) {
+    public JavaLoader(JavaSourceCompiler compiler, ClientClassLoaderHolder loaderHolder, ModulesClassLoaderHolder modulesLoaderHolder,
+            ComponentContainer componentContainer, List<JavaClassConsumer> consumers, JavaCompiledOutputDirectory outputDirectory,
+            ApplicationEventPublisher eventPublisher) {
         this.compiler = compiler;
         this.loaderHolder = loaderHolder;
+        this.modulesLoaderHolder = modulesLoaderHolder;
         this.componentContainer = componentContainer;
         this.consumers = consumers;
         this.outputDirectory = outputDirectory;
@@ -137,9 +139,10 @@ public class JavaLoader {
         }
         effectiveBytecode.putAll(batch.bytecode());
 
-        // Build the new ClientClassLoader from the effective bytecode. Parent is the platform CL so
-        // user code sees JavaHandler, our annotations, Spring, Hibernate, etc.
-        ClassLoader parent = JavaHandler.class.getClassLoader();
+        // Build the new ClientClassLoader from the effective bytecode. Parent is the current modules
+        // classloader generation - its own parent is the platform CL, so user code sees the project's
+        // maven dependency jars AND JavaHandler, our annotations, Spring, Hibernate, etc.
+        ClassLoader parent = modulesLoaderHolder.current();
         ClientClassLoader nextLoader = new ClientClassLoader(parent, effectiveBytecode);
 
         // Resolve every primary (top-level) FQN in the new generation through the new loader. The
@@ -263,10 +266,10 @@ public class JavaLoader {
             }
         }
         // No runtime-compiled client code yet → give the holder an empty ClientClassLoader whose parent
-        // (the platform / application classloader) already resolves the compiled-module classes.
+        // chain (modules loader → platform classloader) already resolves the compiled-module classes.
         ClientClassLoader loader = loaderHolder.current();
         if (loader == null) {
-            loader = new ClientClassLoader(JavaHandler.class.getClassLoader(), Map.of());
+            loader = new ClientClassLoader(modulesLoaderHolder.current(), Map.of());
         }
         return applyGeneration(mergedGeneration(), loader);
     }

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/JavaSourceCompiler.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/JavaSourceCompiler.java
@@ -42,7 +42,7 @@ public class JavaSourceCompiler {
 
     /** Test-only convenience: uses an empty classpath index (relies on {@code java.class.path}). */
     public JavaSourceCompiler() {
-        this(new ClassPathIndex());
+        this(new ClassPathIndex(new ModulesClassLoaderHolder()));
     }
 
     @Autowired

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/synchronizer/JavaDependenciesChangedListener.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/synchronizer/JavaDependenciesChangedListener.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.java.synchronizer;
+
+import org.eclipse.dirigible.components.base.dependencies.DependenciesChangedEvent;
+import org.eclipse.dirigible.engine.java.runtime.ClassPathIndex;
+import org.eclipse.dirigible.engine.java.runtime.CompiledModuleClassProvider;
+import org.eclipse.dirigible.engine.java.runtime.ModulesClassLoaderHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * The Java engine's reaction to a dependency-layer swap: invalidate the compile classpath so client
+ * sources compile against the new JAR set, rediscover AOT compiled modules through the new modules
+ * classloader (registering arrived module classes and unregistering removed ones), and rebuild the
+ * client sources so the new {@code ClientClassLoader} generation parents on the new modules
+ * classloader. Runs synchronously on the swapping thread - the swap pipeline's success includes
+ * this reaction.
+ */
+@Component
+class JavaDependenciesChangedListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JavaDependenciesChangedListener.class);
+
+    /** The class path index. */
+    private final ClassPathIndex classPathIndex;
+
+    /** The compiled module class provider. */
+    private final CompiledModuleClassProvider compiledModuleClassProvider;
+
+    /** The modules loader holder. */
+    private final ModulesClassLoaderHolder modulesLoaderHolder;
+
+    /** The java synchronizer. */
+    private final JavaSynchronizer javaSynchronizer;
+
+    /**
+     * Instantiates a new listener.
+     *
+     * @param classPathIndex the class path index
+     * @param compiledModuleClassProvider the compiled module class provider
+     * @param modulesLoaderHolder the modules loader holder
+     * @param javaSynchronizer the java synchronizer
+     */
+    JavaDependenciesChangedListener(ClassPathIndex classPathIndex, CompiledModuleClassProvider compiledModuleClassProvider,
+            ModulesClassLoaderHolder modulesLoaderHolder, JavaSynchronizer javaSynchronizer) {
+        this.classPathIndex = classPathIndex;
+        this.compiledModuleClassProvider = compiledModuleClassProvider;
+        this.modulesLoaderHolder = modulesLoaderHolder;
+        this.javaSynchronizer = javaSynchronizer;
+    }
+
+    /**
+     * On dependencies changed.
+     *
+     * @param event the event
+     */
+    @EventListener
+    void onDependenciesChanged(DependenciesChangedEvent event) {
+        LOGGER.info("Dependency layer swapped to generation [{}] (added {}, removed {}) - rediscovering AOT modules and rebuilding "
+                + "the client sources", event.getGeneration(), event.getAdded(), event.getRemoved());
+        classPathIndex.invalidate();
+        compiledModuleClassProvider.rediscover(modulesLoaderHolder.current());
+        javaSynchronizer.rebuildOnDependenciesChanged();
+    }
+
+}

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/synchronizer/JavaSynchronizer.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/synchronizer/JavaSynchronizer.java
@@ -217,6 +217,16 @@ public class JavaSynchronizer extends BaseSynchronizer<JavaFile, Long> {
         rebuildAll();
     }
 
+    /**
+     * Recompiles and reloads the whole client codebase outside a synchronization pass - called after a
+     * dependency-layer swap, so client sources compile against the new JAR set and the new
+     * {@code ClientClassLoader} generation parents on the new modules classloader. {@code JavaLoader}'s
+     * own synchronization serializes this with a concurrently running pass.
+     */
+    void rebuildOnDependenciesChanged() {
+        rebuildAll();
+    }
+
     private void rebuildAll() {
         List<JavaFile> all = javaFileService.getAll();
         List<JavaLoader.ClientSource> sources = new ArrayList<>(all.size());

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/controller/CompiledModuleControllerRegistrationTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/controller/CompiledModuleControllerRegistrationTest.java
@@ -24,6 +24,7 @@ import org.eclipse.dirigible.engine.java.runtime.ClientClassLoaderHolder;
 import org.eclipse.dirigible.engine.java.runtime.JavaCompiledOutputDirectory;
 import org.eclipse.dirigible.engine.java.runtime.JavaLoader;
 import org.eclipse.dirigible.engine.java.runtime.JavaSourceCompiler;
+import org.eclipse.dirigible.engine.java.runtime.ModulesClassLoaderHolder;
 import org.eclipse.dirigible.engine.java.spi.LoadedClass;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -62,8 +63,8 @@ class CompiledModuleControllerRegistrationTest {
 
         JavaCompiledOutputDirectory outputDirectory = mock(JavaCompiledOutputDirectory.class);
         when(outputDirectory.get()).thenReturn(tempDir);
-        JavaLoader loader = new JavaLoader(new JavaSourceCompiler(), new ClientClassLoaderHolder(), container, List.of(controllerConsumer),
-                outputDirectory, NOOP_PUBLISHER);
+        JavaLoader loader = new JavaLoader(new JavaSourceCompiler(), new ClientClassLoaderHolder(), new ModulesClassLoaderHolder(),
+                container, List.of(controllerConsumer), outputDirectory, NOOP_PUBLISHER);
 
         // A compiled-module controller already on the classpath (no registry .java, no javac).
         Class<?> type = CompiledSampleController.class;

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/runtime/CompiledModuleClassProviderTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/runtime/CompiledModuleClassProviderTest.java
@@ -13,26 +13,38 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import javax.tools.ToolProvider;
 
 import org.eclipse.dirigible.engine.java.spi.LoadedClass;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Verifies {@link CompiledModuleClassProvider} discovers a
- * {@code META-INF/dirigible/<project>/.compiled} marker on the classpath, derives the project from
- * the path, and loads the listed class through the application classloader - no runtime
+ * {@code META-INF/dirigible/<project>/.compiled} marker through the given classloader, derives the
+ * project from the path, and loads the listed class through that classloader - no runtime
  * compilation.
  */
 class CompiledModuleClassProviderTest {
+
+    @TempDir
+    Path tempDir;
 
     @Test
     void discovers_marker_and_loads_the_listed_class() {
         // javaLoader is unused by discover(); the classpath carries the test fixture marker at
         // src/test/resources/META-INF/dirigible/aot-test-mod/.compiled.
-        CompiledModuleClassProvider provider = new CompiledModuleClassProvider(null);
+        CompiledModuleClassProvider provider = new CompiledModuleClassProvider(null, null);
 
-        List<LoadedClass> discovered = provider.discover();
+        List<LoadedClass> discovered = provider.discover(getClass().getClassLoader());
 
         LoadedClass fixture = discovered.stream()
                                         .filter(c -> c.fqn()
@@ -43,4 +55,51 @@ class CompiledModuleClassProviderTest {
         assertEquals("aot-test-mod", fixture.project(), "project is the path segment under META-INF/dirigible");
         assertSame(AotFixtureClass.class, fixture.type(), "the class is loaded via the application classloader (no compile)");
     }
+
+    @Test
+    void discovers_a_marker_through_a_custom_classloader() throws IOException, ClassNotFoundException {
+        Path moduleJar = aotModuleJar("dyn-mod", "dynmod.DynamicFixture");
+        CompiledModuleClassProvider provider = new CompiledModuleClassProvider(null, null);
+
+        try (ModulesClassLoader modules = new ModulesClassLoader(getClass().getClassLoader(), List.of(moduleJar))) {
+            List<LoadedClass> discovered = provider.discover(modules);
+
+            LoadedClass fixture = discovered.stream()
+                                            .filter(c -> "dynmod.DynamicFixture".equals(c.fqn()))
+                                            .findFirst()
+                                            .orElse(null);
+            assertNotNull(fixture, "the marker inside a modules-classloader jar must be discovered");
+            assertEquals("dyn-mod", fixture.project());
+            assertSame(modules, fixture.type()
+                                       .getClassLoader(),
+                    "the class is loaded through the given classloader (no compile)");
+        }
+    }
+
+    /** Builds an AOT module jar: one compiled class + its {@code .compiled} marker. */
+    private Path aotModuleJar(String project, String fqn) throws IOException {
+        String packageName = fqn.substring(0, fqn.lastIndexOf('.'));
+        String className = fqn.substring(fqn.lastIndexOf('.') + 1);
+        Path sourceDir = Files.createDirectories(tempDir.resolve("src")
+                                                        .resolve(packageName));
+        Path source = sourceDir.resolve(className + ".java");
+        Files.writeString(source, "package %s; public class %s {}".formatted(packageName, className));
+        Path classesDir = Files.createDirectories(tempDir.resolve("classes"));
+        int exitCode = ToolProvider.getSystemJavaCompiler()
+                                   .run(null, null, null, "-d", classesDir.toString(), source.toString());
+        assertEquals(0, exitCode);
+
+        Path jar = tempDir.resolve(project + ".jar");
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jar))) {
+            String classEntry = fqn.replace('.', '/') + ".class";
+            out.putNextEntry(new JarEntry(classEntry));
+            out.write(Files.readAllBytes(classesDir.resolve(classEntry)));
+            out.closeEntry();
+            out.putNextEntry(new JarEntry("META-INF/dirigible/" + project + "/.compiled"));
+            out.write(fqn.getBytes(StandardCharsets.UTF_8));
+            out.closeEntry();
+        }
+        return jar;
+    }
+
 }

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/runtime/JavaLoaderTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/runtime/JavaLoaderTest.java
@@ -78,8 +78,8 @@ class JavaLoaderTest {
         recording = new RecordingConsumer();
         JavaCompiledOutputDirectory outputDirectory = mock(JavaCompiledOutputDirectory.class);
         when(outputDirectory.get()).thenReturn(tempDir);
-        loader = new JavaLoader(new JavaSourceCompiler(), holder, container, List.of(handlerConsumer, recording), outputDirectory,
-                NOOP_PUBLISHER);
+        loader = new JavaLoader(new JavaSourceCompiler(), holder, new ModulesClassLoaderHolder(), container,
+                List.of(handlerConsumer, recording), outputDirectory, NOOP_PUBLISHER);
     }
 
     @Test
@@ -165,8 +165,8 @@ class JavaLoaderTest {
         ClientClassLoaderHolder freshHolder = new ClientClassLoaderHolder();
         JavaCompiledOutputDirectory outputDirectory = mock(JavaCompiledOutputDirectory.class);
         when(outputDirectory.get()).thenReturn(tempDir);
-        JavaLoader localLoader = new JavaLoader(new JavaSourceCompiler(), freshHolder, new ComponentContainer(new ClientBeansHolder()),
-                List.of(throwingConsumer, recording), outputDirectory, NOOP_PUBLISHER);
+        JavaLoader localLoader = new JavaLoader(new JavaSourceCompiler(), freshHolder, new ModulesClassLoaderHolder(),
+                new ComponentContainer(new ClientBeansHolder()), List.of(throwingConsumer, recording), outputDirectory, NOOP_PUBLISHER);
 
         localLoader.rebuild(List.of(handlerSource("client.Bomb", "boom"), handlerSource("client.Bystander", "fine")));
 

--- a/modules/engines/engine-graalium/execution-core/pom.xml
+++ b/modules/engines/engine-graalium/execution-core/pom.xml
@@ -25,6 +25,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.dirigible</groupId>
+			<artifactId>dirigible-components-core-java</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.dirigible</groupId>
 			<artifactId>dirigible-engine-graalium-execution</artifactId>
 		</dependency>
 		<dependency>

--- a/modules/engines/engine-graalium/execution-core/src/main/java/org/eclipse/dirigible/graalium/core/DirigibleJavascriptCodeRunner.java
+++ b/modules/engines/engine-graalium/execution-core/src/main/java/org/eclipse/dirigible/graalium/core/DirigibleJavascriptCodeRunner.java
@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
 import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.commons.config.StaticObjects;
 import org.eclipse.dirigible.components.base.spring.BeanProvider;
+import org.eclipse.dirigible.engine.java.runtime.ClientClassLoaderHolder;
 import org.eclipse.dirigible.graalium.core.globals.DirigibleContextGlobalObject;
 import org.eclipse.dirigible.graalium.core.globals.DirigibleEngineTypeGlobalObject;
 import org.eclipse.dirigible.graalium.core.javascript.GraalJSCodeRunner;
@@ -124,6 +125,13 @@ public class DirigibleJavascriptCodeRunner implements CodeRunner<Source, Value> 
         if (externalModuleResolver.isPresent()) {
             builder.addModuleResolver(externalModuleResolver.get());
         }
+
+        // Java.type(...) host lookups resolve through the client classloader, whose parent chain
+        // includes the swappable modules classloader - so JS sees client classes AND the maven
+        // dependency jars projects declare, at their current generation, without a restart.
+        Optional<ClientClassLoaderHolder> clientClassLoaderHolder = BeanProvider.getOptionalBean(ClientClassLoaderHolder.class);
+        builder.addOnBeforeContextCreatedListener(contextBuilder -> clientClassLoaderHolder.map(ClientClassLoaderHolder::current)
+                                                                                           .ifPresent(contextBuilder::hostClassLoader));
 
         return builder.addModuleResolver(new JavaModuleResolver(javaModulesESMProxiesCachePath))
                       .addModuleResolver(new DirigibleModuleResolver(coreModulesESMProxiesCachePath, sourceProvider))

--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/util/MavenFixtures.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/util/MavenFixtures.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.tests.framework.util;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Builds maven fixture artifacts for integration tests - file: repositories, plain library jars and
+ * AOT compiled module jars (compiled classes + the {@code META-INF/dirigible/<project>/.compiled}
+ * marker + a registry payload) - so the tests double as executable documentation of the module jar
+ * format. Everything is produced locally with the JDK compiler; no test touches the network.
+ */
+public final class MavenFixtures {
+
+    private MavenFixtures() {
+        // utility
+    }
+
+    /**
+     * Deploys a jar with a minimal POM into a file:-served fixture repository at the standard maven
+     * layout.
+     *
+     * @param repositoryDir the fixture repository root
+     * @param groupId the group id
+     * @param artifactId the artifact id
+     * @param version the version
+     * @param jar the jar to deploy
+     */
+    public static void deploy(Path repositoryDir, String groupId, String artifactId, String version, Path jar) {
+        try {
+            Path directory = Files.createDirectories(repositoryDir.resolve(groupId.replace('.', '/'))
+                                                                  .resolve(artifactId)
+                                                                  .resolve(version));
+            Files.writeString(directory.resolve(artifactId + "-" + version + ".pom"), """
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>%s</groupId>
+                        <artifactId>%s</artifactId>
+                        <version>%s</version>
+                    </project>
+                    """.formatted(groupId, artifactId, version));
+            Files.copy(jar, directory.resolve(artifactId + "-" + version + ".jar"));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to deploy [" + groupId + ":" + artifactId + ":" + version + "]", e);
+        }
+    }
+
+    /**
+     * Builds a plain library jar from the given sources - the "third-party dependency" fixture.
+     *
+     * @param workDir a scratch directory
+     * @param jarName the jar file name
+     * @param sources FQN to source
+     * @return the built jar
+     */
+    public static Path buildPlainJar(Path workDir, String jarName, Map<String, String> sources) {
+        Path classesDir = compile(workDir, jarName, sources);
+        return jar(workDir.resolve(jarName), classesDir, null, Map.of());
+    }
+
+    /**
+     * Builds an AOT compiled module jar: the compiled classes, the
+     * {@code META-INF/dirigible/<project>/.compiled} marker listing them, and the module's registry
+     * payload under {@code META-INF/dirigible/<project>/}.
+     *
+     * @param workDir a scratch directory
+     * @param jarName the jar file name
+     * @param project the module's project name
+     * @param sources FQN to source - each FQN is listed in the marker
+     * @param payload registry payload as project-relative path to content
+     * @return the built jar
+     */
+    public static Path buildModuleJar(Path workDir, String jarName, String project, Map<String, String> sources,
+            Map<String, String> payload) {
+        Path classesDir = compile(workDir, jarName, sources);
+        String marker = sources.keySet()
+                               .stream()
+                               .sorted()
+                               .collect(Collectors.joining("\n"));
+        Map<String, String> metaInf = payload.entrySet()
+                                             .stream()
+                                             .collect(Collectors.toMap(entry -> "META-INF/dirigible/" + project + "/" + entry.getKey(),
+                                                     Map.Entry::getValue));
+        return jar(workDir.resolve(jarName), classesDir, "META-INF/dirigible/" + project + "/.compiled", metaInf, marker);
+    }
+
+    /**
+     * Compiles the sources against the running test's classpath.
+     *
+     * @param workDir a scratch directory
+     * @param jarName the jar name, used to keep scratch directories distinct
+     * @param sources FQN to source
+     * @return the classes directory
+     */
+    private static Path compile(Path workDir, String jarName, Map<String, String> sources) {
+        try {
+            Path sourcesDir = Files.createDirectories(workDir.resolve(jarName + "-sources"));
+            Path classesDir = Files.createDirectories(workDir.resolve(jarName + "-classes"));
+            String[] arguments = new String[sources.size() + 4];
+            int index = 0;
+            arguments[index++] = "-d";
+            arguments[index++] = classesDir.toString();
+            arguments[index++] = "-cp";
+            arguments[index++] = System.getProperty("java.class.path");
+            for (Map.Entry<String, String> source : sources.entrySet()) {
+                Path file = sourcesDir.resolve(source.getKey()
+                                                     .replace('.', '/')
+                        + ".java");
+                Files.createDirectories(file.getParent());
+                Files.writeString(file, source.getValue());
+                arguments[index++] = file.toString();
+            }
+            JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+            int exitCode = compiler.run(null, null, null, arguments);
+            if (exitCode != 0) {
+                throw new IllegalStateException("Fixture sources failed to compile: " + sources.keySet());
+            }
+            return classesDir;
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to compile the fixture sources", e);
+        }
+    }
+
+    /**
+     * Jar.
+     *
+     * @param jarPath the target jar path
+     * @param classesDir the compiled classes
+     * @param markerEntry the marker entry name, null for a plain jar
+     * @param extraEntries extra entries as entry name to content
+     * @param markerContent the marker content (used when markerEntry is set)
+     * @return the jar path
+     */
+    private static Path jar(Path jarPath, Path classesDir, String markerEntry, Map<String, String> extraEntries, String... markerContent) {
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jarPath)); Stream<Path> files = Files.walk(classesDir)) {
+            for (Path file : files.filter(Files::isRegularFile)
+                                  .toList()) {
+                out.putNextEntry(new JarEntry(classesDir.relativize(file)
+                                                        .toString()
+                                                        .replace('\\', '/')));
+                out.write(Files.readAllBytes(file));
+                out.closeEntry();
+            }
+            if (markerEntry != null) {
+                out.putNextEntry(new JarEntry(markerEntry));
+                out.write(markerContent[0].getBytes(StandardCharsets.UTF_8));
+                out.closeEntry();
+            }
+            for (Map.Entry<String, String> entry : extraEntries.entrySet()) {
+                out.putNextEntry(new JarEntry(entry.getKey()));
+                out.write(entry.getValue()
+                               .getBytes(StandardCharsets.UTF_8));
+                out.closeEntry();
+            }
+            return jarPath;
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to build the fixture jar [" + jarPath + "]", e);
+        }
+    }
+
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/DynamicDependenciesIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/DynamicDependenciesIT.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.eclipse.dirigible.tests.framework.util.MavenFixtures;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.function.Consumer;
+import java.util.jar.JarOutputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasKey;
+
+/**
+ * The restartless dependency lifecycle, end to end over one running platform: an AOT module jar
+ * arrives (via the declaration watcher - zero runtime javac for its classes), a third-party library
+ * becomes importable from registry {@code .java} sources, the module upgrades, a native-library jar
+ * and an unreadable jar are rejected without a partial swap, and the removed module leaves cleanly.
+ * All repositories are file: fixtures built by the test - no network.
+ */
+// One Dirigible boot for the whole journey; the steps build on each other in @Order sequence.
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class DynamicDependenciesIT extends IntegrationTest {
+
+    /** The registry project declaring the maven dependencies. */
+    private static final String PROJECT = "dynamic-deps-it";
+    private static final String PROJECT_JSON_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/project.json";
+    private static final String CLIENT_SOURCE_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/client/LibUser.java";
+
+    /** The AOT module's controller - served straight from the module jar, never compiled at runtime. */
+    private static final String MODULE_ENDPOINT = "/services/java/hello-module/aotdemo/HelloController/hello";
+
+    /** The registry handler importing the third-party fixture library. */
+    private static final String CLIENT_ENDPOINT = "/services/java/" + PROJECT + "/client/LibUser";
+
+    private static final long AWAIT_SECONDS = 60;
+
+    @TempDir
+    static Path tempDir;
+
+    private static Path fixtureRepo;
+    private static Path localRepository;
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @BeforeAll
+    static void prepareFixtures() throws IOException {
+        fixtureRepo = Files.createDirectories(tempDir.resolve("fixture-repo"));
+        localRepository = tempDir.resolve("local-repo");
+        // the fixture repository REPLACES Maven Central, so no request can leave the machine
+        Configuration.set("DIRIGIBLE_MAVEN_REPOSITORIES", "central=" + fixtureRepo.toUri());
+        Configuration.set("DIRIGIBLE_MAVEN_LOCAL_REPO", localRepository.toString());
+        Configuration.set("DIRIGIBLE_DEPENDENCIES_DIR", tempDir.resolve("resolved-modules")
+                                                               .toString());
+
+        Path work = Files.createDirectories(tempDir.resolve("work"));
+        MavenFixtures.deploy(fixtureRepo, "com.example", "hello-module", "1.0.0",
+                MavenFixtures.buildModuleJar(work, "hello-module-1.0.0.jar", "hello-module",
+                        Map.of("aotdemo.HelloController", helloControllerSource("1.0.0")), Map.of("greeting.txt", "v1.0.0")));
+        MavenFixtures.deploy(fixtureRepo, "com.example", "hello-module", "1.1.0",
+                MavenFixtures.buildModuleJar(work, "hello-module-1.1.0.jar", "hello-module",
+                        Map.of("aotdemo.HelloController", helloControllerSource("1.1.0")), Map.of("greeting.txt", "v1.1.0")));
+        MavenFixtures.deploy(fixtureRepo, "com.example", "textlib", "1.0.0",
+                MavenFixtures.buildPlainJar(work, "textlib-1.0.0.jar", Map.of("com.example.textlib.TextLib", """
+                        package com.example.textlib;
+                        public class TextLib {
+                            public static String shout(String input) {
+                                return input.toUpperCase() + "!";
+                            }
+                        }
+                        """)));
+        MavenFixtures.deploy(fixtureRepo, "com.example", "native-lib", "1.0.0",
+                jarWithRawEntries(work.resolve("native-lib-1.0.0.jar"), Map.of("lib/dummy.so", "not really native")));
+        Path brokenJar = work.resolve("broken-1.0.0.jar");
+        Files.writeString(brokenJar, "this is not a jar");
+        MavenFixtures.deploy(fixtureRepo, "com.example", "broken", "1.0.0", brokenJar);
+    }
+
+    @Test
+    @Order(1)
+    void an_aot_module_jar_activates_without_restart_via_the_declaration_watcher() {
+        writeProjectJson("""
+                { "type": "maven", "id": "com.example:hello-module:1.0.0" }""");
+
+        // no resolve call - the watcher notices the changed declaration and runs the swap pipeline;
+        // the response proves zero runtime javac: the class is served by the modules classloader
+        awaitEndpoint(MODULE_ENDPOINT, "hello from 1.0.0 via dirigible-modules");
+
+        assertThat(registryContent("/hello-module/greeting.txt")).isEqualTo("v1.0.0");
+    }
+
+    @Test
+    @Order(2)
+    void a_registry_java_source_compiles_against_a_declared_third_party_library() {
+        repository.createResource(CLIENT_SOURCE_PATH, """
+                package client;
+                import jakarta.servlet.http.HttpServletRequest;
+                import jakarta.servlet.http.HttpServletResponse;
+                import org.eclipse.dirigible.engine.java.handler.JavaHandler;
+                import com.example.textlib.TextLib;
+                public class LibUser implements JavaHandler {
+                    @Override
+                    public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
+                        response.getWriter().write(TextLib.shout("dirigible"));
+                    }
+                }
+                """.getBytes(StandardCharsets.UTF_8), false, "text/x-java", true);
+        // the source registers (and fails to compile - the library is not declared yet)
+        synchronizationProcessor.forceProcessSynchronizers();
+
+        writeProjectJson("""
+                { "type": "maven", "id": "com.example:hello-module:1.0.0" },
+                { "type": "maven", "id": "com.example:textlib:1.0.0" }""");
+        resolveExpecting(response -> response.body("failures", anEmptyMap()));
+
+        awaitEndpoint(CLIENT_ENDPOINT, "DIRIGIBLE!");
+    }
+
+    @Test
+    @Order(3)
+    void an_upgraded_module_swaps_its_classes_and_registry_payload() {
+        writeProjectJson("""
+                { "type": "maven", "id": "com.example:hello-module:1.1.0" },
+                { "type": "maven", "id": "com.example:textlib:1.0.0" }""");
+        resolveExpecting(response -> response.body("failures", anEmptyMap()));
+
+        awaitEndpoint(MODULE_ENDPOINT, "hello from 1.1.0 via dirigible-modules");
+        assertThat(registryContent("/hello-module/greeting.txt")).isEqualTo("v1.1.0");
+        // the old version's jar stays untouched at its immutable versioned path
+        assertThat(localRepository.resolve("com/example/hello-module/1.0.0/hello-module-1.0.0.jar")).exists();
+    }
+
+    @Test
+    @Order(4)
+    void a_native_library_jar_is_rejected_and_the_installed_generation_keeps_serving() {
+        writeProjectJson("""
+                { "type": "maven", "id": "com.example:hello-module:1.1.0" },
+                { "type": "maven", "id": "com.example:textlib:1.0.0" },
+                { "type": "maven", "id": "com.example:native-lib:1.0.0" }""");
+        resolveExpecting(response -> response.body("failures", hasKey("modules-swap"))
+                                             .body("failures.'modules-swap'", containsString("lib/dummy.so"))
+                                             .body("failures.'modules-swap'", containsString("platform")));
+
+        // no partial swap - the previous generation answers as before
+        awaitEndpoint(MODULE_ENDPOINT, "hello from 1.1.0 via dirigible-modules");
+        awaitEndpoint(CLIENT_ENDPOINT, "DIRIGIBLE!");
+    }
+
+    @Test
+    @Order(5)
+    void an_unreadable_jar_aborts_the_swap_and_the_installed_generation_keeps_serving() {
+        writeProjectJson("""
+                { "type": "maven", "id": "com.example:hello-module:1.1.0" },
+                { "type": "maven", "id": "com.example:textlib:1.0.0" },
+                { "type": "maven", "id": "com.example:broken:1.0.0" }""");
+        resolveExpecting(response -> response.body("failures", hasKey("modules-swap"))
+                                             .body("failures.'modules-swap'", containsString("not a readable archive")));
+
+        awaitEndpoint(MODULE_ENDPOINT, "hello from 1.1.0 via dirigible-modules");
+    }
+
+    @Test
+    @Order(6)
+    void a_removed_module_unregisters_its_classes_and_registry_payload() {
+        writeProjectJson("""
+                { "type": "maven", "id": "com.example:textlib:1.0.0" }""");
+        resolveExpecting(response -> response.body("failures", anEmptyMap()));
+
+        awaitEndpointStatus(MODULE_ENDPOINT, 404);
+        assertThat(repository.hasResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/hello-module/greeting.txt")).isFalse();
+        // the surviving dependency keeps serving
+        awaitEndpoint(CLIENT_ENDPOINT, "DIRIGIBLE!");
+    }
+
+    private void writeProjectJson(String dependencyEntries) {
+        String content = """
+                {
+                    "guid": "%s",
+                    "dependencies": [
+                %s
+                    ]
+                }
+                """.formatted(PROJECT, dependencyEntries.indent(8));
+        repository.createResource(PROJECT_JSON_PATH, content.getBytes(StandardCharsets.UTF_8), false, "application/json", true);
+    }
+
+    private void resolveExpecting(Consumer<ValidatableResponse> assertions) {
+        restAssuredExecutor.execute(() -> {
+            ValidatableResponse response = given().when()
+                                                  .post("/services/core/dependencies/resolve")
+                                                  .then()
+                                                  .statusCode(200)
+                                                  .contentType(ContentType.JSON);
+            assertions.accept(response);
+        });
+    }
+
+    private void awaitEndpoint(String endpoint, String expectedBodyFragment) {
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get(endpoint)
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body(containsString(expectedBodyFragment)),
+                AWAIT_SECONDS);
+    }
+
+    private void awaitEndpointStatus(String endpoint, int expectedStatus) {
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get(endpoint)
+                                                 .then()
+                                                 .statusCode(expectedStatus),
+                AWAIT_SECONDS);
+    }
+
+    private String registryContent(String registryRelativePath) {
+        return new String(repository.getResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + registryRelativePath)
+                                    .getContent(),
+                StandardCharsets.UTF_8);
+    }
+
+    private static String helloControllerSource(String version) {
+        return """
+                package aotdemo;
+                import org.eclipse.dirigible.sdk.http.Controller;
+                import org.eclipse.dirigible.sdk.http.Get;
+                @Controller
+                public class HelloController {
+                    @Get("/hello")
+                    public String hello() {
+                        return "hello from %s via " + getClass().getClassLoader().getName();
+                    }
+                }
+                """.formatted(version);
+    }
+
+    private static Path jarWithRawEntries(Path jarPath, Map<String, String> entries) throws IOException {
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jarPath))) {
+            for (Map.Entry<String, String> entry : entries.entrySet()) {
+                out.putNextEntry(new JarEntry(entry.getKey()));
+                out.write(entry.getValue()
+                               .getBytes(StandardCharsets.UTF_8));
+                out.closeEntry();
+            }
+        }
+        return jarPath;
+    }
+
+}


### PR DESCRIPTION
## Overview

A change to any project's `maven` dependencies now takes effect **without restarting the platform**: a new swappable classloader layer sits between the application classloader and the client-code generations, and a seven-step pipeline (resolve → validate → registry payload → swap → AOT rediscovery → compile-classpath invalidation → client rebuild) reconciles every declaration change into the running system. New AOT module JARs register their classes and payload, third-party libraries become importable from registry `.java` sources and JS (`Java.type`), and removed or upgraded JARs leave cleanly. A failed resolution, a native-library JAR or an unreadable JAR aborts before the first side effect - the installed generation keeps serving (no partial swap). With no `maven` declarations the boot behavior is unchanged, `/modules` drop-in jars included.

## Worked example (from the `DynamicDependenciesIT` run)

`project.json` diff:

```diff
 {
     "guid": "dynamic-deps-it",
     "dependencies": [
-        { "type": "maven", "id": "com.example:hello-module:1.0.0" },
+        { "type": "maven", "id": "com.example:hello-module:1.1.0" },
         { "type": "maven", "id": "com.example:textlib:1.0.0" }
     ]
 }
```

One full swap in the log (upgrade 1.0.0 → 1.1.0):

```
o.e.d.e.j.r.ModulesClassLoaderHolder      - Modules classloader generation [4] installed over [2] jar(s)
o.e.d.c.d.DependencySynchronizer          - Dependency layer swapped to generation [4]: added [com.example:hello-module:1.1.0], removed [com.example:hello-module:1.0.0]
o.e.d.e.j.s.JavaDependenciesChangedListener - Dependency layer swapped to generation [4] (added [com.example:hello-module:1.1.0], removed [com.example:hello-module:1.0.0]) - rediscovering AOT modules and rebuilding the client sources
o.e.d.e.j.r.CompiledModuleClassProvider   - Registered [1] class(es) from AOT compiled module(s) on the classpath
```

Before / after HTTP responses of the upgrade (same JVM, no restart):

```
GET /services/java/hello-module/aotdemo/HelloController/hello
before: hello from 1.0.0 via dirigible-modules
after:  hello from 1.1.0 via dirigible-modules
```

The `via dirigible-modules` suffix is the serving classloader's name - the AOT classes are never compiled at runtime.

Fixes: #6778.