### PR TITLE
fix(jobs): a client-Java job is registered for a tenant provisioned later (#6786)

### DIFF
--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/scheduled/ScheduledClassConsumer.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/scheduled/ScheduledClassConsumer.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.eclipse.dirigible.components.base.tenant.TenantPostProvisioningStep;
 import org.eclipse.dirigible.components.jobs.domain.Job;
 import org.eclipse.dirigible.components.jobs.handler.JavaJobExecutor;
 import org.eclipse.dirigible.components.jobs.manager.JobsManager;
@@ -58,10 +59,22 @@ import org.springframework.stereotype.Component;
  * registration carries it over instead of switching the job back on - a class load happens at every
  * server start and on every client-Java rebuild. A genuinely unloaded class, or a job that a
  * reloaded class no longer declares, unschedules and removes its rows.
+ *
+ * <p>
+ * <b>Tenants outlive a generation.</b> The per-tenant fan-out below runs at class-load time, and a
+ * client-Java generation is JVM-wide and only rebuilt when the Java synchronizer goes dirty on a
+ * publish - so a tenant provisioned afterwards would have no {@code Job} row and no Quartz trigger
+ * for any client-Java job, with nothing in the Jobs perspective to point at the cause. This
+ * consumer is therefore also a {@link TenantPostProvisioningStep} that re-registers what it is
+ * tracking once a provisioning round completes, exactly as the sibling
+ * {@code ListenerClassConsumer} tops up a late tenant's subscriptions. The top-up needs no
+ * per-tenant bookkeeping of its own because a registration is idempotent by construction: it lands
+ * on the existing row and {@link JobsManager#scheduleJob} returns early once the job and its
+ * trigger are there.
  */
 @Component
 @Order(400)
-public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean {
+public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean, TenantPostProvisioningStep {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledClassConsumer.class);
 
@@ -73,8 +86,8 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
     private final JobService jobService;
     private final TenantContext tenantContext;
 
-    /** fqn -> the base job names it registered (a class may declare several @Scheduled methods). */
-    private final ConcurrentMap<String, List<String>> registered = new ConcurrentHashMap<>();
+    /** fqn -> the jobs it declared (a class may declare several @Scheduled methods). */
+    private final ConcurrentMap<String, List<JobDeclaration>> registered = new ConcurrentHashMap<>();
 
     @Autowired
     public ScheduledClassConsumer(ComponentContainer componentContainer, JobsManager jobsManager, JobService jobService,
@@ -113,11 +126,11 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
         // rather than unregistering everything first. A re-registration must find (and update) the
         // existing Job row, because that row carries operator state - above all the enabled flag,
         // which a delete-then-recreate would silently reset to true (#6626).
-        List<String> names = new ArrayList<>();
+        List<JobDeclaration> declarations = new ArrayList<>();
 
         if (jobHandler) {
             JobHandler job = (JobHandler) instance;
-            register(names, info.fqn(), info.fqn(), job.cron());
+            declarations.add(JobDeclaration.of(info.fqn(), job.cron()));
         } else {
             for (Method method : type.getDeclaredMethods()) {
                 Scheduled annotation = method.getAnnotation(Scheduled.class);
@@ -128,23 +141,48 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
                     LOGGER.error("@Scheduled method [{}#{}] must be public and take no parameters; skipped.", info.fqn(), method.getName());
                     continue;
                 }
-                register(names, info.fqn(), info.fqn() + "#" + method.getName(), annotation.expression());
+                declarations.add(JobDeclaration.of(info.fqn() + "#" + method.getName(), annotation.expression()));
             }
         }
 
-        if (names.isEmpty()) {
+        if (declarations.isEmpty()) {
             unregister(info.fqn());
             LOGGER.warn("Scheduled job [{}] produced no schedule.", info.fqn());
             return;
         }
-        retainOnly(info.fqn(), names);
-        registered.put(info.fqn(), names);
+        List<JobDeclaration> scheduled = new ArrayList<>();
+        for (JobDeclaration declaration : declarations) {
+            if (register(declaration)) {
+                scheduled.add(declaration);
+            }
+        }
+        retainOnly(info.fqn(), scheduled);
+        registered.put(info.fqn(), scheduled);
     }
 
     @Override
     public void onClassUnloaded(LoadedClass info) {
         unregister(info.fqn());
         LOGGER.info("Unscheduled Java class [{}].", info.fqn());
+    }
+
+    /**
+     * Re-register every job of every loaded class, so a tenant provisioned after the last client-Java
+     * rebuild gets its {@code Job} rows and Quartz triggers too. Called once a provisioning round has
+     * actually provisioned something - {@code TenantsProvisioner} skips the post-provisioning steps
+     * when no tenant was in INITIAL status - so this is not a per-round cost.
+     *
+     * <p>
+     * Unlike the listener consumer's top-up this does not track which tenants it has already covered,
+     * and does not need to: re-registering finds the existing row and updates it in place (keeping the
+     * operator's enabled flag), and {@link JobsManager#scheduleJob} returns early when the job and its
+     * trigger already exist. A second consumer on a JMS destination competes for messages; a second
+     * registration of the same job is a no-op.
+     */
+    @Override
+    public void execute() {
+        registered.values()
+                  .forEach(declarations -> declarations.forEach(this::register));
     }
 
     @Override
@@ -158,9 +196,18 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
     /**
      * Register one job (a JobHandler class or a single @Scheduled method) as a Job on the shared
      * scheduler.
+     *
+     * <p>
+     * Serialized against the other registrations: the post-provisioning top-up runs on the provisioning
+     * thread and a rebuild registers from the synchronizer's, and the find-then-save below is exactly
+     * the window in which two of them could insert the same job row twice.
+     *
+     * @return true if the job is now registered in every tenant
      */
-    private void register(List<String> sink, String fqn, String handler, String expression) {
-        String name = handler.replace('#', '.');
+    private synchronized boolean register(JobDeclaration declaration) {
+        String name = declaration.name();
+        String handler = declaration.handler();
+        String expression = declaration.expression();
         // Register the job PER TENANT (like the JS .job/scheduled.ts synchronizer does): each tenant
         // gets its own scheduled row + tenant-prefixed Quartz job. The job body runs in that tenant's
         // context at fire time (the jobs engine restores it from the job data), so a global client
@@ -199,11 +246,12 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
                 jobsManager.scheduleJob(job);
                 return null;
             });
-            sink.add(name);
             LOGGER.info("Registered client-Java job [{}] (handler [{}]) with cron '{}' on the shared scheduler.", name, handler,
                     expression);
+            return true;
         } catch (Exception e) {
             LOGGER.error("Failed to register client-Java job [{}] with cron '{}': {}", handler, expression, e.getMessage(), e);
+            return false;
         }
     }
 
@@ -212,27 +260,34 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
      * was renamed or removed. The ones it still declares were just re-registered onto their existing
      * rows, so they keep their operator state.
      */
-    private void retainOnly(String fqn, List<String> current) {
-        List<String> previous = registered.get(fqn);
+    private void retainOnly(String fqn, List<JobDeclaration> current) {
+        List<JobDeclaration> previous = registered.get(fqn);
         if (previous == null) {
             return;
         }
-        List<String> stale = new ArrayList<>(previous);
-        stale.removeAll(current);
+        List<String> currentNames = current.stream()
+                                           .map(JobDeclaration::name)
+                                           .toList();
+        List<String> stale = previous.stream()
+                                     .map(JobDeclaration::name)
+                                     .filter(name -> !currentNames.contains(name))
+                                     .toList();
         remove(stale);
     }
 
     /** Unschedule + remove the Job rows a class previously registered (per tenant). */
     private void unregister(String fqn) {
-        List<String> names = registered.remove(fqn);
-        if (names == null) {
+        List<JobDeclaration> declarations = registered.remove(fqn);
+        if (declarations == null) {
             return;
         }
-        remove(names);
+        remove(declarations.stream()
+                           .map(JobDeclaration::name)
+                           .toList());
     }
 
     /** Unschedule + delete the given job rows, per tenant. */
-    private void remove(List<String> names) {
+    private synchronized void remove(List<String> names) {
         for (String name : names) {
             try {
                 tenantContext.executeForEachTenant(() -> {
@@ -252,6 +307,19 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
             } catch (Exception e) {
                 LOGGER.warn("Failed to unregister client-Java job [{}]: {}", name, e.getMessage());
             }
+        }
+    }
+
+    /**
+     * One job a loaded class declares: the {@code Job} row's name, the handler the jobs engine
+     * dispatches to ({@code <fqn>} or {@code <fqn>#<method>}), and its cron expression. Kept per class
+     * because a re-registration - for a late tenant, above all - needs the whole declaration, not just
+     * the name it produced.
+     */
+    private record JobDeclaration(String name, String handler, String expression) {
+
+        static JobDeclaration of(String handler, String expression) {
+            return new JobDeclaration(handler.replace('#', '.'), handler, expression);
         }
     }
 

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/scheduled/ScheduledClassConsumerTenantRegistrationTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/scheduled/ScheduledClassConsumerTenantRegistrationTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.java.scheduled;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.dirigible.components.base.callable.CallableResultAndException;
+import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.eclipse.dirigible.components.jobs.domain.Job;
+import org.eclipse.dirigible.components.jobs.manager.JobsManager;
+import org.eclipse.dirigible.components.jobs.service.JobService;
+import org.eclipse.dirigible.engine.java.component.ComponentContainer;
+import org.eclipse.dirigible.engine.java.spi.LoadedClass;
+import org.eclipse.dirigible.sdk.job.Scheduled;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A client-Java job has to exist in EVERY tenant, including one provisioned after the class was
+ * loaded. The fan-out runs at class-load time only, and a client-Java generation is JVM-wide and
+ * rebuilt solely when the Java synchronizer goes dirty on a publish - so without the
+ * post-provisioning top-up a tenant created later has no {@code Job} row and no Quartz trigger for
+ * any client-Java job, and the Jobs perspective shows nothing to switch on.
+ */
+class ScheduledClassConsumerTenantRegistrationTest {
+
+    /** A method-level job, so the assertions also cover the {@code <fqn>#<method>} handler shape. */
+    static class ReportsJob {
+
+        @Scheduled(expression = "0 0 6 * * ?")
+        public void sendDaily() {
+            // The registration, not the run, is what this test is about.
+        }
+    }
+
+    private static final String DEFAULT_TENANT_ID = "default-tenant";
+    private static final String JOB_NAME = ReportsJob.class.getName() + ".sendDaily";
+    private static final String JOB_HANDLER = ReportsJob.class.getName() + "#sendDaily";
+
+    /** The tenants {@code executeForEachTenant} fans out over; mutable, so a test can add one. */
+    private final Map<String, Tenant> provisionedTenants = new LinkedHashMap<>();
+
+    /** The tenant whose context the fan-out is currently simulating. */
+    private final AtomicReference<String> currentTenantId = new AtomicReference<>();
+
+    /** The tenants a job was actually scheduled for, in order. */
+    private final List<String> scheduledForTenants = new ArrayList<>();
+
+    /** The rows a tenant already has, keyed by tenant id then job name - the "DB" of this test. */
+    private final Map<String, Map<String, Job>> rowsByTenant = new LinkedHashMap<>();
+
+    private JobsManager jobsManager;
+    private JobService jobService;
+    private ScheduledClassConsumer consumer;
+
+    @BeforeEach
+    @SuppressWarnings("rawtypes")
+    void setUp() throws Exception {
+        addTenant(DEFAULT_TENANT_ID);
+        addTenant("acme");
+
+        ComponentContainer componentContainer = mock(ComponentContainer.class);
+        when(componentContainer.instanceOf(ReportsJob.class)).thenReturn(Optional.of(new ReportsJob()));
+
+        jobsManager = mock(JobsManager.class);
+        // The Quartz job name is tenant-prefixed by JobsManager itself, so the tenant in scope at the
+        // moment of scheduling IS the observable for "which tenants got this job".
+        doAnswer(invocation -> {
+            scheduledForTenants.add(currentTenantId.get());
+            return null;
+        }).when(jobsManager)
+          .scheduleJob(any());
+
+        jobService = mock(JobService.class);
+        // Each tenant sees only its own rows, the way the tenant-routed datasource has it: findByName
+        // THROWS when absent (it does not return null), which is what "brand new" looks like here.
+        when(jobService.findByName(anyString())).thenAnswer(invocation -> {
+            String name = invocation.getArgument(0);
+            Job row = rows().get(name);
+            if (row == null) {
+                throw new IllegalArgumentException("Job with name does not exist: " + name);
+            }
+            return row;
+        });
+        when(jobService.save(any())).thenAnswer(invocation -> {
+            Job job = invocation.getArgument(0);
+            rows().put(job.getName(), job);
+            return job;
+        });
+
+        TenantContext tenantContext = mock(TenantContext.class);
+        // Run the callable once per provisioned tenant, inline, with that tenant current.
+        when(tenantContext.executeForEachTenant(any())).thenAnswer(invocation -> {
+            for (String tenantId : new ArrayList<>(provisionedTenants.keySet())) {
+                currentTenantId.set(tenantId);
+                ((CallableResultAndException) invocation.getArgument(0)).call();
+            }
+            currentTenantId.set(null);
+            return List.of();
+        });
+
+        consumer = new ScheduledClassConsumer(componentContainer, jobsManager, jobService, tenantContext);
+    }
+
+    @Test
+    void aLoadedJobIsRegisteredInEveryProvisionedTenant() {
+        loadJob();
+
+        assertEquals(List.of(DEFAULT_TENANT_ID, "acme"), scheduledForTenants);
+    }
+
+    @Test
+    void aTenantProvisionedAfterTheClassWasLoadedIsRegisteredByThePostProvisioningStep() {
+        loadJob();
+        scheduledForTenants.clear();
+
+        addTenant("beta");
+        consumer.execute();
+
+        row("beta");
+        assertEquals(List.of(DEFAULT_TENANT_ID, "acme", "beta"), scheduledForTenants,
+                "the top-up re-registers every tenant; scheduling an already-scheduled job is a no-op");
+    }
+
+    @Test
+    void theTopUpRegistersTheSameCronAndHandlerTheClassDeclared() {
+        loadJob();
+
+        addTenant("beta");
+        consumer.execute();
+
+        // Tracking only the job NAME would be enough to know WHAT to re-register but not HOW: the
+        // cron expression and the handler have to be kept with it, or the late tenant gets a row
+        // that never fires.
+        Job lateRow = row("beta");
+        assertEquals("0 0 6 * * ?", lateRow.getExpression());
+        assertEquals(JOB_HANDLER, lateRow.getHandler());
+    }
+
+    @Test
+    void theTopUpKeepsTheOperatorsDisableInTheTenantsThatAlreadyHadTheJob() throws Exception {
+        loadJob();
+        // The operator switches the job off in one tenant through the Jobs perspective.
+        row("acme").setEnabled(false);
+
+        addTenant("beta");
+        consumer.execute();
+
+        assertFalse(row("acme").isEnabled(), "topping up a late tenant must not switch the job back on in the others (#6626)");
+        verify(jobService, never()).delete(any());
+        verify(jobsManager, never()).unscheduleJob(anyString(), anyString());
+    }
+
+    /** The job row a tenant holds — the assertion subject, so its absence reads as the failure. */
+    private Job row(String tenantId) {
+        Job job = rowsByTenant.getOrDefault(tenantId, Map.of())
+                              .get(JOB_NAME);
+        assertNotNull(job, "tenant [" + tenantId + "] has no row for the client-Java job [" + JOB_NAME + "]");
+        return job;
+    }
+
+    private Map<String, Job> rows() {
+        return rowsByTenant.computeIfAbsent(currentTenantId.get(), tenantId -> new LinkedHashMap<>());
+    }
+
+    private void addTenant(String tenantId) {
+        Tenant tenant = mock(Tenant.class);
+        when(tenant.getId()).thenReturn(tenantId);
+        when(tenant.isDefault()).thenReturn(DEFAULT_TENANT_ID.equals(tenantId));
+        provisionedTenants.put(tenantId, tenant);
+    }
+
+    private void loadJob() {
+        consumer.onClassLoaded(new LoadedClass("sample", ReportsJob.class.getName(), ReportsJob.class, ReportsJob.class.getClassLoader()));
+    }
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaJobTenantIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaJobTenantIT.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.eclipse.dirigible.components.api.messaging.MessagingFacade;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.components.jobs.tenant.JobNameCreator;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.tenant.DirigibleTestTenant;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
+/**
+ * A client-Java job must exist in a NON-DEFAULT tenant — including one provisioned after the class
+ * was loaded.
+ *
+ * <p>
+ * The per-tenant fan-out runs at class-load time, and a client-Java generation is JVM-wide and only
+ * rebuilt when the Java synchronizer goes dirty on a publish ({@code JavaSynchronizer} is not
+ * multitenant, so the synchronizer-retriggering post-provisioning step does not reach it either). A
+ * tenant created afterwards therefore had no {@code Job} row and no Quartz trigger for any
+ * client-Java job — no {@code JobHandler} bean, no {@code @Scheduled} method — and nothing pointed
+ * at the cause: the Jobs perspective simply showed nothing to enable.
+ *
+ * <p>
+ * Both phases go all the way to a real execution: the job's Quartz key is triggered by name and the
+ * client bean's body has to publish into the tenant it fires for, which the test then draws back
+ * inside that tenant's context. The Quartz name is computed through the platform's own
+ * {@link JobNameCreator}, so a key the test and the registration merely agreed to spell the same
+ * wrong way would fail; and the job body is only reached if the row, the {@code JobDetail} and the
+ * tenant stamped into its job data are all there. Triggering by hand rather than waiting on a cron
+ * is deliberate — the schedule is a "never" expression, so the job stays inert for the rest of the
+ * suite instead of firing every second in the background.
+ *
+ * <p>
+ * The phases differ only in the interleaving that is the actual hazard — a tenant appearing before
+ * the class is loaded, and a tenant appearing after — and they share one tenant, because
+ * provisioning a tenant is by far the most expensive thing here.
+ */
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class JavaJobTenantIT extends IntegrationTest {
+
+    private static final String PROJECT = "java-job-tenant-it";
+
+    /** The user-defined job group — the only one routed through the handler/engine dispatch. */
+    private static final String JOB_GROUP = "defined";
+
+    /** A cron that never fires: the test triggers the job itself, and nothing else should. */
+    private static final String NEVER = "0 0 0 1 1 ? 2099";
+
+    /** The tenant both phases use; provisioned by the first one that needs it. */
+    private static DirigibleTestTenant tenant;
+
+    /** Covers the compile + registration lag after a forced synchronization. */
+    private static final int REGISTRATION_TIMEOUT_SECONDS = 90;
+
+    /** Per attempt — short, because a failed attempt is retried with a fresh trigger. */
+    private static final long RECEIVE_TIMEOUT_MILLIS = 2000;
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    @Autowired
+    private TenantContext tenantContext;
+
+    @Autowired
+    private Scheduler scheduler;
+
+    @Autowired
+    private JobNameCreator jobNameCreator;
+
+    @Test
+    @Order(1)
+    void aTenantProvisionedAfterTheClassWasLoadedGetsTheJobToo() throws SchedulerException {
+        // The class is loaded while only the default tenant exists...
+        publishJob("OnProvisionJob", "on-provision");
+
+        // ...and the tenant appears afterwards. Nothing re-runs the load-time fan-out here, so only
+        // the post-provisioning top-up can give this tenant the job.
+        provisionTenant();
+
+        assertJobRunsInTheTenant("OnProvisionJob", "on-provision");
+    }
+
+    @Test
+    @Order(2)
+    void aJobLoadedWhileATenantExistsIsRegisteredForIt() throws SchedulerException {
+        // Reverse order: the tenant is already there when the class is loaded, so this is the
+        // load-time fan-out's job.
+        provisionTenant();
+
+        publishJob("OnLoadJob", "on-load");
+
+        assertJobRunsInTheTenant("OnLoadJob", "on-load");
+    }
+
+    /**
+     * Provision the shared tenant, once per class.
+     *
+     * <p>
+     * The provisioning job is triggered explicitly rather than waited for: its schedule is
+     * {@code DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS} wide (15 minutes by default) and the
+     * only prompt firing is the one at startup, so a test that merely waited would be racing that boot
+     * firing — which is exactly how a second tenant in the same class silently timed out.
+     */
+    private void provisionTenant() throws SchedulerException {
+        if (tenant != null) {
+            return;
+        }
+        DirigibleTestTenant created = new DirigibleTestTenant(PROJECT);
+        createTenants(created);
+        scheduler.triggerJob(JobKey.jobKey("TenantsProvisioningJob", "system"));
+        waitForTenantProvisioning(created);
+        tenant = created;
+    }
+
+    /**
+     * Trigger the job under the tenant's own Quartz key and draw back what its body published, retrying
+     * the whole exchange: the registration lands some time after the forced synchronization returns,
+     * and until it does there is no key to trigger.
+     */
+    private void assertJobRunsInTheTenant(String className, String destinationSuffix) {
+        String queue = PROJECT + "-out-" + destinationSuffix;
+        String jobName = "demo." + className;
+
+        String[] received = new String[1];
+        Awaitility.await()
+                  .pollInterval(1, TimeUnit.SECONDS)
+                  .atMost(REGISTRATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                  .until(() -> tenantContext.execute(tenant.getId(), () -> {
+                      JobKey jobKey = JobKey.jobKey(jobNameCreator.toTenantName(jobName), JOB_GROUP);
+                      if (!scheduler.checkExists(jobKey)) {
+                          return false;
+                      }
+                      scheduler.triggerJob(jobKey);
+                      try {
+                          received[0] = MessagingFacade.receiveFromQueue(queue, RECEIVE_TIMEOUT_MILLIS);
+                          return true;
+                      } catch (RuntimeException notYet) {
+                          return false;
+                      }
+                  }));
+
+        assertEquals("ran:" + destinationSuffix, received[0],
+                "the job must run for the tenant it was triggered in, and its publish must come back to that tenant");
+    }
+
+    /** Write a client job source into the registry and reconcile it. */
+    private void publishJob(String className, String destinationSuffix) {
+        String source = """
+                package demo;
+
+                import org.eclipse.dirigible.sdk.component.Component;
+                import org.eclipse.dirigible.sdk.job.JobHandler;
+                import org.eclipse.dirigible.sdk.messaging.Producer;
+
+                @Component
+                public class %s implements JobHandler {
+
+                    @Override
+                    public String cron() {
+                        return "%s";
+                    }
+
+                    @Override
+                    public void run() {
+                        Producer.sendToQueue("%s-out-%s", "ran:%s");
+                    }
+                }
+                """.formatted(className, NEVER, PROJECT, destinationSuffix, destinationSuffix);
+
+        repository.createResource(sourcePath(className), source.getBytes(StandardCharsets.UTF_8), false, "text/x-java", true);
+        synchronizationProcessor.forceProcessSynchronizers();
+    }
+
+    private static String sourcePath(String className) {
+        return IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/demo/" + className + ".java";
+    }
+}


### PR DESCRIPTION
Closes #6786.

## 1. Reproduced first

Confirmed at runtime, not only read in the code. The new IT's first phase — publish a client-Java job, *then* provision a tenant — errors with `ConditionTimeoutException` after 90s on unmodified `master`, while its second phase (tenant first, class load after) passes. The log says it in three lines:

```
08:39:15.454  ScheduledClassConsumer - Registered client-Java job [demo.OnProvisionJob] ... on the shared scheduler.
08:39:15.869  TenantsProvisioner     - Tenant [... name=java-job-tenant-it, status=PROVISIONED] has been provisioned successfully.
08:39:15.869  TenantsProvisioner     - Starting post provisioning process...
```

One registration, from the load-time fan-out, when only the default tenant existed — and nothing after the tenant appears. The tenant has no `Job` row and no Quartz trigger, so there is no key to fire and nothing in the Jobs perspective to switch on.

With the fix the top-up lands exactly inside the post-provisioning window, and both phases pass in 29.7s against 121s of timeout before:

```
08:41:53.598 [main]              ScheduledClassConsumer - Registered client-Java job [demo.OnProvisionJob] ...
08:41:54.023 [Scheduler_Worker]  TenantsProvisioner     - Tenant [... name=java-job-tenant-it] has been provisioned successfully.
08:41:54.023 [Scheduler_Worker]  TenantsProvisioner     - Starting post provisioning process...
08:41:54.031 [Scheduler_Worker]  ScheduledClassConsumer - Registered client-Java job [demo.OnProvisionJob] ...
08:41:54.364 [Scheduler_Worker]  TenantsProvisioner     - Post provisioning process has completed.
```

## 2. Which of the two designs, and why not the other one

**Option 1, narrow — mirroring #6782.** Option 2 wanted a shared `engine-java` hook that re-drives the per-tenant part of every `JavaClassConsumer`, and the issue already named the hazard: a blanket "re-notify the generation" rebuilds the `ComponentContainer` and hands every client bean a new instance, re-running `@PostConstruct`. That is a much bigger hammer than "schedule the tenant that is missing".

The more useful point is that **the shared mechanism already exists, one layer up**: `TenantPostProvisioningStep`. After this change `engine-java` has exactly two tenant-aware consumers — listeners and jobs — and both implement it directly (`grep -n "executeForEachTenant" components/engine/engine-java/src/main/java` returns those two files and nothing else; controllers, websockets and handlers are request-scoped and tenant-neutral by construction). A third one would implement the same interface, in three lines, with no new SPI to design. Inventing a `JavaClassConsumer`-level re-drive would add an indirection over what Spring already does — each consumer registering itself as a step — and would drag the container rebuild in with it.

## 3. The change

- **`ScheduledClassConsumer` is a `TenantPostProvisioningStep`.** `execute()` re-registers every job of every loaded class, so a tenant provisioned after the last client-Java rebuild gets its rows and triggers.
- **No per-tenant bookkeeping, deliberately — unlike the listener half.** Re-registering finds the existing row and updates it in place (which is what preserves the operator's enabled flag, #6626), and `JobsManager.scheduleJob` returns early once the job and its trigger exist. The listener consumer needs its careful `isSubscribed()` skip for a real reason — a second JMS consumer *competes* for messages — whereas a second `save` + `scheduleJob` of the same job is genuinely a no-op. And the top-up is not a per-round cost: `TenantsProvisioner.provision()` calls the post-provisioning steps only `if (!tenants.isEmpty())`, i.e. only when a tenant was actually in INITIAL status.
- **The tracked declaration now carries the cron and the handler, not just the job name** (`fqn → List<JobDeclaration>`). This is the one place the issue's "needs no new bookkeeping" is slightly optimistic: knowing *what* to re-register is not enough, the top-up also needs *how*, or the late tenant gets a row that never fires. `JobDeclaration.of` owns the one naming rule there is (`<fqn>#<method>` handler → `<fqn>.<method>` row name).
- **`register` and `remove` are `synchronized`.** The top-up runs on the provisioning thread while a rebuild registers from the synchronizer's, and the find-then-save inside is exactly the window in which two of them could insert the same job row twice.

## 4. Tests

- `ScheduledClassConsumerTenantRegistrationTest` — the load-time fan-out across tenants, the post-provisioning top-up registering a late tenant, that the top-up carries the declared cron and handler (the guard against tracking names only), and that topping up a late tenant does not switch the job back on in the tenants that already had it. Verified to fail without the fix, with a message that names the missing tenant rather than an NPE.
- `JavaJobTenantIT` — a client `JobHandler` in a non-default tenant, in both interleavings. It goes all the way to a real execution: the Quartz key is computed through the platform's own `JobNameCreator`, triggered by name, and the job body publishes into the tenant it fires for, which the test draws back inside that tenant's context — so it only passes if the row, the `JobDetail` and the tenant stamped into its job data are all there, and a key the test and the registration merely agreed to spell the same wrong way would fail. The cron is a "never" expression and the fire is triggered by hand, so the job stays inert for the rest of the suite instead of firing in the background; the tenant is provisioned by triggering `TenantsProvisioningJob` explicitly rather than racing its 15-minute schedule, and shared by both phases.

Verified: both unit test classes for `engine-java`, the `JavaJobTenantIT` run (failing before, passing after), the `release`-profile javadoc build on `engine-java` (no `error:`), and `formatter:validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
