### PR TITLE
fix(dependencies): a module jar cannot name its way out of the registry, and a package-only build boots

### DIFF
--- a/build/application/pom.xml
+++ b/build/application/pom.xml
@@ -275,21 +275,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <!-- the JVM invokes the agent before main on `java -jar` launches (JEP 261),
-                                 handing the platform the Instrumentation that appends scope-platform
-                                 dependency jars to the system classloader without a restart; the
-                                 repackage goal preserves this entry in the executable jar -->
-                            <Launcher-Agent-Class>org.eclipse.dirigible.launcher.agent.DirigibleLauncherAgent</Launcher-Agent-Class>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
@@ -363,6 +348,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <!-- Pinned: an unpinned antrun resolves to 1.3 under older local Maven installs,
+                     where the injection below silently degrades - the known local-vs-CI split behind
+                     LauncherAgentDeliveryIT failing on developer machines while green on CI. -->
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <!-- Turns the resolved dependency list into the provided-BOM (a standard
@@ -405,9 +394,20 @@
                         </goals>
                         <configuration>
                             <target>
-                                <zip destfile="${project.build.directory}/${project.build.finalName}-executable.jar" update="true" keepcompression="true">
+                                <!-- The manifest attribute is added HERE, together with the classes it
+                                     names, never at package time: a manifest naming an agent class the
+                                     archive does not carry aborts `java -jar` before main (JEP 261), so
+                                     a build that stops at package must produce a jar with NO agent (it
+                                     boots, without restartless dependency delivery) rather than a jar
+                                     that cannot boot at all. The jar task merges the attribute into the
+                                     existing manifest; keepcompression preserves the STORED nested
+                                     BOOT-INF jars Spring Boot's loader requires. -->
+                                <jar destfile="${project.build.directory}/${project.build.finalName}-executable.jar" update="true" keepcompression="true">
                                     <fileset dir="${project.build.directory}/launcher-agent-root" includes="org/**"/>
-                                </zip>
+                                    <manifest>
+                                        <attribute name="Launcher-Agent-Class" value="org.eclipse.dirigible.launcher.agent.DirigibleLauncherAgent"/>
+                                    </manifest>
+                                </jar>
                             </target>
                         </configuration>
                     </execution>

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ModuleJarInspector.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ModuleJarInspector.java
@@ -43,6 +43,12 @@ final class ModuleJarInspector {
     private static final String DIRIGIBLE_ROOT = "META-INF/dirigible/";
 
     /**
+     * A registry project name must be a plain path segment - no dots-only names, no separators - so it
+     * can never escape the registry when concatenated into a repository path.
+     */
+    private static final java.util.regex.Pattern PLAIN_PROJECT_NAME = java.util.regex.Pattern.compile("[A-Za-z0-9][A-Za-z0-9._-]*");
+
+    /**
      * Instantiates a new module jar inspector.
      */
     private ModuleJarInspector() {
@@ -72,7 +78,19 @@ final class ModuleJarInspector {
                     String rest = name.substring(DIRIGIBLE_ROOT.length());
                     int slash = rest.indexOf('/');
                     if (slash > 0) {
-                        projects.add(rest.substring(0, slash));
+                        String project = rest.substring(0, slash);
+                        // The project name becomes a registry path segment: on removal it is handed to
+                        // ClasspathExpander.remove, whose repository path is plain string concatenation -
+                        // a crafted "META-INF/dirigible/../x" entry would name the project ".." and its
+                        // removal would delete the registry root. Refuse anything that is not a plain
+                        // name, loudly: a jar carrying such an entry is malformed or malicious, and the
+                        // expand side already rejects its kind (the Zip-Slip guard).
+                        if (!PLAIN_PROJECT_NAME.matcher(project)
+                                               .matches()) {
+                            throw new IOException("Module jar [" + jarPath.getFileName() + "] declares an invalid registry project name ["
+                                    + project + "] under META-INF/dirigible/ - refusing the jar");
+                        }
+                        projects.add(project);
                     }
                 } else if (name.endsWith(".so") || name.endsWith(".dylib") || name.endsWith(".dll")) {
                     nativeLibraries.add(name);

--- a/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/ModuleJarInspectorTest.java
+++ b/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/ModuleJarInspectorTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * A module jar's registry payload names become repository path segments, so the inspector must
+ * refuse any name that could escape the registry: on removal the name is concatenated into
+ * {@code /registry/public/<name>}, where a {@code ..} would resolve to the registry root and its
+ * removal would delete everything.
+ */
+class ModuleJarInspectorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void aPlainProjectNameIsAccepted() throws IOException {
+        Path jar = jarWithEntries("META-INF/dirigible/my-project/file.txt", "META-INF/dirigible/my-project/sub/other.txt");
+
+        ModuleJarInspector.Inspection inspection = ModuleJarInspector.inspect(jar);
+
+        assertEquals(Set.of("my-project"), inspection.projects(), "the payload's project should be reported once");
+    }
+
+    @Test
+    void aParentTraversalProjectNameIsRefused() throws IOException {
+        Path jar = jarWithEntries("META-INF/dirigible/../x/file.txt");
+
+        IOException refused = assertThrows(IOException.class, () -> ModuleJarInspector.inspect(jar),
+                "a '..' project name resolves to the registry root on removal and must never pass inspection");
+        assertTrue(refused.getMessage()
+                          .contains("invalid registry project name"),
+                "the refusal should name the problem: " + refused.getMessage());
+    }
+
+    @Test
+    void aBackslashBearingProjectNameIsRefused() throws IOException {
+        Path jar = jarWithEntries("META-INF/dirigible/..\\evil/file.txt");
+
+        assertThrows(IOException.class, () -> ModuleJarInspector.inspect(jar),
+                "a backslash-bearing name is a path on Windows and must never pass inspection");
+    }
+
+    private Path jarWithEntries(String... entryNames) throws IOException {
+        Path jar = tempDir.resolve("module.jar");
+        try (OutputStream file = Files.newOutputStream(jar); JarOutputStream out = new JarOutputStream(file)) {
+            for (String entryName : entryNames) {
+                out.putNextEntry(new JarEntry(entryName));
+                out.write("content".getBytes(StandardCharsets.UTF_8));
+                out.closeEntry();
+            }
+        }
+        return jar;
+    }
+}


### PR DESCRIPTION
Closes #6860 and #6861 — two hardening fixes on the #6776 dynamic-dependencies pipeline, found reviewing the 14.29/14.30 wave.

- **#6860**: `ModuleJarInspector` refuses a registry project name that is not a plain path segment (`[A-Za-z0-9][A-Za-z0-9._-]*`). The name is concatenated into `/registry/public/<name>` on removal, so a crafted `META-INF/dirigible/../x` entry named the project `..` and its removal deleted the registry root. Covered by `ModuleJarInspectorTest` (accepted plain name, refused `..`, refused backslash).
- **#6861**: the `Launcher-Agent-Class` manifest attribute now rides the same `pre-integration-test` ant step that injects the agent classes (the ant `jar` task merges it into the existing manifest, `keepcompression` preserved). A `package`-only build — the documented dev loop — previously produced a jar whose manifest named classes the archive lacked, which aborts `java -jar` before main; now it produces an agent-less jar that boots (verified by an actual boot), and the full build produces the complete pair (`LauncherAgentDeliveryIT`, as before).
- Bonus: `maven-antrun-plugin` pinned to 3.1.0 — unpinned, older local Mavens resolved 1.3 where the injection silently degraded, which is why `LauncherAgentDeliveryIT` failed on developer machines while green on CI. With the pin it passes locally (3/3 verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)