### PR TITLE
docs(data-structures): a schema's foreign keys are dropped by design, not by omission

### DIFF
--- a/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/synchronizer/SchemasSynchronizer.java
+++ b/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/synchronizer/SchemasSynchronizer.java
@@ -321,9 +321,16 @@ public class SchemasSynchronizer extends MultitenantBaseSynchronizer<Schema, Lon
      * created nowhere. They are carried over here.
      *
      * <p>
-     * The foreign keys a {@code .schema} may declare are deliberately NOT carried: they have never
-     * reached the database from this path either, and emitting them now would change the DDL of every
-     * already-generated application, which is a change of its own and not this one's to make.
+     * The foreign keys a {@code .schema} declares are dropped here, and that is the design, not a gap
+     * waiting to be closed: <b>a foreign key never becomes a database constraint</b>. Referential
+     * integrity is checked at the business layer - the generated repository and controller - because a
+     * constraint in the schema binds insert and delete ORDER into the database, where seeds, imports,
+     * regeneration and deletes would all have to obey an ordering nothing in the model asked for.
+     *
+     * <p>
+     * A unique key is the opposite case and does belong in the database: it says what a row
+     * <em>is</em>, so it has to hold for every writer at once - including the ones that never route
+     * through the application.
      *
      * @param table the parsed table
      * @return the constraints to attach


### PR DESCRIPTION
Comment only — no behaviour change.

The javadoc I added in #6793 explained the dropped foreign keys as something that "would change the DDL of every already-generated application, which is a change of its own and not this one's to make". That reads as a gap someone should eventually close, and it is the opposite of the rule: **a foreign key never becomes a database constraint.** Referential integrity is checked at the business layer — the generated repository and controller — because a constraint in the schema binds insert and delete *order* into the database, where seeds, imports, regeneration and deletes would all have to obey an ordering nothing in the model asked for.

The comment now says that, and says why a unique key is the opposite case and does belong in the database: it defines what a row *is*, so it has to hold for every writer at once, including the ones that never route through the application.

Left as-is deliberately: `carryUniqueConstraints` still carries only the unique keys, which is the behaviour that shipped and is correct.