### PR TITLE
First-party sign-in for the cognito profile: USER_SRP_AUTH login establishing the standard session, IdP-hint passthrough, configurable login page

### DIFF
--- a/components/security/security-client-registration/src/main/java/org/eclipse/dirigible/components/security/oauth/service/DynamicClientRegistrationRepository.java
+++ b/components/security/security-client-registration/src/main/java/org/eclipse/dirigible/components/security/oauth/service/DynamicClientRegistrationRepository.java
@@ -99,7 +99,15 @@ public class DynamicClientRegistrationRepository
 
     @Override
     public org.springframework.security.oauth2.client.registration.ClientRegistration findByRegistrationId(String registrationId) {
-        return REGISTRATIONS.get(registrationId);
+        org.springframework.security.oauth2.client.registration.ClientRegistration registration = REGISTRATIONS.get(registrationId);
+        if (registration == null) {
+            // the store is populated when something iterates it - historically the generated login
+            // page. A direct lookup can come first (a custom login page, a native login), so a miss
+            // triggers the same initialization before giving up.
+            iterator();
+            registration = REGISTRATIONS.get(registrationId);
+        }
+        return registration;
     }
 
     public Optional<ClientRegistration> findById(String id) {

--- a/components/security/security-client-registration/src/test/java/org/eclipse/dirigible/components/security/oauth/service/DynamicClientRegistrationRepositoryTest.java
+++ b/components/security/security-client-registration/src/test/java/org/eclipse/dirigible/components/security/oauth/service/DynamicClientRegistrationRepositoryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.eclipse.dirigible.components.security.oauth.client.CognitoDefaultTenantProperties;
+import org.eclipse.dirigible.components.security.oauth.client.KeycloakDefaultTenantProperties;
+import org.eclipse.dirigible.components.security.oauth.domain.ClientRegistration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link DynamicClientRegistrationRepository} - most importantly that a direct
+ * lookup initializes the lazily populated store. Historically only the generated login page
+ * iterated the repository, so with a custom login page (or a native login as the first request)
+ * every {@code findByRegistrationId} answered {@code null} and both the authorization redirect and
+ * the native sign-in failed.
+ */
+@ExtendWith(MockitoExtension.class)
+class DynamicClientRegistrationRepositoryTest {
+
+    @Mock
+    private ClientRegistrationService service;
+
+    @Mock
+    private CognitoDefaultTenantProperties cognitoProperties;
+
+    @Mock
+    private KeycloakDefaultTenantProperties keycloakProperties;
+
+    @Test
+    void aDirectLookupInitializesTheStore() {
+        ClientRegistration stored = new ClientRegistration("test-tenant", "lazy-lookup-client", "", "client-id", "client-secret",
+                "{baseUrl}/login/oauth2/code/{registrationId}", "authorization_code", "openid", "https://idp.example.org/oauth2/token",
+                "https://idp.example.org/oauth2/authorize", "https://idp.example.org/oauth2/userInfo", "https://idp.example.org",
+                "https://idp.example.org/jwks", "email");
+        when(service.getAll()).thenReturn(List.of(stored));
+        DynamicClientRegistrationRepository repository =
+                new DynamicClientRegistrationRepository(service, cognitoProperties, keycloakProperties);
+
+        org.springframework.security.oauth2.client.registration.ClientRegistration found =
+                repository.findByRegistrationId("lazy-lookup-client");
+
+        assertNotNull(found);
+        assertEquals("lazy-lookup-client", found.getRegistrationId());
+        assertEquals("client-id", found.getClientId());
+    }
+
+    @Test
+    void anUnknownRegistrationStaysUnknown() {
+        when(service.getAll()).thenReturn(List.of());
+        DynamicClientRegistrationRepository repository =
+                new DynamicClientRegistrationRepository(service, cognitoProperties, keycloakProperties);
+
+        assertNull(repository.findByRegistrationId("never-registered"));
+    }
+}

--- a/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoIdpClient.java
+++ b/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoIdpClient.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.cognito;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+
+/**
+ * Thin client for the unauthenticated {@code cognito-idp} authentication APIs
+ * ({@code InitiateAuth}, {@code RespondToAuthChallenge}) over their JSON wire protocol - the calls
+ * need no request signing and no AWS SDK.
+ *
+ * <p>
+ * Request bodies carry authentication material (SRP proofs, challenge answers), so nothing here
+ * logs them, and failures surface only the service error type plus its message.
+ */
+@Profile("cognito")
+@Component
+class CognitoIdpClient {
+
+    private static final String TARGET_PREFIX = "AWSCognitoIdentityProviderService.";
+    private static final String CONTENT_TYPE = "application/x-amz-json-1.1";
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
+
+    private static final Gson GSON = new Gson();
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+                                                    .connectTimeout(CONNECT_TIMEOUT)
+                                                    .build();
+
+    /**
+     * Calls {@code InitiateAuth} with the {@code USER_SRP_AUTH} flow.
+     *
+     * @param pool the user pool
+     * @param clientId the app client id
+     * @param authParameters the auth parameters ({@code USERNAME}, {@code SRP_A}, optional
+     *        {@code SECRET_HASH})
+     * @param userContextData the optional client-side collector blob for threat protection
+     * @return the service response
+     * @throws CognitoIdpException when the service refuses the call or is unreachable
+     */
+    JsonObject initiateAuth(CognitoUserPool pool, String clientId, Map<String, String> authParameters, String userContextData) {
+        JsonObject request = new JsonObject();
+        request.addProperty("AuthFlow", "USER_SRP_AUTH");
+        request.addProperty("ClientId", clientId);
+        request.add("AuthParameters", toJson(authParameters));
+        addUserContextData(request, userContextData);
+        return call(pool, "InitiateAuth", request);
+    }
+
+    /**
+     * Calls {@code RespondToAuthChallenge}.
+     *
+     * @param pool the user pool
+     * @param clientId the app client id
+     * @param challengeName the challenge being answered
+     * @param session the opaque session state from the previous step
+     * @param challengeResponses the challenge responses
+     * @param userContextData the optional client-side collector blob for threat protection
+     * @return the service response
+     * @throws CognitoIdpException when the service refuses the call or is unreachable
+     */
+    JsonObject respondToAuthChallenge(CognitoUserPool pool, String clientId, String challengeName, String session,
+            Map<String, String> challengeResponses, String userContextData) {
+        JsonObject request = new JsonObject();
+        request.addProperty("ChallengeName", challengeName);
+        request.addProperty("ClientId", clientId);
+        if (StringUtils.hasText(session)) {
+            request.addProperty("Session", session);
+        }
+        request.add("ChallengeResponses", toJson(challengeResponses));
+        addUserContextData(request, userContextData);
+        return call(pool, "RespondToAuthChallenge", request);
+    }
+
+    private JsonObject call(CognitoUserPool pool, String operation, JsonObject request) {
+        HttpRequest httpRequest = HttpRequest.newBuilder()
+                                             .uri(URI.create(pool.endpoint()))
+                                             .timeout(REQUEST_TIMEOUT)
+                                             .header("Content-Type", CONTENT_TYPE)
+                                             .header("X-Amz-Target", TARGET_PREFIX + operation)
+                                             .POST(HttpRequest.BodyPublishers.ofString(GSON.toJson(request), StandardCharsets.UTF_8))
+                                             .build();
+        HttpResponse<String> response;
+        try {
+            response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        } catch (IOException ex) {
+            throw new CognitoIdpException(null, "The [" + operation + "] call to [" + pool.endpoint() + "] failed", ex);
+        } catch (InterruptedException ex) {
+            Thread.currentThread()
+                  .interrupt();
+            throw new CognitoIdpException(null, "The [" + operation + "] call to [" + pool.endpoint() + "] was interrupted", ex);
+        }
+        if (response.statusCode() == 200) {
+            return GSON.fromJson(response.body(), JsonObject.class);
+        }
+        throw toServiceException(operation, response);
+    }
+
+    private static CognitoIdpException toServiceException(String operation, HttpResponse<String> response) {
+        String errorType = null;
+        String message = null;
+        try {
+            JsonObject error = GSON.fromJson(response.body(), JsonObject.class);
+            if (error != null) {
+                errorType = asString(error, "__type");
+                message = asString(error, "message");
+                if (message == null) {
+                    message = asString(error, "Message");
+                }
+            }
+        } catch (JsonSyntaxException ex) {
+            // a non-JSON error page from an intermediary - the status code is all there is
+        }
+        if (errorType != null && errorType.contains("#")) {
+            errorType = errorType.substring(errorType.indexOf('#') + 1);
+        }
+        return new CognitoIdpException(errorType, "The [" + operation + "] call failed with status [" + response.statusCode()
+                + "], error type [" + errorType + "]: " + message);
+    }
+
+    private static String asString(JsonObject object, String member) {
+        return object.has(member) && object.get(member)
+                                           .isJsonPrimitive() ? object.get(member)
+                                                                      .getAsString()
+                                                   : null;
+    }
+
+    private static JsonObject toJson(Map<String, String> parameters) {
+        JsonObject json = new JsonObject();
+        parameters.forEach(json::addProperty);
+        return json;
+    }
+
+    private static void addUserContextData(JsonObject request, String userContextData) {
+        if (StringUtils.hasText(userContextData)) {
+            JsonObject contextData = new JsonObject();
+            contextData.addProperty("EncodedData", userContextData);
+            request.add("UserContextData", contextData);
+        }
+    }
+}

--- a/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoIdpException.java
+++ b/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoIdpException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.cognito;
+
+/**
+ * A failed {@code cognito-idp} API call. Carries the service error type (e.g.
+ * {@code NotAuthorizedException}) so the caller can map it onto a normalized outcome - the raw
+ * message stays a server-side diagnostic.
+ */
+class CognitoIdpException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The service error type, or {@code null} when the call failed before a service answer. */
+    private final String errorType;
+
+    CognitoIdpException(String errorType, String message) {
+        super(message);
+        this.errorType = errorType;
+    }
+
+    CognitoIdpException(String errorType, String message, Throwable cause) {
+        super(message, cause);
+        this.errorType = errorType;
+    }
+
+    /**
+     * The service error type.
+     *
+     * @return the error type, or {@code null} when the call failed without a service answer
+     */
+    String getErrorType() {
+        return errorType;
+    }
+}

--- a/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoNativeLoginProvider.java
+++ b/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoNativeLoginProvider.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.cognito;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginChallenge;
+import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginChallengeAnswer;
+import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginCredentials;
+import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginException;
+import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginProvider;
+import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginResult;
+import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginTokens;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import com.google.gson.JsonObject;
+
+/**
+ * First-party Cognito sign-in over the {@code USER_SRP_AUTH} flow - deliberately not
+ * {@code USER_PASSWORD_AUTH}: with SRP the password is used only to compute a zero-knowledge proof,
+ * so it never crosses the wire from the platform to AWS.
+ *
+ * <p>
+ * Everything is derived from the client registration the login runs against (client id/secret, pool
+ * coordinates from the issuer URI), so per-tenant registrations work without extra configuration.
+ * Challenges beyond the password verifier ({@code NEW_PASSWORD_REQUIRED}, the MFA family,
+ * {@code CUSTOM_CHALLENGE}) are surfaced to the caller as a round-trip rather than failure, and
+ * provider error codes are normalized - raw messages stay server-side.
+ */
+@Profile("cognito")
+@Component
+class CognitoNativeLoginProvider implements NativeLoginProvider {
+
+    private static final String PASSWORD_VERIFIER = "PASSWORD_VERIFIER";
+    private static final String USERNAME = "USERNAME";
+
+    private final CognitoIdpClient idpClient;
+    private final String defaultRegistrationId;
+
+    CognitoNativeLoginProvider(CognitoIdpClient idpClient,
+            @Value("${spring.security.oauth2.client.registration.cognito.client-name:cognito}") String defaultRegistrationId) {
+        this.idpClient = idpClient;
+        this.defaultRegistrationId = defaultRegistrationId;
+    }
+
+    /**
+     * The registration used when a login request does not name one - the default tenant's.
+     *
+     * @return the default client registration id
+     */
+    @Override
+    public String getDefaultRegistrationId() {
+        return defaultRegistrationId;
+    }
+
+    /**
+     * Runs the SRP handshake: {@code InitiateAuth} with the ephemeral public key, then the
+     * {@code PASSWORD_VERIFIER} challenge with the password claim signature.
+     *
+     * @param registration the client registration the login runs against
+     * @param credentials the first-party credentials
+     * @return the tokens, or the next challenge Cognito requires
+     */
+    @Override
+    public NativeLoginResult authenticate(ClientRegistration registration, NativeLoginCredentials credentials) {
+        CognitoUserPool pool = pool(registration);
+        CognitoSrp srp = new CognitoSrp();
+        Map<String, String> authParameters = new LinkedHashMap<>();
+        authParameters.put(USERNAME, credentials.username());
+        authParameters.put("SRP_A", srp.srpA());
+        addSecretHash(authParameters, registration, credentials.username());
+        try {
+            JsonObject response = idpClient.initiateAuth(pool, registration.getClientId(), authParameters, credentials.userContextData());
+            if (!PASSWORD_VERIFIER.equals(asString(response, "ChallengeName"))) {
+                return toResult(response, credentials.username());
+            }
+            return verifyPassword(pool, registration, srp, credentials, response);
+        } catch (CognitoIdpException ex) {
+            throw normalized(ex);
+        }
+    }
+
+    /**
+     * Answers a surfaced challenge ({@code NEW_PASSWORD_REQUIRED}, {@code SOFTWARE_TOKEN_MFA},
+     * {@code SMS_MFA}, {@code EMAIL_OTP}, {@code CUSTOM_CHALLENGE}, ...).
+     *
+     * @param registration the client registration the login runs against
+     * @param answer the challenge answer
+     * @return the tokens, or the next challenge Cognito requires
+     */
+    @Override
+    public NativeLoginResult answerChallenge(ClientRegistration registration, NativeLoginChallengeAnswer answer) {
+        CognitoUserPool pool = pool(registration);
+        Map<String, String> responses = new LinkedHashMap<>(answer.responses());
+        responses.put(USERNAME, answer.username());
+        addSecretHash(responses, registration, answer.username());
+        try {
+            JsonObject response = idpClient.respondToAuthChallenge(pool, registration.getClientId(), answer.challenge(), answer.session(),
+                    responses, answer.userContextData());
+            return toResult(response, answer.username());
+        } catch (CognitoIdpException ex) {
+            throw normalized(ex);
+        }
+    }
+
+    private NativeLoginResult verifyPassword(CognitoUserPool pool, ClientRegistration registration, CognitoSrp srp,
+            NativeLoginCredentials credentials, JsonObject initiation) {
+        JsonObject parameters = initiation.getAsJsonObject("ChallengeParameters");
+        String userIdForSrp = parameters != null ? asString(parameters, "USER_ID_FOR_SRP") : null;
+        String secretBlock = parameters != null ? asString(parameters, "SECRET_BLOCK") : null;
+        String srpB = parameters != null ? asString(parameters, "SRP_B") : null;
+        String salt = parameters != null ? asString(parameters, "SALT") : null;
+        if (userIdForSrp == null || secretBlock == null || srpB == null || salt == null) {
+            throw new NativeLoginException(NativeLoginException.Outcome.AUTHENTICATION_FAILED,
+                    "Cognito answered the SRP initiation without the expected challenge parameters");
+        }
+        byte[] key = srp.passwordAuthenticationKey(pool.poolName(), userIdForSrp, credentials.password(), new BigInteger(srpB, 16),
+                new BigInteger(salt, 16));
+        String timestamp = CognitoSrp.timestamp(Instant.now());
+        Map<String, String> responses = new LinkedHashMap<>();
+        responses.put(USERNAME, userIdForSrp);
+        responses.put("PASSWORD_CLAIM_SECRET_BLOCK", secretBlock);
+        responses.put("PASSWORD_CLAIM_SIGNATURE",
+                CognitoSrp.passwordClaimSignature(key, pool.poolName(), userIdForSrp, secretBlock, timestamp));
+        responses.put("TIMESTAMP", timestamp);
+        addSecretHash(responses, registration, userIdForSrp);
+        JsonObject response = idpClient.respondToAuthChallenge(pool, registration.getClientId(), PASSWORD_VERIFIER,
+                asString(initiation, "Session"), responses, credentials.userContextData());
+        return toResult(response, userIdForSrp);
+    }
+
+    private static NativeLoginResult toResult(JsonObject response, String canonicalUsername) {
+        JsonObject authenticationResult = response.has("AuthenticationResult") && response.get("AuthenticationResult")
+                                                                                          .isJsonObject()
+                                                                                                  ? response.getAsJsonObject(
+                                                                                                          "AuthenticationResult")
+                                                                                                  : null;
+        if (authenticationResult != null) {
+            String idToken = asString(authenticationResult, "IdToken");
+            String accessToken = asString(authenticationResult, "AccessToken");
+            if (idToken == null || accessToken == null) {
+                throw new NativeLoginException(NativeLoginException.Outcome.AUTHENTICATION_FAILED,
+                        "Cognito answered the authentication without the expected tokens");
+            }
+            Long expiresIn = authenticationResult.has("ExpiresIn") && authenticationResult.get("ExpiresIn")
+                                                                                          .isJsonPrimitive()
+                                                                                                  ? authenticationResult.get("ExpiresIn")
+                                                                                                                        .getAsLong()
+                                                                                                  : null;
+            return new NativeLoginTokens(idToken, accessToken, asString(authenticationResult, "RefreshToken"), expiresIn);
+        }
+        String challengeName = asString(response, "ChallengeName");
+        if (challengeName == null) {
+            throw new NativeLoginException(NativeLoginException.Outcome.AUTHENTICATION_FAILED,
+                    "Cognito answered with neither tokens nor a challenge");
+        }
+        Map<String, String> parameters = new LinkedHashMap<>();
+        JsonObject challengeParameters = response.has("ChallengeParameters") && response.get("ChallengeParameters")
+                                                                                        .isJsonObject()
+                                                                                                ? response.getAsJsonObject(
+                                                                                                        "ChallengeParameters")
+                                                                                                : null;
+        if (challengeParameters != null) {
+            challengeParameters.entrySet()
+                               .forEach(entry -> parameters.put(entry.getKey(), entry.getValue()
+                                                                                     .getAsString()));
+        }
+        // the follow-up must run for the canonical user Cognito resolved, not the typed alias
+        parameters.putIfAbsent(USERNAME, canonicalUsername);
+        return new NativeLoginChallenge(challengeName, asString(response, "Session"), parameters);
+    }
+
+    private static NativeLoginException normalized(CognitoIdpException exception) {
+        String errorType = exception.getErrorType() != null ? exception.getErrorType() : "";
+        NativeLoginException.Outcome outcome = switch (errorType) {
+            // UserNotFoundException maps to the same outcome to avoid user enumeration
+            case "NotAuthorizedException", "UserNotFoundException" -> NativeLoginException.Outcome.INVALID_CREDENTIALS;
+            case "PasswordResetRequiredException" -> NativeLoginException.Outcome.PASSWORD_RESET_REQUIRED;
+            case "UserNotConfirmedException" -> NativeLoginException.Outcome.USER_NOT_CONFIRMED;
+            case "CodeMismatchException" -> NativeLoginException.Outcome.CODE_MISMATCH;
+            case "ExpiredCodeException" -> NativeLoginException.Outcome.CODE_EXPIRED;
+            case "InvalidPasswordException" -> NativeLoginException.Outcome.INVALID_PASSWORD;
+            case "TooManyRequestsException", "TooManyFailedAttemptsException", "LimitExceededException" -> NativeLoginException.Outcome.TOO_MANY_ATTEMPTS;
+            default -> NativeLoginException.Outcome.AUTHENTICATION_FAILED;
+        };
+        return new NativeLoginException(outcome, "Cognito refused the authentication with [" + errorType + "]", exception);
+    }
+
+    private static CognitoUserPool pool(ClientRegistration registration) {
+        return CognitoUserPool.fromIssuer(registration.getProviderDetails()
+                                                      .getIssuerUri());
+    }
+
+    private static void addSecretHash(Map<String, String> parameters, ClientRegistration registration, String username) {
+        if (StringUtils.hasText(registration.getClientSecret())) {
+            parameters.put("SECRET_HASH", CognitoSrp.secretHash(registration.getClientId(), registration.getClientSecret(), username));
+        }
+    }
+
+    private static String asString(JsonObject object, String member) {
+        return object.has(member) && object.get(member)
+                                           .isJsonPrimitive() ? object.get(member)
+                                                                      .getAsString()
+                                                   : null;
+    }
+}

--- a/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoNativeLoginProvider.java
+++ b/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoNativeLoginProvider.java
@@ -20,7 +20,6 @@ import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginExcepti
 import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginProvider;
 import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginResult;
 import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginTokens;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.stereotype.Component;
@@ -46,13 +45,16 @@ class CognitoNativeLoginProvider implements NativeLoginProvider {
     private static final String PASSWORD_VERIFIER = "PASSWORD_VERIFIER";
     private static final String USERNAME = "USERNAME";
 
-    private final CognitoIdpClient idpClient;
-    private final String defaultRegistrationId;
+    /**
+     * The registration id {@code DynamicClientRegistrationRepository} registers the default-tenant
+     * Cognito client under (the registration's name, not its {@code client-name} label).
+     */
+    private static final String DEFAULT_REGISTRATION_ID = "cognito";
 
-    CognitoNativeLoginProvider(CognitoIdpClient idpClient,
-            @Value("${spring.security.oauth2.client.registration.cognito.client-name:cognito}") String defaultRegistrationId) {
+    private final CognitoIdpClient idpClient;
+
+    CognitoNativeLoginProvider(CognitoIdpClient idpClient) {
         this.idpClient = idpClient;
-        this.defaultRegistrationId = defaultRegistrationId;
     }
 
     /**
@@ -62,7 +64,7 @@ class CognitoNativeLoginProvider implements NativeLoginProvider {
      */
     @Override
     public String getDefaultRegistrationId() {
-        return defaultRegistrationId;
+        return DEFAULT_REGISTRATION_ID;
     }
 
     /**

--- a/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoSecurityConfiguration.java
+++ b/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoSecurityConfiguration.java
@@ -20,6 +20,7 @@ import org.eclipse.dirigible.components.base.http.access.HttpSecurityURIConfigur
 import org.eclipse.dirigible.components.base.http.roles.Roles;
 import org.eclipse.dirigible.components.base.util.AuthoritiesUtil;
 import org.eclipse.dirigible.components.security.oauth.ScopeRoleJwtAuthoritiesConverter;
+import org.eclipse.dirigible.components.security.oauth2.IdpHintAuthorizationRequestResolver;
 import org.eclipse.dirigible.components.security.oauth2.OAuth2SessionRevalidationFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,12 +34,14 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
+import org.springframework.util.StringUtils;
 
 /**
  * The Class OAuth2SecurityConfiguration.
@@ -70,7 +73,9 @@ public class CognitoSecurityConfiguration {
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http, HttpSecurityURIConfigurator httpSecurityURIConfigurator,
             ScopeRoleJwtAuthoritiesConverter scopeRoleJwtAuthoritiesConverter, CognitoLogoutSuccessHandler cognitoLogoutSuccessHandler,
-            OAuth2AuthorizedClientService authorizedClientService) throws Exception {
+            OAuth2AuthorizedClientService authorizedClientService, ClientRegistrationRepository clientRegistrationRepository)
+            throws Exception {
+        String loginPage = DirigibleConfig.SECURITY_LOGIN_PAGE.getStringValue();
         http.authorizeHttpRequests(authz -> authz.requestMatchers("/oauth2/**", "/login/**")
                                                  .permitAll())
             .csrf(csrf -> csrf.disable())
@@ -80,6 +85,11 @@ public class CognitoSecurityConfiguration {
             .oauth2Client(Customizer.withDefaults())
             .oauth2Login(oauth2 -> {
                 oauth2.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig.userAuthoritiesMapper(userAuthoritiesMapper()));
+                oauth2.authorizationEndpoint(authorizationEndpoint -> authorizationEndpoint.authorizationRequestResolver(
+                        new IdpHintAuthorizationRequestResolver(clientRegistrationRepository)));
+                if (StringUtils.hasText(loginPage)) {
+                    oauth2.loginPage(loginPage);
+                }
             })
             .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder())
                                                                  .jwtAuthenticationConverter(

--- a/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoSecurityConfiguration.java
+++ b/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoSecurityConfiguration.java
@@ -28,7 +28,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.GrantedAuthority;
@@ -76,17 +75,22 @@ public class CognitoSecurityConfiguration {
             OAuth2AuthorizedClientService authorizedClientService, ClientRegistrationRepository clientRegistrationRepository)
             throws Exception {
         String loginPage = DirigibleConfig.SECURITY_LOGIN_PAGE.getStringValue();
+        // both oauth2Client and oauth2Login register an authorization-request redirect filter, and
+        // the client one runs first - the resolver must be set on both for the hints to pass through
+        IdpHintAuthorizationRequestResolver authorizationRequestResolver =
+                new IdpHintAuthorizationRequestResolver(clientRegistrationRepository);
         http.authorizeHttpRequests(authz -> authz.requestMatchers("/oauth2/**", "/login/**")
                                                  .permitAll())
             .csrf(csrf -> csrf.disable())
             .addFilterBefore(new OAuth2SessionRevalidationFilter(authorizedClientService, userAuthoritiesMapper()),
                     AuthorizationFilter.class)
             .headers(headers -> headers.frameOptions(frameOpts -> frameOpts.disable()))
-            .oauth2Client(Customizer.withDefaults())
+            .oauth2Client(oauth2Client -> oauth2Client.authorizationCodeGrant(
+                    grant -> grant.authorizationRequestResolver(authorizationRequestResolver)))
             .oauth2Login(oauth2 -> {
                 oauth2.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig.userAuthoritiesMapper(userAuthoritiesMapper()));
-                oauth2.authorizationEndpoint(authorizationEndpoint -> authorizationEndpoint.authorizationRequestResolver(
-                        new IdpHintAuthorizationRequestResolver(clientRegistrationRepository)));
+                oauth2.authorizationEndpoint(
+                        authorizationEndpoint -> authorizationEndpoint.authorizationRequestResolver(authorizationRequestResolver));
                 if (StringUtils.hasText(loginPage)) {
                     oauth2.loginPage(loginPage);
                 }

--- a/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoSrp.java
+++ b/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoSrp.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.cognito;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.Locale;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * The client side of Cognito's {@code USER_SRP_AUTH} flow - one instance per authentication
+ * attempt, holding the ephemeral SRP key pair. Pure JCA against Cognito's published group
+ * parameters (the RFC 5054 3072-bit group, g = 2), mirroring AWS's reference implementation
+ * byte-for-byte, since the server derives the same values from the same canonicalization
+ * ({@link BigInteger#toByteArray()} of every intermediate).
+ *
+ * <p>
+ * With SRP the password is used only to compute a zero-knowledge proof, so it never crosses the
+ * wire from the platform to AWS.
+ */
+class CognitoSrp {
+
+    /** The RFC 5054 3072-bit group prime, as published for Cognito SRP. */
+    private static final String HEX_N = "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74"
+            + "020BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F1437"
+            + "4FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED"
+            + "EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3DC2007CB8A163BF05"
+            + "98DA48361C55D39A69163FA8FD24CF5F83655D23DCA3AD961C62F356208552BB"
+            + "9ED529077096966D670C354E4ABC9804F1746C08CA18217C32905E462E36CE3B"
+            + "E39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9DE2BCBF695581718"
+            + "3995497CEA956AE515D2261898FA051015728E5A8AAAC42DAD33170D04507A33"
+            + "A85521ABDF1CBA64ECFB850458DBEF0A8AEA71575D060C7DB3970F85A6E1E4C7"
+            + "ABF5AE8CDB0933D71E8C94E04A25619DCEE3D2261AD2EE6BF12FFA06D98A0864"
+            + "D87602733EC86A64521F2B18177B200CBBE117577A615D6C770988C0BAD946E2"
+            + "08E24FA074E5AB3143DB5BFCE0FD108E4B82D120A93AD2CAFFFFFFFFFFFFFFFF";
+
+    static final BigInteger N = new BigInteger(HEX_N, 16);
+    private static final BigInteger G = BigInteger.valueOf(2);
+
+    /** The SRP multiplier parameter k = H(N | g). */
+    private static final BigInteger K;
+
+    private static final int EPHEMERAL_KEY_LENGTH_BITS = 1024;
+    private static final int DERIVED_KEY_SIZE_BYTES = 16;
+    private static final String DERIVED_KEY_INFO = "Caldera Derived Key";
+
+    private static final String HMAC_SHA_256 = "HmacSHA256";
+
+    /** Cognito's expected password-claim timestamp shape, e.g. {@code Tue Aug 18 08:32:12 UTC 2026}. */
+    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("EEE MMM d HH:mm:ss 'UTC' yyyy", Locale.US)
+                                                                               .withZone(ZoneOffset.UTC);
+
+    static {
+        MessageDigest digest = sha256();
+        digest.update(N.toByteArray());
+        K = new BigInteger(1, digest.digest(G.toByteArray()));
+    }
+
+    /** The ephemeral SRP private key. */
+    private final BigInteger a;
+
+    /** The ephemeral SRP public key A = g^a mod N. */
+    private final BigInteger bigA;
+
+    CognitoSrp() {
+        this(new SecureRandom());
+    }
+
+    CognitoSrp(SecureRandom random) {
+        BigInteger generatedA;
+        BigInteger generatedBigA;
+        do {
+            generatedA = new BigInteger(EPHEMERAL_KEY_LENGTH_BITS, random).mod(N);
+            generatedBigA = G.modPow(generatedA, N);
+        } while (generatedBigA.mod(N)
+                              .equals(BigInteger.ZERO));
+        this.a = generatedA;
+        this.bigA = generatedBigA;
+    }
+
+    /**
+     * The {@code SRP_A} auth parameter for {@code InitiateAuth}.
+     *
+     * @return the ephemeral public key as hex
+     */
+    String srpA() {
+        return bigA.toString(16);
+    }
+
+    /**
+     * Derives the password authentication key for the {@code PASSWORD_VERIFIER} challenge.
+     *
+     * @param poolName the user pool name (the pool id after the region prefix)
+     * @param userIdForSrp the {@code USER_ID_FOR_SRP} challenge parameter
+     * @param password the user's password
+     * @param srpB the server's ephemeral public key ({@code SRP_B}, hex-decoded)
+     * @param salt the user's salt ({@code SALT}, hex-decoded)
+     * @return the 16-byte derived key the password claim is signed with
+     */
+    byte[] passwordAuthenticationKey(String poolName, String userIdForSrp, String password, BigInteger srpB, BigInteger salt) {
+        if (srpB.mod(N)
+                .equals(BigInteger.ZERO)) {
+            throw new SecurityException("SRP error: B cannot be zero");
+        }
+        MessageDigest digest = sha256();
+        digest.update(bigA.toByteArray());
+        BigInteger u = new BigInteger(1, digest.digest(srpB.toByteArray()));
+        if (u.equals(BigInteger.ZERO)) {
+            throw new SecurityException("SRP error: the hash of A and B cannot be zero");
+        }
+
+        digest.reset();
+        digest.update(poolName.getBytes(StandardCharsets.UTF_8));
+        digest.update(userIdForSrp.getBytes(StandardCharsets.UTF_8));
+        digest.update(":".getBytes(StandardCharsets.UTF_8));
+        byte[] userIdPasswordHash = digest.digest(password.getBytes(StandardCharsets.UTF_8));
+
+        digest.reset();
+        digest.update(salt.toByteArray());
+        BigInteger x = new BigInteger(1, digest.digest(userIdPasswordHash));
+
+        BigInteger s = srpB.subtract(K.multiply(G.modPow(x, N)))
+                           .modPow(a.add(u.multiply(x)), N)
+                           .mod(N);
+        return hkdf(s.toByteArray(), u.toByteArray());
+    }
+
+    /**
+     * Signs the password claim for the {@code PASSWORD_VERIFIER} challenge response.
+     *
+     * @param key the derived password authentication key
+     * @param poolName the user pool name
+     * @param userIdForSrp the {@code USER_ID_FOR_SRP} challenge parameter
+     * @param secretBlockBase64 the {@code SECRET_BLOCK} challenge parameter, as received
+     * @param timestamp the claim timestamp, from {@link #timestamp(Instant)}
+     * @return the Base64-encoded {@code PASSWORD_CLAIM_SIGNATURE}
+     */
+    static String passwordClaimSignature(byte[] key, String poolName, String userIdForSrp, String secretBlockBase64, String timestamp) {
+        Mac mac = hmacSha256(key);
+        mac.update(poolName.getBytes(StandardCharsets.UTF_8));
+        mac.update(userIdForSrp.getBytes(StandardCharsets.UTF_8));
+        mac.update(Base64.getDecoder()
+                         .decode(secretBlockBase64));
+        return Base64.getEncoder()
+                     .encodeToString(mac.doFinal(timestamp.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    /**
+     * Computes the {@code SECRET_HASH} auth parameter for app clients with a client secret.
+     *
+     * @param clientId the app client id
+     * @param clientSecret the app client secret
+     * @param username the username the parameter accompanies
+     * @return the Base64-encoded secret hash
+     */
+    static String secretHash(String clientId, String clientSecret, String username) {
+        Mac mac = hmacSha256(clientSecret.getBytes(StandardCharsets.UTF_8));
+        mac.update(username.getBytes(StandardCharsets.UTF_8));
+        return Base64.getEncoder()
+                     .encodeToString(mac.doFinal(clientId.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    /**
+     * Formats the password-claim timestamp the way Cognito expects it.
+     *
+     * @param moment the moment to format
+     * @return the formatted timestamp
+     */
+    static String timestamp(Instant moment) {
+        return TIMESTAMP_FORMAT.format(moment);
+    }
+
+    private static byte[] hkdf(byte[] ikm, byte[] salt) {
+        byte[] pseudoRandomKey = hmacSha256(salt).doFinal(ikm);
+        Mac expansion = hmacSha256(pseudoRandomKey);
+        expansion.update(DERIVED_KEY_INFO.getBytes(StandardCharsets.UTF_8));
+        byte[] block = expansion.doFinal(new byte[] {1});
+        byte[] key = new byte[DERIVED_KEY_SIZE_BYTES];
+        System.arraycopy(block, 0, key, 0, DERIVED_KEY_SIZE_BYTES);
+        return key;
+    }
+
+    private static MessageDigest sha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 is not available", ex);
+        }
+    }
+
+    private static Mac hmacSha256(byte[] key) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_SHA_256);
+            mac.init(new SecretKeySpec(key, HMAC_SHA_256));
+            return mac;
+        } catch (NoSuchAlgorithmException | InvalidKeyException ex) {
+            throw new IllegalStateException(HMAC_SHA_256 + " is not available", ex);
+        }
+    }
+}

--- a/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoUserPool.java
+++ b/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoUserPool.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.cognito;
+
+import java.net.URI;
+
+/**
+ * The coordinates of a Cognito user pool, derived from a client registration's issuer URI
+ * ({@code https://cognito-idp.<region>.amazonaws.com/<poolId>}) - so the native login needs no
+ * configuration beyond what the OAuth2 registration already carries.
+ *
+ * @param endpoint the {@code cognito-idp} API endpoint for the pool's region
+ * @param poolId the user pool id (e.g. {@code eu-central-1_AbCdEfGhI})
+ */
+record CognitoUserPool(String endpoint, String poolId) {
+
+    /**
+     * Parses the pool coordinates from the registration's issuer URI.
+     *
+     * @param issuerUri the issuer URI
+     * @return the user pool
+     * @throws IllegalStateException when the issuer URI is not a Cognito user pool issuer
+     */
+    static CognitoUserPool fromIssuer(String issuerUri) {
+        URI uri = issuerUri != null ? URI.create(issuerUri) : null;
+        String host = uri != null ? uri.getHost() : null;
+        String path = uri != null && uri.getPath() != null ? uri.getPath() : "";
+        String poolId = path.startsWith("/") ? path.substring(1) : path;
+        if (host == null || !host.startsWith("cognito-idp.") || !poolId.contains("_") || poolId.contains("/")) {
+            throw new IllegalStateException("The issuer URI [" + issuerUri + "] is not a Cognito user pool issuer");
+        }
+        return new CognitoUserPool("https://" + host + "/", poolId);
+    }
+
+    /**
+     * The pool name - the part of the pool id after the region prefix, used in the SRP password claim.
+     *
+     * @return the pool name
+     */
+    String poolName() {
+        return poolId.substring(poolId.indexOf('_') + 1);
+    }
+}

--- a/components/security/security-cognito/src/test/java/org/eclipse/dirigible/components/security/cognito/CognitoNativeLoginProviderTest.java
+++ b/components/security/security-cognito/src/test/java/org/eclipse/dirigible/components/security/cognito/CognitoNativeLoginProviderTest.java
@@ -57,7 +57,7 @@ class CognitoNativeLoginProviderTest {
 
     @BeforeEach
     void setUp() {
-        provider = new CognitoNativeLoginProvider(idpClient, "default-tenant");
+        provider = new CognitoNativeLoginProvider(idpClient);
         registration = ClientRegistration.withRegistrationId("default-tenant")
                                          .clientId("client-id")
                                          .clientSecret("client-secret")
@@ -68,6 +68,11 @@ class CognitoNativeLoginProviderTest {
                                          .issuerUri("https://cognito-idp.eu-central-1.amazonaws.com/eu-central-1_TestPool1")
                                          .userNameAttributeName("email")
                                          .build();
+    }
+
+    @Test
+    void theDefaultRegistrationIsTheOneTheDefaultTenantClientIsRegisteredUnder() {
+        assertEquals("cognito", provider.getDefaultRegistrationId());
     }
 
     @Test

--- a/components/security/security-cognito/src/test/java/org/eclipse/dirigible/components/security/cognito/CognitoNativeLoginProviderTest.java
+++ b/components/security/security-cognito/src/test/java/org/eclipse/dirigible/components/security/cognito/CognitoNativeLoginProviderTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.cognito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginChallenge;
+import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginChallengeAnswer;
+import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginCredentials;
+import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginException;
+import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginResult;
+import org.eclipse.dirigible.components.security.oauth2.login.NativeLoginTokens;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+/**
+ * Unit tests for {@link CognitoNativeLoginProvider} - the SRP handshake orchestration, the
+ * challenge round-trip and the normalization of Cognito error codes.
+ */
+@ExtendWith(MockitoExtension.class)
+class CognitoNativeLoginProviderTest {
+
+    private static final Gson GSON = new Gson();
+    private static final String USER_ID_FOR_SRP = "3b3f18f4-1c3d-4b6e-9f9a-0e2f4c1a5d77";
+
+    @Mock
+    private CognitoIdpClient idpClient;
+
+    private CognitoNativeLoginProvider provider;
+    private ClientRegistration registration;
+
+    @BeforeEach
+    void setUp() {
+        provider = new CognitoNativeLoginProvider(idpClient, "default-tenant");
+        registration = ClientRegistration.withRegistrationId("default-tenant")
+                                         .clientId("client-id")
+                                         .clientSecret("client-secret")
+                                         .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                                         .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                                         .authorizationUri("https://cognito.example.org/oauth2/authorize")
+                                         .tokenUri("https://cognito.example.org/oauth2/token")
+                                         .issuerUri("https://cognito-idp.eu-central-1.amazonaws.com/eu-central-1_TestPool1")
+                                         .userNameAttributeName("email")
+                                         .build();
+    }
+
+    @Test
+    void aPasswordLoginRunsTheSrpHandshakeAndReturnsTheTokens() {
+        when(idpClient.initiateAuth(any(), eq("client-id"), anyMap(), any())).thenReturn(passwordVerifierChallenge());
+        when(idpClient.respondToAuthChallenge(any(), eq("client-id"), eq("PASSWORD_VERIFIER"), eq("session-1"), anyMap(),
+                any())).thenReturn(authenticated());
+
+        NativeLoginResult result =
+                provider.authenticate(registration, new NativeLoginCredentials("jane.doe@example.org", "the-password", null));
+
+        NativeLoginTokens tokens = assertInstanceOf(NativeLoginTokens.class, result);
+        assertEquals("id-token", tokens.idToken());
+        assertEquals("access-token", tokens.accessToken());
+        assertEquals("refresh-token", tokens.refreshToken());
+        assertEquals(3600L, tokens.expiresInSeconds());
+
+        ArgumentCaptor<Map<String, String>> initiation = ArgumentCaptor.forClass(Map.class);
+        verify(idpClient).initiateAuth(any(), eq("client-id"), initiation.capture(), any());
+        assertEquals("jane.doe@example.org", initiation.getValue()
+                                                       .get("USERNAME"));
+        assertNotNull(initiation.getValue()
+                                .get("SRP_A"));
+        assertNotNull(initiation.getValue()
+                                .get("SECRET_HASH"));
+
+        ArgumentCaptor<Map<String, String>> verifier = ArgumentCaptor.forClass(Map.class);
+        verify(idpClient).respondToAuthChallenge(any(), eq("client-id"), eq("PASSWORD_VERIFIER"), eq("session-1"), verifier.capture(),
+                any());
+        // the verifier answers for the canonical user Cognito resolved, not the typed alias
+        assertEquals(USER_ID_FOR_SRP, verifier.getValue()
+                                              .get("USERNAME"));
+        assertEquals("c2VjcmV0LWJsb2Nr", verifier.getValue()
+                                                 .get("PASSWORD_CLAIM_SECRET_BLOCK"));
+        assertNotNull(verifier.getValue()
+                              .get("PASSWORD_CLAIM_SIGNATURE"));
+        assertNotNull(verifier.getValue()
+                              .get("TIMESTAMP"));
+        assertEquals(CognitoSrp.secretHash("client-id", "client-secret", USER_ID_FOR_SRP), verifier.getValue()
+                                                                                                   .get("SECRET_HASH"));
+    }
+
+    @Test
+    void anMfaChallengeIsSurfacedWithTheCanonicalUsername() {
+        when(idpClient.initiateAuth(any(), anyString(), anyMap(), any())).thenReturn(passwordVerifierChallenge());
+        when(idpClient.respondToAuthChallenge(any(), anyString(), eq("PASSWORD_VERIFIER"), anyString(), anyMap(), any())).thenReturn(
+                GSON.fromJson("{\"ChallengeName\":\"SOFTWARE_TOKEN_MFA\",\"Session\":\"session-2\",\"ChallengeParameters\":{}}",
+                        JsonObject.class));
+
+        NativeLoginResult result =
+                provider.authenticate(registration, new NativeLoginCredentials("jane.doe@example.org", "the-password", null));
+
+        NativeLoginChallenge challenge = assertInstanceOf(NativeLoginChallenge.class, result);
+        assertEquals("SOFTWARE_TOKEN_MFA", challenge.name());
+        assertEquals("session-2", challenge.session());
+        assertEquals(USER_ID_FOR_SRP, challenge.parameters()
+                                               .get("USERNAME"));
+    }
+
+    @Test
+    void aChallengeAnswerCarriesTheUsernameAndSecretHash() {
+        when(idpClient.respondToAuthChallenge(any(), eq("client-id"), eq("SOFTWARE_TOKEN_MFA"), eq("session-2"), anyMap(),
+                any())).thenReturn(authenticated());
+
+        NativeLoginResult result = provider.answerChallenge(registration, new NativeLoginChallengeAnswer("SOFTWARE_TOKEN_MFA", "session-2",
+                USER_ID_FOR_SRP, Map.of("SOFTWARE_TOKEN_MFA_CODE", "123456"), null));
+
+        assertInstanceOf(NativeLoginTokens.class, result);
+        ArgumentCaptor<Map<String, String>> responses = ArgumentCaptor.forClass(Map.class);
+        verify(idpClient).respondToAuthChallenge(any(), eq("client-id"), eq("SOFTWARE_TOKEN_MFA"), eq("session-2"), responses.capture(),
+                any());
+        assertEquals("123456", responses.getValue()
+                                        .get("SOFTWARE_TOKEN_MFA_CODE"));
+        assertEquals(USER_ID_FOR_SRP, responses.getValue()
+                                               .get("USERNAME"));
+        assertNotNull(responses.getValue()
+                               .get("SECRET_HASH"));
+    }
+
+    @Test
+    void anUnknownUserNormalizesToInvalidCredentials() {
+        when(idpClient.initiateAuth(any(), anyString(), anyMap(), any())).thenThrow(
+                new CognitoIdpException("UserNotFoundException", "User does not exist."));
+
+        NativeLoginException exception = assertThrows(NativeLoginException.class,
+                () -> provider.authenticate(registration, new NativeLoginCredentials("who@example.org", "any", null)));
+
+        assertEquals(NativeLoginException.Outcome.INVALID_CREDENTIALS, exception.getOutcome());
+    }
+
+    @Test
+    void throttlingNormalizesToTooManyAttempts() {
+        when(idpClient.initiateAuth(any(), anyString(), anyMap(), any())).thenThrow(
+                new CognitoIdpException("TooManyRequestsException", "Rate exceeded"));
+
+        NativeLoginException exception = assertThrows(NativeLoginException.class,
+                () -> provider.authenticate(registration, new NativeLoginCredentials("jane.doe@example.org", "any", null)));
+
+        assertEquals(NativeLoginException.Outcome.TOO_MANY_ATTEMPTS, exception.getOutcome());
+    }
+
+    @Test
+    void aTransportFailureNormalizesToAuthenticationFailed() {
+        when(idpClient.initiateAuth(any(), anyString(), anyMap(), any())).thenThrow(new CognitoIdpException(null, "unreachable"));
+
+        NativeLoginException exception = assertThrows(NativeLoginException.class,
+                () -> provider.authenticate(registration, new NativeLoginCredentials("jane.doe@example.org", "any", null)));
+
+        assertEquals(NativeLoginException.Outcome.AUTHENTICATION_FAILED, exception.getOutcome());
+    }
+
+    @Test
+    void aRegistrationWithoutClientSecretSendsNoSecretHash() {
+        ClientRegistration withoutSecret = ClientRegistration.withRegistrationId("default-tenant")
+                                                             .clientId("client-id")
+                                                             .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                                                             .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                                                             .authorizationUri("https://cognito.example.org/oauth2/authorize")
+                                                             .tokenUri("https://cognito.example.org/oauth2/token")
+                                                             .issuerUri(
+                                                                     "https://cognito-idp.eu-central-1.amazonaws.com/eu-central-1_TestPool1")
+                                                             .userNameAttributeName("email")
+                                                             .build();
+        when(idpClient.initiateAuth(any(), anyString(), anyMap(), any())).thenReturn(passwordVerifierChallenge());
+        when(idpClient.respondToAuthChallenge(any(), anyString(), anyString(), anyString(), anyMap(), any())).thenReturn(authenticated());
+
+        provider.authenticate(withoutSecret, new NativeLoginCredentials("jane.doe@example.org", "the-password", null));
+
+        ArgumentCaptor<Map<String, String>> initiation = ArgumentCaptor.forClass(Map.class);
+        verify(idpClient).initiateAuth(any(), anyString(), initiation.capture(), any());
+        assertNull(initiation.getValue()
+                             .get("SECRET_HASH"));
+    }
+
+    private static JsonObject passwordVerifierChallenge() {
+        CognitoSrp serverFacingSrp = new CognitoSrp();
+        JsonObject response = new JsonObject();
+        response.addProperty("ChallengeName", "PASSWORD_VERIFIER");
+        response.addProperty("Session", "session-1");
+        JsonObject parameters = new JsonObject();
+        parameters.addProperty("USER_ID_FOR_SRP", USER_ID_FOR_SRP);
+        parameters.addProperty("USERNAME", USER_ID_FOR_SRP);
+        // any valid group element works for the handshake shape - the signature is not verified here
+        parameters.addProperty("SRP_B", serverFacingSrp.srpA());
+        parameters.addProperty("SALT", "aa00bb11");
+        parameters.addProperty("SECRET_BLOCK", "c2VjcmV0LWJsb2Nr");
+        response.add("ChallengeParameters", parameters);
+        return response;
+    }
+
+    private static JsonObject authenticated() {
+        return GSON.fromJson("{\"AuthenticationResult\":{\"IdToken\":\"id-token\",\"AccessToken\":\"access-token\","
+                + "\"RefreshToken\":\"refresh-token\",\"ExpiresIn\":3600,\"TokenType\":\"Bearer\"}}", JsonObject.class);
+    }
+}

--- a/components/security/security-cognito/src/test/java/org/eclipse/dirigible/components/security/cognito/CognitoSrpTest.java
+++ b/components/security/security-cognito/src/test/java/org/eclipse/dirigible/components/security/cognito/CognitoSrpTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.cognito;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Base64;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link CognitoSrp}. The round-trip test plays the server side of the SRP protocol
+ * (verifier from the registered password, ephemeral B, shared secret S = (A * v^u)^b) with an
+ * independent transcription of the math, so a canonicalization slip on either side of the client
+ * implementation fails the key comparison.
+ */
+class CognitoSrpTest {
+
+    private static final BigInteger N = CognitoSrp.N;
+    private static final BigInteger G = BigInteger.valueOf(2);
+
+    private static final String POOL_NAME = "TestPool1";
+    private static final String USER_ID = "3b3f18f4-1c3d-4b6e-9f9a-0e2f4c1a5d77";
+    private static final String PASSWORD = "correct horse battery staple";
+
+    @Test
+    void clientAndServerDeriveTheSameKey() throws Exception {
+        SecureRandom random = new SecureRandom();
+        CognitoSrp client = new CognitoSrp(random);
+        BigInteger bigA = new BigInteger(client.srpA(), 16);
+
+        byte[] saltBytes = new byte[16];
+        random.nextBytes(saltBytes);
+        BigInteger salt = new BigInteger(1, saltBytes);
+
+        // server-side registration: the password verifier v = g^x
+        BigInteger x = computeX(salt);
+        BigInteger v = G.modPow(x, N);
+
+        // server-side ephemeral key pair: B = k*v + g^b
+        BigInteger k = computeK();
+        BigInteger b = new BigInteger(1024, random).mod(N);
+        BigInteger bigB = k.multiply(v)
+                           .add(G.modPow(b, N))
+                           .mod(N);
+
+        // server-side shared secret: S = (A * v^u)^b
+        BigInteger u = hashToInt(bigA.toByteArray(), bigB.toByteArray());
+        BigInteger s = bigA.multiply(v.modPow(u, N))
+                           .modPow(b, N)
+                           .mod(N);
+        byte[] serverKey = hkdf(s.toByteArray(), u.toByteArray());
+
+        byte[] clientKey = client.passwordAuthenticationKey(POOL_NAME, USER_ID, PASSWORD, bigB, salt);
+
+        assertArrayEquals(serverKey, clientKey);
+    }
+
+    @Test
+    void aWrongPasswordDerivesADifferentKey() throws Exception {
+        SecureRandom random = new SecureRandom();
+        CognitoSrp client = new CognitoSrp(random);
+        BigInteger bigA = new BigInteger(client.srpA(), 16);
+
+        BigInteger salt = new BigInteger(1, new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
+        BigInteger x = computeX(salt);
+        BigInteger v = G.modPow(x, N);
+        BigInteger k = computeK();
+        BigInteger b = new BigInteger(1024, random).mod(N);
+        BigInteger bigB = k.multiply(v)
+                           .add(G.modPow(b, N))
+                           .mod(N);
+        BigInteger u = hashToInt(bigA.toByteArray(), bigB.toByteArray());
+        BigInteger s = bigA.multiply(v.modPow(u, N))
+                           .modPow(b, N)
+                           .mod(N);
+        byte[] serverKey = hkdf(s.toByteArray(), u.toByteArray());
+
+        byte[] clientKey = client.passwordAuthenticationKey(POOL_NAME, USER_ID, "not the password", bigB, salt);
+
+        assertNotEquals(Base64.getEncoder()
+                              .encodeToString(serverKey),
+                Base64.getEncoder()
+                      .encodeToString(clientKey));
+    }
+
+    @Test
+    void aZeroServerKeyIsRefused() {
+        CognitoSrp client = new CognitoSrp();
+        assertThrows(SecurityException.class, () -> client.passwordAuthenticationKey(POOL_NAME, USER_ID, PASSWORD, N, BigInteger.ONE));
+    }
+
+    @Test
+    void timestampMatchesCognitosExpectedShape() {
+        assertEquals("Tue Aug 18 08:32:12 UTC 2026", CognitoSrp.timestamp(Instant.parse("2026-08-18T08:32:12Z")));
+        // the day of month is not zero-padded
+        assertEquals("Sat Aug 8 01:02:03 UTC 2026", CognitoSrp.timestamp(Instant.parse("2026-08-08T01:02:03Z")));
+    }
+
+    @Test
+    void secretHashMatchesTheDocumentedComputation() {
+        assertEquals("P2LsDP7jcVEDCxd4Nkf43mVmWNwtq/gqVKPQHji+KAM=",
+                CognitoSrp.secretHash("client-id", "client-secret", "jane.doe@example.org"));
+    }
+
+    @Test
+    void passwordClaimSignatureIsTheHmacOverPoolUserSecretBlockAndTimestamp() throws Exception {
+        byte[] key = new byte[] {9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 9, 8, 7, 6, 5, 4};
+        byte[] secretBlock = new byte[] {42, 42, 42, 42};
+        String timestamp = "Tue Aug 18 08:32:12 UTC 2026";
+
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(key, "HmacSHA256"));
+        mac.update(POOL_NAME.getBytes(StandardCharsets.UTF_8));
+        mac.update(USER_ID.getBytes(StandardCharsets.UTF_8));
+        mac.update(secretBlock);
+        String expected = Base64.getEncoder()
+                                .encodeToString(mac.doFinal(timestamp.getBytes(StandardCharsets.UTF_8)));
+
+        String actual = CognitoSrp.passwordClaimSignature(key, POOL_NAME, USER_ID, Base64.getEncoder()
+                                                                                         .encodeToString(secretBlock),
+                timestamp);
+
+        assertEquals(expected, actual);
+    }
+
+    private static BigInteger computeX(BigInteger salt) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        digest.update(POOL_NAME.getBytes(StandardCharsets.UTF_8));
+        digest.update(USER_ID.getBytes(StandardCharsets.UTF_8));
+        digest.update(":".getBytes(StandardCharsets.UTF_8));
+        byte[] userIdPasswordHash = digest.digest(PASSWORD.getBytes(StandardCharsets.UTF_8));
+        digest.reset();
+        digest.update(salt.toByteArray());
+        return new BigInteger(1, digest.digest(userIdPasswordHash));
+    }
+
+    private static BigInteger computeK() throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        digest.update(N.toByteArray());
+        return new BigInteger(1, digest.digest(G.toByteArray()));
+    }
+
+    private static BigInteger hashToInt(byte[] first, byte[] second) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        digest.update(first);
+        return new BigInteger(1, digest.digest(second));
+    }
+
+    private static byte[] hkdf(byte[] ikm, byte[] salt) throws Exception {
+        Mac extraction = Mac.getInstance("HmacSHA256");
+        extraction.init(new SecretKeySpec(salt, "HmacSHA256"));
+        byte[] pseudoRandomKey = extraction.doFinal(ikm);
+
+        Mac expansion = Mac.getInstance("HmacSHA256");
+        expansion.init(new SecretKeySpec(pseudoRandomKey, "HmacSHA256"));
+        expansion.update("Caldera Derived Key".getBytes(StandardCharsets.UTF_8));
+        byte[] block = expansion.doFinal(new byte[] {1});
+
+        byte[] key = new byte[16];
+        System.arraycopy(block, 0, key, 0, 16);
+        return key;
+    }
+}

--- a/components/security/security-cognito/src/test/java/org/eclipse/dirigible/components/security/cognito/CognitoUserPoolTest.java
+++ b/components/security/security-cognito/src/test/java/org/eclipse/dirigible/components/security/cognito/CognitoUserPoolTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.cognito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link CognitoUserPool} - the pool coordinates derived from a registration's
+ * issuer URI.
+ */
+class CognitoUserPoolTest {
+
+    @Test
+    void parsesThePoolCoordinatesFromTheIssuer() {
+        CognitoUserPool pool = CognitoUserPool.fromIssuer("https://cognito-idp.eu-central-1.amazonaws.com/eu-central-1_AbCdEfGhI");
+
+        assertEquals("https://cognito-idp.eu-central-1.amazonaws.com/", pool.endpoint());
+        assertEquals("eu-central-1_AbCdEfGhI", pool.poolId());
+        assertEquals("AbCdEfGhI", pool.poolName());
+    }
+
+    @Test
+    void refusesANonCognitoIssuer() {
+        assertThrows(IllegalStateException.class, () -> CognitoUserPool.fromIssuer("https://idp.example.org/realms/master"));
+    }
+
+    @Test
+    void refusesAMissingIssuer() {
+        assertThrows(IllegalStateException.class, () -> CognitoUserPool.fromIssuer(null));
+    }
+}

--- a/components/security/security-keycloak/src/main/java/org/eclipse/dirigible/components/security/keycloak/KeycloakSecurityConfiguration.java
+++ b/components/security/security-keycloak/src/main/java/org/eclipse/dirigible/components/security/keycloak/KeycloakSecurityConfiguration.java
@@ -81,6 +81,10 @@ public class KeycloakSecurityConfiguration {
             KeycloakLogoutSuccessHandler keycloakLogoutSuccessHandler, OAuth2AuthorizedClientService authorizedClientService,
             ClientRegistrationRepository clientRegistrationRepository) throws Exception {
         String loginPage = DirigibleConfig.SECURITY_LOGIN_PAGE.getStringValue();
+        // both oauth2Client and oauth2Login register an authorization-request redirect filter, and
+        // the client one runs first - the resolver must be set on both for the hints to pass through
+        IdpHintAuthorizationRequestResolver authorizationRequestResolver =
+                new IdpHintAuthorizationRequestResolver(clientRegistrationRepository);
         http.authorizeHttpRequests(authz -> authz.requestMatchers("/oauth2/**", "/login/**")
                                                  .permitAll())
             .csrf(csrf -> csrf.disable())
@@ -88,12 +92,13 @@ public class KeycloakSecurityConfiguration {
             .addFilterBefore(new OAuth2SessionRevalidationFilter(authorizedClientService, userAuthoritiesMapper()),
                     AuthorizationFilter.class)
             .headers(headers -> headers.frameOptions(frameOpts -> frameOpts.sameOrigin()))
-            .oauth2Client(Customizer.withDefaults())
+            .oauth2Client(oauth2Client -> oauth2Client.authorizationCodeGrant(
+                    grant -> grant.authorizationRequestResolver(authorizationRequestResolver)))
             .oauth2Login(Customizer.withDefaults())
             .oauth2Login(oauth2 -> {
                 oauth2.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig.userAuthoritiesMapper(userAuthoritiesMapper()));
-                oauth2.authorizationEndpoint(authorizationEndpoint -> authorizationEndpoint.authorizationRequestResolver(
-                        new IdpHintAuthorizationRequestResolver(clientRegistrationRepository)));
+                oauth2.authorizationEndpoint(
+                        authorizationEndpoint -> authorizationEndpoint.authorizationRequestResolver(authorizationRequestResolver));
                 if (StringUtils.hasText(loginPage)) {
                     oauth2.loginPage(loginPage);
                 }

--- a/components/security/security-keycloak/src/main/java/org/eclipse/dirigible/components/security/keycloak/KeycloakSecurityConfiguration.java
+++ b/components/security/security-keycloak/src/main/java/org/eclipse/dirigible/components/security/keycloak/KeycloakSecurityConfiguration.java
@@ -20,6 +20,7 @@ import org.eclipse.dirigible.components.base.http.access.HttpSecurityURIConfigur
 import org.eclipse.dirigible.components.base.http.roles.Roles;
 import org.eclipse.dirigible.components.base.util.AuthoritiesUtil;
 import org.eclipse.dirigible.components.security.oauth.ScopeRoleJwtAuthoritiesConverter;
+import org.eclipse.dirigible.components.security.oauth2.IdpHintAuthorizationRequestResolver;
 import org.eclipse.dirigible.components.security.oauth2.OAuth2SessionRevalidationFilter;
 import org.eclipse.dirigible.components.tenants.tenant.TenantContextInitFilter;
 import org.slf4j.Logger;
@@ -35,6 +36,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -42,6 +44,7 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
+import org.springframework.util.StringUtils;
 
 /**
  * The Class KeycloakSecurityConfiguration.
@@ -75,8 +78,9 @@ public class KeycloakSecurityConfiguration {
     @Bean
     SecurityFilterChain configure(HttpSecurity http, TenantContextInitFilter tenantContextInitFilter,
             HttpSecurityURIConfigurator httpSecurityURIConfigurator, ScopeRoleJwtAuthoritiesConverter scopeRoleJwtAuthoritiesConverter,
-            KeycloakLogoutSuccessHandler keycloakLogoutSuccessHandler, OAuth2AuthorizedClientService authorizedClientService)
-            throws Exception {
+            KeycloakLogoutSuccessHandler keycloakLogoutSuccessHandler, OAuth2AuthorizedClientService authorizedClientService,
+            ClientRegistrationRepository clientRegistrationRepository) throws Exception {
+        String loginPage = DirigibleConfig.SECURITY_LOGIN_PAGE.getStringValue();
         http.authorizeHttpRequests(authz -> authz.requestMatchers("/oauth2/**", "/login/**")
                                                  .permitAll())
             .csrf(csrf -> csrf.disable())
@@ -88,6 +92,11 @@ public class KeycloakSecurityConfiguration {
             .oauth2Login(Customizer.withDefaults())
             .oauth2Login(oauth2 -> {
                 oauth2.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig.userAuthoritiesMapper(userAuthoritiesMapper()));
+                oauth2.authorizationEndpoint(authorizationEndpoint -> authorizationEndpoint.authorizationRequestResolver(
+                        new IdpHintAuthorizationRequestResolver(clientRegistrationRepository)));
+                if (StringUtils.hasText(loginPage)) {
+                    oauth2.loginPage(loginPage);
+                }
             })
             .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder())
                                                                  .jwtAuthenticationConverter(

--- a/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/IdpHintAuthorizationRequestResolver.java
+++ b/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/IdpHintAuthorizationRequestResolver.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth2;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Authorization-request resolver that passes an allowlisted identity-provider hint from
+ * {@code /oauth2/authorization/{registrationId}} through onto the authorize redirect.
+ *
+ * <p>
+ * {@link DefaultOAuth2AuthorizationRequestResolver} drops request parameters, so an application
+ * cannot deep-link a federated login. With the hint forwarded ({@code identity_provider} /
+ * {@code idp_identifier} for Cognito, {@code kc_idp_hint} for Keycloak), the provider redirects
+ * straight to the corporate IdP and its own hosted page is never rendered, keeping SAML/social
+ * federation working in a fully first-party UX. Only the allowlisted parameters are forwarded -
+ * everything else on the request stays dropped, as before.
+ */
+public class IdpHintAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    /** The identity-provider hint parameters known to the supported providers. */
+    private static final Set<String> ALLOWED_PARAMETERS = Set.of("identity_provider", "idp_identifier", "kc_idp_hint");
+
+    private final OAuth2AuthorizationRequestResolver delegate;
+
+    /**
+     * Instantiates the resolver over the default one on the standard authorization base URI.
+     *
+     * @param clientRegistrationRepository the client registration repository
+     */
+    public IdpHintAuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
+        this(new DefaultOAuth2AuthorizationRequestResolver(clientRegistrationRepository,
+                OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI));
+    }
+
+    IdpHintAuthorizationRequestResolver(OAuth2AuthorizationRequestResolver delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * Resolves the authorization request, forwarding any allowlisted hint parameters.
+     *
+     * @param request the request
+     * @return the authorization request, or {@code null} when the request does not match
+     */
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        return withIdpHints(request, delegate.resolve(request));
+    }
+
+    /**
+     * Resolves the authorization request for the given registration, forwarding any allowlisted hint
+     * parameters.
+     *
+     * @param request the request
+     * @param clientRegistrationId the client registration id
+     * @return the authorization request, or {@code null} when the request does not match
+     */
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        return withIdpHints(request, delegate.resolve(request, clientRegistrationId));
+    }
+
+    private static OAuth2AuthorizationRequest withIdpHints(HttpServletRequest request, OAuth2AuthorizationRequest authorizationRequest) {
+        if (authorizationRequest == null) {
+            return null;
+        }
+        Map<String, Object> hints = new LinkedHashMap<>();
+        for (String parameter : ALLOWED_PARAMETERS) {
+            String value = request.getParameter(parameter);
+            if (value != null && !value.isBlank()) {
+                hints.put(parameter, value);
+            }
+        }
+        if (hints.isEmpty()) {
+            return authorizationRequest;
+        }
+        return OAuth2AuthorizationRequest.from(authorizationRequest)
+                                         .additionalParameters(parameters -> parameters.putAll(hints))
+                                         .build();
+    }
+}

--- a/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginChallenge.java
+++ b/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginChallenge.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth2.login;
+
+import java.util.Map;
+
+/**
+ * A challenge the identity provider requires before it issues tokens (e.g. an MFA code or a forced
+ * new password). The caller answers it on a follow-up call carrying the challenge name and the
+ * opaque session state back.
+ *
+ * @param name the provider's challenge name (e.g. {@code SOFTWARE_TOKEN_MFA},
+ *        {@code NEW_PASSWORD_REQUIRED})
+ * @param session the opaque provider session state to carry into the answer
+ * @param parameters the provider's challenge parameters (e.g. the code delivery destination)
+ */
+public record NativeLoginChallenge(String name, String session, Map<String, String> parameters) implements NativeLoginResult {
+}

--- a/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginChallengeAnswer.java
+++ b/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginChallengeAnswer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth2.login;
+
+import java.util.Map;
+
+/**
+ * The answer to a {@link NativeLoginChallenge} returned by a previous authentication step.
+ *
+ * @param challenge the provider's challenge name being answered
+ * @param session the opaque provider session state carried over from the challenge
+ * @param username the username the challenge round-trip runs for (the canonical name from the
+ *        challenge parameters when the provider returned one)
+ * @param responses the challenge response parameters (e.g. the MFA code or the new password) -
+ *        possibly credential material, so never logged or retained
+ * @param userContextData the optional provider-specific client-side collector blob
+ */
+public record NativeLoginChallengeAnswer(String challenge, String session, String username, Map<String, String> responses,
+        String userContextData) {
+
+    /**
+     * Keeps the possibly credential-bearing responses out of the record's generated string form.
+     *
+     * @return the string form without credential material
+     */
+    @Override
+    public String toString() {
+        return "NativeLoginChallengeAnswer[challenge=" + challenge + ", username=" + username + "]";
+    }
+}

--- a/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginCredentials.java
+++ b/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginCredentials.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth2.login;
+
+/**
+ * First-party credentials for a native login. The password transits the platform only for the
+ * duration of the authentication call - implementations and callers must never log or retain it.
+ *
+ * @param username the username as entered by the user
+ * @param password the password as entered by the user
+ * @param userContextData the optional provider-specific client-side collector blob (e.g. Cognito's
+ *        threat-protection context), forwarded verbatim so provider-side risk scoring keeps working
+ *        behind the server-side proxy
+ */
+public record NativeLoginCredentials(String username, String password, String userContextData) {
+
+    /**
+     * Keeps the password out of the record's generated string form.
+     *
+     * @return the string form without credential material
+     */
+    @Override
+    public String toString() {
+        return "NativeLoginCredentials[username=" + username + "]";
+    }
+}

--- a/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginEndpoint.java
+++ b/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginEndpoint.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth2.login;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * First-party sign-in endpoint. Authenticates the user server-side against the identity provider
+ * through the active profile's {@link NativeLoginProvider} and establishes the standard platform
+ * session, so an application can own its login UX instead of redirecting to the provider-hosted
+ * page. On profiles without a provider (basic, github, ...) the endpoint answers 404 and nothing
+ * changes.
+ *
+ * <p>
+ * The contract is a challenge round-trip, not success/failure only: {@code POST /login/native}
+ * takes the credentials and answers either {@code AUTHENTICATED} (session cookie set),
+ * {@code CHALLENGE} (with the provider's challenge name, opaque session state and parameters - the
+ * answer goes to {@code POST /login/native/challenge}), or a normalized failure outcome. Provider
+ * raw messages never reach the client.
+ *
+ * <p>
+ * Credential-handling discipline: the request bodies carry the raw password, so nothing here logs
+ * them, puts them into exceptions or retains them after the provider call returns. Cross-site
+ * request forgery is countered by accepting only {@code application/json} bodies - a cross-origin
+ * browser cannot produce that content type without a CORS preflight, which this endpoint never
+ * grants.
+ */
+@RestController
+class NativeLoginEndpoint {
+
+    /** The Constant LOGGER. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(NativeLoginEndpoint.class);
+
+    private final ObjectProvider<NativeLoginProvider> loginProvider;
+    private final ObjectProvider<ClientRegistrationRepository> clientRegistrationRepository;
+    private final NativeLoginSessionInitializer sessionInitializer;
+
+    NativeLoginEndpoint(ObjectProvider<NativeLoginProvider> loginProvider,
+            ObjectProvider<ClientRegistrationRepository> clientRegistrationRepository, NativeLoginSessionInitializer sessionInitializer) {
+        this.loginProvider = loginProvider;
+        this.clientRegistrationRepository = clientRegistrationRepository;
+        this.sessionInitializer = sessionInitializer;
+    }
+
+    /**
+     * Authenticates the user with the identity provider and mints the platform session.
+     *
+     * @param body the credentials
+     * @param request the request
+     * @param response the response
+     * @return the normalized outcome - {@code AUTHENTICATED} or a {@code CHALLENGE} to answer on
+     *         {@link #challenge(ChallengeRequest, HttpServletRequest, HttpServletResponse)}
+     */
+    @PostMapping(path = "/login/native", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> login(@RequestBody LoginRequest body, HttpServletRequest request,
+            HttpServletResponse response) {
+        NativeLoginProvider provider = requireProvider();
+        if (!StringUtils.hasText(body.username()) || !StringUtils.hasText(body.password())) {
+            throw new NativeLoginException(NativeLoginException.Outcome.INVALID_REQUEST, "Missing username or password");
+        }
+        ClientRegistration registration = resolveRegistration(provider, body.registrationId());
+        NativeLoginResult result =
+                provider.authenticate(registration, new NativeLoginCredentials(body.username(), body.password(), body.userContextData()));
+        return respond(registration, result, request, response);
+    }
+
+    /**
+     * Answers a challenge returned by a previous step and mints the platform session when the provider
+     * is satisfied.
+     *
+     * @param body the challenge answer
+     * @param request the request
+     * @param response the response
+     * @return the normalized outcome - {@code AUTHENTICATED} or the next {@code CHALLENGE}
+     */
+    @PostMapping(path = "/login/native/challenge", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> challenge(@RequestBody ChallengeRequest body, HttpServletRequest request,
+            HttpServletResponse response) {
+        NativeLoginProvider provider = requireProvider();
+        if (!StringUtils.hasText(body.challenge()) || !StringUtils.hasText(body.session()) || !StringUtils.hasText(body.username())) {
+            throw new NativeLoginException(NativeLoginException.Outcome.INVALID_REQUEST, "Missing challenge, session or username");
+        }
+        ClientRegistration registration = resolveRegistration(provider, body.registrationId());
+        Map<String, String> responses = body.responses() != null ? body.responses() : Map.of();
+        NativeLoginResult result = provider.answerChallenge(registration,
+                new NativeLoginChallengeAnswer(body.challenge(), body.session(), body.username(), responses, body.userContextData()));
+        return respond(registration, result, request, response);
+    }
+
+    /**
+     * Translates a failed login step into its normalized outcome - the response body never carries
+     * provider-raw messages.
+     *
+     * @param exception the failure
+     * @return the outcome response
+     */
+    @ExceptionHandler(NativeLoginException.class)
+    public ResponseEntity<Map<String, Object>> onLoginFailure(NativeLoginException exception) {
+        LOGGER.debug("Native login failed with outcome [{}]", exception.getOutcome(), exception);
+        return ResponseEntity.status(statusOf(exception.getOutcome()))
+                             .body(Map.of("outcome", exception.getOutcome()
+                                                              .name()));
+    }
+
+    private NativeLoginProvider requireProvider() {
+        NativeLoginProvider provider = loginProvider.getIfAvailable();
+        if (provider == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Native login is not supported by the active security profile");
+        }
+        return provider;
+    }
+
+    private ClientRegistration resolveRegistration(NativeLoginProvider provider, String registrationId) {
+        String effectiveId = StringUtils.hasText(registrationId) ? registrationId : provider.getDefaultRegistrationId();
+        ClientRegistrationRepository repository = clientRegistrationRepository.getIfAvailable();
+        ClientRegistration registration = repository != null ? repository.findByRegistrationId(effectiveId) : null;
+        if (registration == null) {
+            throw new NativeLoginException(NativeLoginException.Outcome.INVALID_REQUEST,
+                    "Unknown client registration [" + effectiveId + "]");
+        }
+        return registration;
+    }
+
+    private ResponseEntity<Map<String, Object>> respond(ClientRegistration registration, NativeLoginResult result,
+            HttpServletRequest request, HttpServletResponse response) {
+        if (result instanceof NativeLoginTokens tokens) {
+            sessionInitializer.establishSession(registration, tokens, request, response);
+            return ResponseEntity.ok(Map.of("outcome", "AUTHENTICATED"));
+        }
+        NativeLoginChallenge challenge = (NativeLoginChallenge) result;
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("outcome", "CHALLENGE");
+        payload.put("challenge", challenge.name());
+        payload.put("session", challenge.session());
+        payload.put("parameters", challenge.parameters() != null ? challenge.parameters() : Map.of());
+        return ResponseEntity.ok(payload);
+    }
+
+    private static HttpStatus statusOf(NativeLoginException.Outcome outcome) {
+        return switch (outcome) {
+            case INVALID_REQUEST -> HttpStatus.BAD_REQUEST;
+            case TOO_MANY_ATTEMPTS -> HttpStatus.TOO_MANY_REQUESTS;
+            default -> HttpStatus.UNAUTHORIZED;
+        };
+    }
+
+    /**
+     * The sign-in request.
+     *
+     * @param registrationId the client registration to log in against; the provider's default when
+     *        omitted
+     * @param username the username
+     * @param password the password
+     * @param userContextData the optional provider-specific client-side collector blob
+     */
+    record LoginRequest(String registrationId, String username, String password, String userContextData) {
+
+        /**
+         * Keeps the password out of the record's generated string form.
+         *
+         * @return the string form without credential material
+         */
+        @Override
+        public String toString() {
+            return "LoginRequest[registrationId=" + registrationId + ", username=" + username + "]";
+        }
+    }
+
+    /**
+     * The challenge-answer request.
+     *
+     * @param registrationId the client registration to log in against; the provider's default when
+     *        omitted
+     * @param challenge the challenge name being answered
+     * @param session the opaque provider session state from the challenge response
+     * @param username the username the challenge round-trip runs for
+     * @param responses the challenge response parameters
+     * @param userContextData the optional provider-specific client-side collector blob
+     */
+    record ChallengeRequest(String registrationId, String challenge, String session, String username, Map<String, String> responses,
+            String userContextData) {
+
+        /**
+         * Keeps the possibly credential-bearing responses out of the record's generated string form.
+         *
+         * @return the string form without credential material
+         */
+        @Override
+        public String toString() {
+            return "ChallengeRequest[registrationId=" + registrationId + ", challenge=" + challenge + ", username=" + username + "]";
+        }
+    }
+}

--- a/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginException.java
+++ b/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginException.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth2.login;
+
+/**
+ * A failed native login step. Carries a normalized {@link Outcome} - the only thing surfaced to the
+ * client, so provider-raw messages (which risk user enumeration and defeat application-side i18n)
+ * never leave the server.
+ */
+public class NativeLoginException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The normalized login outcomes. Providers map their raw error codes onto these; clients route the
+     * user (retry, reset password, confirm account, ...) based on them.
+     */
+    public enum Outcome {
+        /** The request is malformed or names an unknown client registration. */
+        INVALID_REQUEST,
+        /** The credentials were refused (also covers unknown users, to avoid user enumeration). */
+        INVALID_CREDENTIALS,
+        /** The provider requires a password reset before the user can sign in. */
+        PASSWORD_RESET_REQUIRED,
+        /** The user account exists but has not been confirmed yet. */
+        USER_NOT_CONFIRMED,
+        /** The submitted challenge code did not match. */
+        CODE_MISMATCH,
+        /** The submitted challenge code expired. */
+        CODE_EXPIRED,
+        /** The submitted new password was refused by the provider's password policy. */
+        INVALID_PASSWORD,
+        /** The provider throttled the attempt. */
+        TOO_MANY_ATTEMPTS,
+        /** Any other authentication failure. */
+        AUTHENTICATION_FAILED
+    }
+
+    /** The normalized outcome. */
+    private final Outcome outcome;
+
+    /**
+     * Instantiates a new native login exception.
+     *
+     * @param outcome the normalized outcome
+     * @param message the server-side diagnostic message (never surfaced to the client)
+     */
+    public NativeLoginException(Outcome outcome, String message) {
+        super(message);
+        this.outcome = outcome;
+    }
+
+    /**
+     * Instantiates a new native login exception.
+     *
+     * @param outcome the normalized outcome
+     * @param message the server-side diagnostic message (never surfaced to the client)
+     * @param cause the cause
+     */
+    public NativeLoginException(Outcome outcome, String message, Throwable cause) {
+        super(message, cause);
+        this.outcome = outcome;
+    }
+
+    /**
+     * Gets the normalized outcome.
+     *
+     * @return the outcome
+     */
+    public Outcome getOutcome() {
+        return outcome;
+    }
+}

--- a/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginProvider.java
+++ b/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth2.login;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+
+/**
+ * First-party credential sign-in against the identity provider behind an OAuth2 login profile.
+ *
+ * <p>
+ * An implementation authenticates the user server-side with the provider's native API and returns
+ * provider-validated tokens, so the platform can establish the same session the {@code oauth2Login}
+ * authorization-code callback establishes - without ever rendering the provider-hosted login page.
+ * The mechanics differ per provider (Cognito needs the SRP/challenge API, Keycloak could use the
+ * password grant), which is why this is a contract and the profiles opt in independently.
+ */
+public interface NativeLoginProvider {
+
+    /**
+     * The client registration used when a login request does not name one.
+     *
+     * @return the default client registration id
+     */
+    String getDefaultRegistrationId();
+
+    /**
+     * Authenticates the user with the identity provider.
+     *
+     * @param registration the client registration the login is performed against
+     * @param credentials the first-party credentials
+     * @return the provider-issued tokens, or the challenge the provider requires next
+     * @throws NativeLoginException on authentication failure, carrying a normalized outcome
+     */
+    NativeLoginResult authenticate(ClientRegistration registration, NativeLoginCredentials credentials);
+
+    /**
+     * Answers a challenge the provider returned from a previous {@link #authenticate} or
+     * {@link #answerChallenge} call.
+     *
+     * @param registration the client registration the login is performed against
+     * @param answer the challenge answer
+     * @return the provider-issued tokens, or the next challenge
+     * @throws NativeLoginException on authentication failure, carrying a normalized outcome
+     */
+    NativeLoginResult answerChallenge(ClientRegistration registration, NativeLoginChallengeAnswer answer);
+}

--- a/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginResult.java
+++ b/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginResult.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth2.login;
+
+/**
+ * The outcome of a native login step: either provider-issued tokens or the challenge the provider
+ * requires next.
+ */
+public sealed interface NativeLoginResult permits NativeLoginTokens, NativeLoginChallenge {
+}

--- a/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginSessionInitializer.java
+++ b/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginSessionInitializer.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth2.login;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import org.eclipse.dirigible.components.security.oauth2.OAuth2SessionRevalidationFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Establishes the standard platform session from the tokens a {@link NativeLoginProvider} obtained
+ * - the same authentication the {@code oauth2Login} authorization-code callback establishes.
+ *
+ * <p>
+ * The ID token is validated against the registration's JWKS (issuer, audience, expiry) before
+ * anything else happens. The principal is built from the registration's user-name attribute and the
+ * authorities from the profile's {@link GrantedAuthoritiesMapper}, the session id is changed
+ * against session fixation, and the tokens are registered as an {@link OAuth2AuthorizedClient} so
+ * {@link OAuth2SessionRevalidationFilter} governs the session lifetime exactly as for a hosted
+ * login. Tokens never reach the browser - the client receives only the session cookie.
+ */
+@Component
+class NativeLoginSessionInitializer {
+
+    /** The Constant LOGGER. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(NativeLoginSessionInitializer.class);
+
+    private final ObjectProvider<OAuth2AuthorizedClientService> authorizedClientService;
+    private final ObjectProvider<GrantedAuthoritiesMapper> userAuthoritiesMapper;
+    private final JwtDecoderFactory<ClientRegistration> idTokenDecoderFactory;
+    private final SecurityContextRepository securityContextRepository;
+
+    /**
+     * Instantiates the session initializer.
+     *
+     * @param authorizedClientService the store the tokens are registered into, resolved lazily because
+     *        it only exists on the OAuth2 profiles
+     * @param userAuthoritiesMapper the profile's authorities mapper, when one is defined
+     */
+    @Autowired
+    NativeLoginSessionInitializer(ObjectProvider<OAuth2AuthorizedClientService> authorizedClientService,
+            ObjectProvider<GrantedAuthoritiesMapper> userAuthoritiesMapper) {
+        this(authorizedClientService, userAuthoritiesMapper, new OidcIdTokenDecoderFactory(), new HttpSessionSecurityContextRepository());
+    }
+
+    NativeLoginSessionInitializer(ObjectProvider<OAuth2AuthorizedClientService> authorizedClientService,
+            ObjectProvider<GrantedAuthoritiesMapper> userAuthoritiesMapper, JwtDecoderFactory<ClientRegistration> idTokenDecoderFactory,
+            SecurityContextRepository securityContextRepository) {
+        this.authorizedClientService = authorizedClientService;
+        this.userAuthoritiesMapper = userAuthoritiesMapper;
+        this.idTokenDecoderFactory = idTokenDecoderFactory;
+        this.securityContextRepository = securityContextRepository;
+    }
+
+    /**
+     * Establishes the authenticated session for the user the tokens were issued to.
+     *
+     * @param registration the client registration the login ran against
+     * @param tokens the provider-issued tokens
+     * @param request the request
+     * @param response the response
+     * @throws NativeLoginException when the ID token fails validation
+     */
+    void establishSession(ClientRegistration registration, NativeLoginTokens tokens, HttpServletRequest request,
+            HttpServletResponse response) {
+        OidcIdToken idToken = validateIdToken(registration, tokens.idToken());
+        OAuth2AuthenticationToken authentication = buildAuthentication(registration, idToken, request);
+
+        if (request.getSession(false) != null) {
+            // session-fixation protection: never keep the id a pre-login session was known under
+            request.changeSessionId();
+        }
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        securityContext.setAuthentication(authentication);
+        SecurityContextHolder.setContext(securityContext);
+        securityContextRepository.saveContext(securityContext, request, response);
+
+        registerAuthorizedClient(registration, authentication, tokens);
+        LOGGER.debug("Established a native login session for user [{}] on registration [{}]", authentication.getName(),
+                registration.getRegistrationId());
+    }
+
+    private OidcIdToken validateIdToken(ClientRegistration registration, String idTokenValue) {
+        try {
+            Jwt jwt = idTokenDecoderFactory.createDecoder(registration)
+                                           .decode(idTokenValue);
+            return new OidcIdToken(jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaims());
+        } catch (JwtException ex) {
+            LOGGER.error("The ID token issued for a native login on registration [{}] failed validation", registration.getRegistrationId(),
+                    ex);
+            throw new NativeLoginException(NativeLoginException.Outcome.AUTHENTICATION_FAILED, "ID token validation failed", ex);
+        }
+    }
+
+    private OAuth2AuthenticationToken buildAuthentication(ClientRegistration registration, OidcIdToken idToken,
+            HttpServletRequest request) {
+        OidcUserAuthority oidcUserAuthority = new OidcUserAuthority(idToken);
+        GrantedAuthoritiesMapper authoritiesMapper = userAuthoritiesMapper.getIfAvailable();
+        Collection<? extends GrantedAuthority> authorities =
+                authoritiesMapper != null ? authoritiesMapper.mapAuthorities(List.of(oidcUserAuthority)) : List.of(oidcUserAuthority);
+        String userNameAttributeName = registration.getProviderDetails()
+                                                   .getUserInfoEndpoint()
+                                                   .getUserNameAttributeName();
+        OidcUser oidcUser = StringUtils.hasText(userNameAttributeName) ? new DefaultOidcUser(authorities, idToken, userNameAttributeName)
+                : new DefaultOidcUser(authorities, idToken);
+        OAuth2AuthenticationToken authentication = new OAuth2AuthenticationToken(oidcUser, authorities, registration.getRegistrationId());
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        return authentication;
+    }
+
+    private void registerAuthorizedClient(ClientRegistration registration, OAuth2AuthenticationToken authentication,
+            NativeLoginTokens tokens) {
+        Instant issuedAt = Instant.now();
+        Instant expiresAt = tokens.expiresInSeconds() != null ? issuedAt.plusSeconds(tokens.expiresInSeconds()) : null;
+        OAuth2AccessToken accessToken =
+                new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, tokens.accessToken(), issuedAt, expiresAt);
+        OAuth2RefreshToken refreshToken = tokens.refreshToken() != null ? new OAuth2RefreshToken(tokens.refreshToken(), issuedAt) : null;
+        authorizedClientService.getObject()
+                               .saveAuthorizedClient(
+                                       new OAuth2AuthorizedClient(registration, authentication.getName(), accessToken, refreshToken),
+                                       authentication);
+    }
+}

--- a/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginTokens.java
+++ b/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginTokens.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth2.login;
+
+/**
+ * Tokens issued by the identity provider for a completed native login. The ID token is validated
+ * against the provider JWKS before any session is established; the tokens themselves never reach
+ * the browser.
+ *
+ * @param idToken the OIDC ID token
+ * @param accessToken the access token
+ * @param refreshToken the refresh token, or {@code null} when the provider issued none
+ * @param expiresInSeconds the access token lifetime in seconds, or {@code null} when unknown
+ */
+public record NativeLoginTokens(String idToken, String accessToken, String refreshToken, Long expiresInSeconds)
+        implements NativeLoginResult {
+
+    /**
+     * Keeps the token material out of the record's generated string form.
+     *
+     * @return the string form without token material
+     */
+    @Override
+    public String toString() {
+        return "NativeLoginTokens[expiresInSeconds=" + expiresInSeconds + "]";
+    }
+}

--- a/components/security/security-oauth2/src/test/java/org/eclipse/dirigible/components/security/oauth2/IdpHintAuthorizationRequestResolverTest.java
+++ b/components/security/security-oauth2/src/test/java/org/eclipse/dirigible/components/security/oauth2/IdpHintAuthorizationRequestResolverTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+/**
+ * Unit tests for {@link IdpHintAuthorizationRequestResolver} - the allowlisted identity-provider
+ * hint passthrough onto the authorize redirect.
+ */
+@ExtendWith(MockitoExtension.class)
+class IdpHintAuthorizationRequestResolverTest {
+
+    @Mock
+    private OAuth2AuthorizationRequestResolver delegate;
+
+    private IdpHintAuthorizationRequestResolver resolver;
+    private MockHttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new IdpHintAuthorizationRequestResolver(delegate);
+        request = new MockHttpServletRequest("GET", "/oauth2/authorization/test");
+    }
+
+    @Test
+    void forwardsTheAllowlistedHints() {
+        request.setParameter("identity_provider", "CorporateSaml");
+        request.setParameter("kc_idp_hint", "corporate-oidc");
+        when(delegate.resolve(request)).thenReturn(authorizationRequest());
+
+        OAuth2AuthorizationRequest resolved = resolver.resolve(request);
+
+        assertEquals("CorporateSaml", resolved.getAdditionalParameters()
+                                              .get("identity_provider"));
+        assertEquals("corporate-oidc", resolved.getAdditionalParameters()
+                                               .get("kc_idp_hint"));
+    }
+
+    @Test
+    void dropsEverythingOutsideTheAllowlist() {
+        request.setParameter("identity_provider", "CorporateSaml");
+        request.setParameter("prompt", "none");
+        request.setParameter("redirect_uri", "https://evil.example.org/");
+        when(delegate.resolve(request)).thenReturn(authorizationRequest());
+
+        OAuth2AuthorizationRequest resolved = resolver.resolve(request);
+
+        assertEquals("CorporateSaml", resolved.getAdditionalParameters()
+                                              .get("identity_provider"));
+        assertFalse(resolved.getAdditionalParameters()
+                            .containsKey("prompt"));
+        assertFalse(resolved.getAdditionalParameters()
+                            .containsKey("redirect_uri"));
+    }
+
+    @Test
+    void leavesARequestWithoutHintsUntouched() {
+        OAuth2AuthorizationRequest original = authorizationRequest();
+        when(delegate.resolve(request)).thenReturn(original);
+
+        assertSame(original, resolver.resolve(request));
+    }
+
+    @Test
+    void passesANonMatchingRequestThrough() {
+        when(delegate.resolve(request)).thenReturn(null);
+
+        assertNull(resolver.resolve(request));
+    }
+
+    @Test
+    void forwardsTheHintsOnTheExplicitRegistrationOverloadToo() {
+        request.setParameter("idp_identifier", "corp");
+        when(delegate.resolve(request, "test")).thenReturn(authorizationRequest());
+
+        OAuth2AuthorizationRequest resolved = resolver.resolve(request, "test");
+
+        assertEquals("corp", resolved.getAdditionalParameters()
+                                     .get("idp_identifier"));
+    }
+
+    private static OAuth2AuthorizationRequest authorizationRequest() {
+        return OAuth2AuthorizationRequest.authorizationCode()
+                                         .authorizationUri("https://idp.example.org/oauth2/authorize")
+                                         .clientId("client-id")
+                                         .redirectUri("https://app.example.org/login/oauth2/code/test")
+                                         .state("state-1")
+                                         .build();
+    }
+}

--- a/components/security/security-oauth2/src/test/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginEndpointTest.java
+++ b/components/security/security-oauth2/src/test/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginEndpointTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth2.login;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Unit tests for {@link NativeLoginEndpoint} - the request validation, the provider dispatch, the
+ * challenge round-trip contract and the normalized outcome codes.
+ */
+@ExtendWith(MockitoExtension.class)
+class NativeLoginEndpointTest {
+
+    private static final String REGISTRATION_ID = "default-tenant";
+
+    @Mock
+    private ObjectProvider<NativeLoginProvider> loginProviderProvider;
+
+    @Mock
+    private ObjectProvider<ClientRegistrationRepository> clientRegistrationRepositoryProvider;
+
+    @Mock
+    private NativeLoginProvider loginProvider;
+
+    @Mock
+    private ClientRegistrationRepository clientRegistrationRepository;
+
+    @Mock
+    private NativeLoginSessionInitializer sessionInitializer;
+
+    private NativeLoginEndpoint endpoint;
+    private ClientRegistration registration;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        endpoint = new NativeLoginEndpoint(loginProviderProvider, clientRegistrationRepositoryProvider, sessionInitializer);
+        registration = ClientRegistration.withRegistrationId(REGISTRATION_ID)
+                                         .clientId("client-id")
+                                         .clientSecret("client-secret")
+                                         .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                                         .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                                         .authorizationUri("https://idp.example.org/oauth2/authorize")
+                                         .tokenUri("https://idp.example.org/oauth2/token")
+                                         .userNameAttributeName("email")
+                                         .build();
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @Test
+    void aSuccessfulLoginMintsTheSessionAndAnswersAuthenticated() {
+        stubProviderAndRegistration();
+        NativeLoginTokens tokens = new NativeLoginTokens("id-token", "access-token", "refresh-token", 3600L);
+        when(loginProvider.authenticate(eq(registration), any())).thenReturn(tokens);
+
+        ResponseEntity<Map<String, Object>> result =
+                endpoint.login(new NativeLoginEndpoint.LoginRequest(null, "jane.doe@example.org", "the-password", null), request, response);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals("AUTHENTICATED", result.getBody()
+                                            .get("outcome"));
+        verify(sessionInitializer).establishSession(registration, tokens, request, response);
+    }
+
+    @Test
+    void aChallengeIsSurfacedWithoutMintingASession() {
+        stubProviderAndRegistration();
+        when(loginProvider.authenticate(eq(registration), any())).thenReturn(
+                new NativeLoginChallenge("SOFTWARE_TOKEN_MFA", "session-1", Map.of("USERNAME", "canonical-user")));
+
+        ResponseEntity<Map<String, Object>> result =
+                endpoint.login(new NativeLoginEndpoint.LoginRequest(null, "jane.doe@example.org", "the-password", null), request, response);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals("CHALLENGE", result.getBody()
+                                        .get("outcome"));
+        assertEquals("SOFTWARE_TOKEN_MFA", result.getBody()
+                                                 .get("challenge"));
+        assertEquals("session-1", result.getBody()
+                                        .get("session"));
+        assertEquals(Map.of("USERNAME", "canonical-user"), result.getBody()
+                                                                 .get("parameters"));
+        verifyNoInteractions(sessionInitializer);
+    }
+
+    @Test
+    void aChallengeAnswerIsForwardedNormalized() {
+        stubProviderAndRegistration();
+        NativeLoginTokens tokens = new NativeLoginTokens("id-token", "access-token", "refresh-token", 3600L);
+        when(loginProvider.answerChallenge(eq(registration), any())).thenReturn(tokens);
+
+        ResponseEntity<Map<String, Object>> result = endpoint.challenge(
+                new NativeLoginEndpoint.ChallengeRequest(null, "SOFTWARE_TOKEN_MFA", "session-1", "canonical-user", null, null), request,
+                response);
+
+        assertEquals("AUTHENTICATED", result.getBody()
+                                            .get("outcome"));
+        ArgumentCaptor<NativeLoginChallengeAnswer> answer = ArgumentCaptor.forClass(NativeLoginChallengeAnswer.class);
+        verify(loginProvider).answerChallenge(eq(registration), answer.capture());
+        assertEquals("SOFTWARE_TOKEN_MFA", answer.getValue()
+                                                 .challenge());
+        assertEquals(Map.of(), answer.getValue()
+                                     .responses());
+        verify(sessionInitializer).establishSession(registration, tokens, request, response);
+    }
+
+    @Test
+    void missingCredentialsAreRefusedAsInvalidRequest() {
+        when(loginProviderProvider.getIfAvailable()).thenReturn(loginProvider);
+
+        NativeLoginException exception = assertThrows(NativeLoginException.class,
+                () -> endpoint.login(new NativeLoginEndpoint.LoginRequest(null, "jane.doe@example.org", "", null), request, response));
+
+        assertEquals(NativeLoginException.Outcome.INVALID_REQUEST, exception.getOutcome());
+    }
+
+    @Test
+    void anUnknownRegistrationIsRefusedAsInvalidRequest() {
+        when(loginProviderProvider.getIfAvailable()).thenReturn(loginProvider);
+        when(clientRegistrationRepositoryProvider.getIfAvailable()).thenReturn(clientRegistrationRepository);
+        when(clientRegistrationRepository.findByRegistrationId("unknown")).thenReturn(null);
+
+        NativeLoginException exception = assertThrows(NativeLoginException.class,
+                () -> endpoint.login(new NativeLoginEndpoint.LoginRequest("unknown", "jane.doe@example.org", "the-password", null), request,
+                        response));
+
+        assertEquals(NativeLoginException.Outcome.INVALID_REQUEST, exception.getOutcome());
+    }
+
+    @Test
+    void withoutAProviderTheEndpointAnswersNotFound() {
+        when(loginProviderProvider.getIfAvailable()).thenReturn(null);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> endpoint.login(new NativeLoginEndpoint.LoginRequest(null, "jane.doe@example.org", "the-password", null), request,
+                        response));
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+    }
+
+    @Test
+    void failuresAreAnsweredAsNormalizedOutcomes() {
+        assertOutcomeStatus(NativeLoginException.Outcome.INVALID_REQUEST, HttpStatus.BAD_REQUEST);
+        assertOutcomeStatus(NativeLoginException.Outcome.INVALID_CREDENTIALS, HttpStatus.UNAUTHORIZED);
+        assertOutcomeStatus(NativeLoginException.Outcome.PASSWORD_RESET_REQUIRED, HttpStatus.UNAUTHORIZED);
+        assertOutcomeStatus(NativeLoginException.Outcome.TOO_MANY_ATTEMPTS, HttpStatus.TOO_MANY_REQUESTS);
+    }
+
+    private void assertOutcomeStatus(NativeLoginException.Outcome outcome, HttpStatus expectedStatus) {
+        ResponseEntity<Map<String, Object>> result = endpoint.onLoginFailure(new NativeLoginException(outcome, "diagnostic"));
+        assertEquals(expectedStatus, result.getStatusCode());
+        assertEquals(outcome.name(), result.getBody()
+                                           .get("outcome"));
+    }
+
+    private void stubProviderAndRegistration() {
+        when(loginProviderProvider.getIfAvailable()).thenReturn(loginProvider);
+        when(clientRegistrationRepositoryProvider.getIfAvailable()).thenReturn(clientRegistrationRepository);
+        when(loginProvider.getDefaultRegistrationId()).thenReturn(REGISTRATION_ID);
+        when(clientRegistrationRepository.findByRegistrationId(REGISTRATION_ID)).thenReturn(registration);
+    }
+}

--- a/components/security/security-oauth2/src/test/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginSessionInitializerTest.java
+++ b/components/security/security-oauth2/src/test/java/org/eclipse/dirigible/components/security/oauth2/login/NativeLoginSessionInitializerTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth2.login;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.web.context.SecurityContextRepository;
+
+/**
+ * Unit tests for {@link NativeLoginSessionInitializer} - the ID token validation, the session
+ * minting and the authorized-client registration that puts the session under
+ * {@code OAuth2SessionRevalidationFilter}'s governance.
+ */
+@ExtendWith(MockitoExtension.class)
+class NativeLoginSessionInitializerTest {
+
+    private static final String REGISTRATION_ID = "default-tenant";
+
+    @Mock
+    private ObjectProvider<OAuth2AuthorizedClientService> authorizedClientServiceProvider;
+
+    @Mock
+    private ObjectProvider<GrantedAuthoritiesMapper> userAuthoritiesMapperProvider;
+
+    @Mock
+    private OAuth2AuthorizedClientService authorizedClientService;
+
+    @Mock
+    private JwtDecoderFactory<ClientRegistration> idTokenDecoderFactory;
+
+    @Mock
+    private JwtDecoder jwtDecoder;
+
+    @Mock
+    private SecurityContextRepository securityContextRepository;
+
+    private NativeLoginSessionInitializer initializer;
+    private ClientRegistration registration;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        initializer = new NativeLoginSessionInitializer(authorizedClientServiceProvider, userAuthoritiesMapperProvider,
+                idTokenDecoderFactory, securityContextRepository);
+        registration = ClientRegistration.withRegistrationId(REGISTRATION_ID)
+                                         .clientId("client-id")
+                                         .clientSecret("client-secret")
+                                         .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                                         .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                                         .authorizationUri("https://idp.example.org/oauth2/authorize")
+                                         .tokenUri("https://idp.example.org/oauth2/token")
+                                         .userNameAttributeName("email")
+                                         .build();
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void establishesTheSessionWithTheMappedAuthoritiesAndRegistersTheTokens() {
+        when(idTokenDecoderFactory.createDecoder(registration)).thenReturn(jwtDecoder);
+        when(jwtDecoder.decode("id-token")).thenReturn(idToken());
+        when(authorizedClientServiceProvider.getObject()).thenReturn(authorizedClientService);
+        when(userAuthoritiesMapperProvider.getIfAvailable()).thenReturn(
+                authorities -> List.of(new SimpleGrantedAuthority("ROLE_DEVELOPER")));
+
+        initializer.establishSession(registration, new NativeLoginTokens("id-token", "access-token", "refresh-token", 3600L), request,
+                response);
+
+        OAuth2AuthenticationToken authentication = (OAuth2AuthenticationToken) SecurityContextHolder.getContext()
+                                                                                                    .getAuthentication();
+        assertEquals("jane.doe@example.org", authentication.getName());
+        assertEquals(REGISTRATION_ID, authentication.getAuthorizedClientRegistrationId());
+        assertTrue(authentication.getAuthorities()
+                                 .contains(new SimpleGrantedAuthority("ROLE_DEVELOPER")));
+
+        ArgumentCaptor<SecurityContext> savedContext = ArgumentCaptor.forClass(SecurityContext.class);
+        verify(securityContextRepository).saveContext(savedContext.capture(), any(), any());
+        assertEquals(authentication, savedContext.getValue()
+                                                 .getAuthentication());
+
+        ArgumentCaptor<OAuth2AuthorizedClient> savedClient = ArgumentCaptor.forClass(OAuth2AuthorizedClient.class);
+        verify(authorizedClientService).saveAuthorizedClient(savedClient.capture(), any());
+        assertEquals("jane.doe@example.org", savedClient.getValue()
+                                                        .getPrincipalName());
+        assertEquals("access-token", savedClient.getValue()
+                                                .getAccessToken()
+                                                .getTokenValue());
+        assertNotNull(savedClient.getValue()
+                                 .getAccessToken()
+                                 .getExpiresAt());
+        assertEquals("refresh-token", savedClient.getValue()
+                                                 .getRefreshToken()
+                                                 .getTokenValue());
+    }
+
+    @Test
+    void changesTheSessionIdOfAPreLoginSession() {
+        String preLoginSessionId = request.getSession(true)
+                                          .getId();
+        when(idTokenDecoderFactory.createDecoder(registration)).thenReturn(jwtDecoder);
+        when(jwtDecoder.decode("id-token")).thenReturn(idToken());
+        when(authorizedClientServiceProvider.getObject()).thenReturn(authorizedClientService);
+        when(userAuthoritiesMapperProvider.getIfAvailable()).thenReturn(null);
+
+        initializer.establishSession(registration, new NativeLoginTokens("id-token", "access-token", null, 3600L), request, response);
+
+        assertNotEquals(preLoginSessionId, request.getSession(false)
+                                                  .getId());
+    }
+
+    @Test
+    void anInvalidIdTokenEstablishesNothing() {
+        when(idTokenDecoderFactory.createDecoder(registration)).thenReturn(jwtDecoder);
+        when(jwtDecoder.decode("id-token")).thenThrow(new JwtException("expired"));
+
+        NativeLoginException exception = assertThrows(NativeLoginException.class, () -> initializer.establishSession(registration,
+                new NativeLoginTokens("id-token", "access-token", "refresh-token", 3600L), request, response));
+
+        assertEquals(NativeLoginException.Outcome.AUTHENTICATION_FAILED, exception.getOutcome());
+        assertNull(SecurityContextHolder.getContext()
+                                        .getAuthentication());
+        verifyNoInteractions(securityContextRepository, authorizedClientService);
+    }
+
+    private static Jwt idToken() {
+        Instant issuedAt = Instant.now();
+        return Jwt.withTokenValue("id-token")
+                  .header("alg", "RS256")
+                  .subject("3b3f18f4-1c3d-4b6e-9f9a-0e2f4c1a5d77")
+                  .claim("email", "jane.doe@example.org")
+                  .claim("cognito:groups", List.of("DEVELOPER"))
+                  .issuedAt(issuedAt)
+                  .expiresAt(issuedAt.plusSeconds(300))
+                  .build();
+    }
+}

--- a/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
+++ b/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
@@ -137,6 +137,14 @@ public enum DirigibleConfig {
     /** The basic admin pass. */
     BASIC_ADMIN_PASS("DIRIGIBLE_BASIC_PASSWORD", toBase64("admin")),
 
+    /**
+     * Optional application-owned login page for the OAuth2 login profiles (cognito, keycloak). When
+     * set, unauthenticated browser requests are redirected to this page (typically under the already
+     * public {@code /public/web/}) instead of the identity provider, so the application hosts its own
+     * sign-in UX. Blank keeps the standard redirect to the provider.
+     */
+    SECURITY_LOGIN_PAGE("DIRIGIBLE_SECURITY_LOGIN_PAGE", null),
+
     /** Whether the Java LSP (JDT.LS) integration is enabled. */
     JAVA_LSP_ENABLED("DIRIGIBLE_JAVA_LSP_ENABLED", Boolean.TRUE.toString()),
 


### PR DESCRIPTION
## Overview

Applications on the OAuth2 login profiles can now own their sign-in UX end to end: a `POST /login/native` endpoint authenticates first-party credentials server-side (Cognito via SRP, with the full challenge round-trip) and establishes the standard platform session, federated logins can be deep-linked straight to the corporate IdP, and unauthenticated browsers can be redirected to an application-owned login page instead of the provider-hosted one.

Reference sample: [dirigiblelabs/sample-native-login](https://github.com/dirigiblelabs/sample-native-login).

Fixes: #6828.