### PR TITLE
feat(messaging): a global destination is never tenant-prefixed (#6766)

### DIFF
--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumer.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumer.java
@@ -73,6 +73,15 @@ import jakarta.jms.TextMessage;
  * default tenant.
  *
  * <p>
+ * <b>A global destination is subscribed once.</b> A name marked {@code global:} is a contract with
+ * something outside this deployment and is never tenant-scoped (again
+ * {@link DestinationNameManager}), so fanning it out would open one consumer per tenant on the very
+ * same physical destination - competing for one queue's messages, or handling one topic's message
+ * once per tenant. Those subscriptions are therefore opened once for the whole deployment, and the
+ * tenant a message is handled in comes from its {@code tenant_id} stamp, which for a global
+ * destination is the default tenant.
+ *
+ * <p>
  * Tenants also outlive a generation: this consumer is a {@link TenantPostProvisioningStep}, so a
  * tenant provisioned after the last client-Java rebuild is topped up without disturbing the
  * subscriptions already open. A tenant that goes away leaves its subscriptions behind until the
@@ -184,7 +193,24 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
         stopExisting(fqn);
         Registration registration = new Registration(subscriptions);
         registrations.put(fqn, registration);
+        subscribeGlobal(registration);
         subscribeMissingTenants(fqn, registration);
+    }
+
+    /**
+     * Open this class's global subscriptions - once for the deployment, not once per tenant. Runs on
+     * the loading thread, which has no tenant of its own, and needs none: a global destination resolves
+     * to the same physical name everywhere.
+     */
+    private void subscribeGlobal(Registration registration) {
+        List<Connection> opened = new ArrayList<>();
+        for (Subscription subscription : registration.globalSubscriptions()) {
+            Connection connection = subscribe(subscription, "all tenants (global destination)");
+            if (connection != null) {
+                opened.add(connection);
+            }
+        }
+        registration.globalSubscribed(opened);
     }
 
     /**
@@ -202,8 +228,8 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
                 }
                 List<Connection> opened = new ArrayList<>();
                 boolean complete = true;
-                for (Subscription subscription : registration.subscriptions()) {
-                    Connection connection = subscribe(subscription, tenantId);
+                for (Subscription subscription : registration.tenantSubscriptions()) {
+                    Connection connection = subscribe(subscription, "tenant [" + tenantId + "]");
                     if (connection == null) {
                         complete = false;
                     } else {
@@ -226,12 +252,15 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
     }
 
     /**
-     * Open one subscription. Runs inside the target tenant's context, so the physical destination is
-     * the very name a producer in that tenant computes for the same logical one.
+     * Open one subscription. A tenant-scoped one runs inside the target tenant's context, so the
+     * physical destination is the very name a producer in that tenant computes for the same logical
+     * one; a global one resolves to the bare name regardless.
      *
+     * @param subscription what to subscribe to
+     * @param scope what this subscription covers, for the log
      * @return the connection it opened, or {@code null} if the broker refused the subscription
      */
-    private Connection subscribe(Subscription subscription, String tenantId) {
+    private Connection subscribe(Subscription subscription, String scope) {
         String label = subscription.label();
         String destinationName = destinationNameManager.toTenantName(subscription.destination());
         try {
@@ -242,10 +271,10 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
                     subscription.kind() == ListenerKind.TOPIC ? session.createTopic(destinationName) : session.createQueue(destinationName);
             MessageConsumer consumer = session.createConsumer(destination);
             consumer.setMessageListener(msg -> dispatch(msg, subscription.dispatcher(), label));
-            LOGGER.info("Java @Listener [{}] connected to {} '{}' for tenant [{}].", label, subscription.kind(), destinationName, tenantId);
+            LOGGER.info("Java @Listener [{}] connected to {} '{}' for {}.", label, subscription.kind(), destinationName, scope);
             return connection;
         } catch (JMSException e) {
-            LOGGER.error("Failed to start listener for [{}] in tenant [{}]: {}", label, tenantId, e.getMessage(), e);
+            LOGGER.error("Failed to start listener for [{}] for {}: {}", label, scope, e.getMessage(), e);
             return null;
         }
     }
@@ -331,7 +360,8 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
 
     /**
      * One subscription a loaded class asks for: the <em>logical</em> destination, its kind, and how a
-     * message on it is dispatched. Tenant-independent — the same spec is opened once per tenant.
+     * message on it is dispatched. Tenant-independent — the same spec is opened once per tenant, or
+     * once for the deployment when the destination is global.
      */
     private record Subscription(String destination, ListenerKind kind, Dispatcher dispatcher, String label) {
     }
@@ -339,17 +369,37 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
     /** What one loaded class declared, plus the connections open for it in each tenant. */
     private static final class Registration {
 
-        private final List<Subscription> subscriptions;
+        /** Subscriptions opened once per provisioned tenant. */
+        private final List<Subscription> tenantSubscriptions;
+
+        /** Subscriptions opened once for the whole deployment. */
+        private final List<Subscription> globalSubscriptions;
 
         /** tenant id → the JMS connections open for this class in that tenant. */
         private final Map<String, List<Connection>> connectionsByTenant = new HashMap<>();
 
+        /** The JMS connections open for this class's global destinations. */
+        private List<Connection> globalConnections = List.of();
+
         Registration(List<Subscription> subscriptions) {
-            this.subscriptions = List.copyOf(subscriptions);
+            this.tenantSubscriptions = subscriptions.stream()
+                                                    .filter(subscription -> !DestinationNameManager.isGlobal(subscription.destination()))
+                                                    .toList();
+            this.globalSubscriptions = subscriptions.stream()
+                                                    .filter(subscription -> DestinationNameManager.isGlobal(subscription.destination()))
+                                                    .toList();
         }
 
-        List<Subscription> subscriptions() {
-            return subscriptions;
+        List<Subscription> tenantSubscriptions() {
+            return tenantSubscriptions;
+        }
+
+        List<Subscription> globalSubscriptions() {
+            return globalSubscriptions;
+        }
+
+        void globalSubscribed(List<Connection> connections) {
+            this.globalConnections = List.copyOf(connections);
         }
 
         boolean isSubscribed(String tenantId) {
@@ -361,7 +411,7 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
         }
 
         List<Connection> openConnections() {
-            List<Connection> all = new ArrayList<>();
+            List<Connection> all = new ArrayList<>(globalConnections);
             connectionsByTenant.values()
                                .forEach(all::addAll);
             return all;

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumerTenantSubscriptionTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumerTenantSubscriptionTest.java
@@ -12,6 +12,7 @@ package org.eclipse.dirigible.engine.java.listener;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -65,6 +66,20 @@ class ListenerClassConsumerTenantSubscriptionTest {
         }
     }
 
+    /** A typed listener on a destination shared with another deployment. */
+    static class GlobalOrdersHandler implements MessageHandler {
+
+        @Override
+        public String destination() {
+            return DestinationNameManager.GLOBAL_MARKER + "codbex.orders";
+        }
+
+        @Override
+        public void onMessage(String message) {
+            // The subscription, not the dispatch, is what this test is about.
+        }
+    }
+
     private static final String DEFAULT_TENANT_ID = "default-tenant";
 
     /** The tenants {@code executeForEachTenant} fans out over; mutable, so a test can add one. */
@@ -84,6 +99,7 @@ class ListenerClassConsumerTenantSubscriptionTest {
 
         ComponentContainer componentContainer = mock(ComponentContainer.class);
         when(componentContainer.instanceOf(OrdersHandler.class)).thenReturn(Optional.of(new OrdersHandler()));
+        when(componentContainer.instanceOf(GlobalOrdersHandler.class)).thenReturn(Optional.of(new GlobalOrdersHandler()));
 
         ActiveMQConnectionArtifactsFactory connectionFactory = mock(ActiveMQConnectionArtifactsFactory.class);
         Connection connection = mock(Connection.class);
@@ -106,11 +122,15 @@ class ListenerClassConsumerTenantSubscriptionTest {
             return List.of();
         });
 
-        // Stands in for the real rule: the default tenant keeps the logical name, everyone else is
-        // prefixed. DestinationNameManagerTest owns that rule; here it only has to be applied.
+        // Stands in for the real rule: a global name loses its marker and nothing else, the default
+        // tenant keeps the logical name, everyone else is prefixed. DestinationNameManagerTest owns
+        // that rule; here it only has to be applied.
         DestinationNameManager destinationNameManager = mock(DestinationNameManager.class);
         when(destinationNameManager.toTenantName(anyString())).thenAnswer(invocation -> {
             String logicalName = invocation.getArgument(0);
+            if (DestinationNameManager.isGlobal(logicalName)) {
+                return logicalName.substring(DestinationNameManager.GLOBAL_MARKER.length());
+            }
             String tenantId = currentTenantId.get();
             return DEFAULT_TENANT_ID.equals(tenantId) ? logicalName : tenantId + "###" + logicalName;
         });
@@ -153,6 +173,29 @@ class ListenerClassConsumerTenantSubscriptionTest {
         verify(session, times(1)).createQueue("acme###orders");
     }
 
+    /**
+     * The mirror image of the rule above: a global destination is one physical queue, so fanning it out
+     * per tenant would put N consumers on it — competing for one queue's messages, and handling one
+     * topic's message once per tenant.
+     */
+    @Test
+    void aGlobalDestinationIsSubscribedOnceForTheDeploymentNotOncePerTenant() throws Exception {
+        loadGlobalListener();
+
+        verify(session, times(1)).createQueue("codbex.orders");
+        verify(session, never()).createQueue("acme###" + DestinationNameManager.GLOBAL_MARKER + "codbex.orders");
+    }
+
+    @Test
+    void aTenantProvisionedLaterDoesNotAddASecondGlobalSubscription() throws Exception {
+        loadGlobalListener();
+
+        addTenant("beta");
+        consumer.execute();
+
+        verify(session, times(1)).createQueue("codbex.orders");
+    }
+
     private void addTenant(String tenantId) {
         Tenant tenant = mock(Tenant.class);
         when(tenant.getId()).thenReturn(tenantId);
@@ -163,5 +206,10 @@ class ListenerClassConsumerTenantSubscriptionTest {
     private void loadListener() {
         consumer.onClassLoaded(
                 new LoadedClass("sample", OrdersHandler.class.getName(), OrdersHandler.class, OrdersHandler.class.getClassLoader()));
+    }
+
+    private void loadGlobalListener() {
+        consumer.onClassLoaded(new LoadedClass("sample", GlobalOrdersHandler.class.getName(), GlobalOrdersHandler.class,
+                GlobalOrdersHandler.class.getClassLoader()));
     }
 }

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/DestinationNameManager.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/DestinationNameManager.java
@@ -15,6 +15,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * The single owner of the physical JMS destination name — and therefore the home of the contract
  * that every messaging call site shares.
@@ -45,15 +48,42 @@ import org.springframework.stereotype.Component;
  * the prefix is what keeps one tenant's messages out of another tenant's consumers in the first
  * place, which the property alone cannot do for a queue (competing consumers) or for a synchronous
  * receive.
+ *
+ * <p>
+ * <b>The one exception: a global destination.</b> Tenant scoping is right for a destination that
+ * belongs to the application, and wrong for one that <em>is a contract with someone else</em> — an
+ * integration queue two products agreed on. A name that opens with the {@value #GLOBAL_MARKER}
+ * marker declares exactly that: it resolves to the bare name behind the marker, in every tenant and
+ * on every call site, so a consumer in another deployment — which knows nothing of this one's
+ * tenants — can bind to the name it was given. Convention for such a name is
+ * {@code global:<vendor>.<purpose>}, e.g. {@code global:codbex.orders}, because a global
+ * destination is by definition shared with something the platform cannot see, and only a namespaced
+ * name keeps two products off each other's queues.
+ *
+ * <p>
+ * The trade is deliberate: the destination no longer says which tenant a message belongs to, so a
+ * message published to a global destination is stamped with the <em>default</em> tenant
+ * ({@link TenantPropertyManager}) and the business tenant, if it matters, has to travel in the
+ * payload. Publishing one from a non-default tenant is legitimate but is a contract decision, so it
+ * is logged at WARN — once per tenant and destination, since a producer may run hot.
  */
 @Component
 public class DestinationNameManager {
+
+    /** The Constant GLOBAL_MARKER. */
+    public static final String GLOBAL_MARKER = "global:";
+
+    /** The Constant TENANT_SEPARATOR. */
+    private static final String TENANT_SEPARATOR = "###";
 
     /** The Constant LOGGER. */
     private static final Logger LOGGER = LoggerFactory.getLogger(DestinationNameManager.class);
 
     /** The tenant context. */
     private final TenantContext tenantContext;
+
+    /** Tenant + global destination pairs already warned about. */
+    private final Set<String> warnedGlobalUses = ConcurrentHashMap.newKeySet();
 
     /**
      * Instantiates a new destination name manager.
@@ -65,20 +95,72 @@ public class DestinationNameManager {
     }
 
     /**
+     * Whether a logical destination name declares itself a contract with something outside this
+     * deployment, and is therefore never tenant-scoped.
+     *
+     * @param destinationName the logical destination name
+     * @return true, if the name carries the global marker
+     */
+    public static boolean isGlobal(String destinationName) {
+        return null != destinationName && destinationName.startsWith(GLOBAL_MARKER);
+    }
+
+    /**
      * The physical destination name for a logical one, scoped to the tenant that is current on this
      * thread. Outside any tenant context (a platform thread that never entered one) the name is
-     * returned unchanged.
+     * returned unchanged, and so is a global one, which is never scoped at all.
      *
      * @param destinationName the logical destination name
      * @return the physical destination name to create on the broker
      */
     public String toTenantName(String destinationName) {
+        if (isGlobal(destinationName)) {
+            return toGlobalName(destinationName);
+        }
         if (tenantContext.isNotInitialized()) {
             LOGGER.debug("Tenant context is NOT initialized. Will return destination name as it is. Destination name [{}]",
                     destinationName);
             return destinationName;
         }
         Tenant currentTenant = tenantContext.getCurrentTenant();
-        return currentTenant.isDefault() ? destinationName : currentTenant.getId() + "###" + destinationName;
+        return currentTenant.isDefault() ? destinationName : currentTenant.getId() + TENANT_SEPARATOR + destinationName;
+    }
+
+    /**
+     * Strip the marker and keep the bare name, whatever the current tenant is.
+     *
+     * @param destinationName the marked logical destination name
+     * @return the physical destination name, shared with whoever else agreed on it
+     */
+    private String toGlobalName(String destinationName) {
+        String globalName = destinationName.substring(GLOBAL_MARKER.length());
+        if (globalName.isBlank()) {
+            throw new IllegalArgumentException(
+                    "Destination name [" + destinationName + "] carries the '" + GLOBAL_MARKER + "' marker but names nothing after it.");
+        }
+        warnOnceIfNotDefaultTenant(globalName);
+        return globalName;
+    }
+
+    /**
+     * Note that a tenant is reaching a destination that carries no tenant of its own. Warned once per
+     * tenant and destination: the set is bounded by the destinations an application actually names,
+     * while a producer on a busy queue would otherwise log per message.
+     *
+     * @param globalName the physical destination name
+     */
+    private void warnOnceIfNotDefaultTenant(String globalName) {
+        if (tenantContext.isNotInitialized()) {
+            return;
+        }
+        Tenant currentTenant = tenantContext.getCurrentTenant();
+        if (currentTenant.isDefault()) {
+            return;
+        }
+        if (warnedGlobalUses.add(currentTenant.getId() + TENANT_SEPARATOR + globalName)) {
+            LOGGER.warn("Tenant [{}] uses the global destination [{}], which is shared with every other tenant and with any other "
+                    + "deployment bound to that name. Messages on it are stamped with the default tenant, so a business tenant that "
+                    + "matters downstream has to travel in the payload.", currentTenant.getId(), globalName);
+        }
     }
 }

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenersManager.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenersManager.java
@@ -64,7 +64,15 @@ public class ListenersManager {
     public void startListener(org.eclipse.dirigible.components.listeners.domain.Listener listenerEntity) {
         ListenerDescriptor listenerDescriptor = listenerCreator.fromEntity(listenerEntity);
         if (LISTENERS.containsKey(listenerDescriptor)) {
-            LOGGER.warn("Message consumer for listener [{}] already running!", listenerDescriptor);
+            if (DestinationNameManager.isGlobal(listenerEntity.getName())) {
+                // Every provisioned tenant reaches this artefact, and a global destination resolves to
+                // one physical name for all of them - so the tenants after the first share the single
+                // subscription that is already open. Expected, not a misconfiguration.
+                LOGGER.debug("Listener [{}] is bound to a global destination and is already running for the whole deployment.",
+                        listenerDescriptor);
+            } else {
+                LOGGER.warn("Message consumer for listener [{}] already running!", listenerDescriptor);
+            }
             return;
 
         }

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/MessageProducer.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/MessageProducer.java
@@ -20,7 +20,8 @@ import org.springframework.stereotype.Component;
  * Sends a message to a queue or a topic, resolving the physical destination from the tenant that is
  * current at send time and stamping that tenant onto the message. See
  * {@link DestinationNameManager} for the destination-naming contract this shares with
- * {@link MessageConsumer} and with the subscribing sides.
+ * {@link MessageConsumer} and with the subscribing sides - including the global destination, which
+ * is scoped to no tenant and therefore carries the default tenant's stamp instead.
  */
 @Component
 public class MessageProducer {
@@ -62,7 +63,7 @@ public class MessageProducer {
     public void sendMessageToTopic(String topic, String message) throws JMSException {
         String destinationName = destinationNameManager.toTenantName(topic);
         Destination destination = session.createTopic(destinationName);
-        sendMessage(message, destination);
+        sendMessage(message, destination, DestinationNameManager.isGlobal(topic));
     }
 
     /**
@@ -70,14 +71,19 @@ public class MessageProducer {
      *
      * @param message the message
      * @param destination the destination
+     * @param globalDestination whether the destination is shared beyond this deployment
      * @throws JMSException the JMS exception
      */
-    private void sendMessage(String message, Destination destination) throws JMSException {
+    private void sendMessage(String message, Destination destination, boolean globalDestination) throws JMSException {
         try (jakarta.jms.MessageProducer producer = session.createProducer(destination)) {
             producer.setDeliveryMode(DeliveryMode.PERSISTENT);
 
             TextMessage textMessage = session.createTextMessage(message);
-            tenantPropertyManager.setCurrentTenant(textMessage);
+            if (globalDestination) {
+                tenantPropertyManager.setDefaultTenant(textMessage);
+            } else {
+                tenantPropertyManager.setCurrentTenant(textMessage);
+            }
 
             producer.send(textMessage);
             LOGGER.trace("Message sent in [{}]", destination);
@@ -94,7 +100,7 @@ public class MessageProducer {
     public void sendMessageToQueue(String queue, String message) throws JMSException {
         String destinationName = destinationNameManager.toTenantName(queue);
         Destination destination = session.createQueue(destinationName);
-        sendMessage(message, destination);
+        sendMessage(message, destination, DestinationNameManager.isGlobal(queue));
     }
 
 }

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/TenantPropertyManager.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/TenantPropertyManager.java
@@ -51,15 +51,39 @@ public class TenantPropertyManager {
     }
 
     /**
-     * Sets the current tenant.
+     * Stamp the message with the tenant that is current at send time, which is the tenant its
+     * destination is scoped to.
      *
-     * @param message the new current tenant
+     * @param message the message
      * @throws JMSException the JMS exception
      */
     void setCurrentTenant(Message message) throws JMSException {
-        String tenantId = getCurrentTenantId();
+        setTenant(message, getCurrentTenantId());
+    }
+
+    /**
+     * Stamp the message with the default tenant, for a message published to a global destination. Such
+     * a destination carries no tenant of its own (see {@link DestinationNameManager}), so the stamp
+     * says explicitly what a consumer would otherwise have to fall back to - including a consumer in
+     * another deployment, which has never heard of this one's tenants.
+     *
+     * @param message the message
+     * @throws JMSException the JMS exception
+     */
+    void setDefaultTenant(Message message) throws JMSException {
+        setTenant(message, defualtTenant.getId());
+    }
+
+    /**
+     * Sets the tenant id property.
+     *
+     * @param message the message
+     * @param tenantId the tenant id
+     * @throws JMSException the JMS exception
+     */
+    private void setTenant(Message message, String tenantId) throws JMSException {
         LOGGER.debug("Will set tenant id [{}].", tenantId);
-        message.setObjectProperty(TENANT_ID_PARAM_NAME, getCurrentTenantId());
+        message.setObjectProperty(TENANT_ID_PARAM_NAME, tenantId);
     }
 
     /**

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/DestinationNameManagerTest.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/DestinationNameManagerTest.java
@@ -10,6 +10,8 @@
 package org.eclipse.dirigible.components.listeners.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -44,7 +46,51 @@ class DestinationNameManagerTest {
         assertEquals("acme###" + LOGICAL_NAME, toTenantName("acme", false));
     }
 
+    @Test
+    void aGlobalNameIsNeverPrefixed() {
+        assertEquals("codbex.orders", toTenantName("acme", false, DestinationNameManager.GLOBAL_MARKER + "codbex.orders"),
+                "a global destination is a contract with another deployment, which knows nothing of this one's tenants");
+    }
+
+    @Test
+    void aGlobalNameLosesItsMarkerInTheDefaultTenantToo() {
+        assertEquals("codbex.orders", toTenantName("default-tenant", true, DestinationNameManager.GLOBAL_MARKER + "codbex.orders"),
+                "both sides of the contract must spell the destination the same way in every tenant");
+    }
+
+    @Test
+    void aGlobalNameIsResolvedOutsideAnyTenantContext() {
+        TenantContext tenantContext = mock(TenantContext.class);
+        when(tenantContext.isNotInitialized()).thenReturn(true);
+
+        assertEquals("codbex.orders",
+                new DestinationNameManager(tenantContext).toTenantName(DestinationNameManager.GLOBAL_MARKER + "codbex.orders"),
+                "the client-Java subscriber resolves global destinations on a thread with no tenant of its own");
+    }
+
+    @Test
+    void aMarkerThatNamesNothingIsRejected() {
+        TenantContext tenantContext = mock(TenantContext.class);
+        DestinationNameManager destinationNameManager = new DestinationNameManager(tenantContext);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> destinationNameManager.toTenantName(DestinationNameManager.GLOBAL_MARKER));
+
+        assertTrue(exception.getMessage()
+                            .contains(DestinationNameManager.GLOBAL_MARKER));
+    }
+
+    @Test
+    void aNameThatMerelyContainsTheMarkerIsStillTenantScoped() {
+        assertEquals("acme###not-global:orders", toTenantName("acme", false, "not-global:orders"),
+                "only a name that OPENS with the marker declares itself global");
+    }
+
     private static String toTenantName(String tenantId, boolean defaultTenant) {
+        return toTenantName(tenantId, defaultTenant, LOGICAL_NAME);
+    }
+
+    private static String toTenantName(String tenantId, boolean defaultTenant, String destinationName) {
         Tenant tenant = mock(Tenant.class);
         when(tenant.isDefault()).thenReturn(defaultTenant);
         if (!defaultTenant) {
@@ -53,6 +99,6 @@ class DestinationNameManagerTest {
         TenantContext tenantContext = mock(TenantContext.class);
         when(tenantContext.getCurrentTenant()).thenReturn(tenant);
 
-        return new DestinationNameManager(tenantContext).toTenantName(LOGICAL_NAME);
+        return new DestinationNameManager(tenantContext).toTenantName(destinationName);
     }
 }

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/MessageProducerTest.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/MessageProducerTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -31,6 +32,12 @@ class MessageProducerTest {
 
     /** The Constant TENANT_QUEUE. */
     private static final String TENANT_QUEUE = "1e7252b1-3bca-4285-bd4e-60e19886d063###test-queue";
+
+    /** The Constant GLOBAL_QUEUE. */
+    private static final String GLOBAL_QUEUE = "global:codbex.orders";
+
+    /** The Constant GLOBAL_QUEUE_NAME. */
+    private static final String GLOBAL_QUEUE_NAME = "codbex.orders";
 
     /** The Constant MESSAGE. */
     private static final String MESSAGE = "This is a test message";
@@ -102,6 +109,27 @@ class MessageProducerTest {
 
         verify(jsmProducer).send(txtMessage);
         verify(tenantPropertyManager).setCurrentTenant(txtMessage);
+    }
+
+    /**
+     * A global destination carries no tenant of its own, so the message says which tenant a consumer -
+     * possibly in another deployment - should establish, rather than leaving it to that consumer's
+     * fallback.
+     *
+     * @throws JMSException the JMS exception
+     */
+    @Test
+    void aGlobalDestinationIsStampedWithTheDefaultTenant() throws JMSException {
+        when(destinationNameManager.toTenantName(GLOBAL_QUEUE)).thenReturn(GLOBAL_QUEUE_NAME);
+        when(session.createQueue(GLOBAL_QUEUE_NAME)).thenReturn(queue);
+        when(session.createProducer(queue)).thenReturn(jsmProducer);
+        when(session.createTextMessage(MESSAGE)).thenReturn(txtMessage);
+
+        producer.sendMessageToQueue(GLOBAL_QUEUE, MESSAGE);
+
+        verify(jsmProducer).send(txtMessage);
+        verify(tenantPropertyManager).setDefaultTenant(txtMessage);
+        verify(tenantPropertyManager, never()).setCurrentTenant(txtMessage);
     }
 
 }

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/GlobalDestinationIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/GlobalDestinationIT.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.eclipse.dirigible.components.api.messaging.MessagingFacade;
+import org.eclipse.dirigible.components.api.messaging.TimeoutException;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.eclipse.dirigible.components.listeners.service.DestinationNameManager;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.tenant.DirigibleTestTenant;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
+/**
+ * A destination marked global is the one destination a tenant does not rename.
+ *
+ * <p>
+ * Every other destination a tenant touches is physically {@code <tenantId>###<name>}, which is what
+ * keeps one tenant's messages out of another's — and what makes an integration queue two products
+ * agreed on unreachable, since the other product neither knows the sending tenant nor should have
+ * to. Both halves are asserted here against the platform's own producer and consumer, in a real
+ * non-default tenant: the marked name arrives under the bare name a foreign consumer would bind to,
+ * and the unmarked one demonstrably does not.
+ *
+ * <p>
+ * The receiving side deliberately runs on a thread with no tenant context at all — the closest this
+ * deployment can get to a consumer that has never heard of its tenants.
+ */
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class GlobalDestinationIT extends IntegrationTest {
+
+    /** Named by the convention a global destination is documented with: {@code <vendor>.<purpose>}. */
+    private static final String GLOBAL_QUEUE = "codbex.global-destination-it.orders";
+
+    private static final String TENANT_SCOPED_QUEUE = "global-destination-it-orders";
+
+    private static final String MESSAGE = "an order from another deployment";
+
+    /** Generous: the message is already on the broker, so this only covers dispatch. */
+    private static final long RECEIVE_TIMEOUT_MILLIS = 10_000;
+
+    /** Short: this one is expected to expire, and the queue it draws from must stay empty. */
+    private static final long EXPECTED_TO_EXPIRE_MILLIS = 2_000;
+
+    /** The tenant both tests publish from; provisioned by the first one that needs it. */
+    private static DirigibleTestTenant tenant;
+
+    @Autowired
+    private TenantContext tenantContext;
+
+    @Autowired
+    private Scheduler scheduler;
+
+    @Test
+    @Order(1)
+    void aGlobalDestinationIsReachedByItsBareNameFromOutsideTheTenant() throws SchedulerException {
+        provisionTenant();
+
+        publish(DestinationNameManager.GLOBAL_MARKER + GLOBAL_QUEUE);
+
+        assertEquals(MESSAGE, MessagingFacade.receiveFromQueue(GLOBAL_QUEUE, RECEIVE_TIMEOUT_MILLIS),
+                "a global destination must resolve to the bare name for everyone bound to it");
+    }
+
+    @Test
+    @Order(2)
+    void aDestinationWithoutTheMarkerStaysScopedToItsTenant() throws SchedulerException {
+        provisionTenant();
+
+        publish(TENANT_SCOPED_QUEUE);
+
+        assertThrows(TimeoutException.class, () -> MessagingFacade.receiveFromQueue(TENANT_SCOPED_QUEUE, EXPECTED_TO_EXPIRE_MILLIS),
+                "without the marker the message stays on the tenant's own destination");
+
+        String receivedInTheTenant =
+                tenantContext.execute(tenant.getId(), () -> MessagingFacade.receiveFromQueue(TENANT_SCOPED_QUEUE, RECEIVE_TIMEOUT_MILLIS));
+        assertEquals(MESSAGE, receivedInTheTenant, "the publishing tenant must still find its own message where it left it");
+    }
+
+    /** Publish from the non-default tenant, the context in which the rename applies. */
+    private void publish(String destination) {
+        tenantContext.execute(tenant.getId(), () -> {
+            MessagingFacade.sendToQueue(destination, MESSAGE);
+            return null;
+        });
+    }
+
+    /**
+     * Provision the shared tenant, once per class.
+     *
+     * <p>
+     * The provisioning job is triggered explicitly rather than waited for: its schedule is
+     * {@code DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS} wide, so a test that merely waited would
+     * be racing the single firing at startup.
+     */
+    private void provisionTenant() throws SchedulerException {
+        if (tenant != null) {
+            return;
+        }
+        DirigibleTestTenant created = new DirigibleTestTenant("global-destination-it");
+        createTenants(created);
+        scheduler.triggerJob(JobKey.jobKey("TenantsProvisioningJob", "system"));
+        waitForTenantProvisioning(created);
+        tenant = created;
+    }
+}


### PR DESCRIPTION
Closes #6766.

### The wall

Every destination a tenant touches is physically renamed: `DestinationNameManager.toTenantName` returns `<tenantId>###<name>` for any non-default tenant. That is what keeps one tenant's messages out of another's, and it is right for a destination that belongs to the application.

It is wrong for a destination that **is a contract with someone else** — an integration queue two products agreed on. A publisher in tenant `acme` writes to `acme###codbex.orders`; a consumer in another deployment subscribing to `codbex.orders` never sees it, and cannot subscribe to the prefixed name either — it does not know the sending tenant, and the prefix is an internal isolation mechanism, not an addressing scheme. There was no way to express the difference, so cross-deployment messaging was unavailable in either direction, including for the `inbound` arrival sources that shipped in #6743.

### The marker

A logical name may now open with `global:`, understood platform-wide. `global:codbex.orders` resolves to the physical destination `codbex.orders` — in every tenant, at **every** call site that resolves a destination name. Producer, synchronous consumer, the `.listener` descriptor path and the client-Java subscription path all route through `DestinationNameManager`, so the marker lands in one place and the rest inherit it. (The client-Java path routes through it as of #6782, which is why that one landed first.)

Convention is `global:<vendor>.<purpose>`, documented alongside the marker: a global destination is by definition shared with something the platform cannot see, and only a namespaced name keeps two products off each other's queues.

### What the marker costs, made explicit

- **The destination no longer says which tenant a message belongs to.** A message published to one is stamped with the **default** tenant id in the existing `tenant_id` property (`TenantPropertyManager.setDefaultTenant`), so a foreign deployment's consumer re-establishes a valid context from the stamp rather than relying on `ListenerClassConsumer`'s fallback. A business tenant that matters downstream has to travel in the payload.
- **Using the marker outside the default tenant is logged at WARN** — legitimate, but a contract decision the author must have made deliberately. Warned once per tenant and destination, since a producer may run hot.
- **A marker that names nothing after it is rejected** rather than silently resolving to the empty destination.

### Subscribe once, not once per tenant

Not in the issue, but a direct consequence of the marker. The client-Java path fans a subscription out over the provisioned tenants; a name that resolves to one physical destination would get one consumer per tenant on it — competing for a queue's messages, or handling a topic's message once per tenant. Global subscriptions are therefore opened once for the deployment, on the loading thread, and closed with the rest on unload. The `.listener` path already collapses to a single subscription through its value-keyed descriptor map; that collapse is no longer reported as a misconfiguration.

### Tests

- `DestinationNameManagerTest` — the marker strips in every tenant and outside any tenant context, a name that merely *contains* `global:` stays scoped, an empty marker is rejected.
- `MessageProducerTest` — a global send stamps the default tenant and not the current one.
- `ListenerClassConsumerTenantSubscriptionTest` — one subscription for the deployment, and a tenant provisioned later does not add a second.
- `GlobalDestinationIT` (new, HTTP-free, ~30 s) — publishes both a marked and an unmarked queue from a real provisioned non-default tenant, and asserts that only the marked one is reachable under its bare name, while the unmarked one is still exactly where its own tenant left it. Both legs go through the platform's own producer and consumer, so neither would pass on a prefix the two sides merely agreed to spell the same wrong way.

Ran green locally, and the WARN fires once from the tenant as designed.

### Docs

dirigible-io/dirigible-io.github.io#194 — the message-listeners page gains a *Global destinations* section (what the marker does, where it is understood, the naming convention, the three consequences), and the intent `inbound` docs, which implied a cross-system arrival worked out of the box, now point at it.

### Follow-ups this unblocks

The outbound construct proposed in #6767, and cross-deployment use of the `inbound` arrival sources from #6743.