### PR TITLE
feat(editor-entity): declare a composite unique key in the EDM modeler (#6795)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -1692,6 +1692,12 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             Map<String, Object> constraint = new LinkedHashMap<>();
             constraint.put("name", constraintName.toString());
             constraint.put("columns", columns);
+            // The PROPERTY names, for the .edm twin: the modeler declares a key over properties (so a
+            // later dataName change follows it), and resolves them to columns when it rebuilds the
+            // .model. The columns above are what the schema template emits.
+            constraint.put("properties", names.stream()
+                                              .map(IntentNaming::pascalCase)
+                                              .collect(Collectors.joining(",")));
             constraint.put("columnsCsv", columns.stream()
                                                 .map(column -> String.valueOf(column.get("name")))
                                                 .collect(Collectors.joining(",")));
@@ -2611,6 +2617,7 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             }
         }
         sb.append(" </entities>\n");
+        appendUniqueKeys(sb, entities);
         sb.append(" <perspectives>\n");
         for (Map<String, Object> perspective : perspectives) {
             sb.append("  <perspective><name>")
@@ -2629,6 +2636,60 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
         appendMxGraphModel(sb, document, entities);
         sb.append("</model>\n");
         return sb.toString();
+    }
+
+    /**
+     * The composite business keys, as a top-level {@code <uniqueKeys>} section.
+     *
+     * <p>
+     * Top-level, beside {@code <perspectives>} and {@code <navigations>}, rather than nested in the
+     * entity - which is what lets the EDM modeler carry them at all. The modeler renders the canvas by
+     * decoding {@code <mxGraphModel>} and never reads the {@code <entities>} section, so a key nested
+     * there would have to live on an entity CELL, where it would be the first non-scalar value on a
+     * path whose generic codec has only ever seen attributes. The perspectives take the other route -
+     * an array on the graph model, loaded from the raw XML - and so does this.
+     *
+     * <p>
+     * Without this section a model authored from an intent, opened in the modeler and saved for any
+     * unrelated reason, would come back with its keys gone: the save regenerates the {@code .model}
+     * from the {@code .edm}, and what the {@code .edm} cannot say is simply lost.
+     *
+     * @param sb the buffer
+     * @param entities the built entities
+     */
+    private static void appendUniqueKeys(StringBuilder sb, List<Map<String, Object>> entities) {
+        List<Map<String, Object>> keys = new ArrayList<>();
+        for (Map<String, Object> entity : entities) {
+            Object declared = entity.get("uniqueConstraints");
+            if (declared instanceof List<?> list) {
+                for (Object element : list) {
+                    if (element instanceof Map<?, ?> constraint) {
+                        Map<String, Object> key = new LinkedHashMap<>();
+                        key.put("entity", entity.get("name"));
+                        key.put("name", constraint.get("name"));
+                        key.put("properties", constraint.get("properties"));
+                        key.put("message", constraint.get("message"));
+                        keys.add(key);
+                    }
+                }
+            }
+        }
+        if (keys.isEmpty()) {
+            return; // an .edm without keys stays byte-identical to one generated before they existed
+        }
+        sb.append(" <uniqueKeys>\n");
+        for (Map<String, Object> key : keys) {
+            sb.append("  <uniqueKey><entity>")
+              .append(escapeXmlText(key.get("entity")))
+              .append("</entity><name>")
+              .append(escapeXmlText(key.get("name")))
+              .append("</name><properties>")
+              .append(escapeXmlText(key.get("properties")))
+              .append("</properties><message>")
+              .append(escapeXmlText(key.get("message")))
+              .append("</message></uniqueKey>\n");
+        }
+        sb.append(" </uniqueKeys>\n");
     }
 
     /** Entity box width and row heights for the deterministic grid layout. */

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -2639,15 +2639,18 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
     }
 
     /**
-     * The composite business keys, as a top-level {@code <uniqueKeys>} section.
+     * The composite business keys, as {@code <uniqueKey>} entries of the top-level
+     * {@code <constraints>} section.
      *
      * <p>
-     * Top-level, beside {@code <perspectives>} and {@code <navigations>}, rather than nested in the
-     * entity - which is what lets the EDM modeler carry them at all. The modeler renders the canvas by
-     * decoding {@code <mxGraphModel>} and never reads the {@code <entities>} section, so a key nested
-     * there would have to live on an entity CELL, where it would be the first non-scalar value on a
-     * path whose generic codec has only ever seen attributes. The perspectives take the other route -
-     * an array on the graph model, loaded from the raw XML - and so does this.
+     * The section is named for constraints rather than for keys so that a later constraint kind is a
+     * new entry beside {@code <uniqueKey>}, not a second section. Top-level, beside
+     * {@code <perspectives>} and {@code <navigations>}, rather than nested in the entity - which is
+     * what lets the EDM modeler carry them at all. The modeler renders the canvas by decoding
+     * {@code <mxGraphModel>} and never reads the {@code <entities>} section, so a key nested there
+     * would have to live on an entity CELL, where it would be the first non-scalar value on a path
+     * whose generic codec has only ever seen attributes. The perspectives take the other route - an
+     * array on the graph model, loaded from the raw XML - and so does this.
      *
      * <p>
      * Without this section a model authored from an intent, opened in the modeler and saved for any
@@ -2677,7 +2680,7 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
         if (keys.isEmpty()) {
             return; // an .edm without keys stays byte-identical to one generated before they existed
         }
-        sb.append(" <uniqueKeys>\n");
+        sb.append(" <constraints>\n");
         for (Map<String, Object> key : keys) {
             sb.append("  <uniqueKey><entity>")
               .append(escapeXmlText(key.get("entity")))
@@ -2689,7 +2692,7 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
               .append(escapeXmlText(key.get("message")))
               .append("</message></uniqueKey>\n");
         }
-        sb.append(" </uniqueKeys>\n");
+        sb.append(" </constraints>\n");
     }
 
     /** Entity box width and row heights for the deterministic grid layout. */

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmEntityUniqueTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmEntityUniqueTest.java
@@ -88,12 +88,42 @@ class EdmEntityUniqueTest {
      * render it as an attribute value and write it back on the next save.
      */
     @Test
-    void theStructuredValueStaysOutOfTheEdmXml() {
+    void theStructuredValueStaysOutOfTheEntityAttributes() {
         String xml = EdmIntentGenerator.buildEdmXmlForTest(IntentParser.parse(PROVISIONING), "provisioning");
 
         assertTrue(xml.contains("<entity"), "sanity: the XML twin was rendered");
-        assertFalse(xml.contains("uniqueConstraints="), "a structured value belongs only to the .model twin");
+        assertFalse(xml.contains("uniqueConstraints="), "a structured value is never an entity attribute");
         assertFalse(xml.contains("columnsCsv"), "and nothing of it leaks under another name");
+    }
+
+    /**
+     * The key still has to reach the {@code .edm}, as its own top-level section - otherwise opening an
+     * intent-generated model in the EDM modeler and saving it for any unrelated reason regenerates the
+     * {@code .model} from an {@code .edm} that never mentioned the key, and the constraint is gone with
+     * nothing reported.
+     */
+    @Test
+    void theKeyIsCarriedAsATopLevelSectionOverPropertyNames() {
+        String xml = EdmIntentGenerator.buildEdmXmlForTest(IntentParser.parse(PROVISIONING), "provisioning");
+
+        assertTrue(xml.contains("<uniqueKeys>"), "the .edm must carry the keys the modeler round-trips");
+        assertTrue(
+                xml.contains("<uniqueKey><entity>TenantApplication</entity>" + "<name>TenantApplication_Tenant_Application</name>"
+                        + "<properties>Tenant,Application</properties>"
+                        + "<message>This application is already provisioned for the tenant</message></uniqueKey>"),
+                "the section names PROPERTIES, not columns - so a later dataName change follows the key: " + xml);
+    }
+
+    @Test
+    void aModelWithoutKeysGrowsNoSection() {
+        String withoutKeys = PROVISIONING.replace("    unique:\n", "")
+                                         .replace(
+                                                 "      - { fields: [tenant, application], message: \"This application is already provisioned for the tenant\" }\n",
+                                                 "");
+
+        String xml = EdmIntentGenerator.buildEdmXmlForTest(IntentParser.parse(withoutKeys), "provisioning");
+
+        assertFalse(xml.contains("uniqueKeys"), "an .edm without keys stays byte-identical to one generated before they existed");
     }
 
     private static Map<String, Object> onlyConstraint(String yaml) {

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmEntityUniqueTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmEntityUniqueTest.java
@@ -106,7 +106,7 @@ class EdmEntityUniqueTest {
     void theKeyIsCarriedAsATopLevelSectionOverPropertyNames() {
         String xml = EdmIntentGenerator.buildEdmXmlForTest(IntentParser.parse(PROVISIONING), "provisioning");
 
-        assertTrue(xml.contains("<uniqueKeys>"), "the .edm must carry the keys the modeler round-trips");
+        assertTrue(xml.contains("<constraints>"), "the .edm must carry the keys the modeler round-trips");
         assertTrue(
                 xml.contains("<uniqueKey><entity>TenantApplication</entity>" + "<name>TenantApplication_Tenant_Application</name>"
                         + "<properties>Tenant,Application</properties>"
@@ -123,7 +123,7 @@ class EdmEntityUniqueTest {
 
         String xml = EdmIntentGenerator.buildEdmXmlForTest(IntentParser.parse(withoutKeys), "provisioning");
 
-        assertFalse(xml.contains("uniqueKeys"), "an .edm without keys stays byte-identical to one generated before they existed");
+        assertFalse(xml.contains("<constraints>"), "an .edm without keys stays byte-identical to one generated before they existed");
     }
 
     private static Map<String, Object> onlyConstraint(String yaml) {

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/configs/unique-keys-window.js
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/configs/unique-keys-window.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+const viewData = {
+    id: 'edmUniqueKeys',
+    label: 'Unique keys',
+    path: '/services/web/editor-entity/dialogs/unique-keys.html'
+};
+if (typeof exports !== 'undefined') {
+    exports.getView = () => viewData;
+}

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/dialogs/js/unique-keys.js
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/dialogs/js/unique-keys.js
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+angular.module('edmUniqueKeys', ['blimpKit', 'platformView'])
+    .constant('Dialogs', new DialogHub())
+    .controller('UniqueKeysController', ($scope, $document, Dialogs, ViewParameters) => {
+        $scope.state = {
+            isBusy: false,
+            error: false,
+            busyText: 'Loading...',
+        };
+        $scope.showInnerDialog = false;
+        $scope.editElement = {
+            editType: 'Add', // Update
+            index: 0,
+            entity: '',
+            message: '',
+            selected: {}, // property name -> boolean
+        };
+
+        /** The properties of the entity currently chosen in the inner form. */
+        $scope.propertiesOf = (entityName) => {
+            const entity = $scope.dataParameters.entities.find((candidate) => candidate.name === entityName);
+            return entity ? entity.properties : [];
+        };
+
+        /** The chosen properties, in the entity's own order - which is how the key reads. */
+        $scope.chosenProperties = () => $scope.propertiesOf($scope.editElement.entity).filter((name) => $scope.editElement.selected[name]);
+
+        /**
+         * The constraint name, derived exactly as the intent derives it. It is not decorative: the
+         * generated controller matches this name against what the database reports on a violation, so a
+         * key declared here and the same key declared in an intent have to arrive at one name.
+         */
+        $scope.derivedName = () => {
+            const chosen = $scope.chosenProperties();
+            return chosen.length ? [$scope.editElement.entity].concat(chosen).join('_') : '';
+        };
+
+        $scope.derivedMessage = () => {
+            const chosen = $scope.chosenProperties();
+            return chosen.length ? `A ${$scope.editElement.entity} with the same ${chosen.join(', ')} already exists` : '';
+        };
+
+        /** A key needs two or more properties (one is the field-level unique) and must not repeat one. */
+        $scope.isValid = () => {
+            const chosen = $scope.chosenProperties();
+            if (!$scope.editElement.entity || chosen.length < 2) return false;
+            const candidate = `${$scope.editElement.entity}:${chosen.join(',')}`;
+            for (let i = 0; i < $scope.dataParameters.uniqueKeys.length; i++) {
+                if ($scope.editElement.editType === 'Update' && i === $scope.editElement.index) continue;
+                const key = $scope.dataParameters.uniqueKeys[i];
+                if (`${key.entity}:${(key.properties || []).join(',')}` === candidate) return false;
+            }
+            return true;
+        };
+
+        $scope.validationMessage = () => {
+            if (!$scope.editElement.entity) return 'Select the entity the key belongs to.';
+            if ($scope.chosenProperties().length < 2) {
+                return 'Select two or more properties - a key over a single property is the field\'s own "Unique" flag.';
+            }
+            if (!$scope.isValid()) return 'This entity already has a key over exactly these properties.';
+            return '';
+        };
+
+        $scope.add = () => {
+            $scope.editElement.editType = 'Add';
+            $scope.editElement.index = -1;
+            $scope.editElement.entity = '';
+            $scope.editElement.message = '';
+            $scope.editElement.selected = {};
+            $scope.showInnerDialog = true;
+        };
+
+        $scope.edit = (index) => {
+            const key = $scope.dataParameters.uniqueKeys[index];
+            $scope.editElement.editType = 'Update';
+            $scope.editElement.index = index;
+            $scope.editElement.entity = key.entity;
+            $scope.editElement.message = key.message;
+            $scope.editElement.selected = {};
+            (key.properties || []).forEach((name) => { $scope.editElement.selected[name] = true; });
+            $scope.showInnerDialog = true;
+        };
+
+        /** Changing the entity drops the selection - the properties belonged to the other one. */
+        $scope.entityChanged = () => {
+            $scope.editElement.selected = {};
+        };
+
+        $scope.delete = (index) => {
+            $scope.dataParameters.uniqueKeys.splice(index, 1);
+        };
+
+        $scope.innerAction = () => {
+            if (!$scope.isValid()) return;
+            const key = {
+                entity: $scope.editElement.entity,
+                name: $scope.derivedName(),
+                properties: $scope.chosenProperties(),
+                message: $scope.editElement.message ? $scope.editElement.message : $scope.derivedMessage(),
+            };
+            if ($scope.editElement.editType === 'Add') $scope.dataParameters.uniqueKeys.push(key);
+            else $scope.dataParameters.uniqueKeys[$scope.editElement.index] = key;
+            $scope.showInnerDialog = false;
+        };
+
+        $scope.cancel = () => {
+            if (!$scope.state.error && $scope.showInnerDialog) $scope.showInnerDialog = false;
+            else Dialogs.closeWindow();
+        };
+
+        $scope.save = () => {
+            if (!$scope.state.error) {
+                $scope.state.busyText = 'Saving...';
+                $scope.state.isBusy = true;
+                Dialogs.postMessage({
+                    topic: 'edmEditor.unique.keys',
+                    data: { uniqueKeys: $scope.dataParameters.uniqueKeys },
+                });
+            }
+        };
+
+        $scope.dataParameters = ViewParameters.get();
+        angular.element($document[0]).ready(() => {
+            if (!$scope.dataParameters.uniqueKeys) $scope.dataParameters.uniqueKeys = [];
+            if (!$scope.dataParameters.entities) $scope.dataParameters.entities = [];
+        });
+    });

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/dialogs/unique-keys.html
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/dialogs/unique-keys.html
@@ -1,0 +1,126 @@
+<!--
+
+    Copyright (c) 2010-2026 Eclipse Dirigible contributors
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v20.html
+
+    SPDX-FileCopyrightText: Eclipse Dirigible contributors
+    SPDX-License-Identifier: EPL-2.0
+
+-->
+<!DOCTYPE HTML>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="edmUniqueKeys" ng-controller="UniqueKeysController">
+
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="icon" sizes="any" href="data:;base64,iVBORw0KGgo=">
+        <title config-title></title>
+        <script type="text/javascript" src="/services/web/editor-entity/configs/unique-keys-window.js"></script>
+        <meta name="platform-links" category="ng-view,ng-editor">
+        <script type="text/javascript" src="/services/web/editor-entity/dialogs/js/unique-keys.js"></script>
+    </head>
+
+    <body class="bk-vbox">
+        <bk-busy-indicator-extended class="bk-fill-parent" ng-hide="state.error || !state.isBusy" size="l">{{state.busyText}}</bk-busy-indicator-extended>
+
+        <div class="bk-vbox bk-fill-parent" ng-show="!state.error && !state.isBusy && !showInnerDialog">
+            <div class="bk-hbox bk-padding--tiny bk-border--bottom bk-flex-end bk-box--gap">
+                <bk-button compact="true" label="Add" ng-click="add()"></bk-button>
+            </div>
+            <bk-scrollbar class="bk-full-height">
+                <table bk-table outer-borders="bottom">
+                    <thead bk-table-header sticky="true">
+                        <tr bk-table-row>
+                            <th bk-table-header-cell>Entity</th>
+                            <th bk-table-header-cell>Properties</th>
+                            <th bk-table-header-cell>Constraint</th>
+                            <th bk-table-header-cell>Message</th>
+                            <th bk-table-header-cell></th>
+                        </tr>
+                    </thead>
+                    <tbody bk-table-body>
+                        <tr ng-if="!dataParameters.uniqueKeys || dataParameters.uniqueKeys.length === 0" bk-table-row>
+                            <td bk-table-cell no-data="true">There are no unique keys</td>
+                        </tr>
+                        <tr bk-table-row hoverable="false" activable="false" ng-repeat="item in dataParameters.uniqueKeys track by $index">
+                            <td bk-table-cell>{{ item.entity }}</td>
+                            <td bk-table-cell>{{ item.properties.join(', ') }}</td>
+                            <td bk-table-cell>{{ item.name }}</td>
+                            <td bk-table-cell>{{ item.message }}</td>
+                            <td bk-table-cell fit-content="true">
+                                <bk-button compact="true" glyph="sap-icon--edit" state="transparent" aria-label="Edit" ng-click="edit($index)"></bk-button>
+                                <bk-button compact="true" glyph="sap-icon--delete" state="transparent" aria-label="Delete" ng-click="delete($index)"></bk-button>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </bk-scrollbar>
+        </div>
+
+        <bk-scrollbar class="bk-full-height" ng-show="!state.error && !state.isBusy && showInnerDialog">
+            <bk-fieldset class="bk-padding--tiny">
+                <bk-form-group>
+                    <bk-form-item>
+                        <bk-form-label for="keyEntity" required="true" colon="true">Entity</bk-form-label>
+                        <bk-select placeholder="Select an entity" label-id="keyEntity" ng-model="editElement.entity" ng-change="entityChanged()" dropdown-fixed="true">
+                            <bk-option text="{{ entity.name }}" value="entity.name" ng-repeat="entity in dataParameters.entities track by entity.name"></bk-option>
+                        </bk-select>
+                    </bk-form-item>
+
+                    <bk-form-item ng-if="editElement.entity">
+                        <bk-form-label colon="true">Properties</bk-form-label>
+                        <div class="bk-vbox">
+                            <div ng-if="propertiesOf(editElement.entity).length === 0">This entity has no properties yet.</div>
+                            <bk-form-item ng-repeat="property in propertiesOf(editElement.entity) track by property">
+                                <bk-checkbox id="prop-{{ property }}" ng-model="editElement.selected[property]"></bk-checkbox>
+                                <bk-checkbox-label for="prop-{{ property }}">{{ property }}</bk-checkbox-label>
+                            </bk-form-item>
+                        </div>
+                    </bk-form-item>
+
+                    <bk-form-item ng-if="editElement.entity">
+                        <bk-form-label colon="true">Constraint name</bk-form-label>
+                        <div class="bk-padding--tiny">{{ derivedName() || '-' }}</div>
+                    </bk-form-item>
+
+                    <bk-form-item ng-if="editElement.entity">
+                        <bk-form-label for="keyMessage" colon="true">Message</bk-form-label>
+                        <bk-input id="keyMessage" type="text" ng-model="editElement.message" placeholder="{{ derivedMessage() }}"></bk-input>
+                    </bk-form-item>
+
+                    <bk-form-item ng-if="validationMessage()">
+                        <div class="bk-padding--tiny">{{ validationMessage() }}</div>
+                    </bk-form-item>
+                </bk-form-group>
+            </bk-fieldset>
+        </bk-scrollbar>
+
+        <bk-bar compact="true" bar-design="footer" in-page="true" ng-show="!state.error && !state.isBusy">
+            <bk-bar-right>
+                <bk-bar-element ng-show="showInnerDialog">
+                    <bk-button label="{{ editElement.editType }}" ng-disabled="!isValid()" state="emphasized" ng-click="innerAction()"></bk-button>
+                </bk-bar-element>
+                <bk-bar-element ng-hide="showInnerDialog">
+                    <bk-button label="Save" state="emphasized" ng-click="save()"></bk-button>
+                </bk-bar-element>
+                <bk-bar-element>
+                    <bk-button label="Cancel" state="transparent" ng-click="cancel()"></bk-button>
+                </bk-bar-element>
+            </bk-bar-right>
+        </bk-bar>
+
+        <bk-message-page glyph="sap-icon--error" ng-if="state.error">
+            <bk-message-page-title>Dialog encountered an error!</bk-message-page-title>
+            <bk-message-page-subtitle>{{errorMessage}}</bk-message-page-subtitle>
+            <bk-message-page-actions>
+                <bk-button compact="true" label="Close" ng-click="cancel()"></bk-button>
+            </bk-message-page-actions>
+        </bk-message-page>
+        <theme></theme>
+    </body>
+
+</html>

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/extensions/unique-keys-window.extension
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/extensions/unique-keys-window.extension
@@ -1,0 +1,5 @@
+{
+    "module": "editor-entity/configs/unique-keys-window.js",
+    "extensionPoint": "platform-windows",
+    "description": "EDM unique keys dialog window"
+}

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/js/editor.js
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/js/editor.js
@@ -1409,9 +1409,10 @@ angular.module('ui.entity-data.modeler', ['blimpKit', 'platformView', 'Workspace
 				if (element.localName === "model") {
 					for (let j = 0; j < element.children.length; j++) {
 						let keys = element.children[j];
-						if (keys.localName === "uniqueKeys") {
+						if (keys.localName === "constraints") {
 							for (let k = 0; k < keys.children.length; k++) {
 								let item = keys.children[k];
+								if (item.localName !== "uniqueKey") continue;
 								let copy = { properties: [] };
 								for (let m = 0; m < item.children.length; m++) {
 									let attribute = item.children[m];

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/js/editor.js
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/js/editor.js
@@ -374,6 +374,18 @@ angular.module('ui.entity-data.modeler', ['blimpKit', 'platformView', 'Workspace
 		});
 
 		dialogHub.addMessageListener({
+			topic: "edmEditor.unique.keys",
+			handler: (data) => {
+				$scope.graph.model.uniqueKeys = data.uniqueKeys;
+				layoutHub.setEditorDirty({
+					path: $scope.dataParameters.filePath,
+					dirty: true,
+				});
+				dialogHub.closeWindow();
+			}
+		});
+
+		dialogHub.addMessageListener({
 			topic: "edmEditor.navigation.details",
 			handler: (data) => {
 				$scope.graph.model.perspectives = data.perspectives;
@@ -1187,6 +1199,18 @@ angular.module('ui.entity-data.modeler', ['blimpKit', 'platformView', 'Workspace
 				$scope.properties = function () {
 					editor.execute('properties');
 				};
+				$scope.uniqueKeys = () => {
+					dialogHub.showWindow({
+						id: 'edmUniqueKeys',
+						hasHeader: false,
+						params: {
+							uniqueKeys: $scope.graph.model.uniqueKeys ? $scope.graph.model.uniqueKeys : [],
+							entities: collectEntitiesWithProperties($scope.graph),
+						},
+						maxWidth: '1200px',
+						closeButton: false
+					});
+				};
 				$scope.navigation = () => {
 					dialogHub.showWindow({
 						id: 'edmNavDetails',
@@ -1262,6 +1286,7 @@ angular.module('ui.entity-data.modeler', ['blimpKit', 'platformView', 'Workspace
 			codec.decode(doc.documentElement.getElementsByTagName('mxGraphModel')[0], $scope.graph.getModel());
 
 			deserializeFilter($scope.graph);
+			loadUniqueKeys(doc, $scope.graph);
 			loadPerspectives(doc, $scope.graph);
 			loadNavigations(doc, $scope.graph);
 			$scope.graph.model.addListener(mxEvent.START_EDIT, function (_sender, _evt) {
@@ -1350,6 +1375,63 @@ angular.module('ui.entity-data.modeler', ['blimpKit', 'platformView', 'Workspace
 
 			if (restyled) {
 				graph.refresh();
+			}
+		}
+
+		/**
+		 * The entities and their property names, for the unique-key dialog to pick from. The dialog is a
+		 * separate window, so it cannot walk the graph itself - it gets a plain snapshot.
+		 */
+		function collectEntitiesWithProperties(graph) {
+			const entities = [];
+			const parent = graph.getDefaultParent();
+			const childCount = graph.model.getChildCount(parent);
+			for (let i = 0; i < childCount; i++) {
+				const child = graph.model.getChildAt(parent, i);
+				if (graph.model.isEdge(child) || !child.value || !child.value.name) continue;
+				const properties = [];
+				const propertyCount = graph.model.getChildCount(child);
+				for (let j = 0; j < propertyCount; j++) {
+					const property = graph.model.getChildAt(child, j).value;
+					if (property && property.name) properties.push(property.name);
+				}
+				entities.push({ name: child.value.name, properties: properties });
+			}
+			return entities;
+		}
+
+		function loadUniqueKeys(doc, graph) {
+			if (!graph.getModel().uniqueKeys) {
+				graph.getModel().uniqueKeys = [];
+			}
+			for (let i = 0; i < doc.children.length; i++) {
+				let element = doc.children[i];
+				if (element.localName === "model") {
+					for (let j = 0; j < element.children.length; j++) {
+						let keys = element.children[j];
+						if (keys.localName === "uniqueKeys") {
+							for (let k = 0; k < keys.children.length; k++) {
+								let item = keys.children[k];
+								let copy = { properties: [] };
+								for (let m = 0; m < item.children.length; m++) {
+									let attribute = item.children[m];
+									if (attribute.localName === "entity") {
+										copy.entity = attribute.textContent;
+									} else if (attribute.localName === "name") {
+										copy.name = attribute.textContent;
+									} else if (attribute.localName === "properties") {
+										copy.properties = attribute.textContent.split(',').map((p) => p.trim()).filter((p) => p.length > 0);
+									} else if (attribute.localName === "message") {
+										copy.message = attribute.textContent;
+									}
+								}
+								graph.getModel().uniqueKeys.push(copy);
+							}
+							break;
+						}
+					}
+					break;
+				}
 			}
 		}
 

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/js/serializer.js
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/js/serializer.js
@@ -287,7 +287,7 @@ function createModel(graph) {
 	// generic mxCodec has only ever encoded scalars. Guarded on a non-empty list so a model without
 	// keys serializes exactly as it did before they existed.
 	if (graph.getModel().uniqueKeys && graph.getModel().uniqueKeys.length > 0) {
-		model.push(' <uniqueKeys>\n');
+		model.push(' <constraints>\n');
 		for (let i = 0; i < graph.getModel().uniqueKeys.length; i++) {
 			const key = graph.getModel().uniqueKeys[i];
 			let element = '  <uniqueKey>';
@@ -298,7 +298,7 @@ function createModel(graph) {
 			element += '</uniqueKey>\n';
 			model.push(element);
 		}
-		model.push(' </uniqueKeys>\n');
+		model.push(' </constraints>\n');
 	}
 
 	if (graph.getModel().perspectives) {

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/js/serializer.js
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/js/serializer.js
@@ -283,6 +283,24 @@ function createModel(graph) {
 
 	model.push(' </entities>\n');
 
+	// Composite business keys, top-level like the perspectives below - never on an entity cell, whose
+	// generic mxCodec has only ever encoded scalars. Guarded on a non-empty list so a model without
+	// keys serializes exactly as it did before they existed.
+	if (graph.getModel().uniqueKeys && graph.getModel().uniqueKeys.length > 0) {
+		model.push(' <uniqueKeys>\n');
+		for (let i = 0; i < graph.getModel().uniqueKeys.length; i++) {
+			const key = graph.getModel().uniqueKeys[i];
+			let element = '  <uniqueKey>';
+			element += `<entity>${_.escape(key.entity)}</entity>`;
+			element += `<name>${_.escape(key.name)}</name>`;
+			element += `<properties>${_.escape((key.properties || []).join(','))}</properties>`;
+			if (key.message) element += `<message>${_.escape(key.message)}</message>`;
+			element += '</uniqueKey>\n';
+			model.push(element);
+		}
+		model.push(' </uniqueKeys>\n');
+	}
+
 	if (graph.getModel().perspectives) {
 		model.push(' <perspectives>\n');
 		for (let i = 0; i < graph.getModel().perspectives.length; i++) {

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/modeler.html
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/modeler.html
@@ -52,6 +52,7 @@
             <bk-button state="transparent" glyph="sap-icon--list" aria-label="Properties" title="Properties" ng-click="properties()"></bk-button>
             <bk-toolbar-separator></bk-toolbar-separator>
             <bk-button state="transparent" glyph="sap-icon--tree" aria-label="Navigation" title="Navigation" ng-click="navigation()"></bk-button>
+            <bk-button state="transparent" glyph="sap-icon--key" aria-label="Unique keys" title="Unique keys" ng-click="uniqueKeys()"></bk-button>
             <bk-toolbar-separator></bk-toolbar-separator>
             <bk-button state="transparent" glyph="sap-icon--delete" aria-label="Delete" title="Delete" ng-click="delete()" ng-disabled="selection.projectionProp"></bk-button>
             <bk-toolbar-separator></bk-toolbar-separator>

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/template/transform-edm.js
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/template/transform-edm.js
@@ -52,6 +52,18 @@ export function transform(workspaceName, projectName, filePath) {
             console.error("Invalid source model: 'entities' element is null");
         }
 
+        // Composite business keys - declared top-level, resolved back onto their entity by name, the
+        // same way a <relation> is. A key the model cannot resolve (a renamed or deleted entity, an
+        // unknown property) is DROPPED rather than emitted: a constraint over a column that is not
+        // there fails the whole schema, and silently doing nothing is the lesser of the two.
+        if (raw.model.uniqueKeys && raw.model.uniqueKeys.uniqueKey) {
+            if (Array.isArray(raw.model.uniqueKeys.uniqueKey)) {
+                raw.model.uniqueKeys.uniqueKey.forEach(key => { transformUniqueKey(key, root.model.entities) });
+            } else {
+                transformUniqueKey(raw.model.uniqueKeys.uniqueKey, root.model.entities);
+            }
+        }
+
         if (raw.model.perspectives) {
             if (raw.model.perspectives.perspective) {
                 if (Array.isArray(raw.model.perspectives.perspective)) {
@@ -104,6 +116,39 @@ export function transform(workspaceName, projectName, filePath) {
             property[propertyName.substring(1, propertyName.length)] = raw[propertyName];
         }
         return property;
+    }
+
+    function transformUniqueKey(raw, entities) {
+        const entity = entities.find(candidate => candidate.name === raw.entity);
+        if (!entity) {
+            console.error("Skipping unique key [" + raw.name + "]: it names no entity [" + raw.entity + "] of this model");
+            return;
+        }
+        const properties = (raw.properties || '').split(',')
+            .map(name => name.trim())
+            .filter(name => name.length > 0);
+        if (properties.length < 2) {
+            console.error("Skipping unique key [" + raw.name + "] of [" + raw.entity + "]: a key spans two or more properties");
+            return;
+        }
+        const columns = [];
+        for (let i = 0; i < properties.length; i++) {
+            const property = entity.properties.find(candidate => candidate.name === properties[i]);
+            if (!property || !property.dataName) {
+                console.error("Skipping unique key [" + raw.name + "] of [" + raw.entity + "]: it names no property [" + properties[i] + "]");
+                return;
+            }
+            columns.push({ name: property.dataName });
+        }
+        if (!entity.uniqueConstraints) {
+            entity.uniqueConstraints = [];
+        }
+        entity.uniqueConstraints.push({
+            name: raw.name,
+            columns: columns,
+            columnsCsv: columns.map(column => column.name).join(','),
+            message: raw.message ? raw.message : 'A ' + raw.entity + ' with the same ' + properties.join(', ') + ' already exists',
+        });
     }
 
     function transformRelation(relation, entities) {

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/template/transform-edm.js
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/template/transform-edm.js
@@ -56,11 +56,11 @@ export function transform(workspaceName, projectName, filePath) {
         // same way a <relation> is. A key the model cannot resolve (a renamed or deleted entity, an
         // unknown property) is DROPPED rather than emitted: a constraint over a column that is not
         // there fails the whole schema, and silently doing nothing is the lesser of the two.
-        if (raw.model.uniqueKeys && raw.model.uniqueKeys.uniqueKey) {
-            if (Array.isArray(raw.model.uniqueKeys.uniqueKey)) {
-                raw.model.uniqueKeys.uniqueKey.forEach(key => { transformUniqueKey(key, root.model.entities) });
+        if (raw.model.constraints && raw.model.constraints.uniqueKey) {
+            if (Array.isArray(raw.model.constraints.uniqueKey)) {
+                raw.model.constraints.uniqueKey.forEach(key => { transformUniqueKey(key, root.model.entities) });
             } else {
-                transformUniqueKey(raw.model.uniqueKeys.uniqueKey, root.model.entities);
+                transformUniqueKey(raw.model.constraints.uniqueKey, root.model.entities);
             }
         }
 

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/EdmUniqueKeyRoundTripIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/EdmUniqueKeyRoundTripIT.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.restassured.path.json.JsonPath;
+
+/**
+ * Saving an {@code .edm} in the EDM modeler regenerates its {@code .model} from the XML - so
+ * whatever the XML cannot say is destroyed by the next save, for any unrelated edit, with nothing
+ * reported (#6795).
+ *
+ * <p>
+ * That is what makes the {@code <uniqueKeys>} section load-bearing rather than cosmetic: a
+ * composite business key authored in an intent has to survive somebody opening the model in the
+ * modeler and pressing Save. This drives the real save endpoint, which fires the real on-save
+ * transformer, and reads the {@code .model} it produced.
+ */
+class EdmUniqueKeyRoundTripIT extends IntegrationTest {
+
+    private static final String WORKSPACE = "edm-unique-key-it";
+    private static final String PROJECT = "provisioning";
+    private static final String FILES = "/services/ide/workspaces/" + WORKSPACE + "/" + PROJECT;
+
+    /** An {@code .edm} in exactly the shape the intent generator emits for a composite key. */
+    private static final String EDM =
+            """
+                    <model>
+                     <entities>
+                      <entity name="TenantApplication" dataName="PROVISIONING_TENANT_APPLICATION" type="PRIMARY" \
+                    title="TenantApplication" caption="Manage entity TenantApplication" tooltip="TenantApplication" \
+                    layoutType="MANAGE_MASTER" perspectiveName="Provisioning">
+                       <property name="Id" dataName="TENANT_APPLICATION_ID" dataType="INTEGER" dataPrimaryKey="true" dataAutoIncrement="true"></property>
+                       <property name="Tenant" dataName="TENANT_APPLICATION_TENANT" dataType="INTEGER"></property>
+                       <property name="Application" dataName="TENANT_APPLICATION_APPLICATION" dataType="INTEGER"></property>
+                      </entity>
+                     </entities>
+                     <uniqueKeys>
+                      <uniqueKey><entity>TenantApplication</entity><name>TenantApplication_Tenant_Application</name>\
+                    <properties>Tenant,Application</properties><message>This application is already provisioned for the tenant</message></uniqueKey>
+                      <uniqueKey><entity>Ghost</entity><name>Ghost_A_B</name><properties>A,B</properties><message>never</message></uniqueKey>
+                     </uniqueKeys>
+                     <perspectives>
+                      <perspective><name>Provisioning</name><label>Provisioning</label><icon>/services/web/resources/unicons/copy.svg</icon><order>1</order></perspective>
+                     </perspectives>
+                     <navigations>
+                     </navigations>
+                     <mxGraphModel></mxGraphModel>
+                    </model>
+                    """;
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @Test
+    void aKeyDeclaredInTheEdmSurvivesTheSaveThatRebuildsTheModel() {
+        restAssuredExecutor.execute(() -> {
+            given().when()
+                   .post("/services/ide/workspaces/" + WORKSPACE)
+                   .then()
+                   .statusCode(anyOfCreatedOrUnchanged());
+            given().when()
+                   .post("/services/ide/workspaces/" + WORKSPACE + "/" + PROJECT)
+                   .then()
+                   .statusCode(anyOfCreatedOrUnchanged());
+
+            // Creating the file and updating it both fire the on-save transformer that rebuilds the
+            // .model, and this exercises the create - a PUT to a file that is not there is a 404.
+            given().contentType("text/plain")
+                   .body(EDM)
+                   .when()
+                   .post(FILES + "/app.edm")
+                   .then()
+                   .statusCode(anyOfOkOrCreated());
+
+            // ...and again through the update path, which is the one a modeler Save actually takes.
+            given().contentType("text/plain")
+                   .body(EDM)
+                   .when()
+                   .put(FILES + "/app.edm")
+                   .then()
+                   .statusCode(anyOfOkOrCreated());
+
+            String model = given().when()
+                                  .get(FILES + "/app.model")
+                                  .then()
+                                  .statusCode(200)
+                                  .extract()
+                                  .asString();
+
+            JsonPath json = JsonPath.from(model);
+            String base = "model.entities.find { it.name == 'TenantApplication' }.uniqueConstraints[0]";
+            assertEquals("TenantApplication_Tenant_Application", json.getString(base + ".name"),
+                    "the key must survive the rebuild - and keep the name the generated controller matches on: " + model);
+            assertEquals("TENANT_APPLICATION_TENANT,TENANT_APPLICATION_APPLICATION", json.getString(base + ".columnsCsv"),
+                    "the declared PROPERTIES must be resolved to their columns, which is what the schema is emitted from");
+            assertEquals("This application is already provisioned for the tenant", json.getString(base + ".message"));
+
+            // The key naming an entity this model does not have is dropped, not carried: a constraint
+            // over a table that is not there fails the whole schema.
+            assertTrue(!model.contains("Ghost_A_B"), "a key whose entity does not resolve must be dropped: " + model);
+        });
+    }
+
+    /** The idempotent creates answer 201 the first time and 304 afterwards. */
+    private static org.hamcrest.Matcher<Integer> anyOfCreatedOrUnchanged() {
+        return org.hamcrest.Matchers.anyOf(org.hamcrest.Matchers.is(201), org.hamcrest.Matchers.is(304), org.hamcrest.Matchers.is(200));
+    }
+
+    private static org.hamcrest.Matcher<Integer> anyOfOkOrCreated() {
+        return org.hamcrest.Matchers.anyOf(org.hamcrest.Matchers.is(200), org.hamcrest.Matchers.is(201), org.hamcrest.Matchers.is(204));
+    }
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/EdmUniqueKeyRoundTripIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/EdmUniqueKeyRoundTripIT.java
@@ -26,7 +26,7 @@ import io.restassured.path.json.JsonPath;
  * reported (#6795).
  *
  * <p>
- * That is what makes the {@code <uniqueKeys>} section load-bearing rather than cosmetic: a
+ * That is what makes the {@code <constraints>} section load-bearing rather than cosmetic: a
  * composite business key authored in an intent has to survive somebody opening the model in the
  * modeler and pressing Save. This drives the real save endpoint, which fires the real on-save
  * transformer, and reads the {@code .model} it produced.
@@ -50,11 +50,11 @@ class EdmUniqueKeyRoundTripIT extends IntegrationTest {
                        <property name="Application" dataName="TENANT_APPLICATION_APPLICATION" dataType="INTEGER"></property>
                       </entity>
                      </entities>
-                     <uniqueKeys>
+                     <constraints>
                       <uniqueKey><entity>TenantApplication</entity><name>TenantApplication_Tenant_Application</name>\
                     <properties>Tenant,Application</properties><message>This application is already provisioned for the tenant</message></uniqueKey>
                       <uniqueKey><entity>Ghost</entity><name>Ghost_A_B</name><properties>A,B</properties><message>never</message></uniqueKey>
-                     </uniqueKeys>
+                     </constraints>
                      <perspectives>
                       <perspective><name>Provisioning</name><label>Provisioning</label><icon>/services/web/resources/unicons/copy.svg</icon><order>1</order></perspective>
                      </perspectives>


### PR DESCRIPTION
Closes #6795.

### Two problems, one of them silent

[#6763](https://github.com/eclipse-dirigible/dirigible/issues/6763) gave an entity a business key spanning more than one column. The intent could declare one; the **modeler could not** — its property dialog offers only the single-column Unique flag.

The second half is worse and is the reason this could not wait. The modeler **regenerates the `.model` from the `.edm` on every save**, and the `.edm` had no representation for such a key. So opening an intent-generated model in the modeler and saving it — for any unrelated edit — dropped every key from the `.model`, and the next generation emitted a table without the constraint. Nothing reported it.

### Why top-level rather than on the entity

The key is a `<uniqueKey>` entry of a top-level `<constraints>` section beside `<perspectives>` and `<navigations>`, **not** nested in the entity, and that is a safety property rather than a style choice.

The modeler renders the canvas by decoding `<mxGraphModel>` and never reads the `<entities>` section. A key held on an entity **cell** would therefore be the first non-scalar value on a path whose generic `mxCodec` — no `mxObjectCodec` is registered for `Entity`/`Property` — has only ever encoded primitives as attributes. A codec that failed to round-trip it would lose the key *silently on reopen*, which is the worst failure mode available here. The perspectives already take the other route: an array on the graph model, loaded from the raw XML by a dedicated function, hand-written back by the serializer, never touched by the codec. This follows them.

Attaching a top-level declaration back to its entity by name is likewise established — `transformRelation` already does exactly that.

### Shape

```xml
<constraints>
  <uniqueKey><entity>TenantApplication</entity><name>TenantApplication_Tenant_Application</name>
    <properties>Tenant,Application</properties><message>This application is already provisioned for the tenant</message></uniqueKey>
</constraints>
```

It names **properties**, not columns, so a later `dataName` change follows the key; `transform-edm.js` resolves them when it rebuilds the `.model`. The constraint name derives as `<Entity>_<Prop>_<Prop>` — the same derivation the intent uses, because the generated controller matches that name against what the database reports on a violation, so both authoring surfaces have to arrive at one name.

A key naming an entity or property the model does not have is **dropped** with an error logged, rather than emitted against a table that is not there.

The dialog is its own window like the navigation one rather than a tab in the entity dialog, since these are rarely authored by hand. It picks the entity, ticks two or more of its properties, shows the derived constraint name, and prefills the message.

### One deviation from the issue

The issue sketched `<keys>` / `<key>`. The section is `<constraints>` and each entry is `<uniqueKey>`: in a data model "keys" reads as primary keys, and naming the section for the KIND of thing it holds means a later constraint kind is a new entry rather than a second top-level section. The loader skips entries it does not recognise, so that later kind can arrive without breaking an older editor.

### Tests

- **`EdmUniqueKeyRoundTripIT`** — the one that protects users. It drives the real save endpoint (both the create and the update path, since a modeler Save takes the update one) and asserts the rebuilt `.model` keeps the key, its resolved columns and its message, and drops the unresolvable one.
- **`EdmEntityUniqueTest`** — the emission side, including that a model *without* keys grows no section at all, so an `.edm` generated before this existed is byte-identical.

678 engine-intent unit tests and the IT green locally.

### Docs

dirigible-io/dirigible-io.github.io#198 — the Entity Data Modeler page gains a *Unique keys* section.
