### PR TITLE
Tenant resolution from the user's selection, validated against identity provider groups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,6 +323,19 @@ User projects can declare a `*.nativeapp` JSON file that turns an external web s
 
 **Detailed guide:** [`components/engine/engine-native-apps/CLAUDE.md`](components/engine/engine-native-apps/CLAUDE.md). Read it before changing anything under that module — it covers the synchronizer model, kinds + start modes, port resolution, the stop / teardown contract (three layered guarantees), the dual-DELETE rehydrate requirement, PID + port logging, the proxy filter chain, placeholder expansion, the credentials field naming, the management endpoint's role policy, integration-test patterns including the no-manual-cleanup rule, and the macOS gotchas (Python 3.14 bind regression, wildcard-vs-loopback `ServerSocket` probe, `PollingWatchService` deadlock).
 
+## Tenant resolution strategy (`core-tenants` + `core-base`)
+
+How the current tenant of a request is determined is configurable through `DIRIGIBLE_TENANT_RESOLUTION_STRATEGY` (`TenantResolutionStrategy` in `core-base`, read once per `TenantExtractor` instance, i.e. at context refresh):
+
+- **`SUBDOMAIN`** (default, unchanged behaviour) — the subdomain of the `host` / `x-forwarded-host` header is matched against `DIRIGIBLE_TENANT_SUBDOMAIN_REGEX` and looked up by subdomain. A host naming no registered tenant is answered with the 404 written by `TenantContextInitFilter`. Every tenant needs its own host.
+- **`TOKEN_GROUPS`** — the tenant is the one the user selected, read from the HTTP session attribute `TenantSelectionConstants.SELECTED_TENANT_ID_SESSION_ATTRIBUTE` and required to be `PROVISIONED`. The host is never consulted, so one host serves every tenant. No session, no selection, an unknown selection, or a tenant that is not provisioned yet all fall back to the **default tenant** — machine-to-machine calls and anonymous requests carry no session, and a stale selection must not lock a user out.
+
+`TOKEN_GROUPS` exists for deployments where authorization is carried in identity provider groups named **`<tenantId>.<appId>.<role>`** (e.g. `acme.library.Owner`). `TenantGroupsParser` (`core-base`, `base/tenant/groups/`, free of Spring/servlet/OAuth2 types) turns a user's groups into `UserTenantAssignments`: groups of this deployment's application (`DIRIGIBLE_APP_ID`) become that tenant's roles, groups of other applications are ignored, and non-tenant-bearing groups (plain `DEVELOPER`, `OPERATOR`) stay global roles. The role part may contain dots; tenant and application ids may not. The groups claim is `DIRIGIBLE_TENANT_GROUPS_CLAIM` (`cognito:groups` by default, `groups` on Keycloak realms). **Who writes the session attribute is the identity provider side, which is not in the platform yet** — until it is, `TOKEN_GROUPS` resolves every request to the default tenant.
+
+`TenantResolutionConfigValidator` (`core-tenants`) refuses to start on an unusable combination: with `TOKEN_GROUPS` the app id must be set and dot-free, `DIRIGIBLE_MULTI_TENANT_MODE` must be true, the groups claim non-blank, and `DIRIGIBLE_MULTI_TENANT_MODE_COGNITO_SINGLE_USER_POOL` (the legacy `custom:tenant` model, still read by `CognitoTenantFilter` / `KeycloakTenantFilter`, which keep resolving by subdomain) must be off. It validates **in its constructor** on purpose — a half-usable resolution setup must abort the context refresh rather than serve requests that silently land in the wrong tenant.
+
+Caches: `TenantExtractor.TENANT_CACHE` (by subdomain) and `TENANT_ID_CACHE` (provisioned tenants by id), both 10 min. Use `TenantExtractor.evictFromCaches(tenantId, subdomain)` after changing a tenant's registration or status; `TenantService.save/delete` already do.
+
 ## Tenant-aware configuration (`commons-config` + `core-configurations`)
 
 Each tenant can override selected configuration values; overrides are resolved **per request**, scoped to the current tenant. Added on PR [#6205](https://github.com/eclipse-dirigible/dirigible/pull/6205).

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/tenant/TenantResolutionStrategy.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/tenant/TenantResolutionStrategy.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.tenant;
+
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.commons.config.InvalidConfigException;
+
+/**
+ * How the current tenant is resolved for an incoming request.
+ *
+ * <p>
+ * The strategy is a deployment-wide decision, configured through
+ * {@link DirigibleConfig#TENANT_RESOLUTION_STRATEGY}. It lives in core-base because both the
+ * resolution itself (core-tenants) and the identity providers that feed it (security-cognito,
+ * security-keycloak) have to agree on it.
+ */
+public enum TenantResolutionStrategy {
+
+    /**
+     * The tenant is the subdomain of the request host, matched against
+     * {@link DirigibleConfig#TENANT_SUBDOMAIN_REGEX}. Every tenant needs its own host.
+     */
+    SUBDOMAIN,
+
+    /**
+     * The tenant is the one the user selected, validated against the identity provider groups named
+     * {@code <tenantId>.<appId>.<role>}. One host serves every tenant of the application.
+     */
+    TOKEN_GROUPS;
+
+    /**
+     * Resolves the configured strategy.
+     *
+     * @return the configured strategy, {@link #SUBDOMAIN} when nothing is configured
+     * @throws InvalidConfigException if the configured value is not a known strategy
+     */
+    public static TenantResolutionStrategy fromConfiguration() {
+        String configuredValue = DirigibleConfig.TENANT_RESOLUTION_STRATEGY.getStringValue();
+        return parse(configuredValue);
+    }
+
+    /**
+     * Parses a strategy name, tolerating surrounding whitespace and any letter case.
+     *
+     * @param value the configured value
+     * @return the matching strategy, {@link #SUBDOMAIN} for a blank value
+     * @throws InvalidConfigException if the value is not a known strategy
+     */
+    static TenantResolutionStrategy parse(String value) {
+        if (value == null || value.isBlank()) {
+            return SUBDOMAIN;
+        }
+        String normalizedValue = value.trim()
+                                      .toUpperCase();
+        for (TenantResolutionStrategy strategy : values()) {
+            if (strategy.name()
+                        .equals(normalizedValue)) {
+                return strategy;
+            }
+        }
+        throw new InvalidConfigException(
+                "Unknown tenant resolution strategy [" + value + "] configured in [" + DirigibleConfig.TENANT_RESOLUTION_STRATEGY.getKey()
+                        + "]. Supported values: [" + SUBDOMAIN + ", " + TOKEN_GROUPS + "]",
+                DirigibleConfig.TENANT_RESOLUTION_STRATEGY.getKey());
+    }
+}

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/tenant/groups/TenantGroupsParser.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/tenant/groups/TenantGroupsParser.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.tenant.groups;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Reads a user's identity provider groups as tenant assignments for one application.
+ *
+ * <p>
+ * A tenant-bearing group is named {@code <tenantId>.<appId>.<role>}, e.g.
+ * {@code acme.library.Owner}. The tenant id and the application id must not contain a dot; the role
+ * may (so {@code acme.library.Tenant.Owner} grants the role {@code Tenant.Owner}). Groups of other
+ * applications are ignored - one identity provider serves the whole fleet - and groups that are not
+ * tenant-bearing at all (plain staff groups such as {@code DEVELOPER}) become global roles.
+ *
+ * <p>
+ * The logic is intentionally free of any Spring, servlet or OAuth2 types, so every identity
+ * provider configuration can reuse it and it can be unit tested in isolation.
+ */
+public final class TenantGroupsParser {
+
+    /** Tenant id and application id may not contain a dot; the role may. */
+    private static final Pattern TENANT_GROUP_PATTERN = Pattern.compile("^(?<tenant>[^.]+)\\.(?<app>[^.]+)\\.(?<role>.+)$");
+
+    private TenantGroupsParser() {}
+
+    /**
+     * Parses the groups of a user into the tenants and roles they grant in this application.
+     *
+     * @param groups the raw group names, e.g. from the configured groups claim; may be {@code null} or
+     *        contain {@code null} entries
+     * @param appId the id of this application, as it appears in the group names; must not be blank
+     * @return the assignments, never {@code null}
+     * @throws IllegalArgumentException if {@code appId} is blank - without it no group can be
+     *         attributed to a tenant, which is a misconfiguration rather than an empty result
+     */
+    public static UserTenantAssignments parse(Collection<String> groups, String appId) {
+        if (appId == null || appId.isBlank()) {
+            throw new IllegalArgumentException("The application id is required to parse tenant groups");
+        }
+        if (groups == null || groups.isEmpty()) {
+            return UserTenantAssignments.empty();
+        }
+        String applicationId = appId.trim();
+        Map<String, Set<String>> tenantRoles = new LinkedHashMap<>();
+        Set<String> globalRoles = new LinkedHashSet<>();
+
+        for (String group : groups) {
+            if (group == null || group.isBlank()) {
+                continue;
+            }
+            String groupName = group.trim();
+            Matcher matcher = TENANT_GROUP_PATTERN.matcher(groupName);
+            if (!matcher.matches()) {
+                globalRoles.add(groupName);
+                continue;
+            }
+            if (!applicationId.equals(matcher.group("app"))) {
+                continue;
+            }
+            tenantRoles.computeIfAbsent(matcher.group("tenant"), tenantId -> new LinkedHashSet<>())
+                       .add(matcher.group("role"));
+        }
+        return new UserTenantAssignments(tenantRoles, globalRoles);
+    }
+}

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/tenant/groups/UserTenantAssignments.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/tenant/groups/UserTenantAssignments.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.tenant.groups;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What a user's identity provider groups say about this application: which tenants the user may
+ * enter and with which roles, plus the roles that are not bound to any tenant.
+ *
+ * @param tenantRoles the roles the user has per tenant id, for this application only
+ * @param globalRoles the roles that carry no tenant (staff groups such as {@code DEVELOPER})
+ */
+public record UserTenantAssignments(Map<String, Set<String>> tenantRoles, Set<String> globalRoles) {
+
+    /** The empty assignments. */
+    private static final UserTenantAssignments EMPTY = new UserTenantAssignments(Collections.emptyMap(), Collections.emptySet());
+
+    /**
+     * Instantiates unmodifiable assignments, copying whatever was passed in.
+     *
+     * @param tenantRoles the roles per tenant id; may be {@code null}
+     * @param globalRoles the tenant-less roles; may be {@code null}
+     */
+    public UserTenantAssignments {
+        tenantRoles = copyOf(tenantRoles);
+        globalRoles = globalRoles == null ? Collections.emptySet() : Collections.unmodifiableSet(new LinkedHashSet<>(globalRoles));
+    }
+
+    private static Map<String, Set<String>> copyOf(Map<String, Set<String>> tenantRoles) {
+        if (tenantRoles == null || tenantRoles.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, Set<String>> copy = new LinkedHashMap<>();
+        tenantRoles.forEach((tenantId, roles) -> copy.put(tenantId, Collections.unmodifiableSet(new LinkedHashSet<>(roles))));
+        return Collections.unmodifiableMap(copy);
+    }
+
+    /**
+     * The assignments of a user with no groups at all.
+     *
+     * @return empty assignments
+     */
+    public static UserTenantAssignments empty() {
+        return EMPTY;
+    }
+
+    /**
+     * The roles the user has in a tenant.
+     *
+     * @param tenantId the tenant id
+     * @return the roles, empty when the user is not assigned to that tenant
+     */
+    public Set<String> rolesFor(String tenantId) {
+        return tenantRoles.getOrDefault(tenantId, Collections.emptySet());
+    }
+
+    /**
+     * The tenants the user may enter, in the order their groups were read.
+     *
+     * @return the tenant ids
+     */
+    public Set<String> tenantIds() {
+        return tenantRoles.keySet();
+    }
+
+    /**
+     * Whether the user is assigned to no tenant of this application. Such a user is either staff
+     * (global roles only) or has no access at all.
+     *
+     * @return true if there is no tenant assignment
+     */
+    public boolean hasNoTenants() {
+        return tenantRoles.isEmpty();
+    }
+}

--- a/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/tenant/TenantResolutionStrategyTest.java
+++ b/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/tenant/TenantResolutionStrategyTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.tenant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.commons.config.InvalidConfigException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The configured value is normalized, and an unrecognized one fails loudly instead of silently
+ * falling back to a strategy the operator did not ask for.
+ */
+class TenantResolutionStrategyTest {
+
+    @AfterEach
+    void clearConfiguration() {
+        Configuration.remove(DirigibleConfig.TENANT_RESOLUTION_STRATEGY.getKey());
+    }
+
+    @Test
+    void unsetConfigurationResolvesToSubdomain() {
+        assertEquals(TenantResolutionStrategy.SUBDOMAIN, TenantResolutionStrategy.fromConfiguration());
+    }
+
+    @Test
+    void blankConfigurationResolvesToSubdomain() {
+        assertEquals(TenantResolutionStrategy.SUBDOMAIN, TenantResolutionStrategy.parse("   "));
+        assertEquals(TenantResolutionStrategy.SUBDOMAIN, TenantResolutionStrategy.parse(null));
+    }
+
+    @Test
+    void configuredStrategyIsRead() {
+        DirigibleConfig.TENANT_RESOLUTION_STRATEGY.setStringValue("TOKEN_GROUPS");
+
+        assertEquals(TenantResolutionStrategy.TOKEN_GROUPS, TenantResolutionStrategy.fromConfiguration());
+    }
+
+    @Test
+    void caseAndWhitespaceAreTolerated() {
+        assertEquals(TenantResolutionStrategy.TOKEN_GROUPS, TenantResolutionStrategy.parse(" token_groups "));
+        assertEquals(TenantResolutionStrategy.SUBDOMAIN, TenantResolutionStrategy.parse("Subdomain"));
+    }
+
+    @Test
+    void unknownStrategyFailsNamingTheKeyAndTheValidValues() {
+        InvalidConfigException exception = assertThrows(InvalidConfigException.class, () -> TenantResolutionStrategy.parse("SESSION"));
+
+        assertEquals(DirigibleConfig.TENANT_RESOLUTION_STRATEGY.getKey(), exception.getConfigKey());
+        assertTrue(exception.getMessage()
+                            .contains("SESSION"),
+                "the message must quote the offending value: " + exception.getMessage());
+        assertTrue(exception.getMessage()
+                            .contains("TOKEN_GROUPS"),
+                "the message must list the supported values: " + exception.getMessage());
+    }
+}

--- a/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/tenant/groups/TenantGroupsParserTest.java
+++ b/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/tenant/groups/TenantGroupsParserTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.tenant.groups;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The group grammar is {@code <tenantId>.<appId>.<role>}: this application's groups become tenant
+ * roles, other applications' groups are none of this deployment's business, and anything that is
+ * not tenant-bearing stays a global role.
+ */
+class TenantGroupsParserTest {
+
+    private static final String APP_ID = "library";
+
+    @Test
+    void tenantGroupsOfThisApplicationBecomeTenantRoles() {
+        UserTenantAssignments assignments = TenantGroupsParser.parse(List.of("acme.library.Owner", "acme.library.User"), APP_ID);
+
+        assertEquals(Set.of("acme"), assignments.tenantIds());
+        assertEquals(Set.of("Owner", "User"), assignments.rolesFor("acme"));
+        assertTrue(assignments.globalRoles()
+                              .isEmpty());
+    }
+
+    @Test
+    void severalTenantsAreKeptApart() {
+        UserTenantAssignments assignments = TenantGroupsParser.parse(List.of("acme.library.Owner", "globex.library.User"), APP_ID);
+
+        assertEquals(Set.of("acme", "globex"), assignments.tenantIds());
+        assertEquals(Set.of("Owner"), assignments.rolesFor("acme"));
+        assertEquals(Set.of("User"), assignments.rolesFor("globex"));
+    }
+
+    @Test
+    void roleNamesMayContainDots() {
+        UserTenantAssignments assignments = TenantGroupsParser.parse(List.of("acme.library.Tenant.Owner"), APP_ID);
+
+        assertEquals(Set.of("Tenant.Owner"), assignments.rolesFor("acme"));
+    }
+
+    @Test
+    void uuidTenantIdsAreSupported() {
+        String tenantId = "6597d633-b0f9-4cb2-b134-4bf2a52b654f";
+
+        UserTenantAssignments assignments = TenantGroupsParser.parse(List.of(tenantId + ".library.User"), APP_ID);
+
+        assertEquals(Set.of(tenantId), assignments.tenantIds());
+        assertEquals(Set.of("User"), assignments.rolesFor(tenantId));
+    }
+
+    @Test
+    void groupsOfOtherApplicationsAreIgnored() {
+        UserTenantAssignments assignments = TenantGroupsParser.parse(List.of("acme.bi.Owner", "globex.crm.User"), APP_ID);
+
+        assertTrue(assignments.hasNoTenants());
+        assertTrue(assignments.globalRoles()
+                              .isEmpty(),
+                "a tenant group of another application is not a global role");
+    }
+
+    @Test
+    void theApplicationIdIsMatchedExactly() {
+        UserTenantAssignments assignments = TenantGroupsParser.parse(List.of("acme.LIBRARY.Owner", "acme.library2.Owner"), APP_ID);
+
+        assertTrue(assignments.hasNoTenants());
+    }
+
+    @Test
+    void groupsThatAreNotTenantBearingBecomeGlobalRoles() {
+        UserTenantAssignments assignments = TenantGroupsParser.parse(List.of("DEVELOPER", "OPERATOR", "acme.library.Owner"), APP_ID);
+
+        assertEquals(Set.of("DEVELOPER", "OPERATOR"), assignments.globalRoles());
+        assertEquals(Set.of("Owner"), assignments.rolesFor("acme"));
+    }
+
+    @Test
+    void malformedTenantGroupsAreTreatedAsGlobalRoles() {
+        UserTenantAssignments assignments = TenantGroupsParser.parse(List.of("acme.library", ".library.Owner", "acme..Owner"), APP_ID);
+
+        assertTrue(assignments.hasNoTenants());
+        assertEquals(Set.of("acme.library", ".library.Owner", "acme..Owner"), assignments.globalRoles());
+    }
+
+    @Test
+    void duplicatesCollapse() {
+        UserTenantAssignments assignments =
+                TenantGroupsParser.parse(List.of("acme.library.Owner", "acme.library.Owner", "DEVELOPER", "DEVELOPER"), APP_ID);
+
+        assertEquals(Set.of("Owner"), assignments.rolesFor("acme"));
+        assertEquals(Set.of("DEVELOPER"), assignments.globalRoles());
+    }
+
+    @Test
+    void surroundingWhitespaceIsTrimmedAndBlanksSkipped() {
+        UserTenantAssignments assignments =
+                TenantGroupsParser.parse(Arrays.asList("  acme.library.Owner  ", "   ", "", null, " DEVELOPER "), APP_ID);
+
+        assertEquals(Set.of("Owner"), assignments.rolesFor("acme"));
+        assertEquals(Set.of("DEVELOPER"), assignments.globalRoles());
+    }
+
+    @Test
+    void noGroupsYieldEmptyAssignments() {
+        assertTrue(TenantGroupsParser.parse(null, APP_ID)
+                                     .hasNoTenants());
+        assertTrue(TenantGroupsParser.parse(Collections.emptyList(), APP_ID)
+                                     .globalRoles()
+                                     .isEmpty());
+    }
+
+    @Test
+    void aMissingApplicationIdIsAMisconfiguration() {
+        List<String> groups = List.of("acme.library.Owner");
+
+        assertThrows(IllegalArgumentException.class, () -> TenantGroupsParser.parse(groups, null));
+        assertThrows(IllegalArgumentException.class, () -> TenantGroupsParser.parse(groups, "   "));
+    }
+
+    @Test
+    void rolesForAnUnknownTenantAreEmptyAndTheResultIsUnmodifiable() {
+        UserTenantAssignments assignments = TenantGroupsParser.parse(List.of("acme.library.Owner"), APP_ID);
+
+        assertTrue(assignments.rolesFor("unknown")
+                              .isEmpty());
+        assertFalse(assignments.hasNoTenants());
+        assertThrows(UnsupportedOperationException.class, () -> assignments.rolesFor("acme")
+                                                                           .add("Admin"));
+        assertThrows(UnsupportedOperationException.class, () -> assignments.globalRoles()
+                                                                           .add("DEVELOPER"));
+    }
+}

--- a/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/service/TenantService.java
+++ b/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/service/TenantService.java
@@ -74,6 +74,9 @@ public class TenantService {
     public Tenant save(Tenant tenant) {
         Tenant newTenant = tenantRepository.save(tenant);
         TenantExtractor.TENANT_CACHE.put(newTenant.getSubdomain(), Optional.of(TenantImpl.createFromEntity(newTenant)));
+        // the id-keyed cache holds provisioned tenants only, and a save may be what just provisioned
+        // this one - so it is evicted and looked up again rather than written here
+        TenantExtractor.evictFromCaches(newTenant.getId(), null);
         return newTenant;
     }
 
@@ -94,7 +97,7 @@ public class TenantService {
      */
     public void delete(Tenant tenant) {
         tenantRepository.delete(tenant);
-        TenantExtractor.TENANT_CACHE.invalidate(tenant.getSubdomain());
+        TenantExtractor.evictFromCaches(tenant.getId(), tenant.getSubdomain());
     }
 
 }

--- a/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/tenant/TenantContextInitFilter.java
+++ b/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/tenant/TenantContextInitFilter.java
@@ -77,7 +77,7 @@ public class TenantContextInitFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
-        Optional<Tenant> currentTenant = tenantExtractor.determineTenantSubdomain(request);
+        Optional<Tenant> currentTenant = tenantExtractor.determineTenant(request);
         if (currentTenant.isEmpty()) {
             writeNotFoundResponse(request, response, "There is no registered tenant for the current host");
             if (LOGGER.isWarnEnabled()) {

--- a/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/tenant/TenantExtractor.java
+++ b/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/tenant/TenantExtractor.java
@@ -18,6 +18,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.eclipse.dirigible.commons.config.DirigibleConfig;
 import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.base.tenant.TenantResolutionStrategy;
+import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
 import org.eclipse.dirigible.components.tenants.service.TenantService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +29,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 
 @Service
 public class TenantExtractor {
@@ -45,15 +48,103 @@ public class TenantExtractor {
                                                                                .maximumSize(100)
                                                                                .build();
 
+    /**
+     * The provisioned tenants by id, for the {@link TenantResolutionStrategy#TOKEN_GROUPS} strategy. A
+     * mirror of {@link #TENANT_CACHE}, which is keyed by subdomain. A tenant that is not provisioned is
+     * cached as absent, so activating one has to evict it - see
+     * {@link #evictFromCaches(String, String)}.
+     */
+    public static final Cache<String, Optional<Tenant>> TENANT_ID_CACHE = Caffeine.newBuilder()
+                                                                                  .expireAfterWrite(10, TimeUnit.MINUTES)
+                                                                                  .maximumSize(100)
+                                                                                  .build();
+
     private final TenantService tenantService;
     private final boolean multitenantModeEnabled;
+    private final TenantResolutionStrategy resolutionStrategy;
     private final Gson gson;
 
     public TenantExtractor(TenantService tenantService) {
         this.tenantService = tenantService;
         this.multitenantModeEnabled = DirigibleConfig.MULTI_TENANT_MODE_ENABLED.getBooleanValue();
+        this.resolutionStrategy = TenantResolutionStrategy.fromConfiguration();
         this.gson = new GsonBuilder().serializeNulls()
                                      .create();
+    }
+
+    /**
+     * Determines the tenant of the request according to the configured resolution strategy.
+     *
+     * @param request the request
+     * @return the tenant, empty only when the strategy is {@link TenantResolutionStrategy#SUBDOMAIN}
+     *         and the host names no registered tenant
+     */
+    public Optional<Tenant> determineTenant(HttpServletRequest request) {
+        return switch (resolutionStrategy) {
+            case SUBDOMAIN -> determineTenantSubdomain(request);
+            case TOKEN_GROUPS -> determineSelectedTenant(request);
+        };
+    }
+
+    /**
+     * Determines the tenant the user selected, as stored in the session by the identity provider side.
+     *
+     * <p>
+     * Anything else than a session naming a provisioned tenant falls back to the default tenant: a
+     * machine-to-machine call and an anonymous request carry no session at all, and a selection that no
+     * longer resolves must not lock the user out of the instance. The host is never consulted in this
+     * mode, so one host serves every tenant.
+     *
+     * @param request the request
+     * @return the selected tenant, or the default tenant
+     */
+    private Optional<Tenant> determineSelectedTenant(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        Object selectedTenantId =
+                session == null ? null : session.getAttribute(TenantSelectionConstants.SELECTED_TENANT_ID_SESSION_ATTRIBUTE);
+        if (selectedTenantId == null) {
+            LOGGER.debug("No tenant is selected for the current request. Will return the default tenant.");
+            return Optional.of(TenantImpl.getDefaultTenant());
+        }
+        Optional<Tenant> tenant = provisionedTenantById(selectedTenantId.toString());
+        if (tenant.isEmpty()) {
+            LOGGER.warn("Selected tenant [{}] is not a provisioned tenant of this instance. Will return the default tenant.",
+                    selectedTenantId);
+            return Optional.of(TenantImpl.getDefaultTenant());
+        }
+        LOGGER.debug("Found selected tenant [{}].", tenant.get());
+        return tenant;
+    }
+
+    private Optional<Tenant> provisionedTenantById(String tenantId) {
+        return TENANT_ID_CACHE.get(tenantId, id -> {
+            LOGGER.debug("Searching for tenant with id [{}] from database", id);
+            return tenantService.findById(id)
+                                .filter(tenant -> {
+                                    if (tenant.getStatus() == TenantStatus.PROVISIONED) {
+                                        return true;
+                                    }
+                                    LOGGER.warn("Tenant [{}] is in status [{}] and cannot be entered yet.", id, tenant.getStatus());
+                                    return false;
+                                })
+                                .map(TenantImpl::createFromEntity);
+        });
+    }
+
+    /**
+     * Forgets a tenant in both caches, so a change of its registration or status takes effect at once
+     * instead of after the cache expires.
+     *
+     * @param tenantId the tenant id; may be {@code null}
+     * @param subdomain the tenant subdomain; may be {@code null}
+     */
+    public static void evictFromCaches(String tenantId, String subdomain) {
+        if (tenantId != null) {
+            TENANT_ID_CACHE.invalidate(tenantId);
+        }
+        if (subdomain != null) {
+            TENANT_CACHE.invalidate(subdomain);
+        }
     }
 
     /**

--- a/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/tenant/TenantResolutionConfigValidator.java
+++ b/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/tenant/TenantResolutionConfigValidator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.tenant;
+
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.commons.config.InvalidConfigException;
+import org.eclipse.dirigible.components.base.tenant.TenantResolutionStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Refuses to start on a tenant resolution configuration that cannot work.
+ *
+ * <p>
+ * The validation runs in the constructor, so an inconsistent configuration aborts the context
+ * refresh before the instance accepts any traffic. Serving requests with a half-usable resolution
+ * setup is worse than not starting: users would silently land in the wrong tenant, or in no tenant
+ * at all.
+ *
+ * <p>
+ * The class is public because its integration test lives in another module.
+ */
+@Component
+public class TenantResolutionConfigValidator {
+
+    /** The Constant LOGGER. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(TenantResolutionConfigValidator.class);
+
+    /**
+     * Validates the configuration.
+     *
+     * @throws InvalidConfigException if the configured combination cannot resolve tenants
+     */
+    public TenantResolutionConfigValidator() {
+        TenantResolutionStrategy strategy = TenantResolutionStrategy.fromConfiguration();
+        if (strategy != TenantResolutionStrategy.TOKEN_GROUPS) {
+            LOGGER.debug("Tenant resolution strategy is [{}].", strategy);
+            return;
+        }
+        validateTokenGroupsStrategy();
+        LOGGER.info("Tenant resolution strategy is [{}] for application [{}], groups claim [{}].", strategy,
+                DirigibleConfig.APP_ID.getStringValue(), DirigibleConfig.TENANT_GROUPS_CLAIM.getStringValue());
+    }
+
+    private void validateTokenGroupsStrategy() {
+        String appId = DirigibleConfig.APP_ID.getStringValue();
+        if (appId == null || appId.isBlank()) {
+            throw invalidConfig(DirigibleConfig.APP_ID, "it is the application id in the group names <tenantId>.<appId>.<role>");
+        }
+        if (appId.contains(".")) {
+            throw invalidConfig(DirigibleConfig.APP_ID,
+                    "it must not contain a dot - the group name <tenantId>.<appId>.<role> would not be parseable, so no group could ever grant a tenant role. Configured value: ["
+                            + appId + "]");
+        }
+        if (!DirigibleConfig.MULTI_TENANT_MODE_ENABLED.getBooleanValue()) {
+            throw invalidConfig(DirigibleConfig.MULTI_TENANT_MODE_ENABLED,
+                    "tenants cannot be resolved from token groups while the platform runs in single tenant mode");
+        }
+        if (DirigibleConfig.MULTI_TENANT_MODE_COGNITO_SINGLE_USER_POOL_ENABLED.getBooleanValue()) {
+            throw invalidConfig(DirigibleConfig.MULTI_TENANT_MODE_COGNITO_SINGLE_USER_POOL_ENABLED,
+                    "it is the legacy tenant model based on the custom:tenant claim, which the token groups strategy replaces. The two are mutually exclusive");
+        }
+        String groupsClaim = DirigibleConfig.TENANT_GROUPS_CLAIM.getStringValue();
+        if (groupsClaim == null || groupsClaim.isBlank()) {
+            throw invalidConfig(DirigibleConfig.TENANT_GROUPS_CLAIM, "it is the token claim the tenant groups are read from");
+        }
+    }
+
+    private InvalidConfigException invalidConfig(DirigibleConfig config, String reason) {
+        String message = "Invalid configuration [" + config.getKey() + "] while [" + DirigibleConfig.TENANT_RESOLUTION_STRATEGY.getKey()
+                + "] is [" + TenantResolutionStrategy.TOKEN_GROUPS + "]: " + reason;
+        LOGGER.error(message);
+        return new InvalidConfigException(message, config.getKey());
+    }
+}

--- a/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/tenant/TenantSelectionConstants.java
+++ b/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/tenant/TenantSelectionConstants.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.tenant;
+
+/**
+ * What the tenant selection of a user is stored under.
+ *
+ * <p>
+ * The selection is written by the identity provider side (which validates it against the user's
+ * groups) and read here, when the tenant scope of a request is opened - hence a shared constant
+ * rather than a literal on each side.
+ */
+public final class TenantSelectionConstants {
+
+    /** The HTTP session attribute carrying the id of the tenant the user selected. */
+    public static final String SELECTED_TENANT_ID_SESSION_ATTRIBUTE = "dirigible-selected-tenant-id";
+
+    private TenantSelectionConstants() {}
+}

--- a/components/core/core-tenants/src/test/java/org/eclipse/dirigible/components/tenants/tenant/TenantExtractorTest.java
+++ b/components/core/core-tenants/src/test/java/org/eclipse/dirigible/components/tenants/tenant/TenantExtractorTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.tenant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
+import org.eclipse.dirigible.components.tenants.service.TenantService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * The subdomain strategy keeps resolving from the host, the token groups strategy resolves from the
+ * tenant the user selected - and in that mode a request that names no usable tenant lands in the
+ * default tenant instead of being refused, because the host carries no tenant to refuse.
+ */
+class TenantExtractorTest {
+
+    private static final String TENANT_ID = "acme";
+    private static final String TENANT_SUBDOMAIN = "acme";
+
+    private TenantService tenantService;
+
+    @BeforeEach
+    void setUp() {
+        tenantService = mock(TenantService.class);
+        TenantExtractor.TENANT_CACHE.invalidateAll();
+        TenantExtractor.TENANT_ID_CACHE.invalidateAll();
+        DirigibleConfig.MULTI_TENANT_MODE_ENABLED.setBooleanValue(true);
+    }
+
+    @AfterEach
+    void clearConfiguration() {
+        Configuration.remove(DirigibleConfig.TENANT_RESOLUTION_STRATEGY.getKey());
+        Configuration.remove(DirigibleConfig.MULTI_TENANT_MODE_ENABLED.getKey());
+        TenantExtractor.TENANT_CACHE.invalidateAll();
+        TenantExtractor.TENANT_ID_CACHE.invalidateAll();
+    }
+
+    @Test
+    void subdomainStrategyResolvesFromTheHost() {
+        useStrategy("SUBDOMAIN");
+        when(tenantService.findBySubdomain(TENANT_SUBDOMAIN)).thenReturn(Optional.of(provisionedTenant()));
+
+        Optional<Tenant> tenant = newExtractor().determineTenant(requestFromHost(TENANT_SUBDOMAIN + ".dirigible.test"));
+
+        assertEquals(TENANT_ID, tenant.orElseThrow()
+                                      .getId());
+    }
+
+    @Test
+    void subdomainStrategyStillRefusesAnUnregisteredHost() {
+        useStrategy("SUBDOMAIN");
+        when(tenantService.findBySubdomain(anyString())).thenReturn(Optional.empty());
+
+        Optional<Tenant> tenant = newExtractor().determineTenant(requestFromHost("unregistered.dirigible.test"));
+
+        assertTrue(tenant.isEmpty(), "an unregistered subdomain must keep producing the not-found response");
+    }
+
+    @Test
+    void tokenGroupsStrategyResolvesTheSelectedTenant() {
+        useStrategy("TOKEN_GROUPS");
+        when(tenantService.findById(TENANT_ID)).thenReturn(Optional.of(provisionedTenant()));
+
+        Optional<Tenant> tenant = newExtractor().determineTenant(requestWithSelectedTenant(TENANT_ID));
+
+        assertEquals(TENANT_ID, tenant.orElseThrow()
+                                      .getId());
+    }
+
+    @Test
+    void tokenGroupsStrategyIgnoresTheHost() {
+        useStrategy("TOKEN_GROUPS");
+        when(tenantService.findById(TENANT_ID)).thenReturn(Optional.of(provisionedTenant()));
+        HttpServletRequest request = requestWithSelectedTenant(TENANT_ID);
+        when(request.getHeader("host")).thenReturn("some-other-tenant.dirigible.test");
+
+        Optional<Tenant> tenant = newExtractor().determineTenant(request);
+
+        assertEquals(TENANT_ID, tenant.orElseThrow()
+                                      .getId());
+        verify(tenantService, never()).findBySubdomain(anyString());
+    }
+
+    @Test
+    void aRequestWithoutASessionLandsInTheDefaultTenant() {
+        useStrategy("TOKEN_GROUPS");
+        HttpServletRequest request = requestFromHost("unregistered.dirigible.test");
+        when(request.getSession(false)).thenReturn(null);
+
+        Optional<Tenant> tenant = newExtractor().determineTenant(request);
+
+        assertTrue(tenant.orElseThrow()
+                         .isDefault(),
+                "a machine-to-machine or anonymous request carries no session and must not be refused");
+    }
+
+    @Test
+    void aSessionWithoutASelectionLandsInTheDefaultTenant() {
+        useStrategy("TOKEN_GROUPS");
+
+        Optional<Tenant> tenant = newExtractor().determineTenant(requestWithSelectedTenant(null));
+
+        assertTrue(tenant.orElseThrow()
+                         .isDefault());
+    }
+
+    @Test
+    void anUnknownSelectionLandsInTheDefaultTenant() {
+        useStrategy("TOKEN_GROUPS");
+        when(tenantService.findById("gone")).thenReturn(Optional.empty());
+
+        Optional<Tenant> tenant = newExtractor().determineTenant(requestWithSelectedTenant("gone"));
+
+        assertTrue(tenant.orElseThrow()
+                         .isDefault(),
+                "a selection that no longer resolves must not lock the user out of the instance");
+    }
+
+    @Test
+    void aTenantThatIsNotProvisionedYetCannotBeEntered() {
+        useStrategy("TOKEN_GROUPS");
+        org.eclipse.dirigible.components.tenants.domain.Tenant tenantEntity = provisionedTenant();
+        tenantEntity.setStatus(TenantStatus.INITIAL);
+        when(tenantService.findById(TENANT_ID)).thenReturn(Optional.of(tenantEntity));
+
+        Optional<Tenant> tenant = newExtractor().determineTenant(requestWithSelectedTenant(TENANT_ID));
+
+        assertTrue(tenant.orElseThrow()
+                         .isDefault());
+    }
+
+    @Test
+    void theSelectedTenantIsCachedByIdAndEvictable() {
+        useStrategy("TOKEN_GROUPS");
+        when(tenantService.findById(TENANT_ID)).thenReturn(Optional.of(provisionedTenant()));
+        TenantExtractor extractor = newExtractor();
+
+        extractor.determineTenant(requestWithSelectedTenant(TENANT_ID));
+        extractor.determineTenant(requestWithSelectedTenant(TENANT_ID));
+        verify(tenantService, times(1)).findById(TENANT_ID);
+
+        TenantExtractor.evictFromCaches(TENANT_ID, TENANT_SUBDOMAIN);
+        extractor.determineTenant(requestWithSelectedTenant(TENANT_ID));
+        verify(tenantService, times(2)).findById(TENANT_ID);
+    }
+
+    private TenantExtractor newExtractor() {
+        return new TenantExtractor(tenantService);
+    }
+
+    private static void useStrategy(String strategy) {
+        DirigibleConfig.TENANT_RESOLUTION_STRATEGY.setStringValue(strategy);
+    }
+
+    private static org.eclipse.dirigible.components.tenants.domain.Tenant provisionedTenant() {
+        org.eclipse.dirigible.components.tenants.domain.Tenant tenant = new org.eclipse.dirigible.components.tenants.domain.Tenant("-",
+                "Acme", "The Acme tenant", TENANT_SUBDOMAIN, TenantStatus.PROVISIONED);
+        tenant.setId(TENANT_ID);
+        return tenant;
+    }
+
+    private static HttpServletRequest requestFromHost(String host) {
+        HttpServletRequest request = mock(HttpServletRequest.class, Mockito.RETURNS_DEEP_STUBS);
+        when(request.getHeader("host")).thenReturn(host);
+        return request;
+    }
+
+    private static HttpServletRequest requestWithSelectedTenant(String tenantId) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpSession session = mock(HttpSession.class);
+        when(request.getSession(false)).thenReturn(session);
+        when(session.getAttribute(TenantSelectionConstants.SELECTED_TENANT_ID_SESSION_ATTRIBUTE)).thenReturn(tenantId);
+        return request;
+    }
+}

--- a/components/core/core-tenants/src/test/java/org/eclipse/dirigible/components/tenants/tenant/TenantResolutionConfigValidatorTest.java
+++ b/components/core/core-tenants/src/test/java/org/eclipse/dirigible/components/tenants/tenant/TenantResolutionConfigValidatorTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.tenant;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.commons.config.InvalidConfigException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The token groups strategy needs an application id and real multi-tenancy, and cannot coexist with
+ * the legacy single user pool tenant model. Each of those is a startup failure rather than a
+ * runtime surprise.
+ */
+class TenantResolutionConfigValidatorTest {
+
+    @BeforeEach
+    @AfterEach
+    void clearConfiguration() {
+        Configuration.remove(DirigibleConfig.TENANT_RESOLUTION_STRATEGY.getKey());
+        Configuration.remove(DirigibleConfig.APP_ID.getKey());
+        Configuration.remove(DirigibleConfig.TENANT_GROUPS_CLAIM.getKey());
+        Configuration.remove(DirigibleConfig.MULTI_TENANT_MODE_ENABLED.getKey());
+        Configuration.remove(DirigibleConfig.MULTI_TENANT_MODE_COGNITO_SINGLE_USER_POOL_ENABLED.getKey());
+    }
+
+    @Test
+    void theDefaultConfigurationIsValid() {
+        assertDoesNotThrow(TenantResolutionConfigValidator::new);
+    }
+
+    @Test
+    void subdomainStrategyIgnoresTheTokenGroupsSettings() {
+        DirigibleConfig.TENANT_RESOLUTION_STRATEGY.setStringValue("SUBDOMAIN");
+        DirigibleConfig.MULTI_TENANT_MODE_ENABLED.setBooleanValue(false);
+        DirigibleConfig.MULTI_TENANT_MODE_COGNITO_SINGLE_USER_POOL_ENABLED.setBooleanValue(true);
+
+        assertDoesNotThrow(TenantResolutionConfigValidator::new);
+    }
+
+    @Test
+    void aValidTokenGroupsConfigurationIsAccepted() {
+        configureTokenGroups();
+
+        assertDoesNotThrow(TenantResolutionConfigValidator::new);
+    }
+
+    @Test
+    void anUnknownStrategyFailsInAnyMode() {
+        DirigibleConfig.TENANT_RESOLUTION_STRATEGY.setStringValue("SESSION");
+
+        InvalidConfigException exception = assertThrows(InvalidConfigException.class, TenantResolutionConfigValidator::new);
+
+        assertEquals(DirigibleConfig.TENANT_RESOLUTION_STRATEGY.getKey(), exception.getConfigKey());
+    }
+
+    @Test
+    void aMissingApplicationIdFails() {
+        configureTokenGroups();
+        Configuration.remove(DirigibleConfig.APP_ID.getKey());
+
+        assertFailsOn(DirigibleConfig.APP_ID);
+    }
+
+    @Test
+    void aBlankApplicationIdFails() {
+        configureTokenGroups();
+        DirigibleConfig.APP_ID.setStringValue("   ");
+
+        assertFailsOn(DirigibleConfig.APP_ID);
+    }
+
+    @Test
+    void aDottedApplicationIdFails() {
+        configureTokenGroups();
+        DirigibleConfig.APP_ID.setStringValue("codbex.library");
+
+        InvalidConfigException exception = assertFailsOn(DirigibleConfig.APP_ID);
+        assertTrue(exception.getMessage()
+                            .contains("codbex.library"),
+                "the message must quote the offending value: " + exception.getMessage());
+    }
+
+    @Test
+    void singleTenantModeFails() {
+        configureTokenGroups();
+        DirigibleConfig.MULTI_TENANT_MODE_ENABLED.setBooleanValue(false);
+
+        assertFailsOn(DirigibleConfig.MULTI_TENANT_MODE_ENABLED);
+    }
+
+    @Test
+    void theLegacyCognitoSingleUserPoolModelFails() {
+        configureTokenGroups();
+        DirigibleConfig.MULTI_TENANT_MODE_COGNITO_SINGLE_USER_POOL_ENABLED.setBooleanValue(true);
+
+        assertFailsOn(DirigibleConfig.MULTI_TENANT_MODE_COGNITO_SINGLE_USER_POOL_ENABLED);
+    }
+
+    @Test
+    void aBlankGroupsClaimFails() {
+        configureTokenGroups();
+        DirigibleConfig.TENANT_GROUPS_CLAIM.setStringValue("  ");
+
+        assertFailsOn(DirigibleConfig.TENANT_GROUPS_CLAIM);
+    }
+
+    private static void configureTokenGroups() {
+        DirigibleConfig.TENANT_RESOLUTION_STRATEGY.setStringValue("TOKEN_GROUPS");
+        DirigibleConfig.APP_ID.setStringValue("library");
+        DirigibleConfig.MULTI_TENANT_MODE_ENABLED.setBooleanValue(true);
+        DirigibleConfig.MULTI_TENANT_MODE_COGNITO_SINGLE_USER_POOL_ENABLED.setBooleanValue(false);
+    }
+
+    private static InvalidConfigException assertFailsOn(DirigibleConfig expectedKey) {
+        InvalidConfigException exception = assertThrows(InvalidConfigException.class, TenantResolutionConfigValidator::new);
+
+        assertEquals(expectedKey.getKey(), exception.getConfigKey());
+        assertTrue(exception.getMessage()
+                            .contains(expectedKey.getKey()),
+                "the message must name the offending key: " + exception.getMessage());
+        return exception;
+    }
+}

--- a/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
+++ b/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
@@ -129,6 +129,27 @@ public enum DirigibleConfig {
     /** The tenant subdomain regex. */
     TENANT_SUBDOMAIN_REGEX("DIRIGIBLE_TENANT_SUBDOMAIN_REGEX", "^([^\\.]+)\\..+$"),
 
+    /**
+     * How the current tenant is resolved for a request: {@code SUBDOMAIN} (the default - matched from
+     * the host header against {@link #TENANT_SUBDOMAIN_REGEX}) or {@code TOKEN_GROUPS} (the tenant the
+     * user selected, validated against the identity provider groups named
+     * {@code <tenantId>.<appId>.<role>}), which lets one host serve every tenant of the application.
+     */
+    TENANT_RESOLUTION_STRATEGY("DIRIGIBLE_TENANT_RESOLUTION_STRATEGY", "SUBDOMAIN"),
+
+    /**
+     * The id of the application this deployment runs, as it appears in the identity provider group
+     * names {@code <tenantId>.<appId>.<role>}. Groups of other applications are ignored. Mandatory when
+     * {@link #TENANT_RESOLUTION_STRATEGY} is {@code TOKEN_GROUPS}, and it must not contain a dot.
+     */
+    APP_ID("DIRIGIBLE_APP_ID", null),
+
+    /**
+     * The token claim carrying the user groups. AWS Cognito puts them in {@code cognito:groups} (the
+     * default), a Keycloak realm typically in {@code groups}.
+     */
+    TENANT_GROUPS_CLAIM("DIRIGIBLE_TENANT_GROUPS_CLAIM", "cognito:groups"),
+
     SNOWFLAKE_ADMIN_USERNAME("DIRIGIBLE_SNOWFLAKE_ADMIN_USERNAME", null),
 
     /** The basic admin username. */

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantResolutionConfigValidationIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantResolutionConfigValidationIT.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.commons.config.InvalidConfigException;
+import org.eclipse.dirigible.components.tenants.tenant.TenantResolutionConfigValidator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+/**
+ * A tenant resolution configuration that cannot work must stop the platform from starting, rather
+ * than let it serve requests that silently land in the wrong tenant.
+ *
+ * <p>
+ * The assertion is therefore about the Spring context itself: refreshing a context that contains
+ * the validator has to fail. No application is booted - the validator reads the configuration in
+ * its constructor, so a context holding only that bean reproduces the startup behaviour exactly, in
+ * milliseconds instead of minutes.
+ */
+class TenantResolutionConfigValidationIT {
+
+    @BeforeEach
+    @AfterEach
+    void clearConfiguration() {
+        Configuration.remove(DirigibleConfig.TENANT_RESOLUTION_STRATEGY.getKey());
+        Configuration.remove(DirigibleConfig.APP_ID.getKey());
+        Configuration.remove(DirigibleConfig.TENANT_GROUPS_CLAIM.getKey());
+        Configuration.remove(DirigibleConfig.MULTI_TENANT_MODE_ENABLED.getKey());
+        Configuration.remove(DirigibleConfig.MULTI_TENANT_MODE_COGNITO_SINGLE_USER_POOL_ENABLED.getKey());
+    }
+
+    @Test
+    void theDefaultConfigurationStarts() {
+        assertThatCode(TenantResolutionConfigValidationIT::refreshContext).doesNotThrowAnyException();
+    }
+
+    @Test
+    void aValidTokenGroupsConfigurationStarts() {
+        configureTokenGroups();
+
+        assertThatCode(TenantResolutionConfigValidationIT::refreshContext).doesNotThrowAnyException();
+    }
+
+    @Test
+    void aMissingApplicationIdStopsTheStartup() {
+        configureTokenGroups();
+        Configuration.remove(DirigibleConfig.APP_ID.getKey());
+
+        assertStartupFailsOn(DirigibleConfig.APP_ID);
+    }
+
+    @Test
+    void aDottedApplicationIdStopsTheStartup() {
+        configureTokenGroups();
+        DirigibleConfig.APP_ID.setStringValue("codbex.library");
+
+        assertStartupFailsOn(DirigibleConfig.APP_ID);
+    }
+
+    @Test
+    void singleTenantModeStopsTheStartup() {
+        configureTokenGroups();
+        DirigibleConfig.MULTI_TENANT_MODE_ENABLED.setBooleanValue(false);
+
+        assertStartupFailsOn(DirigibleConfig.MULTI_TENANT_MODE_ENABLED);
+    }
+
+    @Test
+    void theLegacyCognitoSingleUserPoolModelStopsTheStartup() {
+        configureTokenGroups();
+        DirigibleConfig.MULTI_TENANT_MODE_COGNITO_SINGLE_USER_POOL_ENABLED.setBooleanValue(true);
+
+        assertStartupFailsOn(DirigibleConfig.MULTI_TENANT_MODE_COGNITO_SINGLE_USER_POOL_ENABLED);
+    }
+
+    @Test
+    void aBlankGroupsClaimStopsTheStartup() {
+        configureTokenGroups();
+        DirigibleConfig.TENANT_GROUPS_CLAIM.setStringValue("   ");
+
+        assertStartupFailsOn(DirigibleConfig.TENANT_GROUPS_CLAIM);
+    }
+
+    @Test
+    void anUnknownStrategyStopsTheStartup() {
+        DirigibleConfig.TENANT_RESOLUTION_STRATEGY.setStringValue("SESSION");
+
+        assertStartupFailsOn(DirigibleConfig.TENANT_RESOLUTION_STRATEGY);
+    }
+
+    private static void configureTokenGroups() {
+        DirigibleConfig.TENANT_RESOLUTION_STRATEGY.setStringValue("TOKEN_GROUPS");
+        DirigibleConfig.APP_ID.setStringValue("library");
+        DirigibleConfig.MULTI_TENANT_MODE_ENABLED.setBooleanValue(true);
+        DirigibleConfig.MULTI_TENANT_MODE_COGNITO_SINGLE_USER_POOL_ENABLED.setBooleanValue(false);
+    }
+
+    private static void refreshContext() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(TenantResolutionConfigValidator.class)) {
+            assertThat(context.getBean(TenantResolutionConfigValidator.class)).isNotNull();
+        }
+    }
+
+    private static void assertStartupFailsOn(DirigibleConfig expectedKey) {
+        assertThatThrownBy(TenantResolutionConfigValidationIT::refreshContext).rootCause()
+                                                                              .isInstanceOf(InvalidConfigException.class)
+                                                                              .hasMessageContaining(expectedKey.getKey());
+    }
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TokenGroupsTenantResolutionIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TokenGroupsTenantResolutionIT.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static org.hamcrest.Matchers.contains;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.sql.SQLException;
+
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.components.base.tenant.DefaultTenant;
+import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.eclipse.dirigible.components.configurations.tenant.TenantConfigurationService;
+import org.eclipse.dirigible.components.tenants.tenant.TenantSelectionConstants;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.tenant.DirigibleTestTenant;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * End-to-end test of the {@code TOKEN_GROUPS} tenant resolution strategy: the tenant of a request
+ * is the one the user selected, kept in the HTTP session, and the host is not consulted at all -
+ * which is what lets a single host serve every tenant of an application.
+ *
+ * <p>
+ * The strategy is selected in a static {@code @BeforeAll}, which is what makes it take effect:
+ * {@code TenantExtractor} reads the configuration once, when the Spring context is refreshed, and
+ * that happens after every {@code @BeforeAll} has run. The context is dirtied after the class and
+ * {@code IntegrationTest} reloads the configuration, so the strategy does not leak into the next
+ * test class.
+ *
+ * <p>
+ * Which tenant a request actually landed in is observed through the tenant's own configuration
+ * table: {@code GET /services/core/configurations/tenant} reads the current tenant's
+ * DIRIGIBLE_CONFIGURATIONS, so a marker seeded per tenant identifies the resolved tenant beyond
+ * doubt. Requests go through MockMvc rather than RestAssured because the session attribute has to
+ * be seeded directly - in this mode there is deliberately no host to route by.
+ */
+// One Dirigible boot for the whole class: the tenant provisioning it needs is expensive and the
+// tests only read.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Tag("slow")
+class TokenGroupsTenantResolutionIT extends IntegrationTest {
+
+    private static final String TENANT_CONFIGURATIONS_PATH = "/services/core/configurations/tenant";
+
+    /** Not an allow-listed key on purpose - it is stored and read back, never injected. */
+    private static final String MARKER_KEY = "TOKEN_GROUPS_IT_TENANT_MARKER";
+
+    private static final String MARKER_OF_DEFAULT_TENANT = "marker-of-the-default-tenant";
+    private static final String MARKER_OF_SELECTED_TENANT = "marker-of-the-selected-tenant";
+
+    private static final String APP_ID = "library";
+
+    /** A host that names no registered tenant - in SUBDOMAIN mode it would be answered with a 404. */
+    private static final String UNREGISTERED_HOST = "unregistered-tenant.localhost";
+
+    private static DirigibleTestTenant provisionedTenant;
+    private static DirigibleTestTenant tenantAwaitingProvisioning;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private TenantContext tenantContext;
+
+    @Autowired
+    @DefaultTenant
+    private Tenant defaultTenant;
+
+    @Autowired
+    private TenantConfigurationService tenantConfigurationService;
+
+    @Autowired
+    private Scheduler scheduler;
+
+    @BeforeAll
+    static void useTokenGroupsResolution() {
+        DirigibleConfig.MULTI_TENANT_MODE_ENABLED.setBooleanValue(true);
+        DirigibleConfig.TENANT_RESOLUTION_STRATEGY.setStringValue("TOKEN_GROUPS");
+        DirigibleConfig.APP_ID.setStringValue(APP_ID);
+    }
+
+    /**
+     * Provisions the tenant and seeds the markers, once for the class.
+     *
+     * <p>
+     * The provisioning job is triggered explicitly rather than waited for: its schedule is
+     * {@code DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS} wide (15 minutes by default) and the
+     * only prompt firing is the one at startup.
+     *
+     * @throws SchedulerException if the provisioning job cannot be triggered
+     * @throws SQLException if a marker cannot be written
+     */
+    @BeforeEach
+    void provisionTenantsAndSeedMarkers() throws SchedulerException, SQLException {
+        if (provisionedTenant != null) {
+            return;
+        }
+        DirigibleTestTenant created = new DirigibleTestTenant("token-groups-resolution-it");
+        createTenants(created);
+        scheduler.triggerJob(JobKey.jobKey("TenantsProvisioningJob", "system"));
+        waitForTenantProvisioning(created);
+        provisionedTenant = created;
+
+        // Registered after the provisioning pass, so it stays in status INITIAL for this class.
+        DirigibleTestTenant awaiting = new DirigibleTestTenant("token-groups-unprovisioned-it");
+        createTenants(awaiting);
+        tenantAwaitingProvisioning = awaiting;
+
+        seedMarker(defaultTenant.getId(), MARKER_OF_DEFAULT_TENANT);
+        seedMarker(provisionedTenant.getId(), MARKER_OF_SELECTED_TENANT);
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMINISTRATOR"})
+    void theSelectedTenantOfTheSessionIsTheTenantOfTheRequest() throws Exception {
+        mvc.perform(get(TENANT_CONFIGURATIONS_PATH).sessionAttr(TenantSelectionConstants.SELECTED_TENANT_ID_SESSION_ATTRIBUTE,
+                provisionedTenant.getId()))
+           .andExpect(status().isOk())
+           .andExpect(markerIs(MARKER_OF_SELECTED_TENANT));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMINISTRATOR"})
+    void theHostIsNotConsultedAtAll() throws Exception {
+        // Same selection, a host belonging to nobody, and a host belonging to another tenant.
+        mvc.perform(get(TENANT_CONFIGURATIONS_PATH).header("host", UNREGISTERED_HOST)
+                                                   .sessionAttr(TenantSelectionConstants.SELECTED_TENANT_ID_SESSION_ATTRIBUTE,
+                                                           provisionedTenant.getId()))
+           .andExpect(status().isOk())
+           .andExpect(markerIs(MARKER_OF_SELECTED_TENANT));
+
+        mvc.perform(get(TENANT_CONFIGURATIONS_PATH).header("host", tenantAwaitingProvisioning.getHost())
+                                                   .sessionAttr(TenantSelectionConstants.SELECTED_TENANT_ID_SESSION_ATTRIBUTE,
+                                                           provisionedTenant.getId()))
+           .andExpect(status().isOk())
+           .andExpect(markerIs(MARKER_OF_SELECTED_TENANT));
+    }
+
+    /**
+     * The counterpart of {@code EnabledMultitenantModeIT.testUnregisteredTenantResolution}, which
+     * expects a 404 for this very host: in this mode the host carries no tenant, so there is nothing to
+     * refuse.
+     */
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMINISTRATOR"})
+    void anUnknownHostIsNoLongerRefused() throws Exception {
+        mvc.perform(get(TENANT_CONFIGURATIONS_PATH).header("host", UNREGISTERED_HOST))
+           .andExpect(status().isOk())
+           .andExpect(markerIs(MARKER_OF_DEFAULT_TENANT));
+    }
+
+    /**
+     * A machine-to-machine call and an anonymous request carry no session at all, so they must land in
+     * the default tenant instead of being refused.
+     */
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMINISTRATOR"})
+    void aRequestWithoutASelectionLandsInTheDefaultTenant() throws Exception {
+        mvc.perform(get(TENANT_CONFIGURATIONS_PATH))
+           .andExpect(status().isOk())
+           .andExpect(markerIs(MARKER_OF_DEFAULT_TENANT));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMINISTRATOR"})
+    void aSelectionThatNoLongerResolvesLandsInTheDefaultTenant() throws Exception {
+        mvc.perform(get(TENANT_CONFIGURATIONS_PATH).sessionAttr(TenantSelectionConstants.SELECTED_TENANT_ID_SESSION_ATTRIBUTE,
+                "a-tenant-that-was-never-registered"))
+           .andExpect(status().isOk())
+           .andExpect(markerIs(MARKER_OF_DEFAULT_TENANT));
+    }
+
+    /**
+     * A tenant can be in the user's groups before this instance has finished provisioning it. Entering
+     * it would mean working in a half-built schema, so the request lands in the default tenant.
+     */
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMINISTRATOR"})
+    void aTenantThatIsNotProvisionedYetCannotBeEntered() throws Exception {
+        mvc.perform(get(TENANT_CONFIGURATIONS_PATH).sessionAttr(TenantSelectionConstants.SELECTED_TENANT_ID_SESSION_ATTRIBUTE,
+                tenantAwaitingProvisioning.getId()))
+           .andExpect(status().isOk())
+           .andExpect(markerIs(MARKER_OF_DEFAULT_TENANT));
+    }
+
+    private void seedMarker(String tenantId, String marker) throws SQLException {
+        try {
+            tenantContext.execute(tenantId, () -> {
+                tenantConfigurationService.set(MARKER_KEY, marker);
+                return null;
+            });
+        } catch (SQLException | RuntimeException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to seed the marker of tenant [" + tenantId + "]", ex);
+        }
+    }
+
+    private static org.springframework.test.web.servlet.ResultMatcher markerIs(String expectedMarker) {
+        return jsonPath("$[?(@.key=='" + MARKER_KEY + "')].value", contains(expectedMarker));
+    }
+}


### PR DESCRIPTION
## Why

Multi-tenant deployments today need **one host per tenant**: the tenant of a request is the subdomain of the `host` header. That is a poor fit for a fleet of applications behind a single identity provider, where authorization is already carried in groups named `<tenantId>.<appId>.<role>` (e.g. `acme.library.Owner`) and a user may belong to several tenants of the same application.

This adds an **opt-in** second resolution strategy so one host can serve every tenant of an application. `SUBDOMAIN` stays the default and its behaviour is unchanged, including the two legacy identity provider tenant filters.

## What works after this PR

```bash
DIRIGIBLE_TENANT_RESOLUTION_STRATEGY=TOKEN_GROUPS
DIRIGIBLE_APP_ID=library
DIRIGIBLE_TENANT_GROUPS_CLAIM=cognito:groups   # 'groups' on a Keycloak realm
DIRIGIBLE_MULTI_TENANT_MODE=true
```

- `TenantExtractor.determineTenant(request)` dispatches on the strategy. In `TOKEN_GROUPS` mode the tenant is the one stored in the HTTP session (`TenantSelectionConstants.SELECTED_TENANT_ID_SESSION_ATTRIBUTE`) and required to be `PROVISIONED`. The host is never consulted, so this mode also never produces the "no registered tenant for the current host" 404.
- No session, no selection, an unknown selection, or a tenant that is not provisioned yet all fall back to the **default tenant**: machine-to-machine calls and anonymous requests carry no session at all, and a stale selection must not lock a user out of the instance.
- `TenantGroupsParser` (`core-base`, free of Spring/servlet/OAuth2 types) turns a user's groups into `UserTenantAssignments` - this application's groups become tenant roles, other applications' groups are ignored, non-tenant-bearing groups such as `DEVELOPER` stay global roles. The role part may contain dots, tenant and application ids may not.
- Selected tenants are cached by id (mirroring the subdomain cache) and `TenantExtractor.evictFromCaches(id, subdomain)` forgets both, so a tenant that becomes provisioned is enterable at once rather than after 10 minutes.
- `TenantResolutionConfigValidator` refuses to start on a combination that cannot work: with `TOKEN_GROUPS` the app id must be set and dot-free (a dotted one makes the group grammar unparseable), multi-tenant mode must be on, the groups claim non-blank, and the legacy Cognito single-user-pool tenant model - which this strategy replaces - must be off.

## What follows

**Writing** the session attribute is the identity provider side: mapping the user's global roles at login, a tenant selection endpoint, a filter that redirects a user with several tenants to a picker, and the picker page itself. Those live in `security-cognito` and come as a separate PR; until then `TOKEN_GROUPS` resolves every request to the default tenant, which is why this PR is useful but not yet complete as a user-facing feature.

## Two idioms that are new to the repo

- **Config validation in a constructor.** A half-usable tenant resolution setup is worse than a failed startup: users would silently land in the wrong tenant. Validating in the constructor aborts the context refresh before the port opens; an `ApplicationReadyEvent` listener would fail after traffic is already accepted.
- **An assertion that the context must NOT start.** `TenantResolutionConfigValidationIT` refreshes an `AnnotationConfigApplicationContext` holding just the validator, per invalid combination. It boots no application, so the whole matrix runs in milliseconds.

## Tests

- Unit: `TenantGroupsParserTest` (13), `TenantResolutionStrategyTest` (5), `TenantResolutionConfigValidatorTest` (10), `TenantExtractorTest` (9 - strategy dispatch, session cases, non-provisioned tenant, id caching and eviction). The last two are the first tests in `core-tenants`.
- Integration: `TokenGroupsTenantResolutionIT` (6) boots the platform in the new mode and proves *which* tenant a request landed in, observed through the resolved tenant's own `DIRIGIBLE_CONFIGURATIONS` table (a marker seeded per tenant); it includes the counterpart of `EnabledMultitenantModeIT.testUnregisteredTenantResolution`, which expects a 404 for that very host in subdomain mode. `TenantResolutionConfigValidationIT` (8) covers the startup matrix.
- Regression: `EnabledMultitenantModeIT`, `DisabledMultitenantModeIT`, `TenantConfigurationIT` pass unmodified; `mvn -T 1C formatter:validate` clean.

```bash
mvn -pl modules/commons/commons-config,components/core/core-base,components/core/core-tenants -am clean install -P unit-tests
mvn install -P integration-tests -pl tests/tests-integrations \
    -Dit.test="TokenGroupsTenantResolutionIT,TenantResolutionConfigValidationIT"
```

## Note on the session attribute name

The attribute is `dirigible-selected-tenant-id`, following the existing `dirigible-act-as-user` convention in `ActAsFacade` rather than a dotted name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)