### PR TITLE
Dependency lockfile, provided-BOM, and shadowing report

### DIFF
--- a/build/application/pom.xml
+++ b/build/application/pom.xml
@@ -293,6 +293,22 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
+                        <!-- the input of the provided-BOM: this module's own resolved runtime
+                             dependencies, which are exactly what spring-boot:repackage packs into
+                             BOOT-INF/lib (never derived by unzipping the assembled artifact - a
+                             reactor-built module's jar does not live at a local-repository path) -->
+                        <id>list-provided-dependencies</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>list</goal>
+                        </goals>
+                        <configuration>
+                            <includeScope>runtime</includeScope>
+                            <sort>true</sort>
+                            <outputFile>${project.build.directory}/provided-dependencies.txt</outputFile>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>unpack-launcher-agent</id>
                         <phase>prepare-package</phase>
                         <goals>
@@ -326,6 +342,27 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
+                    <execution>
+                        <!-- Turns the resolved dependency list into the provided-BOM (a standard
+                             dependencyManagement POM) inside the classes, so it ships embedded in
+                             the artifact as META-INF/dirigible-provided-bom.xml - the resolver reads
+                             it to treat platform-shipped coordinates as provided and to report
+                             shadowing. Runs in prepare-package, before the jar is assembled. -->
+                        <id>generate-provided-bom</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <java classname="org.eclipse.dirigible.components.dependencies.ProvidedBomGenerator" classpathref="maven.runtime.classpath" fork="true" failonerror="true">
+                                    <arg value="${project.build.directory}/provided-dependencies.txt"/>
+                                    <arg value="${project.build.outputDirectory}/META-INF/dirigible-provided-bom.xml"/>
+                                    <arg value="${project.version}"/>
+                                </java>
+                            </target>
+                        </configuration>
+                    </execution>
                     <execution>
                         <!-- The launcher agent's classes must sit at the executable jar's ROOT: the
                              JVM loads the Launcher-Agent-Class through the system classloader before

--- a/build/application/pom.xml
+++ b/build/application/pom.xml
@@ -309,6 +309,28 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <!-- stages the BOM generator on its own: the generator is deliberately
+                             dependency-free, so the forked java below needs only this one jar on
+                             its command line - the full runtime classpath would exceed the Windows
+                             CreateProcess length limit (error=206) -->
+                        <id>copy-bom-generator</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.eclipse.dirigible</groupId>
+                                    <artifactId>dirigible-components-core-dependencies</artifactId>
+                                    <version>${project.version}</version>
+                                    <outputDirectory>${project.build.directory}/bom-generator</outputDirectory>
+                                    <destFileName>bom-generator.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>unpack-launcher-agent</id>
                         <phase>prepare-package</phase>
                         <goals>
@@ -347,7 +369,11 @@
                              dependencyManagement POM) inside the classes, so it ships embedded in
                              the artifact as META-INF/dirigible-provided-bom.xml - the resolver reads
                              it to treat platform-shipped coordinates as provided and to report
-                             shadowing. Runs in prepare-package, before the jar is assembled. -->
+                             shadowing. Runs in prepare-package, before the jar is assembled.
+                             Forked with ONLY the staged generator jar on the classpath: the full
+                             runtime classpath would exceed the Windows CreateProcess command-line
+                             length limit (error=206), and a non-forked java is no alternative -
+                             Ant installs a SecurityManager for it, which JDK 18+ refuses. -->
                         <id>generate-provided-bom</id>
                         <phase>prepare-package</phase>
                         <goals>
@@ -355,7 +381,7 @@
                         </goals>
                         <configuration>
                             <target>
-                                <java classname="org.eclipse.dirigible.components.dependencies.ProvidedBomGenerator" classpathref="maven.runtime.classpath" fork="true" failonerror="true">
+                                <java classname="org.eclipse.dirigible.components.dependencies.ProvidedBomGenerator" classpath="${project.build.directory}/bom-generator/bom-generator.jar" fork="true" failonerror="true">
                                     <arg value="${project.build.directory}/provided-dependencies.txt"/>
                                     <arg value="${project.build.outputDirectory}/META-INF/dirigible-provided-bom.xml"/>
                                     <arg value="${project.version}"/>

--- a/build/application/src/test/java/org/eclipse/dirigible/LauncherAgentDeliveryIT.java
+++ b/build/application/src/test/java/org/eclipse/dirigible/LauncherAgentDeliveryIT.java
@@ -78,7 +78,9 @@ class LauncherAgentDeliveryIT {
     @Test
     void the_executable_jar_carries_the_provided_bom() throws IOException {
         try (JarFile jar = new JarFile(executableJar().toFile())) {
-            ZipEntry bom = jar.getEntry("BOOT-INF/classes/META-INF/dirigible-provided-bom.xml");
+            // the ZIP-layout repackage keeps the original jar's META-INF at the ROOT, where the
+            // system classloader sees it on -jar launches
+            ZipEntry bom = jar.getEntry("META-INF/dirigible-provided-bom.xml");
             assertNotNull(bom, "the provided-BOM must ship inside the artifact - the resolver's shadowing detection reads it");
             String content = new String(jar.getInputStream(bom)
                                            .readAllBytes(),

--- a/build/application/src/test/java/org/eclipse/dirigible/LauncherAgentDeliveryIT.java
+++ b/build/application/src/test/java/org/eclipse/dirigible/LauncherAgentDeliveryIT.java
@@ -76,6 +76,21 @@ class LauncherAgentDeliveryIT {
     }
 
     @Test
+    void the_executable_jar_carries_the_provided_bom() throws IOException {
+        try (JarFile jar = new JarFile(executableJar().toFile())) {
+            ZipEntry bom = jar.getEntry("BOOT-INF/classes/META-INF/dirigible-provided-bom.xml");
+            assertNotNull(bom, "the provided-BOM must ship inside the artifact - the resolver's shadowing detection reads it");
+            String content = new String(jar.getInputStream(bom)
+                                           .readAllBytes(),
+                    StandardCharsets.UTF_8);
+            assertTrue(content.contains("<artifactId>dirigible-provided-bom</artifactId>"),
+                    "the embedded BOM must be the standard dependencyManagement POM");
+            assertTrue(content.contains("<groupId>com.google.code.gson</groupId>"),
+                    "the BOM must enumerate the platform's BOOT-INF/lib inventory");
+        }
+    }
+
+    @Test
     void a_jar_launch_installs_the_agent_before_main() throws IOException, InterruptedException {
         Path workingDirectory = Files.createDirectories(tempDir.resolve("launch"));
         ProcessBuilder builder = new ProcessBuilder("java", "-jar", executableJar().toAbsolutePath()

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ArtifactStatus.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ArtifactStatus.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+/**
+ * The reported status of one artifact in the dependency report - every artifact the endpoint knows
+ * carries exactly one of the {@code STATUS_*} values, so nothing about the dependency layer is ever
+ * silent: shadowing, mediation, integrity failures and frozen-mode rejections all surface here.
+ *
+ * @param coordinate the groupId:artifactId:version coordinate (or the declared id when the
+ *        declaration itself failed)
+ * @param scope module or platform
+ * @param status one of the {@code STATUS_*} values
+ * @param message what happened, operator-readable
+ */
+record ArtifactStatus(String coordinate, String scope, String status, String message) {
+
+    /** Serving in this process. */
+    static final String STATUS_ACTIVE = "active";
+
+    /** Takes effect at the next launch. */
+    static final String STATUS_PENDING_RESTART = "pending-restart";
+
+    /** The platform provides a different version; the declared one is inert. */
+    static final String STATUS_SHADOWED = "shadowed";
+
+    /** More than one version was requested; mediation chose this artifact's. */
+    static final String STATUS_MEDIATED = "mediated";
+
+    /** Not activated - declaration, resolution, integrity or activation failure. */
+    static final String STATUS_FAILED = "failed";
+
+    /** Rejected in frozen mode - the coordinate is not part of the lockfile. */
+    static final String STATUS_FROZEN_MISMATCH = "frozen-mismatch";
+
+    /** The module scope name as reported. */
+    static final String SCOPE_MODULE = "module";
+
+    /** The platform scope name as reported. */
+    static final String SCOPE_PLATFORM = "platform";
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DeclaredDependencies.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DeclaredDependencies.java
@@ -20,12 +20,14 @@ import java.util.stream.Collectors;
  * @param dependencies the declared dependencies in registry order
  * @param errors the declaration errors that never reached resolution (bad coordinate, version
  *        range, unknown scope, ...), keyed by the declared id or the declaring project
+ * @param declaredBy the declaring projects per declared coordinate - the lockfile's
+ *        {@code requestedBy} attribution
  */
-record DeclaredDependencies(Set<MavenDependency> dependencies, Map<String, String> errors) {
+record DeclaredDependencies(Set<MavenDependency> dependencies, Map<String, String> errors, Map<String, Set<String>> declaredBy) {
 
     /**
      * A change-detection fingerprint of the declarations - stable across collection order, different
-     * for any semantic change (coordinate, scope, exclusions, or a declaration error).
+     * for any semantic change (coordinate, scope, exclusions, attribution, or a declaration error).
      *
      * @return the fingerprint
      */
@@ -40,6 +42,11 @@ record DeclaredDependencies(Set<MavenDependency> dependencies, Map<String, Strin
                               .map(entry -> entry.getKey() + "=" + entry.getValue())
                               .sorted()
                               .collect(Collectors.joining(";"));
-        return declared + "||" + failed;
+        String attribution = declaredBy.entrySet()
+                                       .stream()
+                                       .map(entry -> entry.getKey() + "=" + new TreeSet<>(entry.getValue()))
+                                       .sorted()
+                                       .collect(Collectors.joining(";"));
+        return declared + "||" + failed + "||" + attribution;
     }
 }

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesEndpoint.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesEndpoint.java
@@ -52,14 +52,15 @@ class DependenciesEndpoint {
     }
 
     /**
-     * Runs the union resolution on demand.
+     * Runs the union resolution on demand - in frozen mode this re-activates the locked set and
+     * surfaces any declaration the lock does not carry.
      *
      * @return the resolved state
      */
     @PostMapping("resolve")
     @RolesAllowed({"ADMINISTRATOR", "OPERATOR"})
     ResponseEntity<DependenciesState> resolve() {
-        if (!dependenciesService.isDynamicEnabled()) {
+        if (!dependenciesService.isDynamicEnabled() && !dependenciesService.isFrozen()) {
             throw new ResponseStatusException(HttpStatus.CONFLICT,
                     "Dynamic dependency resolution is disabled - set DIRIGIBLE_DEPENDENCIES_DYNAMIC=true to enable it");
         }

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesInitializer.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesInitializer.java
@@ -21,7 +21,9 @@ import org.springframework.stereotype.Component;
  * Resolves the maven dependencies declared across the registry projects at startup - ordered after
  * the synchronization initializer, so the project.json files are present in the registry. The
  * resolved jars are activated through the modules classloader immediately; the run also arms the
- * declaration watcher by recording the first fingerprint.
+ * declaration watcher by recording the first fingerprint. A frozen instance
+ * ({@code DIRIGIBLE_DEPENDENCIES_FROZEN=true}) boots through here too - its activation verifies
+ * every locked artifact's checksum before anything serves.
  */
 @Order(ApplicationReadyEventListeners.DEPENDENCIES_INITIALIZER)
 @Component
@@ -48,7 +50,7 @@ class DependenciesInitializer implements ApplicationListener<ApplicationReadyEve
      */
     @Override
     public void onApplicationEvent(ApplicationReadyEvent event) {
-        if (!dependenciesService.isDynamicEnabled()) {
+        if (!dependenciesService.isDynamicEnabled() && !dependenciesService.isFrozen()) {
             LOGGER.debug("Dynamic dependency resolution is disabled");
             return;
         }

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesService.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesService.java
@@ -271,7 +271,7 @@ class DependenciesService {
             return state(true, declared, List.of(), Map.of(), Map.of(LOCKFILE_FAILURE_KEY, message), List.of(), report, localRepository);
         }
 
-        FrozenPlan plan = FrozenResolution.plan(lockfile.get(), declared, localRepository);
+        FrozenPlan plan = FrozenResolution.plan(lockfile.get(), declared, localRepository, ProvidedBom.fromClasspath());
         List<Path> platformArtifacts = plan.artifacts(ArtifactStatus.SCOPE_PLATFORM);
         List<PlatformScopeInstaller.PlatformArtifactState> platformStates =
                 platformArtifacts.isEmpty() ? List.of() : platformScopeInstaller.install(localRepository, platformArtifacts);
@@ -302,6 +302,11 @@ class DependenciesService {
 
         List<ArtifactStatus> report = new ArrayList<>();
         reportDeclarationErrors(declared, report);
+        plan.shadowed()
+            .forEach(shadowed -> report.add(shadowedStatus(shadowed, null)));
+        plan.provided()
+            .forEach(coordinate -> report.add(new ArtifactStatus(coordinate, null, ArtifactStatus.STATUS_ACTIVE,
+                    "Provided by the platform - satisfied without a download")));
         plan.mismatched()
             .forEach(coordinate -> report.add(new ArtifactStatus(coordinate, null, ArtifactStatus.STATUS_FROZEN_MISMATCH, plan.failures()
                                                                                                                               .get(coordinate))));
@@ -447,6 +452,19 @@ class DependenciesService {
     }
 
     /**
+     * The status of one shadowed declaration.
+     *
+     * @param shadowed the shadowed declaration
+     * @param scope the scope name, null when unknown
+     * @return the status
+     */
+    private static ArtifactStatus shadowedStatus(ResolutionResult.Shadowed shadowed, String scope) {
+        return new ArtifactStatus(shadowed.groupArtifact() + ":" + shadowed.requested(), scope, ArtifactStatus.STATUS_SHADOWED,
+                "requested: " + shadowed.requested() + ", provided: " + shadowed.providedVersion()
+                        + " - parent-first delegation serves the platform's version; the declared version is inert");
+    }
+
+    /**
      * Reports the declaration errors.
      *
      * @param declared the declared dependencies
@@ -472,9 +490,7 @@ class DependenciesService {
     private void reportResolution(ResolutionResult result, List<ResolvedArtifact> verified, Map<String, String> integrityFailures,
             boolean swapped, String scope, List<ArtifactStatus> report) {
         result.shadowed()
-              .forEach(shadowed -> report.add(new ArtifactStatus(shadowed.groupArtifact() + ":" + shadowed.requested(), scope,
-                      ArtifactStatus.STATUS_SHADOWED, "requested: " + shadowed.requested() + ", provided: " + shadowed.providedVersion()
-                              + " - parent-first delegation serves the platform's version; the declared version is inert")));
+              .forEach(shadowed -> report.add(shadowedStatus(shadowed, scope)));
         result.provided()
               .forEach(coordinate -> report.add(new ArtifactStatus(coordinate, scope, ArtifactStatus.STATUS_ACTIVE,
                       "Provided by the platform - satisfied without a download")));

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesService.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesService.java
@@ -9,29 +9,39 @@
  */
 package org.eclipse.dirigible.components.dependencies;
 
+import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.commons.config.DirigibleConfig;
 import org.eclipse.dirigible.components.dependencies.DependencySynchronizer.SwapOutcome;
+import org.eclipse.dirigible.components.dependencies.FrozenResolution.FrozenPlan;
+import org.eclipse.dirigible.components.dependencies.ResolutionResult.ResolvedArtifact;
 import org.eclipse.dirigible.engine.java.runtime.ModulesClassLoaderHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Orchestrates the declare - resolve - activate flow: collects the maven declarations of all
- * registry projects, resolves their union into the local repository and reconciles the resolved
+ * Orchestrates the declare - resolve - verify - activate flow: collects the maven declarations of
+ * all registry projects, resolves their union into the local repository, verifies every artifact
+ * against the lockfile's recorded SHA-256 before anything activates, and reconciles the verified
  * JARs into the running system through the {@link DependencySynchronizer} - a dependency change
- * takes effect without restarting the platform. The resolved-modules directory is still maintained
- * as the launch-time seed.
+ * takes effect without restarting the platform. Every fully clean resolution rewrites the lockfile;
+ * in frozen mode ({@code DIRIGIBLE_DEPENDENCIES_FROZEN=true}) the lockfile IS the resolution and no
+ * remote repository is ever consulted. The resolved-modules directory is still maintained as the
+ * launch-time seed.
  */
 @Component
 class DependenciesService {
@@ -41,6 +51,9 @@ class DependenciesService {
     /** The failures key carrying a swap abort. */
     private static final String SWAP_FAILURE_KEY = "modules-swap";
 
+    /** The failures key carrying a frozen boot without a lockfile. */
+    private static final String LOCKFILE_FAILURE_KEY = "project-lock.json";
+
     /** The collector. */
     private final ProjectDependenciesCollector collector;
 
@@ -49,6 +62,9 @@ class DependenciesService {
 
     /** The linker. */
     private final ResolvedModulesLinker linker;
+
+    /** The lockfile store. */
+    private final LockfileStore lockfileStore;
 
     /** The dependency synchronizer. */
     private final DependencySynchronizer dependencySynchronizer;
@@ -71,16 +87,18 @@ class DependenciesService {
      * @param collector the collector
      * @param resolver the resolver
      * @param linker the linker
+     * @param lockfileStore the lockfile store
      * @param dependencySynchronizer the dependency synchronizer
      * @param platformScopeInstaller the platform scope installer
      * @param loaderHolder the loader holder
      */
     DependenciesService(ProjectDependenciesCollector collector, DependencyResolver resolver, ResolvedModulesLinker linker,
-            DependencySynchronizer dependencySynchronizer, PlatformScopeInstaller platformScopeInstaller,
+            LockfileStore lockfileStore, DependencySynchronizer dependencySynchronizer, PlatformScopeInstaller platformScopeInstaller,
             ModulesClassLoaderHolder loaderHolder) {
         this.collector = collector;
         this.resolver = resolver;
         this.linker = linker;
+        this.lockfileStore = lockfileStore;
         this.dependencySynchronizer = dependencySynchronizer;
         this.platformScopeInstaller = platformScopeInstaller;
         this.loaderHolder = loaderHolder;
@@ -96,6 +114,15 @@ class DependenciesService {
     }
 
     /**
+     * Whether the instance runs in frozen mode.
+     *
+     * @return true when frozen
+     */
+    boolean isFrozen() {
+        return DirigibleConfig.DEPENDENCIES_FROZEN.getBooleanValue();
+    }
+
+    /**
      * The fingerprint of the declarations the last resolution processed - the watcher compares the
      * registry against it.
      *
@@ -106,36 +133,84 @@ class DependenciesService {
     }
 
     /**
-     * Runs the resolution of both dependency tiers and reconciles the results into the running system -
-     * the platform tier (appended to the system classloader) first, then the module tier (the swappable
-     * modules classloader). A failure on one tier never aborts the other; on any module-tier failure
-     * the installed modules-classloader generation keeps serving.
+     * Runs the resolution of both dependency tiers and reconciles the results into the running system.
+     * In frozen mode the activated set comes from the lockfile alone; otherwise the union is resolved,
+     * verified against the lockfile and activated - the platform tier (appended to the system
+     * classloader) first, then the module tier (the swappable modules classloader). A failure on one
+     * tier never aborts the other; on any module-tier failure the installed modules-classloader
+     * generation keeps serving.
      *
      * @return the resolved state
      */
     synchronized DependenciesState resolveAndActivate() {
         DeclaredDependencies declared = collector.collect();
         lastDeclaredFingerprint = declared.fingerprint();
-        Set<MavenDependency> platformDeclared = scoped(declared, MavenDependency.Scope.PLATFORM);
-        Set<MavenDependency> moduleDeclared = scoped(declared, MavenDependency.Scope.MODULE);
         Path localRepository = MavenResolverConfig.fromConfiguration()
                                                   .localRepository();
+        DependenciesState state = isFrozen() ? activateFrozen(declared, localRepository) : resolveDynamic(declared, localRepository);
+        lastState.set(state);
+        LOGGER.info(
+                "Maven dependency {} completed: [{}] declared, [{}] jar(s) activated, [{}] platform-scoped, [{}] mediated,"
+                        + " [{}] failure(s), classloader generation [{}]",
+                state.frozen() ? "frozen activation" : "resolution", state.declared()
+                                                                          .size(),
+                state.artifacts()
+                     .size(),
+                state.platform()
+                     .size(),
+                state.mediated()
+                     .size(),
+                state.failures()
+                     .size(),
+                state.classLoaderGeneration());
+        return state;
+    }
+
+    /**
+     * The dynamic flow: resolve both tiers, verify every resolved artifact against the lockfile's
+     * recorded checksum, activate the verified set and - only after a fully clean pass - rewrite the
+     * lockfile.
+     *
+     * @param declared the declared dependencies
+     * @param localRepository the local repository
+     * @return the state
+     */
+    private DependenciesState resolveDynamic(DeclaredDependencies declared, Path localRepository) {
+        Set<MavenDependency> platformDeclared = scoped(declared, MavenDependency.Scope.PLATFORM);
+        Set<MavenDependency> moduleDeclared = scoped(declared, MavenDependency.Scope.MODULE);
 
         // platform tier - append-only system-classloader additions; its failures never gate the
         // module swap
-        ResolutionResult platformResult =
-                platformDeclared.isEmpty() ? new ResolutionResult(List.of(), Map.of(), Map.of()) : resolver.resolve(platformDeclared);
-        List<PlatformScopeInstaller.PlatformArtifactState> platformStates =
-                platformDeclared.isEmpty() ? List.of() : platformScopeInstaller.install(localRepository, platformResult.artifacts());
-
-        // module tier - gated on the declaration errors and its own resolution failures only
+        ResolutionResult platformResult = platformDeclared.isEmpty() ? ResolutionResult.empty() : resolver.resolve(platformDeclared);
         ResolutionResult moduleResult = resolver.resolve(moduleDeclared);
+
+        // integrity: every resolved artifact is hashed, and one the lockfile already records must
+        // match the recorded SHA-256 - a mismatch is a hard per-artifact failure, the artifact is
+        // not activated and its seed link is evicted so no later launch picks it up either
+        Optional<Lockfile> lockfile = lockfileStore.read();
+        Map<String, String> hashes = new LinkedHashMap<>();
+        Map<String, String> integrityFailures = new LinkedHashMap<>();
+        List<ResolvedArtifact> verifiedModule = verify(moduleResult.resolved(), lockfile, hashes, integrityFailures);
+        List<ResolvedArtifact> verifiedPlatform = verify(platformResult.resolved(), lockfile, hashes, integrityFailures);
+        moduleResult.resolved()
+                    .stream()
+                    .filter(artifact -> integrityFailures.containsKey(artifact.coordinate()))
+                    .forEach(artifact -> linker.remove(localRepository, artifact.path()));
+        platformResult.resolved()
+                      .stream()
+                      .filter(artifact -> integrityFailures.containsKey(artifact.coordinate()))
+                      .forEach(artifact -> linker.remove(localRepository, artifact.path()));
+
+        List<PlatformScopeInstaller.PlatformArtifactState> platformStates =
+                verifiedPlatform.isEmpty() ? List.of() : platformScopeInstaller.install(localRepository, paths(verifiedPlatform));
+
+        // module tier - gated on the declaration errors and its own resolution failures only; an
+        // integrity failure is per-artifact by design (the verified rest still activates)
         Map<String, String> moduleGate = new LinkedHashMap<>(declared.errors());
         moduleGate.putAll(moduleResult.failures());
         SwapOutcome outcome;
         if (moduleGate.isEmpty()) {
-            outcome = dependencySynchronizer.swap(localRepository, moduleResult.artifacts(), platformResult.artifacts(),
-                    moduleResult.mediated());
+            outcome = dependencySynchronizer.swap(localRepository, paths(verifiedModule), paths(verifiedPlatform), moduleResult.mediated());
         } else {
             outcome = SwapOutcome.kept(null);
             LOGGER.error("Not swapping the dependency layer: [{}] declaration/resolution failure(s) - the installed generation keeps "
@@ -145,47 +220,344 @@ class DependenciesService {
         Map<String, String> failures = new LinkedHashMap<>(declared.errors());
         failures.putAll(platformResult.failures());
         failures.putAll(moduleResult.failures());
+        failures.putAll(integrityFailures);
         if (outcome.error() != null) {
             failures.put(SWAP_FAILURE_KEY, outcome.error());
         }
 
         // both tiers seed the next launch's classpath through the resolved-modules directory;
         // stale links are removed only after a fully clean pass
-        List<Path> allArtifacts = new ArrayList<>(moduleResult.artifacts());
-        for (Path artifact : platformResult.artifacts()) {
-            if (!allArtifacts.contains(artifact)) {
-                allArtifacts.add(artifact);
-            }
+        List<ResolvedArtifact> allArtifacts = union(verifiedModule, verifiedPlatform);
+        linker.sync(localRepository, paths(allArtifacts), failures.isEmpty());
+
+        // the lockfile records only fully clean resolutions - a partial pass must never launder a
+        // failed or tampered artifact into the trusted set
+        if (failures.isEmpty()) {
+            lockfileStore.write(buildLockfile(declared, moduleResult, platformResult, verifiedModule, verifiedPlatform, hashes));
         }
-        linker.sync(localRepository, allArtifacts, failures.isEmpty());
 
         Map<String, String> mediated = new LinkedHashMap<>(moduleResult.mediated());
         mediated.putAll(platformResult.mediated());
 
-        DependenciesState state = new DependenciesState(isDynamicEnabled(), declared.dependencies()
-                                                                                    .stream()
-                                                                                    .map(MavenDependency::coordinate)
-                                                                                    .toList(),
-                allArtifacts.stream()
-                            .map(Path::toString)
-                            .toList(),
-                mediated, failures, platformStates, localRepository.toString(), linker.directory()
-                                                                                      .toString(),
+        List<ArtifactStatus> report = new ArrayList<>();
+        reportDeclarationErrors(declared, report);
+        reportResolution(moduleResult, verifiedModule, integrityFailures, outcome.swapped(), ArtifactStatus.SCOPE_MODULE, report);
+        reportResolution(platformResult, List.of(), integrityFailures, outcome.swapped(), ArtifactStatus.SCOPE_PLATFORM, report);
+        platformStates.forEach(state -> report.add(
+                new ArtifactStatus(state.coordinate(), ArtifactStatus.SCOPE_PLATFORM, state.status(), state.message())));
+
+        return state(false, declared, paths(allArtifacts), mediated, failures, platformStates, report, localRepository);
+    }
+
+    /**
+     * The frozen flow: the lockfile is the resolution - every locked artifact is checksum-verified from
+     * the local repository and activated, every declaration the lock does not carry is rejected, and no
+     * remote repository is ever consulted.
+     *
+     * @param declared the declared dependencies
+     * @param localRepository the local repository
+     * @return the state
+     */
+    private DependenciesState activateFrozen(DeclaredDependencies declared, Path localRepository) {
+        Optional<Lockfile> lockfile = lockfileStore.read();
+        if (lockfile.isEmpty()) {
+            String message = "DIRIGIBLE_DEPENDENCIES_FROZEN=true but there is no lockfile at [" + lockfileStore.path()
+                    + "] - nothing is activated in frozen mode without a lock. Run one dynamic resolution to produce it.";
+            LOGGER.error("Frozen-mode activation failed: {}", message);
+            List<ArtifactStatus> report = new ArrayList<>();
+            declared.dependencies()
+                    .forEach(dependency -> report.add(new ArtifactStatus(dependency.coordinate(), scopeName(dependency),
+                            ArtifactStatus.STATUS_FROZEN_MISMATCH, message)));
+            return state(true, declared, List.of(), Map.of(), Map.of(LOCKFILE_FAILURE_KEY, message), List.of(), report, localRepository);
+        }
+
+        FrozenPlan plan = FrozenResolution.plan(lockfile.get(), declared, localRepository);
+        List<Path> platformArtifacts = plan.artifacts(ArtifactStatus.SCOPE_PLATFORM);
+        List<PlatformScopeInstaller.PlatformArtifactState> platformStates =
+                platformArtifacts.isEmpty() ? List.of() : platformScopeInstaller.install(localRepository, platformArtifacts);
+
+        Map<String, String> moduleGate = new LinkedHashMap<>(declared.errors());
+        SwapOutcome outcome;
+        if (moduleGate.isEmpty()) {
+            outcome =
+                    dependencySynchronizer.swap(localRepository, plan.artifacts(ArtifactStatus.SCOPE_MODULE), platformArtifacts, Map.of());
+        } else {
+            outcome = SwapOutcome.kept(null);
+            LOGGER.error("Not swapping the dependency layer: [{}] declaration failure(s) - the installed generation keeps serving."
+                    + " Failures: {}", moduleGate.size(), moduleGate);
+        }
+
+        Map<String, String> failures = new LinkedHashMap<>(declared.errors());
+        failures.putAll(plan.failures());
+        if (outcome.error() != null) {
+            failures.put(SWAP_FAILURE_KEY, outcome.error());
+        }
+
+        List<Path> allArtifacts = new ArrayList<>(plan.activations()
+                                                      .stream()
+                                                      .map(FrozenResolution.LockedActivation::path)
+                                                      .distinct()
+                                                      .toList());
+        linker.sync(localRepository, allArtifacts, failures.isEmpty());
+
+        List<ArtifactStatus> report = new ArrayList<>();
+        reportDeclarationErrors(declared, report);
+        plan.mismatched()
+            .forEach(coordinate -> report.add(new ArtifactStatus(coordinate, null, ArtifactStatus.STATUS_FROZEN_MISMATCH, plan.failures()
+                                                                                                                              .get(coordinate))));
+        plan.failures()
+            .entrySet()
+            .stream()
+            .filter(failure -> !plan.mismatched()
+                                    .contains(failure.getKey()))
+            .forEach(failure -> report.add(new ArtifactStatus(failure.getKey(), null, ArtifactStatus.STATUS_FAILED, failure.getValue())));
+        for (FrozenResolution.LockedActivation activation : plan.activations()) {
+            if (ArtifactStatus.SCOPE_PLATFORM.equals(activation.artifact()
+                                                               .scope())) {
+                continue; // reported through the platform installer's own state
+            }
+            report.add(activated(activation.artifact()
+                                           .id(),
+                    ArtifactStatus.SCOPE_MODULE, activation.path(), outcome.swapped(), "Activated from the lockfile, checksum verified"));
+        }
+        platformStates.forEach(state -> report.add(
+                new ArtifactStatus(state.coordinate(), ArtifactStatus.SCOPE_PLATFORM, state.status(), state.message())));
+
+        return state(true, declared, allArtifacts, Map.of(), failures, platformStates, report, localRepository);
+    }
+
+    /**
+     * Verifies resolved artifacts against the lockfile - every artifact is hashed (the hash also feeds
+     * the next lockfile write), and one the lock records must match the recorded SHA-256.
+     *
+     * @param resolved the resolved artifacts
+     * @param lockfile the lockfile, when present
+     * @param hashes the computed hashes per coordinate, added to
+     * @param failures the integrity failures per coordinate, added to
+     * @return the verified artifacts
+     */
+    private List<ResolvedArtifact> verify(List<ResolvedArtifact> resolved, Optional<Lockfile> lockfile, Map<String, String> hashes,
+            Map<String, String> failures) {
+        List<ResolvedArtifact> verified = new ArrayList<>();
+        for (ResolvedArtifact artifact : resolved) {
+            String hash;
+            try {
+                hash = LockfileStore.sha256(artifact.path());
+            } catch (IOException e) {
+                failures.put(artifact.coordinate(),
+                        "The resolved artifact [" + artifact.coordinate() + "] is unreadable: " + e.getMessage());
+                LOGGER.error("Integrity verification failed: the resolved artifact [{}] at [{}] is unreadable", artifact.coordinate(),
+                        artifact.path(), e);
+                continue;
+            }
+            hashes.put(artifact.coordinate(), hash);
+            Optional<Lockfile.LockedArtifact> locked = lockfile.flatMap(lock -> lock.artifact(artifact.coordinate()));
+            if (locked.isPresent() && !locked.get()
+                                             .sha256()
+                                             .equals(hash)) {
+                failures.put(artifact.coordinate(), "Checksum mismatch for [" + artifact.coordinate() + "]: expected [" + locked.get()
+                                                                                                                                .sha256()
+                        + "], found [" + hash + "] - the artifact changed since it was locked; not activated");
+                LOGGER.error("Integrity verification failed: checksum mismatch for [{}] at [{}] - the artifact is not activated",
+                        artifact.coordinate(), artifact.path());
+                continue;
+            }
+            verified.add(artifact);
+        }
+        return verified;
+    }
+
+    /**
+     * Builds the lockfile of a fully clean resolution - artifacts and mediations sorted, so two locks
+     * diff line by line.
+     *
+     * @param declared the declared dependencies
+     * @param moduleResult the module-tier resolution
+     * @param platformResult the platform-tier resolution
+     * @param verifiedModule the verified module-tier artifacts
+     * @param verifiedPlatform the verified platform-tier artifacts
+     * @param hashes the computed hashes per coordinate
+     * @return the lockfile
+     */
+    private Lockfile buildLockfile(DeclaredDependencies declared, ResolutionResult moduleResult, ResolutionResult platformResult,
+            List<ResolvedArtifact> verifiedModule, List<ResolvedArtifact> verifiedPlatform, Map<String, String> hashes) {
+        List<Lockfile.LockedArtifact> artifacts = new ArrayList<>();
+        lockArtifacts(verifiedModule, ArtifactStatus.SCOPE_MODULE, declared, hashes, artifacts);
+        lockArtifacts(verifiedPlatform, ArtifactStatus.SCOPE_PLATFORM, declared, hashes, artifacts);
+        artifacts.sort(Comparator.comparing(Lockfile.LockedArtifact::id)
+                                 .thenComparing(Lockfile.LockedArtifact::scope));
+
+        Map<String, Set<String>> requestedVersions = new TreeMap<>(moduleResult.requestedVersions());
+        requestedVersions.putAll(platformResult.requestedVersions());
+        Map<String, String> mediated = new LinkedHashMap<>(moduleResult.mediated());
+        mediated.putAll(platformResult.mediated());
+        List<Lockfile.LockedMediation> mediations = new ArrayList<>();
+        requestedVersions.forEach((groupArtifact, versions) -> {
+            String chosen = mediated.get(groupArtifact);
+            if (chosen == null) {
+                return;
+            }
+            List<String> rejected = versions.stream()
+                                            .filter(version -> !version.equals(chosen))
+                                            .sorted()
+                                            .toList();
+            Map<String, List<String>> requestedBy = new TreeMap<>();
+            versions.forEach(version -> {
+                Set<String> projects = declared.declaredBy()
+                                               .get(groupArtifact + ":" + version);
+                if (projects != null) {
+                    requestedBy.put(version, projects.stream()
+                                                     .sorted()
+                                                     .toList());
+                }
+            });
+            mediations.add(new Lockfile.LockedMediation(groupArtifact, chosen, rejected, requestedBy));
+        });
+
+        String platformVersion = Configuration.get("DIRIGIBLE_PRODUCT_VERSION", "unknown");
+        return new Lockfile(Instant.now()
+                                   .toString(),
+                platformVersion, artifacts, mediations);
+    }
+
+    /**
+     * Locks one tier's verified artifacts.
+     *
+     * @param verified the verified artifacts
+     * @param scope the tier's scope name
+     * @param declared the declared dependencies, for the requestedBy attribution
+     * @param hashes the computed hashes per coordinate
+     * @param artifacts the lock entries to add to
+     */
+    private void lockArtifacts(List<ResolvedArtifact> verified, String scope, DeclaredDependencies declared, Map<String, String> hashes,
+            List<Lockfile.LockedArtifact> artifacts) {
+        for (ResolvedArtifact artifact : verified) {
+            List<String> requestedBy = null;
+            if (artifact.via() == null) {
+                Set<String> projects = declared.declaredBy()
+                                               .get(artifact.coordinate());
+                requestedBy = projects == null ? List.of()
+                        : projects.stream()
+                                  .sorted()
+                                  .toList();
+            }
+            artifacts.add(new Lockfile.LockedArtifact(artifact.coordinate(), hashes.get(artifact.coordinate()), requestedBy, artifact.via(),
+                    scope));
+        }
+    }
+
+    /**
+     * Reports the declaration errors.
+     *
+     * @param declared the declared dependencies
+     * @param report the report to add to
+     */
+    private void reportDeclarationErrors(DeclaredDependencies declared, List<ArtifactStatus> report) {
+        declared.errors()
+                .forEach((coordinate, message) -> report.add(new ArtifactStatus(coordinate, null, ArtifactStatus.STATUS_FAILED, message)));
+    }
+
+    /**
+     * Reports one tier's resolution: shadowed and provided declarations, resolution failures, and - for
+     * the module tier - the per-artifact activation outcome.
+     *
+     * @param result the resolution result
+     * @param verified the verified artifacts to report activation for (empty for the platform tier,
+     *        whose activation the installer reports itself)
+     * @param integrityFailures the integrity failures per coordinate
+     * @param swapped whether the swap installed a new generation
+     * @param scope the tier's scope name
+     * @param report the report to add to
+     */
+    private void reportResolution(ResolutionResult result, List<ResolvedArtifact> verified, Map<String, String> integrityFailures,
+            boolean swapped, String scope, List<ArtifactStatus> report) {
+        result.shadowed()
+              .forEach(shadowed -> report.add(new ArtifactStatus(shadowed.groupArtifact() + ":" + shadowed.requested(), scope,
+                      ArtifactStatus.STATUS_SHADOWED, "requested: " + shadowed.requested() + ", provided: " + shadowed.providedVersion()
+                              + " - parent-first delegation serves the platform's version; the declared version is inert")));
+        result.provided()
+              .forEach(coordinate -> report.add(new ArtifactStatus(coordinate, scope, ArtifactStatus.STATUS_ACTIVE,
+                      "Provided by the platform - satisfied without a download")));
+        result.failures()
+              .forEach((coordinate, message) -> report.add(new ArtifactStatus(coordinate, scope, ArtifactStatus.STATUS_FAILED, message)));
+        result.resolved()
+              .stream()
+              .filter(artifact -> integrityFailures.containsKey(artifact.coordinate()))
+              .forEach(artifact -> report.add(new ArtifactStatus(artifact.coordinate(), scope, ArtifactStatus.STATUS_FAILED,
+                      integrityFailures.get(artifact.coordinate()))));
+        for (ResolvedArtifact artifact : verified) {
+            String groupArtifact = artifact.coordinate()
+                                           .substring(0, artifact.coordinate()
+                                                                 .lastIndexOf(':'));
+            String origin = artifact.via() == null ? "declared" : "via " + artifact.via();
+            if (result.mediated()
+                      .containsKey(groupArtifact)) {
+                report.add(new ArtifactStatus(artifact.coordinate(), scope, ArtifactStatus.STATUS_MEDIATED,
+                        "Version mediation chose [" + result.mediated()
+                                                            .get(groupArtifact)
+                                + "] out of the requested versions " + result.requestedVersions()
+                                                                             .get(groupArtifact)
+                                + "; " + origin));
+                continue;
+            }
+            report.add(activated(artifact.coordinate(), scope, artifact.path(), swapped, capitalize(origin)));
+        }
+    }
+
+    /**
+     * The activation status of one module-tier artifact - active when it is part of the currently
+     * installed generation, failed otherwise (the swap that would have activated it was aborted).
+     *
+     * @param coordinate the coordinate
+     * @param scope the scope name
+     * @param path the jar path
+     * @param swapped whether the swap installed a new generation
+     * @param activeMessage the message when active
+     * @return the status
+     */
+    private ArtifactStatus activated(String coordinate, String scope, Path path, boolean swapped, String activeMessage) {
+        if (swapped || loaderHolder.current()
+                                   .jars()
+                                   .contains(path)) {
+            return new ArtifactStatus(coordinate, scope, ArtifactStatus.STATUS_ACTIVE, activeMessage);
+        }
+        return new ArtifactStatus(coordinate, scope, ArtifactStatus.STATUS_FAILED,
+                "Resolved but not activated - the swap was aborted; see failures");
+    }
+
+    /**
+     * Assembles the reported state.
+     *
+     * @param frozen whether the state comes from a frozen activation
+     * @param declared the declared dependencies
+     * @param artifacts the activated jar paths
+     * @param mediated the mediated versions
+     * @param failures the failures
+     * @param platformStates the platform-tier activation states
+     * @param report the per-artifact report
+     * @param localRepository the local repository
+     * @return the state
+     */
+    private DependenciesState state(boolean frozen, DeclaredDependencies declared, List<Path> artifacts, Map<String, String> mediated,
+            Map<String, String> failures, List<PlatformScopeInstaller.PlatformArtifactState> platformStates, List<ArtifactStatus> report,
+            Path localRepository) {
+        Map<String, List<String>> declaredBy = new LinkedHashMap<>();
+        declared.declaredBy()
+                .forEach((coordinate, projects) -> declaredBy.put(coordinate, projects.stream()
+                                                                                      .sorted()
+                                                                                      .toList()));
+        return new DependenciesState(isDynamicEnabled(), frozen, declared.dependencies()
+                                                                         .stream()
+                                                                         .map(MavenDependency::coordinate)
+                                                                         .toList(),
+                declaredBy, artifacts.stream()
+                                     .map(Path::toString)
+                                     .toList(),
+                mediated, failures, platformStates, report, localRepository.toString(), linker.directory()
+                                                                                              .toString(),
+                lockfileStore.path()
+                             .toString(),
                 loaderHolder.generation(), loaderHolder.retiredGenerationsLive(), Instant.now());
-        lastState.set(state);
-        LOGGER.info(
-                "Maven dependency resolution completed: [{}] declared, [{}] jar(s) {}, [{}] platform-scoped, [{}] mediated, "
-                        + "[{}] failure(s), classloader generation [{}]",
-                state.declared()
-                     .size(),
-                state.artifacts()
-                     .size(),
-                outcome.swapped() ? "active" : "resolved (generation kept)", platformStates.size(), state.mediated()
-                                                                                                         .size(),
-                state.failures()
-                     .size(),
-                state.classLoaderGeneration());
-        return state;
     }
 
     /**
@@ -206,6 +578,56 @@ class DependenciesService {
     }
 
     /**
+     * The reported scope name of one declaration.
+     *
+     * @param dependency the declaration
+     * @return the scope name
+     */
+    private static String scopeName(MavenDependency dependency) {
+        return dependency.scope() == MavenDependency.Scope.PLATFORM ? ArtifactStatus.SCOPE_PLATFORM : ArtifactStatus.SCOPE_MODULE;
+    }
+
+    /**
+     * The union of both tiers' artifacts, first occurrence wins.
+     *
+     * @param module the module-tier artifacts
+     * @param platform the platform-tier artifacts
+     * @return the union
+     */
+    private static List<ResolvedArtifact> union(List<ResolvedArtifact> module, List<ResolvedArtifact> platform) {
+        List<ResolvedArtifact> union = new ArrayList<>(module);
+        Set<Path> seen = new LinkedHashSet<>(paths(module));
+        for (ResolvedArtifact artifact : platform) {
+            if (seen.add(artifact.path())) {
+                union.add(artifact);
+            }
+        }
+        return union;
+    }
+
+    /**
+     * The paths of the artifacts.
+     *
+     * @param artifacts the artifacts
+     * @return the paths
+     */
+    private static List<Path> paths(List<ResolvedArtifact> artifacts) {
+        return artifacts.stream()
+                        .map(ResolvedArtifact::path)
+                        .toList();
+    }
+
+    /**
+     * Capitalizes the first character.
+     *
+     * @param value the value
+     * @return the capitalized value
+     */
+    private static String capitalize(String value) {
+        return value.isEmpty() ? value : Character.toUpperCase(value.charAt(0)) + value.substring(1);
+    }
+
+    /**
      * The current declared / resolved state.
      *
      * @return the state
@@ -213,10 +635,12 @@ class DependenciesService {
     DependenciesState getState() {
         DependenciesState state = lastState.get();
         if (state == null) {
-            return DependenciesState.empty(isDynamicEnabled(), linker.directory()
-                                                                     .toString());
+            return DependenciesState.empty(isDynamicEnabled(), isFrozen(), linker.directory()
+                                                                                 .toString(),
+                    lockfileStore.path()
+                                 .toString());
         }
-        return state.refreshed(isDynamicEnabled(), loaderHolder.generation(), loaderHolder.retiredGenerationsLive());
+        return state.refreshed(isDynamicEnabled(), isFrozen(), loaderHolder.generation(), loaderHolder.retiredGenerationsLive());
     }
 
 }

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesState.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesState.java
@@ -17,46 +17,55 @@ import java.util.Map;
  * The declared / resolved dependency state the endpoint reports.
  *
  * @param enabled whether dynamic dependency resolution is enabled on this instance
+ * @param frozen whether the instance runs in frozen mode (the lockfile is the resolution)
  * @param declared the declared coordinates
+ * @param declaredBy the declaring projects per declared coordinate
  * @param artifacts the resolved jar paths inside the local repository
  * @param mediated the versions chosen where more than one was requested, keyed by
  *        groupId:artifactId
  * @param failures the per-coordinate failure messages
  * @param platform the per-artifact activation states of the platform-scoped dependencies
+ * @param report the per-artifact status report - every artifact carries one of active,
+ *        pending-restart, shadowed, mediated, failed or frozen-mismatch
  * @param localRepository the local repository, null before the first resolution
  * @param resolvedModulesDirectory the directory the resolved jars are linked into (the launch-time
  *        seed; at runtime the jars are served by the modules classloader directly)
+ * @param lockfile the lockfile path
  * @param classLoaderGeneration the installed modules-classloader generation number
  * @param retiredClassLoaders how many retired generations are still pinned by live references
  * @param resolvedAt when the state was resolved, null before the first resolution
  */
-record DependenciesState(boolean enabled, List<String> declared, List<String> artifacts, Map<String, String> mediated,
-        Map<String, String> failures, List<PlatformScopeInstaller.PlatformArtifactState> platform, String localRepository,
-        String resolvedModulesDirectory, int classLoaderGeneration, int retiredClassLoaders, Instant resolvedAt) {
+record DependenciesState(boolean enabled, boolean frozen, List<String> declared, Map<String, List<String>> declaredBy,
+        List<String> artifacts, Map<String, String> mediated, Map<String, String> failures,
+        List<PlatformScopeInstaller.PlatformArtifactState> platform, List<ArtifactStatus> report, String localRepository,
+        String resolvedModulesDirectory, String lockfile, int classLoaderGeneration, int retiredClassLoaders, Instant resolvedAt) {
 
     /**
      * The state before the first resolution.
      *
      * @param enabled whether dynamic dependency resolution is enabled
+     * @param frozen whether the instance runs in frozen mode
      * @param resolvedModulesDirectory the resolved-modules directory
+     * @param lockfile the lockfile path
      * @return the empty state
      */
-    static DependenciesState empty(boolean enabled, String resolvedModulesDirectory) {
-        return new DependenciesState(enabled, List.of(), List.of(), Map.of(), Map.of(), List.of(), null, resolvedModulesDirectory, 0, 0,
-                null);
+    static DependenciesState empty(boolean enabled, boolean frozen, String resolvedModulesDirectory, String lockfile) {
+        return new DependenciesState(enabled, frozen, List.of(), Map.of(), List.of(), Map.of(), Map.of(), List.of(), List.of(), null,
+                resolvedModulesDirectory, lockfile, 0, 0, null);
     }
 
     /**
-     * The same state with the enabled flag and the classloader counters re-read.
+     * The same state with the mode flags and the classloader counters re-read.
      *
-     * @param enabled the current flag value
+     * @param enabled the current enabled flag value
+     * @param frozen the current frozen flag value
      * @param classLoaderGeneration the current generation number
      * @param retiredClassLoaders the current pinned retired-generation count
      * @return the state
      */
-    DependenciesState refreshed(boolean enabled, int classLoaderGeneration, int retiredClassLoaders) {
-        return new DependenciesState(enabled, declared, artifacts, mediated, failures, platform, localRepository, resolvedModulesDirectory,
-                classLoaderGeneration, retiredClassLoaders, resolvedAt);
+    DependenciesState refreshed(boolean enabled, boolean frozen, int classLoaderGeneration, int retiredClassLoaders) {
+        return new DependenciesState(enabled, frozen, declared, declaredBy, artifacts, mediated, failures, platform, report,
+                localRepository, resolvedModulesDirectory, lockfile, classLoaderGeneration, retiredClassLoaders, resolvedAt);
     }
 
 }

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesWatcher.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesWatcher.java
@@ -49,7 +49,7 @@ class DependenciesWatcher {
      */
     @Scheduled(initialDelay = 10_000, fixedDelay = 5_000)
     void watch() {
-        if (!dependenciesService.isDynamicEnabled()) {
+        if (!dependenciesService.isDynamicEnabled() && !dependenciesService.isFrozen()) {
             return;
         }
         String last = dependenciesService.lastDeclaredFingerprint();

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/FrozenResolution.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/FrozenResolution.java
@@ -49,8 +49,11 @@ final class FrozenResolution {
      *        the lock), keyed by coordinate
      * @param mismatched the declared coordinates the lock does not carry - reported as
      *        {@code frozen-mismatch}
+     * @param provided the declared coordinates the platform provides at the declared version
+     * @param shadowed the declared coordinates the platform provides at a different version
      */
-    record FrozenPlan(List<LockedActivation> activations, Map<String, String> failures, Set<String> mismatched) {
+    record FrozenPlan(List<LockedActivation> activations, Map<String, String> failures, Set<String> mismatched, List<String> provided,
+            List<ResolutionResult.Shadowed> shadowed) {
 
         /**
          * The activations of one scope.
@@ -78,21 +81,40 @@ final class FrozenResolution {
 
     /**
      * Plans the frozen activation - verifies every locked artifact against the local repository and
-     * rejects every declaration the lock does not carry.
+     * rejects every declaration the lock does not carry. A declaration the platform provides is never a
+     * mismatch: it was never lockable in the first place, and the embedded provided-BOM answers without
+     * any network - a provided one is satisfied, a different-version one stays a loud {@code shadowed}
+     * report exactly as in dynamic mode.
      *
      * @param lockfile the lockfile
      * @param declared the declared dependencies
      * @param localRepository the local repository the locked artifacts must already live in
+     * @param bom the provided-BOM
      * @return the plan
      */
-    static FrozenPlan plan(Lockfile lockfile, DeclaredDependencies declared, Path localRepository) {
+    static FrozenPlan plan(Lockfile lockfile, DeclaredDependencies declared, Path localRepository, ProvidedBom bom) {
         Map<String, String> failures = new LinkedHashMap<>();
         Set<String> mismatched = new LinkedHashSet<>();
+        List<String> provided = new ArrayList<>();
+        List<ResolutionResult.Shadowed> shadowed = new ArrayList<>();
 
         Set<String> lockedIds = new LinkedHashSet<>();
         lockfile.artifacts()
                 .forEach(artifact -> lockedIds.add(artifact.id()));
         for (MavenDependency dependency : declared.dependencies()) {
+            String[] parts = dependency.coordinate()
+                                       .split(":", -1);
+            String providedVersion = bom.providedVersion(parts[0] + ":" + parts[1]);
+            if (providedVersion != null) {
+                if (providedVersion.equals(parts[2])) {
+                    provided.add(dependency.coordinate());
+                } else {
+                    shadowed.add(new ResolutionResult.Shadowed(parts[0] + ":" + parts[1], parts[2], providedVersion));
+                    LOGGER.warn("Declared [{}:{}] is SHADOWED: requested [{}], the platform provides [{}] - parent-first delegation"
+                            + " serves the platform's version", parts[0], parts[1], parts[2], providedVersion);
+                }
+                continue;
+            }
             if (!lockedIds.contains(dependency.coordinate())) {
                 String message = "Declared as [" + dependency.coordinate() + "] but not part of [project-lock.json] - frozen mode"
                         + " (DIRIGIBLE_DEPENDENCIES_FROZEN=true) activates the locked set only. Unfreeze the instance or rebuild the"
@@ -131,7 +153,7 @@ final class FrozenResolution {
             }
             activations.add(new LockedActivation(artifact, jar));
         }
-        return new FrozenPlan(activations, failures, mismatched);
+        return new FrozenPlan(activations, failures, mismatched, provided, shadowed);
     }
 
     /**

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/FrozenResolution.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/FrozenResolution.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Frozen-mode resolution ({@code DIRIGIBLE_DEPENDENCIES_FROZEN=true}): the activated set comes from
+ * the lockfile alone. No remote repository is consulted, no version is re-mediated and no new
+ * coordinate is accepted - a declaration the lock does not carry is rejected with a
+ * {@code frozen-mismatch}, and every locked artifact is activated only after its SHA-256 matches
+ * the recorded one. This is the boot gate immutable production images run: same lockfile, same
+ * bytes, or a loud per-artifact failure.
+ */
+final class FrozenResolution {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FrozenResolution.class);
+
+    /**
+     * Instantiates are not needed.
+     */
+    private FrozenResolution() {
+        // utility
+    }
+
+    /**
+     * The frozen activation plan.
+     *
+     * @param activations the checksum-verified locked artifacts and their local-repository paths
+     * @param failures the per-coordinate failures (missing file, checksum mismatch, coordinate not in
+     *        the lock), keyed by coordinate
+     * @param mismatched the declared coordinates the lock does not carry - reported as
+     *        {@code frozen-mismatch}
+     */
+    record FrozenPlan(List<LockedActivation> activations, Map<String, String> failures, Set<String> mismatched) {
+
+        /**
+         * The activations of one scope.
+         *
+         * @param scope the scope name (module or platform)
+         * @return the jar paths in lock order
+         */
+        List<Path> artifacts(String scope) {
+            return activations.stream()
+                              .filter(activation -> scope.equals(activation.artifact()
+                                                                           .scope()))
+                              .map(LockedActivation::path)
+                              .toList();
+        }
+    }
+
+    /**
+     * One verified locked artifact.
+     *
+     * @param artifact the lock entry
+     * @param path the jar path inside the local repository
+     */
+    record LockedActivation(Lockfile.LockedArtifact artifact, Path path) {
+    }
+
+    /**
+     * Plans the frozen activation - verifies every locked artifact against the local repository and
+     * rejects every declaration the lock does not carry.
+     *
+     * @param lockfile the lockfile
+     * @param declared the declared dependencies
+     * @param localRepository the local repository the locked artifacts must already live in
+     * @return the plan
+     */
+    static FrozenPlan plan(Lockfile lockfile, DeclaredDependencies declared, Path localRepository) {
+        Map<String, String> failures = new LinkedHashMap<>();
+        Set<String> mismatched = new LinkedHashSet<>();
+
+        Set<String> lockedIds = new LinkedHashSet<>();
+        lockfile.artifacts()
+                .forEach(artifact -> lockedIds.add(artifact.id()));
+        for (MavenDependency dependency : declared.dependencies()) {
+            if (!lockedIds.contains(dependency.coordinate())) {
+                String message = "Declared as [" + dependency.coordinate() + "] but not part of [project-lock.json] - frozen mode"
+                        + " (DIRIGIBLE_DEPENDENCIES_FROZEN=true) activates the locked set only. Unfreeze the instance or rebuild the"
+                        + " lock with a dynamic resolution to add or change dependencies.";
+                mismatched.add(dependency.coordinate());
+                failures.put(dependency.coordinate(), message);
+                LOGGER.error("Frozen-mode mismatch: {}", message);
+            }
+        }
+
+        List<LockedActivation> activations = new ArrayList<>();
+        for (Lockfile.LockedArtifact artifact : lockfile.artifacts()) {
+            Path jar = artifactPath(localRepository, artifact.id());
+            if (jar == null) {
+                failures.put(artifact.id(), "The locked coordinate [" + artifact.id() + "] is not a valid groupId:artifactId:version");
+                continue;
+            }
+            if (!Files.isRegularFile(jar)) {
+                failures.put(artifact.id(),
+                        "The locked artifact [" + artifact.id() + "] is missing from the local repository [" + jar + "] - not activated");
+                LOGGER.error("Frozen-mode activation failed: the locked artifact [{}] is missing from [{}]", artifact.id(), jar);
+                continue;
+            }
+            try {
+                String actual = LockfileStore.sha256(jar);
+                if (!actual.equals(artifact.sha256())) {
+                    failures.put(artifact.id(), "Checksum mismatch for the locked artifact [" + artifact.id() + "]: expected ["
+                            + artifact.sha256() + "], found [" + actual + "] - not activated");
+                    LOGGER.error("Frozen-mode activation failed: checksum mismatch for [{}] at [{}]", artifact.id(), jar);
+                    continue;
+                }
+            } catch (IOException e) {
+                failures.put(artifact.id(), "The locked artifact [" + artifact.id() + "] is unreadable: " + e.getMessage());
+                LOGGER.error("Frozen-mode activation failed: the locked artifact [{}] at [{}] is unreadable", artifact.id(), jar, e);
+                continue;
+            }
+            activations.add(new LockedActivation(artifact, jar));
+        }
+        return new FrozenPlan(activations, failures, mismatched);
+    }
+
+    /**
+     * The local-repository jar path of a locked coordinate.
+     *
+     * @param localRepository the local repository
+     * @param coordinate the groupId:artifactId:version coordinate
+     * @return the path, null when the coordinate is malformed
+     */
+    private static Path artifactPath(Path localRepository, String coordinate) {
+        String[] parts = coordinate.split(":", -1);
+        if (parts.length != 3 || parts[0].isBlank() || parts[1].isBlank() || parts[2].isBlank()) {
+            return null;
+        }
+        return localRepository.resolve(parts[0].replace('.', '/'))
+                              .resolve(parts[1])
+                              .resolve(parts[2])
+                              .resolve(parts[1] + "-" + parts[2] + ".jar");
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/Lockfile.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/Lockfile.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * The dependency lockfile ({@code project-lock.json}) - the reproducibility record of one union
+ * resolution. Written after every fully clean resolution, verified before every activation, and in
+ * frozen mode ({@code DIRIGIBLE_DEPENDENCIES_FROZEN=true}) it IS the resolution: the activated set
+ * comes from here alone, checksum-verified, without consulting any remote repository.
+ *
+ * <p>
+ * The lock is instance-level, not per-project: the union resolution mediates versions across all
+ * registry projects, so only one file can faithfully record the outcome. Reviewability comes from
+ * the per-artifact attribution instead - a root artifact carries the projects that requested it
+ * ({@code requestedBy}), a transitive one the declared root that pulled it in ({@code via}) - and
+ * from the deterministic, sorted serialization, which keeps the diff between two locks reviewable.
+ *
+ * @param resolvedAt when the recorded resolution completed, ISO-8601
+ * @param platform the platform version the resolution ran on
+ * @param artifacts the activated artifacts in sorted order
+ * @param mediated the version mediations of the recorded resolution, in sorted order
+ */
+record Lockfile(String resolvedAt, String platform, List<LockedArtifact> artifacts, List<LockedMediation> mediated) {
+
+    /**
+     * Copies the collections defensively.
+     *
+     * @param resolvedAt when the recorded resolution completed
+     * @param platform the platform version
+     * @param artifacts the activated artifacts
+     * @param mediated the version mediations
+     */
+    Lockfile {
+        artifacts = artifacts == null ? List.of() : List.copyOf(artifacts);
+        mediated = mediated == null ? List.of() : List.copyOf(mediated);
+    }
+
+    /**
+     * One activated artifact.
+     *
+     * @param id the groupId:artifactId:version coordinate
+     * @param sha256 the SHA-256 of the jar, hex
+     * @param requestedBy the projects declaring the artifact, null for a transitive one
+     * @param via the declared root that pulled the artifact in, null for a declared root
+     * @param scope module or platform
+     */
+    record LockedArtifact(String id, String sha256, List<String> requestedBy, String via, String scope) {
+    }
+
+    /**
+     * One version mediation.
+     *
+     * @param id the groupId:artifactId
+     * @param chosen the version mediation chose
+     * @param rejected the requested versions mediation rejected
+     * @param requestedBy the projects directly declaring each version, keyed by version; empty for
+     *        purely transitive requests
+     */
+    record LockedMediation(String id, String chosen, List<String> rejected, Map<String, List<String>> requestedBy) {
+    }
+
+    /**
+     * The locked artifact with the given coordinate.
+     *
+     * @param coordinate the groupId:artifactId:version coordinate
+     * @return the artifact, empty when the lock does not carry it
+     */
+    Optional<LockedArtifact> artifact(String coordinate) {
+        return artifacts.stream()
+                        .filter(artifact -> artifact.id()
+                                                    .equals(coordinate))
+                        .findFirst();
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/LockfileStore.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/LockfileStore.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Optional;
+
+/**
+ * Reads and writes the dependency lockfile - the configured path or {@code project-lock.json}
+ * inside the resolved-modules directory, so baking that one directory into an image carries the
+ * whole reproducibility bundle (the seed jars plus the lock that verifies them).
+ *
+ * <p>
+ * The serialization is deliberately deterministic (sorted artifacts, stable field order, pretty
+ * printed), so two locks diff line by line - the reviewability the lockfile exists for.
+ */
+@Component
+class LockfileStore {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LockfileStore.class);
+
+    /** The lockfile name inside the resolved-modules directory. */
+    private static final String LOCKFILE_NAME = "project-lock.json";
+
+    /**
+     * A plain Gson - the shared helpers exclude fields without {@code @Expose} and would silently
+     * serialize nothing.
+     */
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting()
+                                                      .disableHtmlEscaping()
+                                                      .create();
+
+    /** The linker owning the resolved-modules directory the default path derives from. */
+    private final ResolvedModulesLinker linker;
+
+    /**
+     * Instantiates a new lockfile store.
+     *
+     * @param linker the resolved-modules linker
+     */
+    LockfileStore(ResolvedModulesLinker linker) {
+        this.linker = linker;
+    }
+
+    /**
+     * The lockfile path - the configured location or {@code project-lock.json} inside the
+     * resolved-modules directory.
+     *
+     * @return the path
+     */
+    Path path() {
+        String configured = DirigibleConfig.DEPENDENCIES_LOCKFILE.getStringValue();
+        if (configured != null && !configured.isBlank()) {
+            return Path.of(configured);
+        }
+        return linker.directory()
+                     .resolve(LOCKFILE_NAME);
+    }
+
+    /**
+     * Reads the lockfile.
+     *
+     * @return the lockfile, empty when absent or unreadable
+     */
+    Optional<Lockfile> read() {
+        Path path = path();
+        if (!Files.isRegularFile(path)) {
+            return Optional.empty();
+        }
+        try {
+            Lockfile lockfile = GSON.fromJson(Files.readString(path, StandardCharsets.UTF_8), Lockfile.class);
+            return Optional.ofNullable(lockfile);
+        } catch (IOException | JsonParseException e) {
+            LOGGER.error("The lockfile [{}] is unreadable - it is ignored until the next clean resolution rewrites it", path, e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Writes the lockfile.
+     *
+     * @param lockfile the lockfile
+     */
+    void write(Lockfile lockfile) {
+        Path path = path();
+        try {
+            Files.createDirectories(path.getParent());
+            Files.writeString(path, GSON.toJson(lockfile), StandardCharsets.UTF_8);
+            LOGGER.info("Lockfile [{}] written: [{}] artifact(s), [{}] mediation(s)", path, lockfile.artifacts()
+                                                                                                    .size(),
+                    lockfile.mediated()
+                            .size());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write the lockfile [" + path + "]", e);
+        }
+    }
+
+    /**
+     * The SHA-256 of a file, hex.
+     *
+     * @param file the file
+     * @return the digest
+     * @throws IOException when the file is unreadable
+     */
+    static String sha256(Path file) throws IOException {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is mandated by every JVM", e);
+        }
+        try (InputStream in = Files.newInputStream(file)) {
+            byte[] buffer = new byte[64 * 1024];
+            int read;
+            while ((read = in.read(buffer)) >= 0) {
+                digest.update(buffer, 0, read);
+            }
+        }
+        return HexFormat.of()
+                        .formatHex(digest.digest());
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/MavenDependencyResolver.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/MavenDependencyResolver.java
@@ -24,7 +24,9 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.collection.CollectResult;
+import org.eclipse.aether.collection.DependencyCollectionContext;
 import org.eclipse.aether.collection.DependencyCollectionException;
+import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.graph.Exclusion;
@@ -40,18 +42,22 @@ import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.supplier.RepositorySystemSupplier;
 import org.eclipse.aether.util.artifact.JavaScopes;
+import org.eclipse.aether.util.graph.selector.AndDependencySelector;
 import org.eclipse.aether.util.graph.transformer.ConflictResolver;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
 import org.eclipse.aether.util.repository.DefaultAuthenticationSelector;
 import org.eclipse.aether.util.repository.DefaultMirrorSelector;
 import org.eclipse.aether.util.repository.DefaultProxySelector;
 import org.eclipse.dirigible.components.dependencies.MavenResolverConfig.MavenRepository;
+import org.eclipse.dirigible.components.dependencies.ResolutionResult.ResolvedArtifact;
+import org.eclipse.dirigible.components.dependencies.ResolutionResult.Shadowed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -63,7 +69,10 @@ import java.util.stream.Collectors;
 /**
  * The {@link DependencyResolver} over the Apache Maven Artifact Resolver - coordinates are taken
  * programmatically (no POM generation, no external mvn binary) and resolved in one union collect
- * request so Maven's standard version mediation applies globally.
+ * request so Maven's standard version mediation applies globally. Every coordinate the
+ * {@link ProvidedBom} lists is treated as provided - never downloaded, pruned from the graph - and
+ * a declared coordinate the platform provides at a different version is reported as shadowed (see
+ * {@link ProvidedBom} for why the report, not child-first loading, is the feature).
  */
 @Component
 class MavenDependencyResolver implements DependencyResolver {
@@ -73,24 +82,30 @@ class MavenDependencyResolver implements DependencyResolver {
     /** The configuration source - read on every resolution so runtime changes take effect. */
     private final Supplier<MavenResolverConfig> configSupplier;
 
+    /** The provided-BOM source - what the platform image already ships. */
+    private final Supplier<ProvidedBom> bomSupplier;
+
     /** The repository system - thread-safe and configuration-independent, created once. */
     private final RepositorySystem repositorySystem;
 
     /**
-     * Instantiates the resolver reading its configuration from the environment.
+     * Instantiates the resolver reading its configuration from the environment and the provided-BOM
+     * from the classpath.
      */
     MavenDependencyResolver() {
-        this(MavenResolverConfig::fromConfiguration);
+        this(MavenResolverConfig::fromConfiguration, ProvidedBom::fromClasspath);
     }
 
     /**
-     * Instantiates the resolver with an explicit configuration source - the constructor the unit tests
-     * use to point at file-based fixture repositories.
+     * Instantiates the resolver with explicit configuration and provided-BOM sources - the constructor
+     * the unit tests use to point at file-based fixture repositories.
      *
      * @param configSupplier the configuration source
+     * @param bomSupplier the provided-BOM source
      */
-    MavenDependencyResolver(Supplier<MavenResolverConfig> configSupplier) {
+    MavenDependencyResolver(Supplier<MavenResolverConfig> configSupplier, Supplier<ProvidedBom> bomSupplier) {
         this.configSupplier = configSupplier;
+        this.bomSupplier = bomSupplier;
         this.repositorySystem = new RepositorySystemSupplier().get();
     }
 
@@ -111,9 +126,12 @@ class MavenDependencyResolver implements DependencyResolver {
     @Override
     public ResolutionResult resolve(Set<MavenDependency> declared) {
         Map<String, String> failures = new LinkedHashMap<>();
-        List<MavenDependency> resolvable = new ArrayList<>(declared);
+        ProvidedBom bom = bomSupplier.get();
+        List<String> provided = new ArrayList<>();
+        List<Shadowed> shadowed = new ArrayList<>();
+        List<MavenDependency> resolvable = partition(declared, bom, provided, shadowed);
         if (resolvable.isEmpty()) {
-            return new ResolutionResult(List.of(), Map.of(), failures);
+            return new ResolutionResult(List.of(), Map.of(), Map.of(), failures, provided, shadowed);
         }
 
         // the collect request merges duplicate groupId:artifactId root dependencies before conflict
@@ -130,7 +148,7 @@ class MavenDependencyResolver implements DependencyResolver {
         }
 
         MavenResolverConfig config = configSupplier.get();
-        DefaultRepositorySystemSession session = newSession(config);
+        DefaultRepositorySystemSession session = newSession(config, bom);
         List<RemoteRepository> repositories = remoteRepositories(session, config);
         String repositoriesDescription = describe(repositories);
         LOGGER.info("Resolving [{}] declared maven dependency(ies) from repositories [{}] into local repository [{}]", resolvable.size(),
@@ -145,28 +163,70 @@ class MavenDependencyResolver implements DependencyResolver {
                     repositoriesDescription, e);
             resolvable.forEach(
                     dependency -> failures.putIfAbsent(dependency.coordinate(), "Dependency graph collection failed: " + e.getMessage()));
-            return new ResolutionResult(List.of(), Map.of(), failures);
+            return new ResolutionResult(List.of(), Map.of(), Map.of(), failures, provided, shadowed);
         }
 
         Map<String, String> winnerVersions = new LinkedHashMap<>();
         List<DependencyNode> winners = new ArrayList<>();
-        walk(collectResult.getRoot(), requestedVersions, winnerVersions, winners);
+        Map<DependencyNode, String> winnerVia = new IdentityHashMap<>();
+        walk(collectResult.getRoot(), null, requestedVersions, winnerVersions, winners, winnerVia);
 
-        List<Path> artifacts = resolveArtifacts(session, winners, failures, repositoriesDescription);
+        List<ResolvedArtifact> resolved = resolveArtifacts(session, winners, winnerVia, failures, repositoriesDescription);
         Map<String, String> mediated = mediated(requestedVersions, winnerVersions);
-        mediated.forEach((ga, version) -> LOGGER.info("Version mediation chose [{}:{}] out of the requested versions {}", ga, version,
-                requestedVersions.get(ga)));
-        return new ResolutionResult(artifacts, mediated, failures);
+        Map<String, Set<String>> contested = new LinkedHashMap<>();
+        mediated.forEach((ga, version) -> {
+            contested.put(ga, requestedVersions.get(ga));
+            LOGGER.info("Version mediation chose [{}:{}] out of the requested versions {}", ga, version, requestedVersions.get(ga));
+        });
+        return new ResolutionResult(resolved, mediated, contested, failures, provided, shadowed);
+    }
+
+    /**
+     * Partitions the declared dependencies against the provided-BOM: a coordinate the platform provides
+     * at the declared version is satisfied without a download, one it provides at a different version
+     * is reported as shadowed (parent-first delegation would serve the platform's version anyway), and
+     * everything else proceeds to resolution.
+     *
+     * @param declared the declared dependencies
+     * @param bom the provided-BOM
+     * @param provided the platform-satisfied coordinates to add to
+     * @param shadowed the shadowed declarations to add to
+     * @return the dependencies to resolve
+     */
+    private List<MavenDependency> partition(Set<MavenDependency> declared, ProvidedBom bom, List<String> provided,
+            List<Shadowed> shadowed) {
+        List<MavenDependency> resolvable = new ArrayList<>();
+        for (MavenDependency dependency : declared) {
+            String[] parts = dependency.coordinate()
+                                       .split(":", -1);
+            String groupArtifact = parts[0] + ":" + parts[1];
+            String providedVersion = bom.providedVersion(groupArtifact);
+            if (providedVersion == null) {
+                resolvable.add(dependency);
+            } else if (providedVersion.equals(parts[2])) {
+                provided.add(dependency.coordinate());
+                LOGGER.info("Declared [{}] is provided by the platform - satisfied without a download", dependency.coordinate());
+            } else {
+                shadowed.add(new Shadowed(groupArtifact, parts[2], providedVersion));
+                LOGGER.warn(
+                        "Declared [{}] is SHADOWED: requested [{}], the platform provides [{}] - parent-first delegation serves"
+                                + " the platform's version, so the declared version is inert and is not downloaded",
+                        groupArtifact, parts[2], providedVersion);
+            }
+        }
+        return resolvable;
     }
 
     /**
      * Creates the session - local repository, offline mode, verbose conflict resolution (so version
-     * mediation is reportable) and the settings.xml mirror / proxy / server selectors.
+     * mediation is reportable), the settings.xml mirror / proxy / server selectors and the provided-BOM
+     * pruning selector.
      *
      * @param config the configuration
+     * @param bom the provided-BOM
      * @return the session
      */
-    private DefaultRepositorySystemSession newSession(MavenResolverConfig config) {
+    private DefaultRepositorySystemSession newSession(MavenResolverConfig config, ProvidedBom bom) {
         DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
         session.setLocalRepositoryManager(repositorySystem.newLocalRepositoryManager(session, new LocalRepository(config.localRepository()
                                                                                                                         .toFile())));
@@ -177,6 +237,11 @@ class MavenDependencyResolver implements DependencyResolver {
         // remote repositories are instance-level operator configuration - a repository declared
         // inside a dependency's POM must not redirect where artifacts are downloaded from
         session.setIgnoreArtifactDescriptorRepositories(true);
+        if (!bom.isEmpty()) {
+            // a platform-provided transitive is pruned with its subtree - the platform already
+            // carries what its own version needs, exactly like Maven's provided scope
+            session.setDependencySelector(new AndDependencySelector(session.getDependencySelector(), new ProvidedPruningSelector(bom)));
+        }
         Settings settings = readSettings(config.settingsXml());
         if (settings != null) {
             session.setMirrorSelector(mirrorSelector(settings));
@@ -184,6 +249,54 @@ class MavenDependencyResolver implements DependencyResolver {
             session.setAuthenticationSelector(authenticationSelector(settings));
         }
         return session;
+    }
+
+    /**
+     * Prunes platform-provided coordinates from the dependency graph - they are never downloaded and
+     * never enter the modules tier; at runtime parent-first delegation serves the platform's copy.
+     */
+    private static final class ProvidedPruningSelector implements DependencySelector {
+
+        /** The provided-BOM. */
+        private final ProvidedBom bom;
+
+        /**
+         * Instantiates a new selector.
+         *
+         * @param bom the provided-BOM
+         */
+        private ProvidedPruningSelector(ProvidedBom bom) {
+            this.bom = bom;
+        }
+
+        /**
+         * Select dependency.
+         *
+         * @param dependency the dependency
+         * @return false when the platform provides the coordinate
+         */
+        @Override
+        public boolean selectDependency(Dependency dependency) {
+            Artifact artifact = dependency.getArtifact();
+            String providedVersion = bom.providedVersion(artifact.getGroupId() + ":" + artifact.getArtifactId());
+            if (providedVersion == null) {
+                return true;
+            }
+            LOGGER.debug("Transitive [{}:{}:{}] is provided by the platform as [{}] - pruned from the graph", artifact.getGroupId(),
+                    artifact.getArtifactId(), artifact.getVersion(), providedVersion);
+            return false;
+        }
+
+        /**
+         * Derive child selector.
+         *
+         * @param context the context
+         * @return this selector - the decision is context-free
+         */
+        @Override
+        public DependencySelector deriveChildSelector(DependencyCollectionContext context) {
+            return this;
+        }
     }
 
     /**
@@ -214,15 +327,18 @@ class MavenDependencyResolver implements DependencyResolver {
     /**
      * Walks the verbose dependency graph - conflict losers are retained as leaves carrying the winner
      * reference, so both the winners (the classpath) and every requested version (the mediation report)
-     * come out of one walk.
+     * come out of one walk. Each winner is attributed to the declared root whose subtree it was first
+     * seen in, so the lockfile can record how a transitive artifact entered the classpath.
      *
      * @param node the node whose children are walked
+     * @param via the declared root owning this subtree, null at the graph root
      * @param requestedVersions all requested versions per groupId:artifactId
      * @param winnerVersions the winning version per groupId:artifactId
      * @param winners the winner nodes in graph order
+     * @param winnerVia the declared root per winner node, absent for the roots themselves
      */
-    private void walk(DependencyNode node, Map<String, Set<String>> requestedVersions, Map<String, String> winnerVersions,
-            List<DependencyNode> winners) {
+    private void walk(DependencyNode node, String via, Map<String, Set<String>> requestedVersions, Map<String, String> winnerVersions,
+            List<DependencyNode> winners, Map<DependencyNode, String> winnerVia) {
         for (DependencyNode child : node.getChildren()) {
             Artifact artifact = child.getArtifact();
             if (artifact == null) {
@@ -237,8 +353,12 @@ class MavenDependencyResolver implements DependencyResolver {
             }
             if (winnerVersions.putIfAbsent(ga, artifact.getVersion()) == null && isClasspathScope(child)) {
                 winners.add(child);
+                if (via != null) {
+                    winnerVia.put(child, via);
+                }
             }
-            walk(child, requestedVersions, winnerVersions, winners);
+            String childVia = via != null ? via : ga + ":" + artifact.getVersion();
+            walk(child, childVia, requestedVersions, winnerVersions, winners, winnerVia);
         }
     }
 
@@ -260,12 +380,13 @@ class MavenDependencyResolver implements DependencyResolver {
      *
      * @param session the session
      * @param winners the winner nodes
+     * @param winnerVia the declared root per winner node
      * @param failures the per-coordinate failures to add to
      * @param repositoriesDescription the repositories, for the error log
-     * @return the resolved jar paths
+     * @return the resolved artifacts
      */
-    private List<Path> resolveArtifacts(RepositorySystemSession session, List<DependencyNode> winners, Map<String, String> failures,
-            String repositoriesDescription) {
+    private List<ResolvedArtifact> resolveArtifacts(RepositorySystemSession session, List<DependencyNode> winners,
+            Map<DependencyNode, String> winnerVia, Map<String, String> failures, String repositoriesDescription) {
         List<ArtifactRequest> requests = winners.stream()
                                                 .map(ArtifactRequest::new)
                                                 .toList();
@@ -275,12 +396,15 @@ class MavenDependencyResolver implements DependencyResolver {
         } catch (ArtifactResolutionException e) {
             results = e.getResults();
         }
-        List<Path> artifacts = new ArrayList<>();
+        List<ResolvedArtifact> artifacts = new ArrayList<>();
         for (ArtifactResult result : results) {
             if (result.isResolved()) {
-                artifacts.add(result.getArtifact()
-                                    .getFile()
-                                    .toPath());
+                Artifact resolved = result.getArtifact();
+                String coordinate = resolved.getGroupId() + ":" + resolved.getArtifactId() + ":" + resolved.getVersion();
+                artifacts.add(new ResolvedArtifact(coordinate, resolved.getFile()
+                                                                       .toPath(),
+                        winnerVia.get(result.getRequest()
+                                            .getDependencyNode())));
             } else {
                 Artifact artifact = result.getRequest()
                                           .getArtifact();

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ProjectDependenciesCollector.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ProjectDependenciesCollector.java
@@ -56,9 +56,10 @@ class ProjectDependenciesCollector {
     DeclaredDependencies collect() {
         Set<MavenDependency> dependencies = new LinkedHashSet<>();
         Map<String, String> errors = new LinkedHashMap<>();
+        Map<String, Set<String>> declaredBy = new LinkedHashMap<>();
         ICollection registry = repository.getCollection(IRepositoryStructure.PATH_REGISTRY_PUBLIC);
         if (!registry.exists()) {
-            return new DeclaredDependencies(dependencies, errors);
+            return new DeclaredDependencies(dependencies, errors, declaredBy);
         }
         for (ICollection project : registry.getCollections()) {
             IResource descriptor = project.getResource(ProjectMetadata.PROJECT_METADATA_FILE_NAME);
@@ -74,10 +75,10 @@ class ProjectDependenciesCollector {
                 continue;
             }
             if (metadata != null) {
-                collectDeclared(project.getName(), metadata, dependencies, errors);
+                collectDeclared(project.getName(), metadata, dependencies, errors, declaredBy);
             }
         }
-        return new DeclaredDependencies(dependencies, errors);
+        return new DeclaredDependencies(dependencies, errors, declaredBy);
     }
 
     /**
@@ -88,8 +89,10 @@ class ProjectDependenciesCollector {
      * @param metadata the parsed project.json
      * @param dependencies the collected dependencies to add to
      * @param errors the declaration errors to add to
+     * @param declaredBy the declaring projects per coordinate to add to
      */
-    static void collectDeclared(String project, ProjectMetadata metadata, Set<MavenDependency> dependencies, Map<String, String> errors) {
+    static void collectDeclared(String project, ProjectMetadata metadata, Set<MavenDependency> dependencies, Map<String, String> errors,
+            Map<String, Set<String>> declaredBy) {
         for (ProjectMetadataDependency declared : metadata.getDependencies()) {
             String type = declared.getType();
             if (ProjectMetadataDependency.TYPE_GIT.equalsIgnoreCase(type)) {
@@ -109,6 +112,8 @@ class ProjectDependenciesCollector {
                 MavenDependency.Scope scope = MavenDependency.Scope.parse(declared.getScope());
                 List<String> exclusions = declared.getExclusions();
                 dependencies.add(new MavenDependency(id, scope, exclusions == null ? List.of() : exclusions));
+                declaredBy.computeIfAbsent(id, key -> new LinkedHashSet<>())
+                          .add(project);
             } catch (IllegalArgumentException e) {
                 errors.put(id, "Project [" + project + "]: " + e.getMessage());
                 LOGGER.error("Invalid maven dependency [{}] declared by project [{}]", id, project, e);

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ProvidedBom.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ProvidedBom.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The provided-BOM: the {@code groupId:artifactId:version} inventory of every JAR the platform's
+ * fat jar ships in {@code BOOT-INF/lib}, generated at build time from the build's own resolved
+ * dependencies and embedded as {@code META-INF/dirigible-provided-bom.xml} - so an offline or
+ * air-gapped instance knows what is provided without any remote fetch, and a distribution building
+ * its own fat jar embeds its own inventory.
+ *
+ * <p>
+ * The resolver treats every listed coordinate as <b>provided</b>: never downloaded into the modules
+ * tier, never appended to the system classloader. A project declaring a listed
+ * {@code groupId:artifactId} at the platform's version is simply satisfied; at a <b>different</b>
+ * version it is reported as {@code shadowed} with both versions - loudly, in the log, the endpoint
+ * and the IDE view.
+ *
+ * <p>
+ * <b>Why the report is the fix, and child-first loading was rejected.</b> The modules classloader
+ * is deliberately parent-first, so a platform-provided class always wins and a differing declared
+ * version is inert. Child-first ("give the project the Jackson it asked for") looks like the
+ * obliging alternative, but it trades a <i>visible</i> problem for an <i>invisible</i> one: the
+ * platform's own code keeps loading its version while module code loads another, and the two meet
+ * across every API boundary that passes such an object - producing {@code LinkageError}s and
+ * {@code ClassCastException}s of the same FQN at arbitrary call sites, at arbitrary times, with
+ * stack traces that name neither declaration. A {@code shadowed} report names the exact coordinate
+ * and both versions at resolution time; that is the feature.
+ */
+final class ProvidedBom {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProvidedBom.class);
+
+    /** The embedded BOM resource the application build generates. */
+    static final String BOM_RESOURCE = "META-INF/dirigible-provided-bom.xml";
+
+    /** The classpath BOM, loaded once - the embedded resource cannot change within a process. */
+    private static volatile ProvidedBom classpathBom;
+
+    /** The provided version per groupId:artifactId. */
+    private final Map<String, String> providedVersions;
+
+    /**
+     * Instantiates a new provided BOM.
+     *
+     * @param providedVersions the provided version per groupId:artifactId
+     */
+    ProvidedBom(Map<String, String> providedVersions) {
+        this.providedVersions = Map.copyOf(providedVersions);
+    }
+
+    /**
+     * The BOM embedded in the running platform - empty when the classpath carries none (plain unit
+     * tests, exploded developer runs of a single module).
+     *
+     * @return the provided BOM
+     */
+    static ProvidedBom fromClasspath() {
+        ProvidedBom bom = classpathBom;
+        if (bom == null) {
+            synchronized (ProvidedBom.class) {
+                bom = classpathBom;
+                if (bom == null) {
+                    bom = load();
+                    classpathBom = bom;
+                }
+            }
+        }
+        return bom;
+    }
+
+    /**
+     * Loads the embedded BOM resource.
+     *
+     * @return the provided BOM, empty when absent or unreadable
+     */
+    private static ProvidedBom load() {
+        try (InputStream in = ProvidedBom.class.getClassLoader()
+                                               .getResourceAsStream(BOM_RESOURCE)) {
+            if (in == null) {
+                LOGGER.info("No provided-BOM on the classpath ([{}]) - shadowing detection is inactive", BOM_RESOURCE);
+                return new ProvidedBom(Map.of());
+            }
+            ProvidedBom bom = parse(in);
+            LOGGER.info("Provided-BOM loaded: the platform provides [{}] artifact(s)", bom.providedVersions.size());
+            return bom;
+        } catch (IOException | ParserConfigurationException | SAXException e) {
+            LOGGER.error("The provided-BOM [{}] is unreadable - shadowing detection is inactive", BOM_RESOURCE, e);
+            return new ProvidedBom(Map.of());
+        }
+    }
+
+    /**
+     * Parses a standard {@code dependencyManagement} BOM.
+     *
+     * @param in the BOM content
+     * @return the provided BOM
+     * @throws ParserConfigurationException when the parser cannot be configured
+     * @throws SAXException when the content is not well-formed XML
+     * @throws IOException when the content is unreadable
+     */
+    static ProvidedBom parse(InputStream in) throws ParserConfigurationException, SAXException, IOException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        Document document = factory.newDocumentBuilder()
+                                   .parse(in);
+        Map<String, String> versions = new LinkedHashMap<>();
+        NodeList dependencies = document.getElementsByTagName("dependency");
+        for (int index = 0; index < dependencies.getLength(); index++) {
+            Element dependency = (Element) dependencies.item(index);
+            String groupId = childText(dependency, "groupId");
+            String artifactId = childText(dependency, "artifactId");
+            String version = childText(dependency, "version");
+            if (groupId != null && artifactId != null && version != null) {
+                versions.putIfAbsent(groupId + ":" + artifactId, version);
+            }
+        }
+        return new ProvidedBom(versions);
+    }
+
+    /**
+     * The version the platform provides for a groupId:artifactId.
+     *
+     * @param groupArtifact the groupId:artifactId
+     * @return the provided version, null when the platform does not provide the artifact
+     */
+    String providedVersion(String groupArtifact) {
+        return providedVersions.get(groupArtifact);
+    }
+
+    /**
+     * Whether the BOM lists nothing.
+     *
+     * @return true when empty
+     */
+    boolean isEmpty() {
+        return providedVersions.isEmpty();
+    }
+
+    /**
+     * The text of a direct child element.
+     *
+     * @param parent the parent element
+     * @param name the child element name
+     * @return the trimmed text, null when the child is absent or blank
+     */
+    private static String childText(Element parent, String name) {
+        for (Node child = parent.getFirstChild(); child != null; child = child.getNextSibling()) {
+            if (child.getNodeType() == Node.ELEMENT_NODE && name.equals(child.getNodeName())) {
+                String text = child.getTextContent();
+                return text == null || text.isBlank() ? null : text.trim();
+            }
+        }
+        return null;
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ProvidedBomGenerator.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ProvidedBomGenerator.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Generates the provided-BOM at <b>build time</b> - invoked by the application build (see
+ * {@code build/application/pom.xml}) on the output of {@code maven-dependency-plugin:list}, i.e.
+ * the build's own resolved runtime dependencies, which are exactly what the Spring Boot repackage
+ * puts into {@code BOOT-INF/lib}. Deriving the inventory from the resolved dependency list (and
+ * never by unzipping the assembled artifact) keeps the BOM correct for reactor-built modules whose
+ * jars do not live at local-repository paths.
+ *
+ * <p>
+ * The output is a standard {@code dependencyManagement} POM
+ * ({@code org.eclipse.dirigible:dirigible-provided-bom}), written into the application's classes as
+ * {@link ProvidedBom#BOM_RESOURCE} so it ships inside the artifact itself. Entries are sorted, so
+ * two builds of the same dependency set produce byte-identical BOMs.
+ */
+public final class ProvidedBomGenerator {
+
+    /**
+     * Instantiates are not needed.
+     */
+    private ProvidedBomGenerator() {
+        // build-time tool
+    }
+
+    /**
+     * Generates the BOM.
+     *
+     * @param args the dependency:list output file, the BOM output file and the BOM version
+     * @throws IOException when the list is unreadable or the BOM cannot be written
+     */
+    public static void main(String[] args) throws IOException {
+        if (args.length != 3) {
+            throw new IllegalArgumentException("Usage: ProvidedBomGenerator <dependency-list-file> <bom-output-file> <bom-version>");
+        }
+        Path listFile = Path.of(args[0]);
+        Path bomFile = Path.of(args[1]);
+        String version = args[2];
+
+        Map<String, String> provided = parseDependencyList(Files.readAllLines(listFile, StandardCharsets.UTF_8));
+        if (provided.isEmpty()) {
+            throw new IllegalStateException("The dependency list [" + listFile + "] yielded no artifacts - the provided-BOM would"
+                    + " be empty and shadowing detection dead");
+        }
+        Files.createDirectories(bomFile.getParent());
+        Files.writeString(bomFile, bom(provided, version), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Parses {@code dependency:list} output lines - {@code groupId:artifactId:type[:classifier]:
+     * version:scope}, one artifact per line, surrounded by header and module noise that is skipped.
+     *
+     * @param lines the output lines
+     * @return the version per groupId:artifactId, sorted
+     */
+    static Map<String, String> parseDependencyList(List<String> lines) {
+        Map<String, String> provided = new TreeMap<>();
+        for (String line : lines) {
+            String trimmed = line.trim();
+            int space = trimmed.indexOf(' ');
+            String candidate = space < 0 ? trimmed : trimmed.substring(0, space);
+            String[] parts = candidate.split(":", -1);
+            // g:a:type:v:scope or g:a:type:classifier:v:scope
+            if (parts.length != 5 && parts.length != 6) {
+                continue;
+            }
+            String type = parts[2];
+            String version = parts[parts.length - 2];
+            String scope = parts[parts.length - 1];
+            if (!"jar".equals(type) || parts[0].isBlank() || parts[1].isBlank() || version.isBlank() || scope.isBlank()) {
+                continue;
+            }
+            provided.putIfAbsent(parts[0] + ":" + parts[1], version);
+        }
+        return provided;
+    }
+
+    /**
+     * The BOM content - a standard {@code dependencyManagement} POM.
+     *
+     * @param provided the version per groupId:artifactId, sorted
+     * @param version the BOM version
+     * @return the POM XML
+     */
+    static String bom(Map<String, String> provided, String version) {
+        StringBuilder xml = new StringBuilder();
+        xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        xml.append("<project xmlns=\"http://maven.apache.org/POM/4.0.0\">\n");
+        xml.append("    <modelVersion>4.0.0</modelVersion>\n");
+        xml.append("    <groupId>org.eclipse.dirigible</groupId>\n");
+        xml.append("    <artifactId>dirigible-provided-bom</artifactId>\n");
+        xml.append("    <version>")
+           .append(escape(version))
+           .append("</version>\n");
+        xml.append("    <packaging>pom</packaging>\n");
+        xml.append("    <dependencyManagement>\n");
+        xml.append("        <dependencies>\n");
+        provided.forEach((groupArtifact, artifactVersion) -> {
+            int separator = groupArtifact.indexOf(':');
+            xml.append("            <dependency>\n");
+            xml.append("                <groupId>")
+               .append(escape(groupArtifact.substring(0, separator)))
+               .append("</groupId>\n");
+            xml.append("                <artifactId>")
+               .append(escape(groupArtifact.substring(separator + 1)))
+               .append("</artifactId>\n");
+            xml.append("                <version>")
+               .append(escape(artifactVersion))
+               .append("</version>\n");
+            xml.append("            </dependency>\n");
+        });
+        xml.append("        </dependencies>\n");
+        xml.append("    </dependencyManagement>\n");
+        xml.append("</project>\n");
+        return xml.toString();
+    }
+
+    /**
+     * Escapes the XML-special characters.
+     *
+     * @param value the value
+     * @return the escaped value
+     */
+    private static String escape(String value) {
+        return value.replace("&", "&amp;")
+                    .replace("<", "&lt;")
+                    .replace(">", "&gt;");
+    }
+
+}

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ResolutionResult.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ResolutionResult.java
@@ -14,30 +14,87 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The outcome of a {@link DependencyResolver#resolve(java.util.Set)} call.
  *
- * @param artifacts the resolved jar paths inside the local repository - immutable, versioned
- *        locations that are never copied out or overwritten in place
+ * @param resolved the resolved artifacts - immutable, versioned local-repository locations that are
+ *        never copied out or overwritten in place, each attributed to the declared root that pulled
+ *        it in
  * @param mediated the versions chosen where the dependency graph requested more than one, keyed by
  *        {@code groupId:artifactId}
+ * @param requestedVersions every requested version of the mediated {@code groupId:artifactId}
+ *        entries
  * @param failures the per-coordinate failure messages (unresolvable, bad checksum, unsupported
  *        scope, ...), keyed by the failing coordinate
+ * @param provided the declared coordinates the platform provides at exactly the declared version -
+ *        satisfied without a download
+ * @param shadowed the declared {@code groupId:artifactId} entries the platform provides at a
+ *        different version - the declared version is inert (parent-first delegation serves the
+ *        platform's), reported loudly instead of silently
  */
-public record ResolutionResult(List<Path> artifacts, Map<String, String> mediated, Map<String, String> failures) {
+public record ResolutionResult(List<ResolvedArtifact> resolved, Map<String, String> mediated, Map<String, Set<String>> requestedVersions,
+        Map<String, String> failures, List<String> provided, List<Shadowed> shadowed) {
+
+    /**
+     * One resolved artifact.
+     *
+     * @param coordinate the groupId:artifactId:version coordinate
+     * @param path the jar path inside the local repository
+     * @param via the declared root that pulled the artifact in transitively, null for a declared root
+     *        itself
+     */
+    public record ResolvedArtifact(String coordinate, Path path, String via) {
+    }
+
+    /**
+     * One shadowed declaration.
+     *
+     * @param groupArtifact the groupId:artifactId
+     * @param requested the declared version
+     * @param providedVersion the version the platform provides
+     */
+    public record Shadowed(String groupArtifact, String requested, String providedVersion) {
+    }
 
     /**
      * Copies the collections defensively, keeping their order.
      *
-     * @param artifacts the resolved jar paths
+     * @param resolved the resolved artifacts
      * @param mediated the mediated versions
+     * @param requestedVersions the requested versions of the mediated entries
      * @param failures the per-coordinate failures
+     * @param provided the platform-provided declared coordinates
+     * @param shadowed the shadowed declarations
      */
     public ResolutionResult {
-        artifacts = List.copyOf(artifacts);
+        resolved = List.copyOf(resolved);
         mediated = Collections.unmodifiableMap(new LinkedHashMap<>(mediated));
+        requestedVersions = Collections.unmodifiableMap(new LinkedHashMap<>(requestedVersions));
         failures = Collections.unmodifiableMap(new LinkedHashMap<>(failures));
+        provided = List.copyOf(provided);
+        shadowed = List.copyOf(shadowed);
+    }
+
+    /**
+     * The result of resolving nothing.
+     *
+     * @return the empty result
+     */
+    public static ResolutionResult empty() {
+        return new ResolutionResult(List.of(), Map.of(), Map.of(), Map.of(), List.of(), List.of());
+    }
+
+    /**
+     * The resolved jar paths in graph order.
+     *
+     * @return the paths
+     */
+    public List<Path> artifacts() {
+        return resolved.stream()
+                       .map(ResolvedArtifact::path)
+                       .toList();
     }
 
 }

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ResolvedModulesLinker.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ResolvedModulesLinker.java
@@ -83,6 +83,24 @@ class ResolvedModulesLinker {
     }
 
     /**
+     * Removes one artifact's link from the resolved-modules directory - the eviction path for an
+     * artifact whose integrity verification failed, so the next launch's classpath never carries it.
+     *
+     * @param localRepository the local repository the artifact lives in
+     * @param artifact the artifact path inside it
+     */
+    void remove(Path localRepository, Path artifact) {
+        Path link = directory().resolve(linkName(localRepository, artifact));
+        try {
+            if (Files.deleteIfExists(link)) {
+                LOGGER.warn("Evicted [{}] from the resolved-modules directory - its integrity verification failed", link.getFileName());
+            }
+        } catch (IOException e) {
+            LOGGER.warn("Could not evict the dependency jar [{}]", link, e);
+        }
+    }
+
+    /**
      * The link name - the groupId prefixes the artifact file name so equally named artifacts of
      * different groups never collide.
      *

--- a/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/DependencyResolverTest.java
+++ b/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/DependencyResolverTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -49,7 +50,7 @@ class DependencyResolverTest {
         MavenResolverConfig config = new MavenResolverConfig(localRepository, List.of(new MavenRepository("fixture", repositoryDir.toUri()
                                                                                                                                   .toString(),
                 null, null)), false, null);
-        resolver = new MavenDependencyResolver(() -> config);
+        resolver = new MavenDependencyResolver(() -> config, () -> new ProvidedBom(Map.of()));
     }
 
     @AfterEach

--- a/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/FrozenModeTest.java
+++ b/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/FrozenModeTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import org.eclipse.dirigible.components.dependencies.FrozenResolution.FrozenPlan;
+import org.eclipse.dirigible.components.dependencies.MavenDependency.Scope;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Frozen mode ({@code DIRIGIBLE_DEPENDENCIES_FROZEN=true}): the locked set resolves from the local
+ * repository alone - by construction no remote repository is ever consulted - and a coordinate the
+ * lockfile does not carry is rejected with a pointed error.
+ */
+class FrozenModeTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void the_locked_set_resolves_without_consulting_any_remote_repository() throws IOException {
+        Path moduleJar = deploy("com.example", "mid", "1.0.0");
+        Path platformJar = deploy("com.example", "driver", "2.0.0");
+        Lockfile lockfile = new Lockfile("2026-08-18T09:00:00Z", "15.0.0",
+                List.of(locked("com.example:mid:1.0.0", moduleJar, "module"), locked("com.example:driver:2.0.0", platformJar, "platform")),
+                List.of());
+
+        FrozenPlan plan = FrozenResolution.plan(lockfile, declared(module("com.example:mid:1.0.0")), localRepository());
+
+        assertThat(plan.failures()).isEmpty();
+        assertThat(plan.mismatched()).isEmpty();
+        assertThat(plan.artifacts("module")).containsExactly(moduleJar);
+        assertThat(plan.artifacts("platform")).containsExactly(platformJar);
+    }
+
+    @Test
+    void a_new_coordinate_is_rejected_with_a_pointed_error() throws IOException {
+        Path moduleJar = deploy("com.example", "mid", "1.0.0");
+        Lockfile lockfile =
+                new Lockfile("2026-08-18T09:00:00Z", "15.0.0", List.of(locked("com.example:mid:1.0.0", moduleJar, "module")), List.of());
+
+        FrozenPlan plan = FrozenResolution.plan(lockfile, declared(module("com.example:mid:1.0.0"), module("com.example:brand-new:1.0.0")),
+                localRepository());
+
+        assertThat(plan.mismatched()).containsExactly("com.example:brand-new:1.0.0");
+        assertThat(plan.failures()
+                       .get("com.example:brand-new:1.0.0")).contains("frozen mode")
+                                                           .contains("DIRIGIBLE_DEPENDENCIES_FROZEN")
+                                                           .contains("project-lock.json");
+        // the locked set still activates - a mismatch is per-declaration, not a total failure
+        assertThat(plan.artifacts("module")).containsExactly(moduleJar);
+    }
+
+    @Test
+    void a_missing_locked_artifact_fails_with_the_coordinate_in_the_error() {
+        Lockfile lockfile = new Lockfile("2026-08-18T09:00:00Z", "15.0.0",
+                List.of(new Lockfile.LockedArtifact("com.example:gone:1.0.0", "aa11", List.of("my-project"), null, "module")), List.of());
+
+        FrozenPlan plan = FrozenResolution.plan(lockfile, declared(), localRepository());
+
+        assertThat(plan.activations()).isEmpty();
+        assertThat(plan.failures()
+                       .get("com.example:gone:1.0.0")).contains("missing from the local repository");
+    }
+
+    private Path localRepository() {
+        return tempDir.resolve("local-repo");
+    }
+
+    private Path deploy(String groupId, String artifactId, String version) throws IOException {
+        Path directory = Files.createDirectories(localRepository().resolve(groupId.replace('.', '/'))
+                                                                  .resolve(artifactId)
+                                                                  .resolve(version));
+        Path jar = directory.resolve(artifactId + "-" + version + ".jar");
+        Files.writeString(jar, groupId + ":" + artifactId + ":" + version);
+        return jar;
+    }
+
+    private static Lockfile.LockedArtifact locked(String id, Path jar, String scope) throws IOException {
+        return new Lockfile.LockedArtifact(id, LockfileStore.sha256(jar), List.of("my-project"), null, scope);
+    }
+
+    private static MavenDependency module(String coordinate) {
+        return new MavenDependency(coordinate, Scope.MODULE, List.of());
+    }
+
+    private static DeclaredDependencies declared(MavenDependency... dependencies) {
+        Set<MavenDependency> set = new LinkedHashSet<>(List.of(dependencies));
+        Map<String, Set<String>> declaredBy = new LinkedHashMap<>();
+        for (MavenDependency dependency : dependencies) {
+            declaredBy.computeIfAbsent(dependency.coordinate(), key -> new LinkedHashSet<>())
+                      .add("my-project");
+        }
+        return new DeclaredDependencies(set, Map.of(), declaredBy);
+    }
+
+}

--- a/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/FrozenModeTest.java
+++ b/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/FrozenModeTest.java
@@ -43,7 +43,8 @@ class FrozenModeTest {
                 List.of(locked("com.example:mid:1.0.0", moduleJar, "module"), locked("com.example:driver:2.0.0", platformJar, "platform")),
                 List.of());
 
-        FrozenPlan plan = FrozenResolution.plan(lockfile, declared(module("com.example:mid:1.0.0")), localRepository());
+        FrozenPlan plan =
+                FrozenResolution.plan(lockfile, declared(module("com.example:mid:1.0.0")), localRepository(), new ProvidedBom(Map.of()));
 
         assertThat(plan.failures()).isEmpty();
         assertThat(plan.mismatched()).isEmpty();
@@ -58,7 +59,7 @@ class FrozenModeTest {
                 new Lockfile("2026-08-18T09:00:00Z", "15.0.0", List.of(locked("com.example:mid:1.0.0", moduleJar, "module")), List.of());
 
         FrozenPlan plan = FrozenResolution.plan(lockfile, declared(module("com.example:mid:1.0.0"), module("com.example:brand-new:1.0.0")),
-                localRepository());
+                localRepository(), new ProvidedBom(Map.of()));
 
         assertThat(plan.mismatched()).containsExactly("com.example:brand-new:1.0.0");
         assertThat(plan.failures()
@@ -70,11 +71,32 @@ class FrozenModeTest {
     }
 
     @Test
+    void a_platform_provided_declaration_is_never_a_frozen_mismatch() throws IOException {
+        Path moduleJar = deploy("com.example", "mid", "1.0.0");
+        Lockfile lockfile =
+                new Lockfile("2026-08-18T09:00:00Z", "15.0.0", List.of(locked("com.example:mid:1.0.0", moduleJar, "module")), List.of());
+        ProvidedBom bom = new ProvidedBom(Map.of("com.example:provided-lib", "2.0.0"));
+
+        // provided and shadowed declarations were never lockable - the embedded BOM answers for
+        // them without any network, so a registry that resolves cleanly stays clean when frozen
+        FrozenPlan plan = FrozenResolution.plan(lockfile, declared(module("com.example:mid:1.0.0"),
+                module("com.example:provided-lib:2.0.0"), module("com.example:provided-lib:1.0.0")), localRepository(), bom);
+
+        assertThat(plan.mismatched()).isEmpty();
+        assertThat(plan.failures()).isEmpty();
+        assertThat(plan.provided()).containsExactly("com.example:provided-lib:2.0.0");
+        assertThat(plan.shadowed()).hasSize(1);
+        assertThat(plan.shadowed()
+                       .get(0)
+                       .requested()).isEqualTo("1.0.0");
+    }
+
+    @Test
     void a_missing_locked_artifact_fails_with_the_coordinate_in_the_error() {
         Lockfile lockfile = new Lockfile("2026-08-18T09:00:00Z", "15.0.0",
                 List.of(new Lockfile.LockedArtifact("com.example:gone:1.0.0", "aa11", List.of("my-project"), null, "module")), List.of());
 
-        FrozenPlan plan = FrozenResolution.plan(lockfile, declared(), localRepository());
+        FrozenPlan plan = FrozenResolution.plan(lockfile, declared(), localRepository(), new ProvidedBom(Map.of()));
 
         assertThat(plan.activations()).isEmpty();
         assertThat(plan.failures()

--- a/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/LockfileRoundTripTest.java
+++ b/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/LockfileRoundTripTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The lockfile round trip: written and parsed back byte-faithfully, serialized deterministically so
+ * the diff between two locks is reviewable, and a tampered artifact (one flipped byte) fails the
+ * checksum verification with the coordinate in the error.
+ */
+class LockfileRoundTripTest {
+
+    @TempDir
+    Path tempDir;
+
+    private LockfileStore store;
+    private Path lockfilePath;
+
+    @BeforeEach
+    void setUp() {
+        lockfilePath = tempDir.resolve("project-lock.json");
+        Configuration.set("DIRIGIBLE_DEPENDENCIES_LOCKFILE", lockfilePath.toString());
+        store = new LockfileStore(new ResolvedModulesLinker());
+    }
+
+    @AfterEach
+    void tearDown() {
+        Configuration.set("DIRIGIBLE_DEPENDENCIES_LOCKFILE", "");
+    }
+
+    @Test
+    void writes_and_reads_the_lock_back_faithfully() {
+        Lockfile lockfile = new Lockfile("2026-08-18T09:00:00Z", "15.0.0",
+                List.of(new Lockfile.LockedArtifact("com.example:mid:1.0.0", "aa11", List.of("my-project"), null, "module"),
+                        new Lockfile.LockedArtifact("com.example:leaf:1.0.0", "bb22", null, "com.example:mid:1.0.0", "module")),
+                List.of(new Lockfile.LockedMediation("com.example:leaf", "1.0.0", List.of("0.9.0"),
+                        Map.of("1.0.0", List.of("my-project")))));
+
+        store.write(lockfile);
+
+        assertThat(store.read()).contains(lockfile);
+    }
+
+    @Test
+    void serializes_deterministically_for_reviewable_diffs() {
+        Lockfile lockfile = new Lockfile("2026-08-18T09:00:00Z", "15.0.0",
+                List.of(new Lockfile.LockedArtifact("com.example:leaf:1.0.0", "bb22", List.of(), null, "module")), List.of());
+
+        store.write(lockfile);
+        String first = content();
+        store.write(lockfile);
+
+        assertThat(content()).isEqualTo(first);
+        // the transitive attribution fields are omitted, not written as nulls - the sketch format
+        assertThat(first).doesNotContain("null");
+    }
+
+    @Test
+    void a_tampered_artifact_fails_verification_with_the_coordinate_in_the_error() throws IOException {
+        Path jar = deploy("com.example", "lib", "1.0.0", "original bytes".getBytes());
+        String sha = LockfileStore.sha256(jar);
+        Lockfile lockfile = new Lockfile("2026-08-18T09:00:00Z", "15.0.0",
+                List.of(new Lockfile.LockedArtifact("com.example:lib:1.0.0", sha, List.of("my-project"), null, "module")), List.of());
+
+        byte[] tampered = Files.readAllBytes(jar);
+        tampered[0] ^= 0x01; // one flipped byte
+        Files.write(jar, tampered);
+
+        FrozenResolution.FrozenPlan plan = FrozenResolution.plan(lockfile, declared(), tempDir.resolve("repo"));
+
+        assertThat(plan.activations()).isEmpty();
+        assertThat(plan.failures()).hasSize(1);
+        assertThat(plan.failures()
+                       .get("com.example:lib:1.0.0")).contains("Checksum mismatch")
+                                                     .contains("com.example:lib:1.0.0")
+                                                     .contains(sha);
+    }
+
+    @Test
+    void an_untampered_artifact_verifies_cleanly() throws IOException {
+        Path jar = deploy("com.example", "lib", "1.0.0", "original bytes".getBytes());
+        Lockfile lockfile = new Lockfile("2026-08-18T09:00:00Z", "15.0.0", List.of(
+                new Lockfile.LockedArtifact("com.example:lib:1.0.0", LockfileStore.sha256(jar), List.of("my-project"), null, "module")),
+                List.of());
+
+        FrozenResolution.FrozenPlan plan = FrozenResolution.plan(lockfile, declared(), tempDir.resolve("repo"));
+
+        assertThat(plan.failures()).isEmpty();
+        assertThat(plan.activations()).hasSize(1);
+        assertThat(plan.activations()
+                       .get(0)
+                       .path()).isEqualTo(jar);
+    }
+
+    private String content() {
+        try {
+            return Files.readString(lockfilePath);
+        } catch (IOException e) {
+            throw new IllegalStateException("the lockfile must exist", e);
+        }
+    }
+
+    private Path deploy(String groupId, String artifactId, String version, byte[] content) throws IOException {
+        Path directory = Files.createDirectories(tempDir.resolve("repo")
+                                                        .resolve(groupId.replace('.', '/'))
+                                                        .resolve(artifactId)
+                                                        .resolve(version));
+        Path jar = directory.resolve(artifactId + "-" + version + ".jar");
+        Files.write(jar, content);
+        return jar;
+    }
+
+    private static DeclaredDependencies declared(MavenDependency... dependencies) {
+        Set<MavenDependency> set = new LinkedHashSet<>(List.of(dependencies));
+        return new DeclaredDependencies(set, Map.of(), Map.of());
+    }
+
+}

--- a/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/LockfileRoundTripTest.java
+++ b/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/LockfileRoundTripTest.java
@@ -88,7 +88,7 @@ class LockfileRoundTripTest {
         tampered[0] ^= 0x01; // one flipped byte
         Files.write(jar, tampered);
 
-        FrozenResolution.FrozenPlan plan = FrozenResolution.plan(lockfile, declared(), tempDir.resolve("repo"));
+        FrozenResolution.FrozenPlan plan = FrozenResolution.plan(lockfile, declared(), tempDir.resolve("repo"), new ProvidedBom(Map.of()));
 
         assertThat(plan.activations()).isEmpty();
         assertThat(plan.failures()).hasSize(1);
@@ -105,7 +105,7 @@ class LockfileRoundTripTest {
                 new Lockfile.LockedArtifact("com.example:lib:1.0.0", LockfileStore.sha256(jar), List.of("my-project"), null, "module")),
                 List.of());
 
-        FrozenResolution.FrozenPlan plan = FrozenResolution.plan(lockfile, declared(), tempDir.resolve("repo"));
+        FrozenResolution.FrozenPlan plan = FrozenResolution.plan(lockfile, declared(), tempDir.resolve("repo"), new ProvidedBom(Map.of()));
 
         assertThat(plan.failures()).isEmpty();
         assertThat(plan.activations()).hasSize(1);

--- a/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/ProjectMetadataParsingTest.java
+++ b/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/ProjectMetadataParsingTest.java
@@ -75,12 +75,16 @@ class ProjectMetadataParsingTest {
     void collects_the_maven_declarations_and_skips_the_git_ones() {
         Set<MavenDependency> dependencies = new LinkedHashSet<>();
         Map<String, String> errors = new LinkedHashMap<>();
+        Map<String, Set<String>> declaredBy = new LinkedHashMap<>();
 
-        ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(PROJECT_JSON), dependencies, errors);
+        ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(PROJECT_JSON), dependencies, errors,
+                declaredBy);
 
         assertThat(errors).isEmpty();
         assertThat(dependencies).containsExactly(new MavenDependency("com.businessintents:employees:1.4.0", Scope.MODULE, List.of()),
                 new MavenDependency("com.example:widget:2.1.0", Scope.MODULE, List.of("com.fasterxml.jackson.core:*")));
+        assertThat(declaredBy).containsEntry("com.businessintents:employees:1.4.0", Set.of("my-project"))
+                              .containsEntry("com.example:widget:2.1.0", Set.of("my-project"));
     }
 
     @Test
@@ -95,9 +99,11 @@ class ProjectMetadataParsingTest {
                 """;
         Set<MavenDependency> dependencies = new LinkedHashSet<>();
         Map<String, String> errors = new LinkedHashMap<>();
+        Map<String, Set<String>> declaredBy = new LinkedHashMap<>();
 
         try (LogCaptor logCaptor = LogCaptor.forClass(ProjectDependenciesCollector.class)) {
-            ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies, errors);
+            ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies, errors,
+                    declaredBy);
 
             assertThat(logCaptor.getWarnLogs()).anySatisfy(message -> assertThat(message).contains("npm")
                                                                                          .contains("my-project"));
@@ -118,8 +124,9 @@ class ProjectMetadataParsingTest {
                 """;
         Set<MavenDependency> dependencies = new LinkedHashSet<>();
         Map<String, String> errors = new LinkedHashMap<>();
+        Map<String, Set<String>> declaredBy = new LinkedHashMap<>();
 
-        ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies, errors);
+        ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies, errors, declaredBy);
 
         assertThat(dependencies).isEmpty();
         assertThat(errors).containsKey("com.example:widget:[1.0,2.0)");
@@ -138,8 +145,9 @@ class ProjectMetadataParsingTest {
                 """;
         Set<MavenDependency> dependencies = new LinkedHashSet<>();
         Map<String, String> errors = new LinkedHashMap<>();
+        Map<String, Set<String>> declaredBy = new LinkedHashMap<>();
 
-        ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies, errors);
+        ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies, errors, declaredBy);
 
         assertThat(dependencies).isEmpty();
         assertThat(errors).containsKey("my-project");
@@ -157,8 +165,9 @@ class ProjectMetadataParsingTest {
                 """;
         Set<MavenDependency> dependencies = new LinkedHashSet<>();
         Map<String, String> errors = new LinkedHashMap<>();
+        Map<String, Set<String>> declaredBy = new LinkedHashMap<>();
 
-        ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies, errors);
+        ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies, errors, declaredBy);
 
         // parsed here - rejected as unsupported by the resolver until phase 3
         assertThat(errors).isEmpty();

--- a/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/ProvidedBomTest.java
+++ b/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/ProvidedBomTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import org.eclipse.dirigible.components.dependencies.MavenDependency.Scope;
+import org.eclipse.dirigible.components.dependencies.MavenResolverConfig.MavenRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The provided-BOM contract at the resolver: a coordinate the platform provides at the declared
+ * version is satisfied without a download and without a warning, a different-version request is
+ * reported as shadowed with both versions (and never downloaded - parent-first delegation would
+ * serve the platform's copy anyway), and a platform-provided transitive is pruned from the graph.
+ * All repositories are file: fixtures - no test touches the network.
+ */
+class ProvidedBomTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Path repositoryDir;
+    private Path localRepository;
+    private ProvidedBom bom;
+    private MavenDependencyResolver resolver;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        repositoryDir = Files.createDirectories(tempDir.resolve("fixture-repo"));
+        localRepository = tempDir.resolve("local-repo");
+        MavenResolverConfig config = new MavenResolverConfig(localRepository, List.of(new MavenRepository("fixture", repositoryDir.toUri()
+                                                                                                                                  .toString(),
+                null, null)), false, null);
+        bom = new ProvidedBom(Map.of());
+        resolver = new MavenDependencyResolver(() -> config, () -> bom);
+    }
+
+    @AfterEach
+    void tearDown() {
+        resolver.shutdown();
+    }
+
+    @Test
+    void a_provided_coordinate_at_the_platform_version_is_satisfied_without_a_download() throws IOException {
+        deploy("widget", "1.0.0", "");
+        bom = new ProvidedBom(Map.of("com.example:widget", "1.0.0"));
+
+        ResolutionResult result = resolver.resolve(declared(module("com.example:widget:1.0.0")));
+
+        assertThat(result.provided()).containsExactly("com.example:widget:1.0.0");
+        assertThat(result.shadowed()).isEmpty();
+        assertThat(result.failures()).isEmpty();
+        assertThat(result.artifacts()).isEmpty();
+        // never downloaded - the platform already carries it
+        assertThat(localRepository.resolve("com/example/widget/1.0.0/widget-1.0.0.jar")).doesNotExist();
+    }
+
+    @Test
+    void a_different_version_request_is_shadowed_with_both_versions() {
+        bom = new ProvidedBom(Map.of("com.example:widget", "1.0.0"));
+
+        ResolutionResult result = resolver.resolve(declared(module("com.example:widget:2.0.0")));
+
+        assertThat(result.shadowed()).hasSize(1);
+        ResolutionResult.Shadowed shadowed = result.shadowed()
+                                                   .get(0);
+        assertThat(shadowed.groupArtifact()).isEqualTo("com.example:widget");
+        assertThat(shadowed.requested()).isEqualTo("2.0.0");
+        assertThat(shadowed.providedVersion()).isEqualTo("1.0.0");
+        assertThat(result.provided()).isEmpty();
+        assertThat(result.failures()).isEmpty();
+        // the inert version is not downloaded either - parent-first delegation would never serve it
+        assertThat(localRepository.resolve("com/example/widget/2.0.0/widget-2.0.0.jar")).doesNotExist();
+    }
+
+    @Test
+    void a_provided_transitive_is_pruned_from_the_graph() throws IOException {
+        deploy("leaf", "1.0.0", "");
+        deploy("mid", "1.0.0", dependencyOn("leaf", "1.0.0"));
+        bom = new ProvidedBom(Map.of("com.example:leaf", "1.0.0"));
+
+        ResolutionResult result = resolver.resolve(declared(module("com.example:mid:1.0.0")));
+
+        assertThat(result.failures()).isEmpty();
+        assertThat(result.artifacts()).containsExactly(localRepository.resolve("com/example/mid/1.0.0/mid-1.0.0.jar"));
+        assertThat(localRepository.resolve("com/example/leaf/1.0.0/leaf-1.0.0.jar")).doesNotExist();
+    }
+
+    @Test
+    void the_generated_bom_round_trips_through_the_parser() throws Exception {
+        Map<String, String> provided = ProvidedBomGenerator.parseDependencyList(List.of("The following files have been resolved:",
+                "   com.google.gson:gson:jar:2.13.2:compile -- module com.google.gson", "   com.example:widget:jar:1.0.0:runtime",
+                "   io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.100.Final:runtime",
+                "   com.example:pom-only:pom:1.0.0:compile", "", "   none"));
+        assertThat(provided).containsEntry("com.google.gson:gson", "2.13.2")
+                            .containsEntry("com.example:widget", "1.0.0")
+                            .containsEntry("io.netty:netty-transport-native-epoll", "4.1.100.Final")
+                            .doesNotContainKey("com.example:pom-only");
+
+        String xml = ProvidedBomGenerator.bom(provided, "15.0.0-SNAPSHOT");
+        ProvidedBom parsed = ProvidedBom.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(parsed.providedVersion("com.google.gson:gson")).isEqualTo("2.13.2");
+        assertThat(parsed.providedVersion("com.example:widget")).isEqualTo("1.0.0");
+        assertThat(parsed.providedVersion("com.example:absent")).isNull();
+        assertThat(xml).contains("<artifactId>dirigible-provided-bom</artifactId>")
+                       .contains("<version>15.0.0-SNAPSHOT</version>");
+    }
+
+    private static MavenDependency module(String coordinate) {
+        return new MavenDependency(coordinate, Scope.MODULE, List.of());
+    }
+
+    private static Set<MavenDependency> declared(MavenDependency... dependencies) {
+        return new LinkedHashSet<>(Arrays.asList(dependencies));
+    }
+
+    private void deploy(String artifactId, String version, String dependenciesXml) throws IOException {
+        Path directory = repositoryDir.resolve("com/example")
+                                      .resolve(artifactId)
+                                      .resolve(version);
+        Files.createDirectories(directory);
+        Files.writeString(directory.resolve(artifactId + "-" + version + ".pom"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>%s</artifactId>
+                    <version>%s</version>
+                    %s
+                </project>
+                """.formatted(artifactId, version, dependenciesXml));
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(directory.resolve(artifactId + "-" + version + ".jar")))) {
+            out.putNextEntry(new JarEntry("fixture.txt"));
+            out.write("fixture".getBytes(StandardCharsets.UTF_8));
+            out.closeEntry();
+        }
+    }
+
+    private static String dependencyOn(String artifactId, String version) {
+        return """
+                <dependencies>
+                    <dependency>
+                        <groupId>com.example</groupId>
+                        <artifactId>%s</artifactId>
+                        <version>%s</version>
+                    </dependency>
+                </dependencies>
+                """.formatted(artifactId, version);
+    }
+
+}

--- a/components/group/group-ide/pom.xml
+++ b/components/group/group-ide/pom.xml
@@ -192,6 +192,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-ui-view-dependencies</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
             <artifactId>dirigible-components-ui-view-jvm-monitoring</artifactId>
         </dependency>
         <dependency>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -176,6 +176,7 @@
         <module>ui/view-transfer</module>
         <module>ui/view-translation</module>
         <module>ui/view-artefacts</module>
+        <module>ui/view-dependencies</module>
         <module>ui/view-jvm-monitoring</module>
         <module>ui/view-jvm-threads</module>
         <module>ui/view-monitoring-metrics</module>
@@ -1010,6 +1011,11 @@
             <dependency>
                 <groupId>org.eclipse.dirigible</groupId>
                 <artifactId>dirigible-components-ui-view-artefacts</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.dirigible</groupId>
+                <artifactId>dirigible-components-ui-view-dependencies</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/components/ui/perspective-operations/src/main/resources/META-INF/dirigible/perspective-operations/index.html
+++ b/components/ui/perspective-operations/src/main/resources/META-INF/dirigible/perspective-operations/index.html
@@ -29,7 +29,7 @@
             angular.module('operations', ['platformView', 'platformLayout', 'blimpKit'])
                 .controller('OperationsController', ($scope) => {
                     $scope.layoutConfig = {
-                        views: ['registry', 'repository', 'extensions', 'configurations', 'artefacts', 'jobs', 'listeners', 'tables', 'views', 'websockets', 'logs', 'loggers', 'console'],
+                        views: ['registry', 'repository', 'extensions', 'configurations', 'artefacts', 'dependencies', 'jobs', 'listeners', 'tables', 'views', 'websockets', 'logs', 'loggers', 'console'],
                         viewSettings: {},
                         layoutSettings: {
                             leftPaneMinSize: 340

--- a/components/ui/view-dependencies/pom.xml
+++ b/components/ui/view-dependencies/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.dirigible</groupId>
+		<artifactId>dirigible-components-parent</artifactId>
+		<version>15.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+
+	<name>Components - IDE - Dependencies - View</name>
+	<artifactId>dirigible-components-ui-view-dependencies</artifactId>
+	<packaging>jar</packaging>
+
+	<properties>
+		<license.header.location>../../../licensing-header.txt</license.header.location>
+		<parent.pom.folder>../../../</parent.pom.folder>
+	</properties>
+
+</project>

--- a/components/ui/view-dependencies/src/main/resources/META-INF/dirigible/view-dependencies/configs/dependencies-view.js
+++ b/components/ui/view-dependencies/src/main/resources/META-INF/dirigible/view-dependencies/configs/dependencies-view.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+const viewData = {
+	id: 'dependencies',
+	label: 'Dependencies',
+	region: 'center',
+	lazyLoad: true,
+	path: '/services/web/view-dependencies/dependencies.html'
+};
+if (typeof exports !== 'undefined') {
+	exports.getView = () => viewData;
+}

--- a/components/ui/view-dependencies/src/main/resources/META-INF/dirigible/view-dependencies/dependencies.html
+++ b/components/ui/view-dependencies/src/main/resources/META-INF/dirigible/view-dependencies/dependencies.html
@@ -24,22 +24,18 @@
     </head>
 
     <body class="bk-vbox">
-        <bk-toolbar has-title="false">
-            <bk-toolbar-spacer fixed-width="8px"></bk-toolbar-spacer>
+        <bk-toolbar compact="true" has-title="true">
             <span bk-object-status status="{{ state.frozen ? 'critical' : 'informative' }}" text="{{ state.frozen ? 'FROZEN' : 'DYNAMIC' }}" inverted="true"></span>
             <bk-toolbar-spacer fixed-width="12px"></bk-toolbar-spacer>
             <bk-toolbar-title>Generation {{ state.classLoaderGeneration }}{{ state.resolvedAt ? ' · resolved ' + (state.resolvedAt | date:'medium') : ' · not resolved yet' }}</bk-toolbar-title>
             <bk-toolbar-spacer></bk-toolbar-spacer>
-            <bk-input type="search" placeholder="Search" style="max-width: 240px" ng-keyup="search($event)" ng-model="searchField.text"></bk-input>
-            <bk-toolbar-spacer fixed-width="8px"></bk-toolbar-spacer>
-            <bk-button label="Refresh" ng-click="load()"></bk-button>
-            <bk-toolbar-spacer fixed-width="8px"></bk-toolbar-spacer>
-            <bk-button label="{{ resolving ? 'Resolving…' : 'Resolve' }}" ng-disabled="resolving" ng-click="resolve()"></bk-button>
-            <bk-toolbar-spacer fixed-width="8px"></bk-toolbar-spacer>
-            <bk-button label="Add Dependency…" state="emphasized" ng-click="openAddDialog()"></bk-button>
-            <bk-toolbar-spacer fixed-width="8px"></bk-toolbar-spacer>
+            <bk-input compact="true" type="search" placeholder="Search" style="max-width: 240px" ng-keyup="search($event)" ng-model="searchField.text"></bk-input>
+            <bk-toolbar-separator></bk-toolbar-separator>
+            <bk-button compact="true" label="Refresh" ng-click="load()"></bk-button>
+            <bk-button compact="true" label="{{ resolving ? 'Resolving…' : 'Resolve' }}" ng-disabled="resolving" ng-click="resolve()"></bk-button>
+            <bk-button compact="true" label="Add Dependency…" state="emphasized" ng-click="openAddDialog()"></bk-button>
         </bk-toolbar>
-        <bk-message-strip ng-if="message.text" state="{{ message.state }}" dismissible="true" ng-click="message.text = ''">{{ message.text }}</bk-message-strip>
+        <bk-message-strip type="{{ message.type }}" ng-if="message.text">{{ message.text }}</bk-message-strip>
         <div bk-scrollbar class="bk-full-height">
             <table bk-table display-mode="compact" outer-borders="none">
                 <thead bk-table-header sticky="true" interactive="false">
@@ -73,40 +69,41 @@
             </div>
         </div>
 
-        <bk-dialog visible="addDialog.visible" window-title="Add Dependency" state="{{ addDialog.error ? 'error' : '' }}">
-            <bk-dialog-body>
+        <bk-dialog visible="addDialog.visible" window-min-width="480px">
+            <bk-dialog-header title="Add Dependency"></bk-dialog-header>
+            <bk-dialog-body class="bk-padding">
+                <bk-message-strip type="error" ng-if="addDialog.error">{{ addDialog.error }}</bk-message-strip>
                 <bk-fieldset>
+                    <bk-form-group horizontal="false">
+                        <bk-form-label for="ad-workspace" required colon="true">Workspace</bk-form-label>
+                        <bk-select id="ad-workspace" class="bk-full-width" placeholder="Select a workspace" dropdown-fixed="true" ng-model="addDialog.workspace">
+                            <bk-option ng-repeat="w in addDialog.workspaces" text="{{ w }}" value="w"></bk-option>
+                        </bk-select>
+                    </bk-form-group>
+                    <bk-form-group horizontal="false">
+                        <bk-form-label for="ad-project" required colon="true">Project</bk-form-label>
+                        <bk-select id="ad-project" class="bk-full-width" placeholder="Select a project" dropdown-fixed="true" ng-model="addDialog.project">
+                            <bk-option ng-repeat="p in addDialog.projects" text="{{ p }}" value="p"></bk-option>
+                        </bk-select>
+                    </bk-form-group>
                     <bk-form-group>
                         <bk-form-item>
-                            <bk-form-label for="ad-workspace" required="true">Workspace</bk-form-label>
-                            <bk-select id="ad-workspace" placeholder="Select a workspace" dropdown-fixed="true" ng-model="addDialog.workspace" ng-required="true">
-                                <bk-option ng-repeat="w in addDialog.workspaces" text="{{ w }}" value="w"></bk-option>
-                            </bk-select>
-                        </bk-form-item>
-                        <bk-form-item>
-                            <bk-form-label for="ad-project" required="true">Project</bk-form-label>
-                            <bk-select id="ad-project" placeholder="Select a project" dropdown-fixed="true" ng-model="addDialog.project" ng-required="true">
-                                <bk-option ng-repeat="p in addDialog.projects" text="{{ p }}" value="p"></bk-option>
-                            </bk-select>
-                        </bk-form-item>
-                        <bk-form-item>
-                            <bk-form-label for="ad-id" required="true">Coordinate (groupId:artifactId:version)</bk-form-label>
-                            <bk-input id="ad-id" type="text" placeholder="org.jsoup:jsoup:1.17.2" ng-model="addDialog.id" ng-change="validate()"></bk-input>
-                        </bk-form-item>
-                        <bk-form-item>
-                            <bk-form-label for="ad-scope">Scope</bk-form-label>
-                            <bk-select id="ad-scope" dropdown-fixed="true" ng-model="addDialog.scope">
-                                <bk-option text="module (default) - swappable, restartless add/upgrade/remove" value="'module'"></bk-option>
-                                <bk-option text="platform - system classloader; JDBC drivers and native libraries" value="'platform'"></bk-option>
-                            </bk-select>
+                            <bk-form-label for="ad-id" required colon="true">Coordinate (groupId:artifactId:version)</bk-form-label>
+                            <bk-input id="ad-id" type="text" placeholder="org.jsoup:jsoup:1.17.2" ng-model="addDialog.id" ng-change="validate()" state="{{ addDialog.id && !addDialog.valid ? 'error' : '' }}"></bk-input>
                         </bk-form-item>
                     </bk-form-group>
+                    <bk-form-group horizontal="false">
+                        <bk-form-label for="ad-scope" colon="true">Scope</bk-form-label>
+                        <bk-select id="ad-scope" class="bk-full-width" dropdown-fixed="true" ng-model="addDialog.scope">
+                            <bk-option text="module (default) - swappable, restartless add/upgrade/remove" value="'module'"></bk-option>
+                            <bk-option text="platform - system classloader; JDBC drivers and native libraries" value="'platform'"></bk-option>
+                        </bk-select>
+                    </bk-form-group>
                 </bk-fieldset>
-                <p ng-if="addDialog.error" class="bk-margin-top--sm">{{ addDialog.error }}</p>
             </bk-dialog-body>
-            <bk-dialog-footer>
+            <bk-dialog-footer compact="true">
                 <bk-bar-element>
-                    <bk-button label="Add" state="emphasized" ng-disabled="!addDialog.valid || addDialog.saving" ng-click="addDependency()"></bk-button>
+                    <bk-button label="Add" state="emphasized" ng-disabled="!addDialog.valid || !addDialog.workspace || !addDialog.project || addDialog.saving" ng-click="addDependency()"></bk-button>
                 </bk-bar-element>
                 <bk-bar-element>
                     <bk-button label="Cancel" state="transparent" ng-click="addDialog.visible = false"></bk-button>
@@ -122,7 +119,7 @@
                 const GAV_PATTERN = /^[^\s:]+:[^\s:]+:[^\s:,\[\]\(\)]+$/;
                 $scope.state = { report: [] };
                 $scope.searchField = { text: '' };
-                $scope.message = { text: '', state: 'information' };
+                $scope.message = { text: '', type: 'information' };
                 $scope.resolving = false;
                 $scope.addDialog = { visible: false, workspaces: [], projects: [], scope: 'module', valid: false };
 
@@ -144,7 +141,7 @@
                         $scope.applySearch();
                     }, (error) => {
                         console.error(error);
-                        $scope.message = { text: 'The dependencies state could not be loaded.', state: 'negative' };
+                        $scope.message = { text: 'The dependencies state could not be loaded.', type: 'error' };
                     });
                 };
 
@@ -155,11 +152,11 @@
                         $scope.applySearch();
                         const failures = Object.keys($scope.state.failures || {}).length;
                         $scope.message = failures
-                            ? { text: failures + ' failure(s) - see the report below.', state: 'negative' }
-                            : { text: 'Resolution completed cleanly.', state: 'positive' };
+                            ? { text: failures + ' failure(s) - see the report below.', type: 'error' }
+                            : { text: 'Resolution completed cleanly.', type: 'success' };
                     }, (error) => {
                         console.error(error);
-                        $scope.message = { text: (error.data && error.data.message) || 'The resolution failed.', state: 'negative' };
+                        $scope.message = { text: (error.data && error.data.message) || 'The resolution failed.', type: 'error' };
                     }).finally(() => {
                         $scope.resolving = false;
                     });
@@ -236,7 +233,7 @@
                             dialog.visible = false;
                             $scope.message = {
                                 text: `[${id}] added to ${dialog.project}/project.json - publish the project to activate it.`,
-                                state: 'positive'
+                                type: 'success'
                             };
                         }, (error) => {
                             console.error(error);

--- a/components/ui/view-dependencies/src/main/resources/META-INF/dirigible/view-dependencies/dependencies.html
+++ b/components/ui/view-dependencies/src/main/resources/META-INF/dirigible/view-dependencies/dependencies.html
@@ -1,0 +1,256 @@
+<!--
+
+    Copyright (c) 2010-2026 Eclipse Dirigible contributors
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v20.html
+
+    SPDX-FileCopyrightText: Eclipse Dirigible contributors
+    SPDX-License-Identifier: EPL-2.0
+
+-->
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="dependencies" ng-controller="DependenciesController">
+
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="icon" sizes="any" href="data:;base64,iVBORw0KGgo=">
+        <title config-title></title>
+        <script type="text/javascript" src="/services/web/view-dependencies/configs/dependencies-view.js"></script>
+        <meta name="platform-links" category="ng-view">
+    </head>
+
+    <body class="bk-vbox">
+        <bk-toolbar has-title="false">
+            <bk-toolbar-spacer fixed-width="8px"></bk-toolbar-spacer>
+            <span bk-object-status status="{{ state.frozen ? 'critical' : 'informative' }}" text="{{ state.frozen ? 'FROZEN' : 'DYNAMIC' }}" inverted="true"></span>
+            <bk-toolbar-spacer fixed-width="12px"></bk-toolbar-spacer>
+            <bk-toolbar-title>Generation {{ state.classLoaderGeneration }}{{ state.resolvedAt ? ' · resolved ' + (state.resolvedAt | date:'medium') : ' · not resolved yet' }}</bk-toolbar-title>
+            <bk-toolbar-spacer></bk-toolbar-spacer>
+            <bk-input type="search" placeholder="Search" style="max-width: 240px" ng-keyup="search($event)" ng-model="searchField.text"></bk-input>
+            <bk-toolbar-spacer fixed-width="8px"></bk-toolbar-spacer>
+            <bk-button label="Refresh" ng-click="load()"></bk-button>
+            <bk-toolbar-spacer fixed-width="8px"></bk-toolbar-spacer>
+            <bk-button label="{{ resolving ? 'Resolving…' : 'Resolve' }}" ng-disabled="resolving" ng-click="resolve()"></bk-button>
+            <bk-toolbar-spacer fixed-width="8px"></bk-toolbar-spacer>
+            <bk-button label="Add Dependency…" state="emphasized" ng-click="openAddDialog()"></bk-button>
+            <bk-toolbar-spacer fixed-width="8px"></bk-toolbar-spacer>
+        </bk-toolbar>
+        <bk-message-strip ng-if="message.text" state="{{ message.state }}" dismissible="true" ng-click="message.text = ''">{{ message.text }}</bk-message-strip>
+        <div bk-scrollbar class="bk-full-height">
+            <table bk-table display-mode="compact" outer-borders="none">
+                <thead bk-table-header sticky="true" interactive="false">
+                    <tr bk-table-row>
+                        <th bk-table-header-cell>Coordinate</th>
+                        <th bk-table-header-cell>Scope</th>
+                        <th bk-table-header-cell>Declared by</th>
+                        <th bk-table-header-cell>Status</th>
+                        <th bk-table-header-cell>Details</th>
+                    </tr>
+                </thead>
+                <tbody bk-table-body>
+                    <tr bk-table-row ng-repeat="entry in state.report track by $index" hoverable="true" activable="false" ng-hide="entry.hidden">
+                        <td bk-table-cell><span class="bk-font--mono">{{ entry.coordinate }}</span></td>
+                        <td bk-table-cell fit-content="true">{{ entry.scope || '-' }}</td>
+                        <td bk-table-cell fit-content="true">{{ declaredByOf(entry.coordinate) }}</td>
+                        <td bk-table-cell fit-content="true">
+                            <span bk-object-status status="{{ badge(entry.status) }}" text="{{ entry.status }}" inverted="true" style="white-space: nowrap;"></span>
+                        </td>
+                        <td bk-table-cell>{{ entry.message }}</td>
+                    </tr>
+                    <tr bk-table-row ng-if="!state.report.length">
+                        <td bk-table-cell no-data="true">No dependencies are declared - add a maven entry to a project.json and publish the project.</td>
+                    </tr>
+                </tbody>
+            </table>
+            <div class="bk-padding--sm" style="opacity: 0.75">
+                <div>Lockfile: <span class="bk-font--mono">{{ state.lockfile }}</span></div>
+                <div>Local repository: <span class="bk-font--mono">{{ state.localRepository || '-' }}</span></div>
+                <div>Resolved-modules seed: <span class="bk-font--mono">{{ state.resolvedModulesDirectory }}</span></div>
+            </div>
+        </div>
+
+        <bk-dialog visible="addDialog.visible" window-title="Add Dependency" state="{{ addDialog.error ? 'error' : '' }}">
+            <bk-dialog-body>
+                <bk-fieldset>
+                    <bk-form-group>
+                        <bk-form-item>
+                            <bk-form-label for="ad-workspace" required="true">Workspace</bk-form-label>
+                            <bk-select id="ad-workspace" placeholder="Select a workspace" dropdown-fixed="true" ng-model="addDialog.workspace" ng-required="true">
+                                <bk-option ng-repeat="w in addDialog.workspaces" text="{{ w }}" value="w"></bk-option>
+                            </bk-select>
+                        </bk-form-item>
+                        <bk-form-item>
+                            <bk-form-label for="ad-project" required="true">Project</bk-form-label>
+                            <bk-select id="ad-project" placeholder="Select a project" dropdown-fixed="true" ng-model="addDialog.project" ng-required="true">
+                                <bk-option ng-repeat="p in addDialog.projects" text="{{ p }}" value="p"></bk-option>
+                            </bk-select>
+                        </bk-form-item>
+                        <bk-form-item>
+                            <bk-form-label for="ad-id" required="true">Coordinate (groupId:artifactId:version)</bk-form-label>
+                            <bk-input id="ad-id" type="text" placeholder="org.jsoup:jsoup:1.17.2" ng-model="addDialog.id" ng-change="validate()"></bk-input>
+                        </bk-form-item>
+                        <bk-form-item>
+                            <bk-form-label for="ad-scope">Scope</bk-form-label>
+                            <bk-select id="ad-scope" dropdown-fixed="true" ng-model="addDialog.scope">
+                                <bk-option text="module (default) - swappable, restartless add/upgrade/remove" value="'module'"></bk-option>
+                                <bk-option text="platform - system classloader; JDBC drivers and native libraries" value="'platform'"></bk-option>
+                            </bk-select>
+                        </bk-form-item>
+                    </bk-form-group>
+                </bk-fieldset>
+                <p ng-if="addDialog.error" class="bk-margin-top--sm">{{ addDialog.error }}</p>
+            </bk-dialog-body>
+            <bk-dialog-footer>
+                <bk-bar-element>
+                    <bk-button label="Add" state="emphasized" ng-disabled="!addDialog.valid || addDialog.saving" ng-click="addDependency()"></bk-button>
+                </bk-bar-element>
+                <bk-bar-element>
+                    <bk-button label="Cancel" state="transparent" ng-click="addDialog.visible = false"></bk-button>
+                </bk-bar-element>
+            </bk-dialog-footer>
+        </bk-dialog>
+
+        <script type="text/javascript">
+            angular.module('dependencies', ['platformView', 'blimpKit']).controller('DependenciesController', ($scope, $http, $timeout) => {
+                const STATE_URL = '/services/core/dependencies';
+                const WORKSPACES_URL = '/services/ide/workspaces';
+                // exact versions only - version ranges and blanks are rejected, same as the backend
+                const GAV_PATTERN = /^[^\s:]+:[^\s:]+:[^\s:,\[\]\(\)]+$/;
+                $scope.state = { report: [] };
+                $scope.searchField = { text: '' };
+                $scope.message = { text: '', state: 'information' };
+                $scope.resolving = false;
+                $scope.addDialog = { visible: false, workspaces: [], projects: [], scope: 'module', valid: false };
+
+                $scope.badge = (status) => {
+                    if (status === 'active') return 'positive';
+                    if (status === 'mediated') return 'informative';
+                    if (status === 'pending-restart' || status === 'shadowed') return 'critical';
+                    return 'negative'; // failed, frozen-mismatch
+                };
+
+                $scope.declaredByOf = (coordinate) => {
+                    const projects = ($scope.state.declaredBy || {})[coordinate];
+                    return projects && projects.length ? projects.join(', ') : '-';
+                };
+
+                $scope.load = () => {
+                    $http.get(STATE_URL).then((response) => {
+                        $scope.state = response.data;
+                        $scope.applySearch();
+                    }, (error) => {
+                        console.error(error);
+                        $scope.message = { text: 'The dependencies state could not be loaded.', state: 'negative' };
+                    });
+                };
+
+                $scope.resolve = () => {
+                    $scope.resolving = true;
+                    $http.post(STATE_URL + '/resolve').then((response) => {
+                        $scope.state = response.data;
+                        $scope.applySearch();
+                        const failures = Object.keys($scope.state.failures || {}).length;
+                        $scope.message = failures
+                            ? { text: failures + ' failure(s) - see the report below.', state: 'negative' }
+                            : { text: 'Resolution completed cleanly.', state: 'positive' };
+                    }, (error) => {
+                        console.error(error);
+                        $scope.message = { text: (error.data && error.data.message) || 'The resolution failed.', state: 'negative' };
+                    }).finally(() => {
+                        $scope.resolving = false;
+                    });
+                };
+
+                $scope.applySearch = () => {
+                    const needle = $scope.searchField.text.toLowerCase();
+                    ($scope.state.report || []).forEach((entry) => {
+                        entry.hidden = needle && !(`${entry.coordinate}${entry.status}${entry.message}`.toLowerCase()
+                                                                                                       .includes(needle));
+                    });
+                };
+                let to = 0;
+                $scope.search = () => {
+                    if (to) $timeout.cancel(to);
+                    to = $timeout($scope.applySearch, 200);
+                };
+
+                $scope.openAddDialog = () => {
+                    $scope.addDialog = { visible: true, workspaces: [], projects: [], scope: 'module', id: '', valid: false };
+                    $http.get(WORKSPACES_URL).then((response) => {
+                        $scope.addDialog.workspaces = response.data || [];
+                        if ($scope.addDialog.workspaces.length === 1) {
+                            $scope.addDialog.workspace = $scope.addDialog.workspaces[0];
+                        }
+                    });
+                };
+
+                $scope.$watch('addDialog.workspace', (workspace) => {
+                    if (!workspace) return;
+                    $http.get(`${WORKSPACES_URL}/${encodeURIComponent(workspace)}`).then((response) => {
+                        $scope.addDialog.projects = (response.data.projects || []).map((project) => project.name);
+                    });
+                });
+
+                $scope.validate = () => {
+                    $scope.addDialog.valid = GAV_PATTERN.test(($scope.addDialog.id || '').trim());
+                    $scope.addDialog.error = $scope.addDialog.valid || !($scope.addDialog.id || '').trim()
+                        ? ''
+                        : 'Expected groupId:artifactId:version with an exact version - ranges are not supported.';
+                };
+
+                $scope.addDependency = () => {
+                    const dialog = $scope.addDialog;
+                    if (!dialog.workspace || !dialog.project || !dialog.valid) {
+                        dialog.error = 'Select a workspace and a project and enter a valid coordinate.';
+                        return;
+                    }
+                    dialog.saving = true;
+                    const fileUrl = `${WORKSPACES_URL}/${encodeURIComponent(dialog.workspace)}/${encodeURIComponent(dialog.project)}/project.json`;
+                    $http.get(fileUrl).then((response) => {
+                        save(typeof response.data === 'object' ? response.data : JSON.parse(response.data), false);
+                    }, () => {
+                        // no project.json yet - a minimal one is created around the declaration
+                        save({ guid: dialog.project, dependencies: [], actions: [] }, true);
+                    });
+
+                    const save = (descriptor, create) => {
+                        descriptor.dependencies = descriptor.dependencies || [];
+                        const id = dialog.id.trim();
+                        if (descriptor.dependencies.some((dependency) => dependency.type === 'maven' && dependency.id === id)) {
+                            dialog.error = `The project already declares [${id}].`;
+                            dialog.saving = false;
+                            return;
+                        }
+                        const entry = { type: 'maven', id: id };
+                        if (dialog.scope === 'platform') entry.scope = 'platform';
+                        descriptor.dependencies.push(entry);
+                        const content = JSON.stringify(descriptor, null, 4);
+                        const request = create
+                            ? $http.post(fileUrl, content, { headers: { 'Content-Type': 'text/plain' } })
+                            : $http.put(fileUrl, content, { headers: { 'Content-Type': 'text/plain' } });
+                        request.then(() => {
+                            dialog.visible = false;
+                            $scope.message = {
+                                text: `[${id}] added to ${dialog.project}/project.json - publish the project to activate it.`,
+                                state: 'positive'
+                            };
+                        }, (error) => {
+                            console.error(error);
+                            dialog.error = 'The project.json could not be updated.';
+                        }).finally(() => {
+                            dialog.saving = false;
+                        });
+                    };
+                };
+
+                $scope.load();
+            });
+        </script>
+        <theme></theme>
+    </body>
+
+</html>

--- a/components/ui/view-dependencies/src/main/resources/META-INF/dirigible/view-dependencies/extensions/dependencies.extension
+++ b/components/ui/view-dependencies/src/main/resources/META-INF/dirigible/view-dependencies/extensions/dependencies.extension
@@ -1,0 +1,5 @@
+{
+    "module": "view-dependencies/configs/dependencies-view.js",
+    "extensionPoint": "platform-views",
+    "description": "Dependencies View"
+}

--- a/components/ui/view-dependencies/src/main/resources/META-INF/dirigible/view-dependencies/project.json
+++ b/components/ui/view-dependencies/src/main/resources/META-INF/dirigible/view-dependencies/project.json
@@ -1,0 +1,5 @@
+{
+    "guid": "view-dependencies",
+    "dependencies": [],
+    "actions": []
+}

--- a/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
+++ b/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
@@ -159,6 +159,19 @@ public enum DirigibleConfig {
     DEPENDENCIES_DIR("DIRIGIBLE_DEPENDENCIES_DIR", null),
 
     /**
+     * Whether dependency resolution is frozen: the activated set comes from the lockfile only -
+     * checksum-verified, no re-mediation, no new coordinates, network never consulted. The mode
+     * immutable production images should run.
+     */
+    DEPENDENCIES_FROZEN("DIRIGIBLE_DEPENDENCIES_FROZEN", Boolean.FALSE.toString()),
+
+    /**
+     * Path of the dependency lockfile; blank means project-lock.json inside the resolved-modules
+     * directory.
+     */
+    DEPENDENCIES_LOCKFILE("DIRIGIBLE_DEPENDENCIES_LOCKFILE", null),
+
+    /**
      * Maven local repository; blank means [user home]/.m2/repository when it exists, else [user
      * home]/.dirigible/m2.
      */

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/DependencyLockfileIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/DependencyLockfileIT.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.eclipse.dirigible.tests.framework.util.MavenFixtures;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * The dependency trust chain, end to end over one running platform: a clean resolution writes the
+ * lockfile, a tampered local-repository jar fails its checksum verification while everything else
+ * keeps serving, frozen mode rejects a coordinate the lock does not carry without consulting any
+ * repository, and a platform-provided coordinate declared at a different version is reported as
+ * shadowed - with the platform's own class provably serving. All repositories are file: fixtures
+ * built by the test - no network.
+ */
+// One Dirigible boot for the whole journey; the steps build on each other in @Order sequence.
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class DependencyLockfileIT extends IntegrationTest {
+
+    /** The registry project declaring the maven dependencies. */
+    private static final String PROJECT = "lockfile-it";
+    private static final String PROJECT_JSON_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/project.json";
+    private static final String PROBE_SOURCE_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/client/GsonProbe.java";
+
+    /** The AOT survivor module's controller - proves the rest keeps serving after a failure. */
+    private static final String SURVIVOR_ENDPOINT = "/services/java/survivor-module/survivor/SurvivorController/ping";
+
+    /** The registry handler proving the platform's gson serves, not a declared one. */
+    private static final String PROBE_ENDPOINT = "/services/java/" + PROJECT + "/client/GsonProbe";
+
+    private static final String ALPHA = "com.example:alpha:1.0.0";
+
+    private static final long AWAIT_SECONDS = 60;
+
+    @TempDir
+    static Path tempDir;
+
+    private static Path fixtureRepo;
+    private static Path localRepository;
+    private static Path lockfilePath;
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @BeforeAll
+    static void prepareFixtures() throws IOException {
+        fixtureRepo = Files.createDirectories(tempDir.resolve("fixture-repo"));
+        localRepository = tempDir.resolve("local-repo");
+        Path resolvedModules = tempDir.resolve("resolved-modules");
+        lockfilePath = resolvedModules.resolve("project-lock.json");
+        // the fixture repository REPLACES Maven Central, so no request can leave the machine
+        Configuration.set("DIRIGIBLE_MAVEN_REPOSITORIES", "central=" + fixtureRepo.toUri());
+        Configuration.set("DIRIGIBLE_MAVEN_LOCAL_REPO", localRepository.toString());
+        Configuration.set("DIRIGIBLE_DEPENDENCIES_DIR", resolvedModules.toString());
+        Configuration.set("DIRIGIBLE_DEPENDENCIES_FROZEN", "false");
+
+        Path work = Files.createDirectories(tempDir.resolve("work"));
+        MavenFixtures.deploy(fixtureRepo, "com.example", "alpha", "1.0.0",
+                MavenFixtures.buildPlainJar(work, "alpha-1.0.0.jar", Map.of("com.example.alpha.Alpha", """
+                        package com.example.alpha;
+                        public class Alpha {
+                        }
+                        """)));
+        MavenFixtures.deploy(fixtureRepo, "com.example", "survivor-module", "1.0.0",
+                MavenFixtures.buildModuleJar(work, "survivor-module-1.0.0.jar", "survivor-module", Map.of("survivor.SurvivorController", """
+                        package survivor;
+                        import org.eclipse.dirigible.sdk.http.Controller;
+                        import org.eclipse.dirigible.sdk.http.Get;
+                        @Controller
+                        public class SurvivorController {
+                            @Get("/ping")
+                            public String ping() {
+                                return "survivor alive";
+                            }
+                        }
+                        """), Map.of()));
+        MavenFixtures.deploy(fixtureRepo, "com.example", "gamma", "1.0.0",
+                MavenFixtures.buildPlainJar(work, "gamma-1.0.0.jar", Map.of("com.example.gamma.Gamma", """
+                        package com.example.gamma;
+                        public class Gamma {
+                        }
+                        """)));
+        // a fake gson the platform-provided one must shadow - the marker resource distinguishes it
+        MavenFixtures.deploy(fixtureRepo, "com.google.gson", "gson", "1.0.0-fixture",
+                MavenFixtures.buildPlainJar(work, "gson-1.0.0-fixture.jar", Map.of("com.google.gson.FixtureMarker", """
+                        package com.google.gson;
+                        public class FixtureMarker {
+                        }
+                        """), Map.of("gson-fixture.marker", "the fixture gson, not the platform's")));
+    }
+
+    @Test
+    @Order(1)
+    void a_clean_resolution_writes_the_lockfile() throws IOException {
+        writeProjectJson("""
+                { "type": "maven", "id": "com.example:alpha:1.0.0" },
+                { "type": "maven", "id": "com.example:survivor-module:1.0.0" }""");
+        resolveExpecting(response -> response.body("failures", anEmptyMap())
+                                             .body("frozen", is(false))
+                                             .body("lockfile", containsString("project-lock.json"))
+                                             .body("declaredBy.'com.example:alpha:1.0.0'", hasItem(PROJECT))
+                                             .body("report.findAll { it.coordinate == '" + ALPHA + "' }.status", hasItem("active")));
+
+        awaitEndpoint(SURVIVOR_ENDPOINT, "survivor alive");
+
+        assertThat(lockfilePath).exists();
+        String lock = Files.readString(lockfilePath, StandardCharsets.UTF_8);
+        assertThat(lock).contains("\"id\": \"com.example:alpha:1.0.0\"")
+                        .contains("\"id\": \"com.example:survivor-module:1.0.0\"")
+                        .contains("\"" + PROJECT + "\"")
+                        .contains(sha256(localRepository.resolve("com/example/alpha/1.0.0/alpha-1.0.0.jar")));
+
+        // the second pass verifies every artifact against the just-written lock and stays clean
+        resolveExpecting(response -> response.body("failures", anEmptyMap())
+                                             .body("report.findAll { it.coordinate == '" + ALPHA + "' }.status", hasItem("active")));
+    }
+
+    @Test
+    @Order(2)
+    void a_tampered_artifact_fails_verification_and_the_rest_keeps_serving() throws IOException {
+        Path alphaJar = localRepository.resolve("com/example/alpha/1.0.0/alpha-1.0.0.jar");
+        String lockedSha = sha256(alphaJar);
+        byte[] original = Files.readAllBytes(alphaJar);
+        Files.write(alphaJar, "tampered".getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+
+        try {
+            resolveExpecting(response -> response.body("failures", hasKey(ALPHA))
+                                                 .body("failures.'" + ALPHA + "'", containsString("Checksum mismatch"))
+                                                 .body("report.findAll { it.coordinate == '" + ALPHA + "' }.status", hasItem("failed"))
+                                                 .body("report.findAll { it.coordinate == 'com.example:survivor-module:1.0.0' }.status",
+                                                         hasItem("active"))
+                                                 .body("artifacts", not(hasItem(alphaJar.toString()))));
+
+            // the verified rest keeps serving - an integrity failure is per-artifact, never total
+            awaitEndpoint(SURVIVOR_ENDPOINT, "survivor alive");
+
+            // the failed pass must never launder the tampered artifact into the trusted set
+            assertThat(Files.readString(lockfilePath, StandardCharsets.UTF_8)).contains(lockedSha);
+        } finally {
+            Files.write(alphaJar, original);
+        }
+
+        // the restored artifact matches the lock again and re-activates
+        resolveExpecting(response -> response.body("failures", anEmptyMap())
+                                             .body("report.findAll { it.coordinate == '" + ALPHA + "' }.status", hasItem("active")));
+    }
+
+    @Test
+    @Order(3)
+    void frozen_mode_rejects_a_coordinate_the_lock_does_not_carry() {
+        Configuration.set("DIRIGIBLE_DEPENDENCIES_FROZEN", "true");
+        try {
+            writeProjectJson("""
+                    { "type": "maven", "id": "com.example:alpha:1.0.0" },
+                    { "type": "maven", "id": "com.example:survivor-module:1.0.0" },
+                    { "type": "maven", "id": "com.example:gamma:1.0.0" }""");
+
+            resolveExpecting(response -> response.body("frozen", is(true))
+                                                 .body("failures", hasKey("com.example:gamma:1.0.0"))
+                                                 .body("failures.'com.example:gamma:1.0.0'", containsString("frozen mode"))
+                                                 .body("report.findAll { it.coordinate == 'com.example:gamma:1.0.0' }.status",
+                                                         hasItem("frozen-mismatch"))
+                                                 .body("report.findAll { it.coordinate == '" + ALPHA + "' }.status", hasItem("active")));
+
+            // frozen mode never consulted any repository - the rejected coordinate was not downloaded
+            assertThat(localRepository.resolve("com/example/gamma/1.0.0/gamma-1.0.0.jar")).doesNotExist();
+            awaitEndpoint(SURVIVOR_ENDPOINT, "survivor alive");
+        } finally {
+            Configuration.set("DIRIGIBLE_DEPENDENCIES_FROZEN", "false");
+        }
+
+        writeProjectJson("""
+                { "type": "maven", "id": "com.example:alpha:1.0.0" },
+                { "type": "maven", "id": "com.example:survivor-module:1.0.0" }""");
+        resolveExpecting(response -> response.body("failures", anEmptyMap()));
+    }
+
+    @Test
+    @Order(4)
+    void a_platform_provided_coordinate_is_shadowed_and_the_platform_class_serves() {
+        repository.createResource(PROBE_SOURCE_PATH, """
+                package client;
+                import jakarta.servlet.http.HttpServletRequest;
+                import jakarta.servlet.http.HttpServletResponse;
+                import org.eclipse.dirigible.engine.java.handler.JavaHandler;
+                public class GsonProbe implements JavaHandler {
+                    @Override
+                    public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
+                        String marker = getClass().getClassLoader().getResource("gson-fixture.marker") == null ? "no-marker" : "marker";
+                        response.getWriter().write(marker + ":" + new com.google.gson.Gson().getClass().getName());
+                    }
+                }
+                """.getBytes(StandardCharsets.UTF_8), false, "text/x-java", true);
+        synchronizationProcessor.forceProcessSynchronizers();
+
+        writeProjectJson("""
+                { "type": "maven", "id": "com.example:alpha:1.0.0" },
+                { "type": "maven", "id": "com.example:survivor-module:1.0.0" },
+                { "type": "maven", "id": "com.google.gson:gson:1.0.0-fixture" }""");
+
+        // shadowing is a report, not a failure - the resolution itself stays clean
+        resolveExpecting(response -> response.body("failures", anEmptyMap())
+                                             .body("report.findAll { it.coordinate == 'com.google.gson:gson:1.0.0-fixture' }.status",
+                                                     hasItem("shadowed"))
+                                             .body("report.findAll { it.coordinate == 'com.google.gson:gson:1.0.0-fixture' }.message[0]",
+                                                     containsString("requested: 1.0.0-fixture")));
+
+        // never downloaded - parent-first delegation would never serve it anyway
+        assertThat(localRepository.resolve("com/google/gson/gson/1.0.0-fixture/gson-1.0.0-fixture.jar")).doesNotExist();
+
+        // the class actually loaded is the platform's: the fixture's marker resource is absent and
+        // the platform's Gson answers
+        awaitEndpoint(PROBE_ENDPOINT, "no-marker:com.google.gson.Gson");
+    }
+
+    private void writeProjectJson(String dependencyEntries) {
+        String content = """
+                {
+                    "guid": "%s",
+                    "dependencies": [
+                %s
+                    ]
+                }
+                """.formatted(PROJECT, dependencyEntries.indent(8));
+        repository.createResource(PROJECT_JSON_PATH, content.getBytes(StandardCharsets.UTF_8), false, "application/json", true);
+    }
+
+    private void resolveExpecting(Consumer<ValidatableResponse> assertions) {
+        restAssuredExecutor.execute(() -> {
+            ValidatableResponse response = given().when()
+                                                  .post("/services/core/dependencies/resolve")
+                                                  .then()
+                                                  .statusCode(200)
+                                                  .contentType(ContentType.JSON);
+            assertions.accept(response);
+        });
+    }
+
+    private void awaitEndpoint(String endpoint, String expectedBodyFragment) {
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get(endpoint)
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body(containsString(expectedBodyFragment)),
+                AWAIT_SECONDS);
+    }
+
+    private static String sha256(Path file) throws IOException {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is mandated by every JVM", e);
+        }
+        return HexFormat.of()
+                        .formatHex(digest.digest(Files.readAllBytes(file)));
+    }
+
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/DependencyLockfileIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/DependencyLockfileIT.java
@@ -130,7 +130,7 @@ class DependencyLockfileIT extends IntegrationTest {
                         }
                         """)));
         // a fake gson the platform-provided one must shadow - the marker resource distinguishes it
-        MavenFixtures.deploy(fixtureRepo, "com.google.gson", "gson", "1.0.0-fixture",
+        MavenFixtures.deploy(fixtureRepo, "com.google.code.gson", "gson", "1.0.0-fixture",
                 MavenFixtures.buildPlainJar(work, "gson-1.0.0-fixture.jar", Map.of("com.google.gson.FixtureMarker", """
                         package com.google.gson;
                         public class FixtureMarker {
@@ -245,17 +245,17 @@ class DependencyLockfileIT extends IntegrationTest {
         writeProjectJson("""
                 { "type": "maven", "id": "com.example:alpha:1.0.0" },
                 { "type": "maven", "id": "com.example:survivor-module:1.0.0" },
-                { "type": "maven", "id": "com.google.gson:gson:1.0.0-fixture" }""");
+                { "type": "maven", "id": "com.google.code.gson:gson:1.0.0-fixture" }""");
 
         // shadowing is a report, not a failure - the resolution itself stays clean
         resolveExpecting(response -> response.body("failures", anEmptyMap())
-                                             .body("report.findAll { it.coordinate == 'com.google.gson:gson:1.0.0-fixture' }.status",
+                                             .body("report.findAll { it.coordinate == 'com.google.code.gson:gson:1.0.0-fixture' }.status",
                                                      hasItem("shadowed"))
-                                             .body("report.findAll { it.coordinate == 'com.google.gson:gson:1.0.0-fixture' }.message[0]",
+                                             .body("report.findAll { it.coordinate == 'com.google.code.gson:gson:1.0.0-fixture' }.message[0]",
                                                      containsString("requested: 1.0.0-fixture")));
 
         // never downloaded - parent-first delegation would never serve it anyway
-        assertThat(localRepository.resolve("com/google/gson/gson/1.0.0-fixture/gson-1.0.0-fixture.jar")).doesNotExist();
+        assertThat(localRepository.resolve("com/google/code/gson/gson/1.0.0-fixture/gson-1.0.0-fixture.jar")).doesNotExist();
 
         // the class actually loaded is the platform's: the fixture's marker resource is absent and
         // the platform's Gson answers


### PR DESCRIPTION
## Overview

Part 4 of the *Dynamic dependency management* epic (#6776) - the trust and reproducibility layer over parts 1-3:

- **Lockfile** - every fully clean union resolution writes `project-lock.json` (instance-level, inside the resolved-modules directory, so baking that one directory into an image carries the whole reproducibility bundle): each activated artifact with its SHA-256, the `requestedBy` projects (roots) or the `via` root (transitives) and its scope, plus the version mediations with chosen/rejected versions and per-project attribution. Deterministically sorted, so two locks diff line by line. Before anything activates, every resolved artifact is verified against the lock - a checksum mismatch is a hard per-artifact failure (reported, evicted from the launch seed, not activated) while the verified rest keeps serving, and a failed pass never rewrites the lock, so a tampered artifact can never launder itself into the trusted set.
- **`DIRIGIBLE_DEPENDENCIES_FROZEN=true`** - the mode immutable production images should run: the lockfile IS the resolution. The locked set activates checksum-verified from the local repository, no remote repository is ever consulted, no version is re-mediated, and a declaration the lock does not carry is rejected as `frozen-mismatch` with a pointed error. (`DIRIGIBLE_DEPENDENCIES_LOCKFILE` overrides the lockfile location.)
- **Provided-BOM** - the application build generates a standard `dependencyManagement` POM (`org.eclipse.dirigible:dirigible-provided-bom`) from the build's own resolved runtime dependencies (the Spring Boot repackage input - never by unzipping the artifact) and embeds it as `META-INF/dirigible-provided-bom.xml`, so an air-gapped instance knows what the platform ships without any remote fetch, and a distribution building its own fat jar embeds its own inventory. The resolver treats every listed coordinate as **provided**: never downloaded, pruned from the graph with its subtree.
- **Shadowing report** - a project declaring a `groupId:artifactId` the platform provides at a *different* version gets a WARN with both versions and a `shadowed` status on the endpoint and in the IDE view - the sharpest footgun of the whole mechanism is now impossible to hit silently. Child-first loading as a "fix" was deliberately rejected; the `ProvidedBom` javadoc records why (a visible report at resolution time beats invisible `LinkageError`s of the same FQN at arbitrary call sites).
- **Per-artifact status report** - `GET /services/core/dependencies` now carries a `report` with one accurate status per artifact: `active | pending-restart | shadowed | mediated | failed | frozen-mismatch`, plus `declaredBy` attribution, the `frozen` flag and the lockfile path.
- **IDE Dependencies view** (Operations perspective, next to Artefacts) - read-only rendering of the report (coordinate, scope, declaring projects, status badge, details) plus a minimal *Add Dependency…* dialog that validates the coordinate (exact versions only) and writes the `maven` entry into the selected workspace project's `project.json` - the descriptor stays the API.

## Worked example - the full trust chain

**Declare** (`invoice-app/project.json` in the registry):

```json
{
    "guid": "invoice-app",
    "dependencies": [
        { "type": "maven", "id": "org.apache.poi:poi:5.2.5" },
        { "type": "maven", "id": "com.google.code.gson:gson:2.8.9" }
    ]
}
```

**Resolve** (`POST /services/core/dependencies/resolve`) - gson is shadowed (the platform ships 2.13.2), poi activates, and poi's other transitives (commons-codec, commons-io, commons-collections4, commons-math3, log4j-api) are pruned as platform-provided - only SparseBitSet is actually new:

```
  shadowed  com.google.code.gson:gson:2.8.9   requested: 2.8.9, provided: 2.13.2 - parent-first delegation serves the platform's version; the declared version is inert
    active  org.apache.poi:poi:5.2.5          Declared
    active  com.zaxxer:SparseBitSet:1.3       Via org.apache.poi:poi:5.2.5
```

**The lockfile** (`resolved-modules/project-lock.json`) and its **diff** after upgrading poi to 5.4.0 - two lines of substance, reviewable at a glance:

```diff
   "artifacts": [
     {
       "id": "com.zaxxer:SparseBitSet:1.3",
       "sha256": "f76b85adb0c00721ae267b7cfde4da7f71d3121cc2160c9fc00c0c89f8c53c8a",
-      "via": "org.apache.poi:poi:5.2.5",
+      "via": "org.apache.poi:poi:5.4.0",
       "scope": "module"
     },
     {
-      "id": "org.apache.poi:poi:5.2.5",
-      "sha256": "352e1b44a5777af2df3d7dc408cda9f75f932d0e0125fa1a7d336a13c0a663a7",
+      "id": "org.apache.poi:poi:5.4.0",
+      "sha256": "ace71e79873059e273036674560b50c3d6b945b7ca168b0d4962ad7650ae1eec",
       "requestedBy": [
         "invoice-app"
       ],
```

**Frozen-mode boot** (`DIRIGIBLE_DEPENDENCIES_FROZEN=true`, with an extra `org.commonmark:commonmark:0.24.0` declared that the lock does not carry) - the locked set activates checksum-verified, the shadowed declaration stays a report (the embedded BOM answers without any network), and the new coordinate is rejected without being downloaded:

```
[WARN ] FrozenResolution - Declared [com.google.code.gson:gson] is SHADOWED: requested [2.8.9], the platform provides [2.13.2] - parent-first delegation serves the platform's version
[ERROR] FrozenResolution - Frozen-mode mismatch: Declared as [org.commonmark:commonmark:0.24.0] but not part of [project-lock.json] - frozen mode (DIRIGIBLE_DEPENDENCIES_FROZEN=true) activates the locked set only. Unfreeze the instance or rebuild the lock with a dynamic resolution to add or change dependencies.
[INFO ] DependencySynchronizer - Dependency layer swapped to generation [1]: added [com.zaxxer:SparseBitSet:1.3, org.apache.poi:poi:5.4.0], removed []
[INFO ] DependenciesService - Maven dependency frozen activation completed: [3] declared, [2] jar(s) activated, [0] platform-scoped, [0] mediated, [1] failure(s), classloader generation [1]
```

**The Dependencies view** (Operations perspective) rendering the same state with the `shadowed` badge:

<img width="3000" height="1240" alt="dependencies-view" src="https://github.com/user-attachments/assets/00e0d8b0-ab18-4a40-b4d8-8ae07788d5af" />

## Tests

- Unit: `LockfileRoundTripTest` (round trip, deterministic serialization, a flipped byte fails verification naming the coordinate), `ProvidedBomTest` (provided satisfied without a download, different version shadowed with both versions, provided transitive pruned, generator/parser round trip), `FrozenModeTest` (locked set resolves repository-free, new coordinate rejected with a pointed error, provided declarations are never frozen mismatches).
- Integration: `DependencyLockfileIT` - clean resolution writes the lock; a tampered local-repository jar fails verification while the rest keeps serving and the lock is not rewritten; frozen mode rejects an unlocked coordinate without downloading it; a platform-provided coordinate declared at another version is `shadowed` and the platform's own class provably serves (marker-resource probe). `LauncherAgentDeliveryIT` additionally pins the embedded BOM inside the executable jar.
- All part 1-3 ITs (`DependencyResolutionIT`, `DynamicDependenciesIT`, `PlatformScopeDependencyIT`) stay green with the verification pipeline and the real BOM live.

Fixes: #6780.
