### PR TITLE
feat(intent): a business key over more than one field (#6763)

### DIFF
--- a/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/synchronizer/SchemasSynchronizer.java
+++ b/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/synchronizer/SchemasSynchronizer.java
@@ -141,7 +141,7 @@ public class SchemasSynchronizer extends MultitenantBaseSynchronizer<Schema, Lon
               .forEach(t -> {
                   t.setSchemaReference(schema);
                   // t.setSchema(schema.getName());
-                  t.setConstraints(new TableConstraints(t));
+                  t.setConstraints(carryUniqueConstraints(t));
                   TablesSynchronizer.assignParent(t);
               });
         schema.getViews()
@@ -307,6 +307,83 @@ public class SchemasSynchronizer extends MultitenantBaseSynchronizer<Schema, Lon
         } else {
             throw new IllegalArgumentException(
                     format("Error in parsing columns of table [{0}] in schema [{1}]", table.getName(), location));
+        }
+        setUniqueConstraints(location, structure, table);
+    }
+
+    /**
+     * The table's constraints, attached to the artefact tree.
+     *
+     * <p>
+     * The attachment is a fresh {@link TableConstraints} carrying the table back-reference, which used
+     * to mean discarding whatever the parse had just built. That silently emptied the composite unique
+     * keys a schema declares - they reached the file and went no further, so the business rule was
+     * created nowhere. They are carried over here.
+     *
+     * <p>
+     * The foreign keys a {@code .schema} may declare are deliberately NOT carried: they have never
+     * reached the database from this path either, and emitting them now would change the DDL of every
+     * already-generated application, which is a change of its own and not this one's to make.
+     *
+     * @param table the parsed table
+     * @return the constraints to attach
+     */
+    private static TableConstraints carryUniqueConstraints(Table table) {
+        TableConstraints attached = new TableConstraints(table);
+        TableConstraints parsed = table.getConstraints();
+        if (parsed != null && parsed.getUniqueIndexes() != null) {
+            for (TableConstraintUnique unique : parsed.getUniqueIndexes()) {
+                unique.setConstraints(attached);
+                attached.getUniqueIndexes()
+                        .add(unique);
+            }
+        }
+        return attached;
+    }
+
+    /**
+     * Reads a table's composite unique constraints. A single-column key rides on the column itself
+     * ({@code "unique": true}); a key spanning several columns - the business key that says what a row
+     * IS - has no other expression in a schema, and without this it could only be added to the database
+     * by hand, outside anything the next generation knows about.
+     *
+     * @param location the schema location
+     * @param structure the table structure
+     * @param table the table being built
+     */
+    private static void setUniqueConstraints(String location, JsonObject structure, Table table) {
+        JsonElement constraintsElement = structure.get("constraints");
+        if (constraintsElement == null || !constraintsElement.isJsonObject()) {
+            return;
+        }
+        JsonElement uniqueElement = constraintsElement.getAsJsonObject()
+                                                      .get("uniqueIndexes");
+        if (uniqueElement == null || !uniqueElement.isJsonArray()) {
+            return;
+        }
+        JsonArray uniqueIndexes = uniqueElement.getAsJsonArray();
+        for (int i = 0; i < uniqueIndexes.size(); i++) {
+            JsonObject uniqueIndex = uniqueIndexes.get(i)
+                                                  .getAsJsonObject();
+            JsonElement columnsElement = uniqueIndex.get("columns");
+            if (columnsElement == null || !columnsElement.isJsonArray()) {
+                throw new IllegalArgumentException(format("Unique constraint [{0}] of table [{1}] in schema [{2}] names no columns",
+                        uniqueIndex.get("name"), table.getName(), location));
+            }
+            JsonArray columnsArray = columnsElement.getAsJsonArray();
+            String[] columns = new String[columnsArray.size()];
+            for (int j = 0; j < columnsArray.size(); j++) {
+                columns[j] = columnsArray.get(j)
+                                         .getAsString();
+            }
+            TableConstraintUnique unique = new TableConstraintUnique();
+            unique.setName(uniqueIndex.get("name")
+                                      .getAsString());
+            unique.setColumns(columns);
+            unique.setConstraints(table.getConstraints());
+            table.getConstraints()
+                 .getUniqueIndexes()
+                 .add(unique);
         }
     }
 

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -21,6 +21,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.dirigible.components.base.helpers.JsonHelper;
 import org.eclipse.dirigible.components.intent.generator.IntentEntities;
@@ -50,6 +51,7 @@ import org.eclipse.dirigible.components.intent.model.RelationIntent;
 import org.eclipse.dirigible.components.intent.model.RollupIntent;
 import org.eclipse.dirigible.components.intent.model.SlotsIntent;
 import org.eclipse.dirigible.components.intent.model.UsesIntent;
+import org.eclipse.dirigible.components.intent.model.UniqueIntent;
 import org.eclipse.dirigible.components.intent.parser.IntentValidationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -635,6 +637,13 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
                 // Declarative validations. A List, so it lives only in the .model twin (the scalar-only
                 // .edm XML skips it via the Iterable guard), consumed by the DAO/REST templates.
                 entityMap.put("checks", checkMaps);
+            }
+            // Composite business keys. Like checks, a List living only in the .model twin - read by the
+            // schema template (which emits the constraint) and by the REST template (which turns the
+            // database's violation back into the authored message).
+            List<Map<String, Object>> uniqueMaps = buildUniqueConstraints(entity);
+            if (!uniqueMaps.isEmpty()) {
+                entityMap.put("uniqueConstraints", uniqueMaps);
             }
             entityMap.put("properties", properties);
             entityList.add(entityMap);
@@ -1650,6 +1659,65 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
     }
 
     /**
+     * The entity's composite business keys, resolved to the physical columns they constrain.
+     *
+     * <p>
+     * A name is either an own field or an own to-one relation, and both take the same column form -
+     * {@code <ENTITY>_<NAME>} - so the two need no distinction here; the parser has already rejected
+     * anything with no column on this entity. The constraint is named
+     * {@code <Entity>_<Field1>_<Field2>}, the same descriptive concatenation the foreign keys use, so a
+     * regenerated model produces the identical name and the schema layer sees no change. That name is
+     * also the only handle the database gives back on a violation, which is how the generated
+     * controller finds the authored message again.
+     *
+     * @param entity the entity
+     * @return one map per declared key: its constraint name, its columns in order, and its message
+     */
+    private static List<Map<String, Object>> buildUniqueConstraints(EntityIntent entity) {
+        List<Map<String, Object>> constraints = new ArrayList<>();
+        for (UniqueIntent unique : entity.getUnique()) {
+            List<String> names = unique.getFields();
+            if (names.size() < 2) {
+                continue; // reported by the parser
+            }
+            List<Map<String, Object>> columns = new ArrayList<>(names.size());
+            StringBuilder constraintName = new StringBuilder(entity.getName());
+            for (String name : names) {
+                Map<String, Object> column = new LinkedHashMap<>();
+                column.put("name", IntentNaming.upperSnake(entity.getName()) + "_" + IntentNaming.upperSnake(name));
+                columns.add(column);
+                constraintName.append('_')
+                              .append(IntentNaming.pascalCase(name));
+            }
+            Map<String, Object> constraint = new LinkedHashMap<>();
+            constraint.put("name", constraintName.toString());
+            constraint.put("columns", columns);
+            constraint.put("columnsCsv", columns.stream()
+                                                .map(column -> String.valueOf(column.get("name")))
+                                                .collect(Collectors.joining(",")));
+            constraint.put("message", notBlank(unique.getMessage()) ? unique.getMessage()
+                    : "A " + IntentNaming.humanize(entity.getName())
+                                         .toLowerCase(Locale.ROOT)
+                            + " with the same " + humanizeJoin(names) + " already exists");
+            constraints.add(constraint);
+        }
+        return constraints;
+    }
+
+    /** {@code [tenant, application]} → {@code "tenant and application"}, for a default message. */
+    private static String humanizeJoin(List<String> names) {
+        List<String> humanized = new ArrayList<>(names.size());
+        for (String name : names) {
+            humanized.add(IntentNaming.humanize(name)
+                                      .toLowerCase(Locale.ROOT));
+        }
+        if (humanized.size() == 1) {
+            return humanized.get(0);
+        }
+        return String.join(", ", humanized.subList(0, humanized.size() - 1)) + " and " + humanized.get(humanized.size() - 1);
+    }
+
+    /**
      * The entity's {@code checks} as template-ready maps: {@code exactlyOne} carries the PascalCased
      * own fields; the document-level kinds additionally carry the resolved items entity, the items'
      * back-reference FK property, and the EntityStatus gate property - everything the DAO/REST
@@ -2514,7 +2582,10 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             sb.append("  <entity");
             List<Map<String, Object>> properties = (List<Map<String, Object>>) entity.getOrDefault("properties", List.of());
             for (Map.Entry<String, Object> attr : entity.entrySet()) {
-                if ("properties".equals(attr.getKey())) {
+                // EDM attributes are scalar. A structured value (checks, uniqueConstraints, ...) belongs
+                // only to the .model twin and would render here as a stringified Java collection - the
+                // same guard the mxGraph property cells already apply.
+                if ("properties".equals(attr.getKey()) || attr.getValue() instanceof Iterable || attr.getValue() instanceof Map) {
                     continue;
                 }
                 appendAttribute(sb, attr.getKey(), attr.getValue());

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/EntityIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/EntityIntent.java
@@ -202,6 +202,12 @@ public class EntityIntent {
      * two gated on an EntityStatus seed id so drafting stays unconstrained. See {@link CheckIntent}.
      */
     private List<CheckIntent> checks;
+    /**
+     * Optional business keys spanning more than one column - the composite counterpart of a field's
+     * {@code unique}. Each entry names the fields and/or to-one relations the key spans and the message
+     * a colliding write is answered with. Absent (the default) → the entity has no composite key.
+     */
+    private List<UniqueIntent> unique;
 
     /**
      * Optional read-only registers of the records that REFERENCE this entity - the reverse of an
@@ -493,6 +499,15 @@ public class EntityIntent {
 
     public void setHierarchy(String hierarchy) {
         this.hierarchy = hierarchy;
+    }
+
+    /**
+     * Gets the composite business keys.
+     *
+     * @return the unique declarations, never null
+     */
+    public List<UniqueIntent> getUnique() {
+        return unique == null ? List.of() : unique;
     }
 
     public List<CheckIntent> getChecks() {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/UniqueIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/UniqueIntent.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A business key spanning more than one column of an {@link EntityIntent} - one row per
+ * {@code (tenant, application)}, one assignment per {@code (tenant, user)}, one price per
+ * {@code (product, priceList, validFrom)}.
+ *
+ * <p>
+ * The field-level {@code unique} covers a single column; the rule that says what a row <em>is</em>
+ * across several has no other expression. Left unmodelled it lives in a read-then-write in
+ * hand-written code - a race, and one every writer (an import, an inbound message, a scheduled
+ * create) has to repeat - or in a constraint added to the generated schema by hand, which the next
+ * Generate knows nothing about.
+ *
+ * <p>
+ * {@link #fields} names fields <em>or to-one relations</em>: a relation contributes its foreign-key
+ * column, which is what a pair like {@code (tenant, application)} means. The columns are the key;
+ * the declared order is how it reads and how it is emitted, and does not change which rows collide.
+ * {@link #message} is what a caller is told when a write does.
+ */
+public class UniqueIntent {
+
+    /** The fields and/or to-one relations the business key spans, in the declared order. */
+    private List<String> fields = new ArrayList<>();
+
+    /** The user-facing message when a write collides with an existing row. */
+    private String message;
+
+    /**
+     * Gets the fields and to-one relations the key spans, in the declared order.
+     *
+     * @return the field names, never null
+     */
+    public List<String> getFields() {
+        return fields == null ? List.of() : fields;
+    }
+
+    /**
+     * Gets the user-facing conflict message.
+     *
+     * @return the message, or null when none was authored
+     */
+    public String getMessage() {
+        return message;
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -69,6 +69,7 @@ import org.eclipse.dirigible.components.intent.model.ScheduleIntent;
 import org.eclipse.dirigible.components.intent.model.SeedIntent;
 import org.eclipse.dirigible.components.intent.model.StepIntent;
 import org.eclipse.dirigible.components.intent.model.TransitionIntent;
+import org.eclipse.dirigible.components.intent.model.UniqueIntent;
 import org.eclipse.dirigible.components.intent.model.WidgetIntent;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
@@ -2469,12 +2470,84 @@ public final class IntentParser {
                     validateCheck(entity, check, byName, model.getAggregates(), issues);
                 }
             }
+            if (!entity.getUnique()
+                       .isEmpty()) {
+                validateUnique(entity, issues);
+            }
             if (!entity.getRelated()
                        .isEmpty()) {
                 validateRelated(entity, byName, usesAliases, issues);
             }
         }
         return entityNames;
+    }
+
+    /**
+     * {@code unique:} declares the business keys spanning more than one column - what a row IS when no
+     * single field says it. Every name must resolve to an own field or an own <b>to-one</b> relation of
+     * the entity: a to-one contributes its foreign-key column, which is what a pair like
+     * {@code (tenant, application)} means, while a to-many has no column on this side to constrain. A
+     * cross-model relation is rejected outright - the consumer stores a projection of the target, so
+     * there is no local column either. And a single-name key is rejected naming the field attribute it
+     * duplicates, because two ways to say the same thing is how the two drift apart.
+     *
+     * @param entity the entity carrying the keys
+     * @param issues the collecting issue list
+     */
+    private static void validateUnique(EntityIntent entity, List<String> issues) {
+        Map<String, RelationIntent> relations = new HashMap<>();
+        for (RelationIntent relation : entity.getRelations()) {
+            if (!isBlank(relation.getName())) {
+                relations.put(relation.getName(), relation);
+            }
+        }
+        Set<String> fields = new HashSet<>();
+        for (FieldIntent field : entity.getFields()) {
+            if (!isBlank(field.getName())) {
+                fields.add(field.getName());
+            }
+        }
+        Set<String> keys = new HashSet<>();
+        for (UniqueIntent unique : entity.getUnique()) {
+            String subject = "entity [" + entity.getName() + "] unique";
+            List<String> names = unique.getFields();
+            if (names.isEmpty()) {
+                issues.add(subject + " names no fields");
+                continue;
+            }
+            if (names.size() == 1) {
+                issues.add(subject + " [" + names.get(0) + "] spans a single field - declare unique: true on the field itself");
+                continue;
+            }
+            if (!keys.add(String.join(",", names))) {
+                issues.add(subject + " [" + String.join(", ", names) + "] is declared twice");
+            }
+            Set<String> seen = new HashSet<>();
+            for (String name : names) {
+                if (isBlank(name)) {
+                    issues.add(subject + " names a blank field");
+                    continue;
+                }
+                if (!seen.add(name)) {
+                    issues.add(subject + " names [" + name + "] twice - a key constrains each column once");
+                    continue;
+                }
+                RelationIntent relation = relations.get(name);
+                if (relation != null) {
+                    if (!("manyToOne".equals(relation.getKind()) || "oneToOne".equals(relation.getKind()))) {
+                        issues.add(subject + " names [" + name + "], which is a " + relation.getKind()
+                                + " relation - only a field or a to-one relation has a column on this entity to constrain");
+                    } else if (relation.isCrossModel()) {
+                        issues.add(subject + " names the cross-model relation [" + name
+                                + "] - a cross-model target is stored as a projection, so this entity has no column for it");
+                    }
+                    continue;
+                }
+                if (!fields.contains(name)) {
+                    issues.add(subject + " names [" + name + "], which is not a field or to-one relation of [" + entity.getName() + "]");
+                }
+            }
+        }
     }
 
     /**

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmEntityUniqueTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmEntityUniqueTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator.edm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.eclipse.dirigible.components.intent.parser.IntentParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A composite business key has to arrive at the layer that creates it: the {@code .model} carries
+ * the constraint with its physical columns, from which the schema template emits it and the REST
+ * controller recovers the authored message (#6763).
+ */
+class EdmEntityUniqueTest {
+
+    private static final String PROVISIONING = """
+            name: provisioning
+            entities:
+              - name: Tenant
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: Application
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: TenantApplication
+                unique:
+                  - { fields: [tenant, application], message: "This application is already provisioned for the tenant" }
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: plan, type: string }
+                relations:
+                  - { name: tenant, kind: manyToOne, to: Tenant, required: true }
+                  - { name: application, kind: manyToOne, to: Application, required: true }
+            """;
+
+    @Test
+    void theConstraintCarriesItsPhysicalColumnsInTheDeclaredOrder() {
+        Map<String, Object> constraint = onlyConstraint(PROVISIONING);
+
+        assertEquals("TenantApplication_Tenant_Application", constraint.get("name"),
+                "the same descriptive concatenation the foreign keys use, so a regenerated model names it identically");
+        assertEquals(List.of("TENANT_APPLICATION_TENANT", "TENANT_APPLICATION_APPLICATION"), columnNames(constraint),
+                "a to-one relation contributes its foreign-key column, and the order is the authored one");
+        assertEquals("TENANT_APPLICATION_TENANT,TENANT_APPLICATION_APPLICATION", constraint.get("columnsCsv"));
+        assertEquals("This application is already provisioned for the tenant", constraint.get("message"));
+    }
+
+    @Test
+    void aFieldAndARelationShareTheSameColumnForm() {
+        Map<String, Object> constraint = onlyConstraint(PROVISIONING.replace("[tenant, application]", "[tenant, plan]"));
+
+        assertEquals(List.of("TENANT_APPLICATION_TENANT", "TENANT_APPLICATION_PLAN"), columnNames(constraint));
+    }
+
+    @Test
+    void anUnauthoredMessageStillReadsAsSomethingAUserCanActOn() {
+        Map<String, Object> constraint =
+                onlyConstraint(PROVISIONING.replace(", message: \"This application is already provisioned for the tenant\"", ""));
+
+        assertEquals("A tenant application with the same tenant and application already exists", constraint.get("message"),
+                "a caller must be told what collided even when the author said nothing");
+    }
+
+    @Test
+    void anEntityWithoutAKeyCarriesNothing() {
+        assertNull(entity(PROVISIONING, "Tenant").get("uniqueConstraints"),
+                "the key is absent, not an empty list the schema template would have to guard twice");
+    }
+
+    /**
+     * The {@code .edm} twin is scalar: an editor that met a stringified Java collection there would
+     * render it as an attribute value and write it back on the next save.
+     */
+    @Test
+    void theStructuredValueStaysOutOfTheEdmXml() {
+        String xml = EdmIntentGenerator.buildEdmXmlForTest(IntentParser.parse(PROVISIONING), "provisioning");
+
+        assertTrue(xml.contains("<entity"), "sanity: the XML twin was rendered");
+        assertFalse(xml.contains("uniqueConstraints="), "a structured value belongs only to the .model twin");
+        assertFalse(xml.contains("columnsCsv"), "and nothing of it leaks under another name");
+    }
+
+    private static Map<String, Object> onlyConstraint(String yaml) {
+        List<Map<String, Object>> constraints = constraints(yaml);
+        assertNotNull(constraints, "the entity must carry its declared key");
+        assertEquals(1, constraints.size());
+        return constraints.get(0);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> constraints(String yaml) {
+        return (List<Map<String, Object>>) entity(yaml, "TenantApplication").get("uniqueConstraints");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> columnNames(Map<String, Object> constraint) {
+        return ((List<Map<String, Object>>) constraint.get("columns")).stream()
+                                                                      .map(column -> String.valueOf(column.get("name")))
+                                                                      .toList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> entity(String yaml, String name) {
+        Map<String, Object> model = EdmIntentGenerator.buildModelJsonForTest(IntentParser.parse(yaml), "provisioning");
+        List<Map<String, Object>> entities = (List<Map<String, Object>>) ((Map<String, Object>) model.get("model")).get("entities");
+        return entities.stream()
+                       .filter(entity -> name.equals(entity.get("name")))
+                       .findFirst()
+                       .orElseThrow(() -> new AssertionError("no entity [" + name + "]"));
+    }
+}

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/EntityUniqueIntentTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/EntityUniqueIntentTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.eclipse.dirigible.components.intent.model.EntityIntent;
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.model.UniqueIntent;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Entity-level {@code unique} - the business key spanning more than one column (#6763). Its parse
+ * rules exist because every one of them, unenforced, produces a constraint the database cannot
+ * create or a rule that silently constrains nothing.
+ */
+class EntityUniqueIntentTest {
+
+    private static final String PROVISIONING = """
+            name: provisioning
+            entities:
+              - name: Tenant
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: Application
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: TenantApplication
+                unique:
+                  - { fields: [tenant, application], message: "This application is already provisioned for the tenant" }
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: plan, type: string }
+                relations:
+                  - { name: tenant, kind: manyToOne, to: Tenant, required: true }
+                  - { name: application, kind: manyToOne, to: Application, required: true }
+            """;
+
+    @Test
+    void aKeyOverTwoToOneRelationsParses() {
+        IntentModel model = IntentParser.parse(PROVISIONING);
+
+        List<UniqueIntent> keys = entity(model, "TenantApplication").getUnique();
+        assertEquals(1, keys.size());
+        assertEquals(List.of("tenant", "application"), keys.get(0)
+                                                           .getFields(),
+                "the declared order is the constrained order");
+        assertEquals("This application is already provisioned for the tenant", keys.get(0)
+                                                                                   .getMessage());
+    }
+
+    @Test
+    void aKeyMayMixFieldsAndRelations() {
+        IntentModel model = IntentParser.parse(PROVISIONING.replace("[tenant, application]", "[tenant, plan]"));
+
+        assertEquals(List.of("tenant", "plan"), entity(model, "TenantApplication").getUnique()
+                                                                                  .get(0)
+                                                                                  .getFields());
+    }
+
+    @Test
+    void anEntityWithNoKeysIsUnaffected() {
+        IntentModel model = IntentParser.parse(PROVISIONING);
+
+        assertTrue(entity(model, "Tenant").getUnique()
+                                          .isEmpty(),
+                "unique is absent by default, and absent must mean an empty list, not a null the generators trip over");
+    }
+
+    @Test
+    void aSingleFieldKeyIsRejectedNamingTheFieldAttributeItDuplicates() {
+        assertIssue(PROVISIONING.replace("[tenant, application]", "[tenant]"), "declare unique: true on the field itself");
+    }
+
+    @Test
+    void aNameThatIsNeitherFieldNorRelationIsRejected() {
+        assertIssue(PROVISIONING.replace("[tenant, application]", "[tenant, tier]"),
+                "names [tier], which is not a field or to-one relation");
+    }
+
+    @Test
+    void aToManyRelationIsRejectedBecauseItHasNoColumnHere() {
+        String yaml = PROVISIONING.replace("  - { name: application, kind: manyToOne, to: Application, required: true }",
+                "  - { name: application, kind: oneToMany, to: Application }");
+
+        assertIssue(yaml, "only a field or a to-one relation has a column on this entity to constrain");
+    }
+
+    @Test
+    void aCrossModelRelationIsRejected() {
+        String yaml = """
+                name: provisioning
+                uses:
+                  - { name: catalog }
+                entities:
+                  - name: Tenant
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: TenantApplication
+                    unique:
+                      - { fields: [tenant, application] }
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                    relations:
+                      - { name: tenant, kind: manyToOne, to: Tenant, required: true }
+                      - { name: application, kind: manyToOne, to: Application, model: catalog, required: true }
+                """;
+
+        assertIssue(yaml, "cross-model relation [application]");
+    }
+
+    @Test
+    void aRepeatedNameWithinOneKeyIsRejected() {
+        assertIssue(PROVISIONING.replace("[tenant, application]", "[tenant, tenant]"), "names [tenant] twice");
+    }
+
+    @Test
+    void theSameKeyDeclaredTwiceIsRejected() {
+        String yaml = PROVISIONING.replace(
+                "  - { fields: [tenant, application], message: \"This application is already provisioned for the tenant\" }",
+                "  - { fields: [tenant, application] }\n      - { fields: [tenant, application] }");
+
+        assertIssue(yaml, "is declared twice");
+    }
+
+    private static void assertIssue(String yaml, String expected) {
+        IntentValidationException exception = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+
+        assertTrue(exception.getMessage()
+                            .contains(expected),
+                () -> "expected an issue containing [" + expected + "] but got: " + exception.getMessage());
+    }
+
+    private static EntityIntent entity(IntentModel model, String name) {
+        return model.getEntities()
+                    .stream()
+                    .filter(entity -> name.equals(entity.getName()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("no entity [" + name + "]"));
+    }
+}

--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
@@ -209,7 +209,16 @@ public class ${name}Controller {
 #if($hasReferenceValidations)
         validateReferences(entity);
 #end
+#if($uniqueConstraints && !$uniqueConstraints.isEmpty())
+        ${name}Entity saved;
+        try {
+            saved = repository.save(entity);
+        } catch (RuntimeException e) {
+            throw duplicateOrRethrow(e);
+        }
+#else
         ${name}Entity saved = repository.save(entity);
+#end
         return repository.findOne(saved.#foreach($property in $properties)#if($property.dataPrimaryKey)${property.name}#end#end).orElse(saved);
     }
 #if($attachmentEntity)
@@ -289,14 +298,30 @@ public class ${name}Controller {
 #if($hasReferenceValidations)
         validateReferences(existing);
 #end
+#if($uniqueConstraints && !$uniqueConstraints.isEmpty())
+        try {
+            return repository.update(existing);
+        } catch (RuntimeException e) {
+            throw duplicateOrRethrow(e);
+        }
+#else
         return repository.update(existing);
+#end
 #else
         entity.#foreach($property in $properties)#if($property.dataPrimaryKey)${property.name}#end#end = id;
         validate(entity);
 #if($hasReferenceValidations)
         validateReferences(entity);
 #end
+#if($uniqueConstraints && !$uniqueConstraints.isEmpty())
+        try {
+            return repository.update(entity);
+        } catch (RuntimeException e) {
+            throw duplicateOrRethrow(e);
+        }
+#else
         return repository.update(entity);
+#end
 #end
     }
 
@@ -337,6 +362,44 @@ public class ${name}Controller {
             throw e;
         }
     }
+
+#if($uniqueConstraints && !$uniqueConstraints.isEmpty())
+
+    /**
+     * The composite business keys of ${name}, keyed by the constraint name the database names in the
+     * violation it raises. The names are the ones the model emitted, so this map and the schema cannot
+     * drift.
+     */
+    private static final Map<String, String> DUPLICATE_MESSAGES = Map.ofEntries(
+#foreach($uniqueConstraint in $uniqueConstraints)
+            Map.entry("${uniqueConstraint.name}", "${uniqueConstraint.message}")#if($foreach.hasNext),#end
+#end
+    );
+
+    /**
+     * A write that collided with one of those keys is a conflict the caller can act on - answered with
+     * the authored message - and anything else is rethrown untouched. Matching is on the constraint
+     * name inside the driver's message, which is the only handle the database gives back; every
+     * dialect names the violated constraint there.
+     */
+    private static RuntimeException duplicateOrRethrow(RuntimeException e) {
+        if (isConstraintViolation(e)) {
+            for (Throwable cause = e; cause != null; cause = cause.getCause() == cause ? null : cause.getCause()) {
+                String message = cause.getMessage();
+                if (message == null) {
+                    continue;
+                }
+                String upper = message.toUpperCase(Locale.ROOT);
+                for (Map.Entry<String, String> constraint : DUPLICATE_MESSAGES.entrySet()) {
+                    if (upper.contains(constraint.getKey().toUpperCase(Locale.ROOT))) {
+                        return new ResponseStatusException(HttpStatus.CONFLICT, constraint.getValue());
+                    }
+                }
+            }
+        }
+        return e;
+    }
+#end
 
     /** Whether a persistence failure is (caused by) a database constraint violation. */
     private static boolean isConstraintViolation(Throwable e) {

--- a/components/template/template-application-schema/src/main/resources/META-INF/dirigible/template-application-schema/data/application.schema.template
+++ b/components/template/template-application-schema/src/main/resources/META-INF/dirigible/template-application-schema/data/application.schema.template
@@ -155,6 +155,20 @@
 #else
                     }
                 ]
+#if($model.uniqueConstraints && !$model.uniqueConstraints.isEmpty())
+## A composite business key - one row per (tenant, application). The single-column case stays on the
+## column itself ("unique": true above); this is the only expression of a key spanning several.
+                ,"constraints": {
+                    "uniqueIndexes": [
+#foreach ($uniqueConstraint in $model.uniqueConstraints)
+                        {
+                            "name": "${uniqueConstraint.name}",
+                            "columns": [#foreach ($uniqueColumn in $uniqueConstraint.columns)"${uniqueColumn.name}"#if($foreach.hasNext), #end#end]
+                        }#if($foreach.hasNext),#end
+#end
+                    ]
+                }
+#end
 #end
 #end
 #if($foreach.hasNext)

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -227,6 +227,18 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                   - { name: id,   type: integer, primaryKey: true, generated: true }
                   - { name: name, type: string, required: true, length: 100 }
 
+              # entity-level unique (#6763): the business key spanning more than one column. The
+              # schema gains the composite constraint over (PARTY, CODE) and a colliding write is
+              # answered with the authored message rather than a server error.
+              - name: PartyCode
+                unique:
+                  - { fields: [party, code], message: "This code is already registered for the party" }
+                fields:
+                  - { name: id,   type: integer, primaryKey: true, generated: true }
+                  - { name: code, type: string, required: true, length: 50 }
+                relations:
+                  - { name: party, kind: manyToOne, to: Party, required: true }
+
               # first-class numbering, stampOn: create - the generated DAO allocates the real number
               # at insert from the tenant series that the module's AUTHORED .numbers artefact
               # provisions at publish. The intent references the series by NAME only; the shape
@@ -1355,6 +1367,13 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 "locksWithMaster: false must leave the child's REST writes unguarded");
 
         String schema = contentOf("gen/emission/schema/" + PROJECT + ".schema");
+        // entity-level unique (#6763): the composite key has to reach the schema, which is the only
+        // place it can be created. Asserted here as well as at runtime so a regression says WHICH
+        // layer dropped it.
+        assertTrue(schema.contains("\"PartyCode_Party_Code\""), "the composite business key must be emitted into the schema: " + schema);
+        String partyCodeController = contentOf("gen/emission/api/partycode/PartyCodeController.java");
+        assertTrue(partyCodeController.contains("This code is already registered for the party"),
+                "the generated controller must carry the authored conflict message");
         assertTrue(schema.contains("EMISSION_UNIT_LANG"), "multilingual must emit the _LANG translation table into the schema");
         // manyToMany: the link entity is an ordinary entity from parse time on, so it must reach the
         // schema as its own table and the REST layer as its own (detail) controller. Asserting the
@@ -2590,6 +2609,39 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                                                  .body("{\"Id\":" + entryId + ",\"Date\":\"2026-01-15\",\"Account\":2,\"Status\":2}")
                                                  .when()
                                                  .put(API + "/entry/EntryController/" + entryId)
+                                                 .then()
+                                                 .statusCode(200));
+
+        // entity-level unique (#6763): the composite key exists in the database (the second insert
+        // cannot land) AND the generated controller recognises which key was hit, so the caller is
+        // told what collided instead of getting a 500. The third write flips one column, which must
+        // be accepted - a constraint over (party, code) that rejected a different code would be a
+        // single-column unique wearing a composite name.
+        AtomicInteger partyId = new AtomicInteger();
+        restAssuredExecutor.execute(() -> partyId.set(given().contentType("application/json")
+                                                             .body("{\"Name\":\"Unique Co\"}")
+                                                             .when()
+                                                             .post(API + "/party/PartyController")
+                                                             .then()
+                                                             .statusCode(200)
+                                                             .extract()
+                                                             .path("Id")));
+        restAssuredExecutor.execute(() -> given().contentType("application/json")
+                                                 .body("{\"Party\":" + partyId.get() + ",\"Code\":\"AB-1\"}")
+                                                 .when()
+                                                 .post(API + "/partycode/PartyCodeController")
+                                                 .then()
+                                                 .statusCode(200));
+        restAssuredExecutor.execute(() -> given().contentType("application/json")
+                                                 .body("{\"Party\":" + partyId.get() + ",\"Code\":\"AB-1\"}")
+                                                 .when()
+                                                 .post(API + "/partycode/PartyCodeController")
+                                                 .then()
+                                                 .statusCode(409));
+        restAssuredExecutor.execute(() -> given().contentType("application/json")
+                                                 .body("{\"Party\":" + partyId.get() + ",\"Code\":\"AB-2\"}")
+                                                 .when()
+                                                 .post(API + "/partycode/PartyCodeController")
                                                  .then()
                                                  .statusCode(200));
 

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/SchemaTemplateUniqueConstraintIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/SchemaTemplateUniqueConstraintIT.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.data.structures.domain.Schema;
+import org.eclipse.dirigible.components.data.structures.domain.Table;
+import org.eclipse.dirigible.components.data.structures.domain.TableConstraintUnique;
+import org.eclipse.dirigible.components.data.structures.synchronizer.SchemasSynchronizer;
+import org.eclipse.dirigible.components.engine.template.velocity.VelocityGenerationEngine;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+/**
+ * A composite business key survives the whole way down: the real
+ * {@code application.schema.template} renders it into the {@code .schema}, and the real
+ * {@link SchemasSynchronizer} reads that back as the constraint the table is created with (#6763).
+ *
+ * <p>
+ * The two halves are asserted together on purpose. A key that renders into JSON nobody parses, or a
+ * parser waiting for a shape nothing emits, both look perfectly healthy in isolation - and the
+ * business rule the author wrote silently constrains nothing either way.
+ */
+class SchemaTemplateUniqueConstraintIT extends IntegrationTest {
+
+    /** Classpath location of the template under test (shipped in template-application-schema). */
+    private static final String TEMPLATE_LOCATION = "/META-INF/dirigible/template-application-schema/data/application.schema.template";
+
+    private static final Gson GSON = new Gson();
+
+    @Autowired
+    private VelocityGenerationEngine velocityGenerationEngine;
+
+    @Autowired
+    private SchemasSynchronizer schemasSynchronizer;
+
+    @Test
+    void aCompositeKeyIsEmittedAndParsedBackAsTheTablesConstraint() throws Exception {
+        String schema = render(List.of(entityWithKey()));
+
+        assertNotNull(GSON.fromJson(schema, JsonObject.class), "the emitted schema must be valid JSON");
+
+        Table table = onlyTable(schema);
+        List<TableConstraintUnique> keys = table.getConstraints()
+                                                .getUniqueIndexes();
+        assertEquals(1, keys.size(), "the declared key must reach the table the synchronizer creates");
+        assertEquals("TenantApplication_Tenant_Application", keys.get(0)
+                                                                 .getName());
+        assertEquals(List.of("TENANT_APPLICATION_TENANT", "TENANT_APPLICATION_APPLICATION"), Arrays.asList(keys.get(0)
+                                                                                                               .getColumns()),
+                "the emitted schema keeps the authored order, so regenerating an unchanged model produces an unchanged file");
+    }
+
+    @Test
+    void aTableWithoutAKeyEmitsNoConstraintsAtAll() throws Exception {
+        Map<String, Object> plain = entityWithKey();
+        plain.remove("uniqueConstraints");
+
+        String schema = render(List.of(plain));
+
+        assertNotNull(GSON.fromJson(schema, JsonObject.class), "the emitted schema must still be valid JSON");
+        assertFalse(schema.contains("uniqueIndexes"), "an entity that declares no key must not emit an empty constraints block");
+        assertTrue(onlyTable(schema).getConstraints()
+                                    .getUniqueIndexes()
+                                    .isEmpty());
+    }
+
+    private Table onlyTable(String schema) {
+        Schema parsed = schemasSynchronizer.parseSchema("/unique-it/application.schema", schema);
+        assertEquals(1, parsed.getTables()
+                              .size());
+        return parsed.getTables()
+                     .get(0);
+    }
+
+    private String render(List<Map<String, Object>> models) throws Exception {
+        String template;
+        try (InputStream in = getClass().getResourceAsStream(TEMPLATE_LOCATION)) {
+            assertNotNull(in, "template resource not found on classpath: " + TEMPLATE_LOCATION);
+            template = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("models", models);
+        parameters.put("tablePrefix", "");
+        parameters.put("dataSource", "DefaultDB");
+        byte[] out = velocityGenerationEngine.generate(parameters, TEMPLATE_LOCATION, template.getBytes(StandardCharsets.UTF_8));
+        return new String(out, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * The shape {@code EdmIntentGenerator} puts on the entity for {@code unique: [{fields: [...]}]}.
+     */
+    private static Map<String, Object> entityWithKey() {
+        Map<String, Object> model = new LinkedHashMap<>();
+        model.put("name", "TenantApplication");
+        model.put("dataName", "TENANT_APPLICATION");
+        model.put("type", "PRIMARY");
+        model.put("properties", new ArrayList<>(Arrays.asList(pk("Id", "TENANT_APPLICATION_ID"),
+                column("Tenant", "TENANT_APPLICATION_TENANT"), column("Application", "TENANT_APPLICATION_APPLICATION"))));
+        Map<String, Object> constraint = new LinkedHashMap<>();
+        constraint.put("name", "TenantApplication_Tenant_Application");
+        constraint.put("columns", List.of(Map.of("name", "TENANT_APPLICATION_TENANT"), Map.of("name", "TENANT_APPLICATION_APPLICATION")));
+        constraint.put("message", "This application is already provisioned for the tenant");
+        model.put("uniqueConstraints", new ArrayList<>(List.of(constraint)));
+        return model;
+    }
+
+    private static Map<String, Object> pk(String name, String dataName) {
+        Map<String, Object> property = column(name, dataName);
+        property.put("dataPrimaryKey", Boolean.TRUE);
+        property.put("dataAutoIncrement", Boolean.TRUE);
+        property.put("dataNotNull", Boolean.TRUE);
+        return property;
+    }
+
+    private static Map<String, Object> column(String name, String dataName) {
+        Map<String, Object> property = new LinkedHashMap<>();
+        property.put("name", name);
+        property.put("dataName", dataName);
+        property.put("dataType", "INTEGER");
+        property.put("dataPrimaryKey", Boolean.FALSE);
+        return property;
+    }
+}


### PR DESCRIPTION
Closes #6763.

### The gap

`unique` is a **field** attribute (`FieldIntent.isUnique` → `dataUnique` on the generated property), so a business key spanning more than one column has no expression: one row per `(tenant, application)`, one assignment per `(tenant, user)`, one price per `(product, priceList, validFrom)`. `checks:` covers row conditions and aggregate guards, not uniqueness.

The rule then has nowhere to live in the model, and lands in one of two places instead — a **read-then-write in hand-written code**, which is a race by construction and one every writer has to repeat (the form, an import, an arriving message, a scheduled create), or a **constraint added to the generated schema by hand**, which the next Generate knows nothing about. So the single most important sentence about an entity — what makes two rows the same row — is the one sentence the model does not say.

### The construct

```yaml
entities:
  - name: TenantApplication
    unique:
      - { fields: [tenant, application], message: "This application is already provisioned for the tenant" }
```

`fields:` names fields **or to-one relations** — a relation contributes its foreign-key column, which is what such a pair means. The constraint is named `<Entity>_<Field1>_<Field2>`, the same descriptive concatenation the foreign keys already use, so a regenerated model produces the identical name and the schema layer sees no change.

Parse-time refusals, each because the alternative is a rule that silently constrains nothing: a name that is neither a field nor a to-one of the same entity; a to-many (no column on this side to constrain); a cross-model relation; a single-name key, which names the field attribute it duplicates; a repeated name inside one key; the same key declared twice.

The generated controller answers a colliding create/update with **409** carrying the authored message, matched on the constraint name the database reports — the names are the ones the model emitted, so the map and the schema cannot drift. An unauthored message is derived from the field names.

### The layer that made this reachable

Emitting the constraint into the `.schema` was not enough, and finding out why is most of this change. `SchemasSynchronizer.parseImpl` attached a **fresh** `TableConstraints` to every parsed table immediately after `parseSchema` had built one — so a constraint declared in a `.schema` reached the file and went no further. (The `reassignIds` code right below it, which carefully re-links existing unique/check/foreign-key ids, has been inert for the same reason.) The unique keys are now carried over.

The **foreign keys** a `.schema` declares stay dropped, and that is the design rather than a leftover: a foreign key never becomes a database constraint. Referential integrity is a **business-layer** check — a constraint in the schema would bind insert and delete order into the database, where seeds, imports, regeneration and deletes would all have to obey an ordering nothing in the model asked for. (An earlier revision of this description called that a gap; it is not. Corrected in #6794.)

### A note on the issue's cross-model rule

The issue justifies rejecting a cross-model relation with "the consumer stores a projection, so there is no local column". That rationale does not hold — a cross-model to-one *does* get a local integer FK column (`crossModelRelationProperty` emits one), so such a key would be perfectly emittable. I implemented the rejection as specified anyway, because a too-strict DSL rule can be relaxed later without breaking authored models while a too-permissive one cannot, and I noted the same reasoning in the spec proposal. Worth a deliberate decision rather than inheriting mine.

### Tests

- `EntityUniqueIntentTest` (9) — every parse rule, plus that `unique` is absent-as-empty rather than a null the generators trip over.
- `EdmEntityUniqueTest` (5) — the constraint's name, its physical columns, the derived message, that a field and a relation share one column form, and that the structured value stays out of the scalar `.edm` twin.
- `SchemaTemplateUniqueConstraintIT` — the real `application.schema.template` renders it into valid JSON and the real `SchemasSynchronizer` reads it back as the table's constraint. Both halves together on purpose: a key that renders into JSON nobody parses, and a parser waiting for a shape nothing emits, both look healthy in isolation.
- `IntentEmissionCoverageIT` — end to end on the shipped fixture: the key is in the emitted schema and the authored message in the generated controller, the DDL carries `CREATE UNIQUE INDEX`, a duplicate write is 409, and a write differing in one column still lands.

Full unit suites for the touched modules (659) and both ITs green locally.

### Not included

The **EDM modeler's authoring UI**. Adding it means giving the constraint an `.edm` XML representation (a `<unique>` child element) and threading it through `model.js`, `details.html`/`details.js`, `editor.js`, `serializer.js` and `transform-edm.js` — a self-contained frontend change whose blast radius is every entity save, with no test harness short of a Selenide journey. It should land with its round-trip complete (including the intent generator emitting the element into the `.edm`), not as half of one. The construct is fully usable from the intent today, which is where the issue's examples come from.

### Docs

- dirigible.io: dirigible-io/dirigible-io.github.io#197
- Vendor-neutral spec proposal: IntentFile/intent-specification#35 (left open for the maintainer, proposal-first per their #32)