### PR TITLE
fix(intent): one name per relationship, so the first diagram save renames nothing (#6883)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -536,7 +536,7 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
                     // link feeds document.relationsByEntity, from which appendMxGraphModel emits the mxGraph
                     // edge (owner FK cell -> projection PK cell). The target lives in another model, so
                     // relationLink's target is null and referencedProperty defaults to the projection's "Id".
-                    relations.add(relationLink(name, relation, null, compositionParents, settingEntities));
+                    relations.add(relationLink(name, relation, null, info.perspectiveName()));
                     continue;
                 }
                 boolean composition = !compositionAssigned && relation.isComposition();
@@ -556,7 +556,7 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
                         target == null || target.getIdentity() == null ? null : IntentNaming.pascalCase(target.getIdentity()),
                         target == null ? null : labelFieldName(target), true);
                 properties.add(fkProperty);
-                relations.add(relationLink(name, relation, target, compositionParents, settingEntities));
+                relations.add(relationLink(name, relation, target, targetPerspective));
             }
             // Explicit UI control order (intent `order:`): reorder the properties so the generated
             // form/list controls follow the author's sequence (fields and to-one relations interleaved)
@@ -1293,12 +1293,12 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
         p.put("auditType", "NONE");
         // Relationship metadata the generation reads (Dirigible .model convention): composition vs
         // association + cardinality (composition 1_n; association n_1 for manyToOne, 1_1 for oneToOne);
-        // relationshipName is the FK constraint name <owner>_<target>; relationshipEntityName and
-        // relationshipEntityPerspectiveName drive the dropdown's data-service URL
+        // relationshipName is the relationship's identity (see relationshipName); relationshipEntityName
+        // and relationshipEntityPerspectiveName drive the dropdown's data-service URL
         // (api/<perspective>/<entity>Service.ts) and the create-detail dialog.
         p.put("relationshipType", composition ? "COMPOSITION" : "ASSOCIATION");
         p.put("relationshipCardinality", composition ? "1_n" : (oneToOne ? "1_1" : "n_1"));
-        p.put("relationshipName", ownerEntity + "_" + relation.getTo());
+        p.put("relationshipName", relationshipName(ownerEntity, relation));
         p.put("relationshipEntityName", relation.getTo());
         p.put("relationshipEntityPerspectiveName", targetPerspective);
         p.put("relationshipEntityPerspectiveLabel", "Entities");
@@ -1347,7 +1347,7 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
         p.put("auditType", "NONE");
         p.put("relationshipType", "ASSOCIATION");
         p.put("relationshipCardinality", oneToOne ? "1_1" : "n_1");
-        p.put("relationshipName", ownerEntity + "_" + relation.getTo());
+        p.put("relationshipName", relationshipName(ownerEntity, relation));
         p.put("relationshipEntityName", relation.getTo());
         // The owner's perspective for the target drives the dropdown's REST URL
         // (api/<perspective>/<Entity>Controller). Settings live under "Settings", primaries under their
@@ -2340,20 +2340,45 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
     }
 
     /**
+     * The relationship's identity, and the ONLY place it is computed: {@code <owner>_<PascalCase
+     * relation name>}. Both writers of the {@code .edm} - the {@code <property>} element
+     * ({@link #relationProperty} / {@link #crossModelRelationProperty}) and the {@code <relation>}
+     * element ({@link #relationLink}) - derive it from here, so the two cannot disagree by construction
+     * (#6883).
+     *
+     * <p>
+     * It is derived from the RELATION's name rather than the target entity's because it must be unique
+     * within the owner: an entity with several relations to the same target (a posting rule naming a
+     * dozen accounts, a document with both a customer and a delivery address) collapses onto one name
+     * under the target form, and the {@code .schema}'s foreign keys then all claim the same
+     * {@code constraintName}.
+     */
+    private static String relationshipName(String ownerEntity, RelationIntent relation) {
+        return ownerEntity + "_" + IntentNaming.pascalCase(relation.getName());
+    }
+
+    /**
      * Top-level {@code <relation>} element interleaved with its owning {@code <entity>} in the XML.
-     * {@code relationshipEntityPerspectiveName} is the target's <i>resolved</i> perspective - for a
-     * dependent target that is its composition parent's perspective, mirroring how the EDM editor
-     * writes these links.
+     *
+     * <p>
+     * Its naming attributes restate what the FK {@code <property>} element already carries, so both are
+     * taken from the property's own inputs: {@link #relationshipName} for the identity, and the
+     * perspective the caller ALREADY resolved for the property - for a same-model target the resolved
+     * one (a dependent target's is its composition parent's, mirroring how the EDM editor writes these
+     * links), for a cross-model one the perspective its OWNER model publishes it under. Resolving it
+     * here instead, against this model, cannot see an external target at all and used to fall back to
+     * the entity's own name - which the save then wrote over the property, pointing the generated
+     * lookup URL at a controller that does not exist (#6883).
      */
     private static Map<String, Object> relationLink(String ownerEntity, RelationIntent relation, EntityIntent target,
-            Map<String, String> compositionParents, Set<String> settingEntities) {
+            String targetPerspective) {
         Map<String, Object> link = new LinkedHashMap<>();
-        String linkName = ownerEntity + "_" + IntentNaming.pascalCase(relation.getName());
+        String linkName = relationshipName(ownerEntity, relation);
         link.put("name", linkName);
         link.put("type", "relation");
         link.put("entity", ownerEntity);
         link.put("relationName", linkName);
-        link.put("relationshipEntityPerspectiveName", perspectiveFor(relation.getTo(), compositionParents, settingEntities));
+        link.put("relationshipEntityPerspectiveName", targetPerspective);
         link.put("relationshipEntityPerspectiveLabel", "Entities");
         link.put("property", IntentNaming.pascalCase(relation.getName()));
         link.put("referenced", relation.getTo());

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/template/transform-edm.js
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/template/transform-edm.js
@@ -176,19 +176,39 @@ export function transform(workspaceName, projectName, filePath) {
         });
     }
 
+    // The <relation> element RESTATES naming that the foreign-key <property> element already carries.
+    // The property is the source of truth and its value is kept: it is what the modeler itself edits
+    // (editor.js writes the Relationship-properties dialog onto cell.source.value.relationshipName and
+    // derives the edge label from it), and it is the only one of the two that can carry a cross-model
+    // target's perspective. The <relation> element's copies are a FALLBACK - for an .edm written before
+    // the two writers were converged (#6883), or a modeler save that dropped one. Trusting them renamed
+    // every relationship whose name is not its target's, because serializer.js writes <relation name>
+    // from the source and target ENTITY names; and it repointed every cross-model lookup, because it
+    // writes the perspective off the target CELL, which for a projection is deliberately empty.
+    //
+    // relationshipEntityName is the exception and stays unconditional: no writer puts it on the
+    // <property> (serializer.js emits it on neither the explicit block nor the generic pass), so the
+    // edge's `referenced` - which the modeler keeps live when an edge is redirected - is the only value.
     function transformRelation(relation, entities) {
         entities.forEach(entity => {
             if (entity.name === relation['-entity']) {
                 entity.properties.forEach(property => {
                     if (property.name === relation['-property']) {
-                        property.relationshipName = relation['-name'];
                         property.relationshipEntityName = relation['-referenced'];
-                        property.relationshipEntityPerspectiveName = relation['-relationshipEntityPerspectiveName'];
-                        property.relationshipEntityPerspectiveLabel = relation['-relationshipEntityPerspectiveLabel'];
+                        fillIfAbsent(property, 'relationshipName', relation['-name']);
+                        fillIfAbsent(property, 'relationshipEntityPerspectiveName', relation['-relationshipEntityPerspectiveName']);
+                        fillIfAbsent(property, 'relationshipEntityPerspectiveLabel', relation['-relationshipEntityPerspectiveLabel']);
                     }
                 });
             }
         });
+    }
+
+    function fillIfAbsent(property, key, fallback) {
+        const own = property[key];
+        if (own === undefined || own === null || own === '') {
+            property[key] = fallback;
+        }
     }
 
     function transformPerspective(raw) {

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/EdmModelRoundTripIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/EdmModelRoundTripIT.java
@@ -14,8 +14,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.eclipse.dirigible.repository.api.IRepository;
 import org.eclipse.dirigible.repository.api.IRepositoryStructure;
@@ -26,6 +32,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -50,23 +61,67 @@ import com.google.gson.JsonParser;
  * from the {@code .edm} and caught here as a missing key, and one written but not parsed back is
  * caught as a value mismatch - so a structured attribute cannot ship without {@code .edm}
  * serialization support.
+ *
+ * <p>
+ * Losslessness has a second failure mode the same round-trip exposes: not a value DROPPED, but a
+ * value written TWICE and disagreeing with itself (#6883). A to-one relation's identity used to be
+ * derived independently by the {@code <property>} element (from the TARGET entity) and by the
+ * {@code <relation>} element (from the RELATION name), and the save applied the second over the
+ * first - so an unmodified save renamed relationships and, for a cross-model target, repointed the
+ * generated lookup URL at a controller that does not exist. That divergence was invisible to this
+ * test because every relation in its intent was named after its target, which makes the two
+ * derivations produce the same string. The fixture below deliberately breaks that coincidence -
+ * relations named for their ROLE, two of them to the same target, and one cross-model target
+ * published under a perspective that is not its entity name - and asserts the {@code .edm} is
+ * internally consistent before the save is even attempted.
  */
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class EdmModelRoundTripIT extends IntegrationTest {
 
     private static final String PROJECT = "edm-roundtrip-test";
+    /** Owns the cross-model target, so its perspective is resolvable only from ITS model. */
+    private static final String OWNER_PROJECT = "edm-roundtrip-refs";
     private static final String WORKSPACE = "workspace";
-    private static final String PROJECT_PATH = IRepositoryStructure.PATH_USERS + "/admin/" + WORKSPACE + "/" + PROJECT;
-    private static final String GENERATE_URL =
-            "/services/ide/intent/generate?workspace=" + WORKSPACE + "&project=" + PROJECT + "&path=app.intent";
+    private static final String WORKSPACE_PATH = IRepositoryStructure.PATH_USERS + "/admin/" + WORKSPACE;
+    private static final String PROJECT_PATH = WORKSPACE_PATH + "/" + PROJECT;
+    private static final String OWNER_PROJECT_PATH = WORKSPACE_PATH + "/" + OWNER_PROJECT;
     private static final String EDM_PUT_URL = "/services/ide/workspaces/" + WORKSPACE + "/" + PROJECT + "/rt.edm";
 
-    // A same-model intent whose entities exercise the structured (List/Map) values #6826 was losing:
-    // labelParts + uniqueConstraints + relatedEntities on Category, lookupColumns on Product's FK,
-    // checks on Booking, and rollupGuard on Booking (the child of the capacity-bearing seat roll-up).
+    // The owner of the cross-model target. Currency is a SETTING, so its owner publishes it under the
+    // "Settings" perspective - a perspective that is not the entity's name, which is the only shape in
+    // which the perspective half of #6883 is visible. Nothing but this model can say so, which is the
+    // point: the consuming generator has to read it from here.
+    private static final String OWNER_INTENT_YAML = """
+            name: refs
+            entities:
+              - name: Currency
+                function: Setting
+                fields:
+                  - { name: id,   type: integer, primaryKey: true, generated: true }
+                  - { name: code, type: string,  length: 3 }
+                  - { name: name, type: string,  length: 100 }
+            """;
+
+    // A mostly same-model intent whose entities exercise the structured (List/Map) values #6826 was
+    // losing: labelParts + uniqueConstraints + relatedEntities on Category, lookupColumns on Product's
+    // FK, checks on Booking, and rollupGuard on Booking (the child of the capacity-bearing seat
+    // roll-up).
+    //
+    // Product additionally carries the shapes #6883 needs, none of which existed here before: `owner`
+    // and `reviewer` are named for their ROLE rather than for their target, so the target-derived and
+    // relation-derived identities differ; they both point at the SAME target, so the target-derived
+    // form is not even unique within the entity; and `currency` reaches into another model whose
+    // perspective for the target ("Settings") is not the entity's name.
     private static final String INTENT_YAML = """
             name: rt
+            uses:
+              - { model: refs, project: edm-roundtrip-refs }
             entities:
+              - name: Employee
+                fields:
+                  - { name: id,   type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string,  length: 100 }
+
               - name: Category
                 label: "{code} - {title}"
                 unique:
@@ -85,6 +140,9 @@ class EdmModelRoundTripIT extends IntegrationTest {
                   - { name: price, type: decimal }
                 relations:
                   - { name: Category, kind: manyToOne, to: Category, show: [code, title] }
+                  - { name: owner,    kind: manyToOne, to: Employee }
+                  - { name: reviewer, kind: manyToOne, to: Employee }
+                  - { name: currency, kind: manyToOne, to: Currency, model: refs }
 
               - name: Event
                 fields:
@@ -117,13 +175,15 @@ class EdmModelRoundTripIT extends IntegrationTest {
 
     @Test
     void structured_values_survive_the_edm_to_model_round_trip() {
-        writeIntent(INTENT_YAML);
+        // The owner of the cross-model target first: its .model is what the consumer's generation reads
+        // the target's perspective from, and resolution fails loudly when it is not there.
+        writeIntent(OWNER_PROJECT_PATH, OWNER_INTENT_YAML);
+        generate(OWNER_PROJECT);
+
+        writeIntent(PROJECT_PATH, INTENT_YAML);
 
         // 1. Generate: writes rt.edm AND the complete rt.model (the oracle).
-        restAssuredExecutor.execute(() -> given().when()
-                                                 .post(GENERATE_URL)
-                                                 .then()
-                                                 .statusCode(200));
+        generate(PROJECT);
 
         String edm = contentOf("rt.edm");
         JsonObject modelFromIntent = parseModel(contentOf("rt.model"));
@@ -135,6 +195,17 @@ class EdmModelRoundTripIT extends IntegrationTest {
         for (String key : new String[] {"rollupGuard", "checks", "labelParts", "relatedEntities", "lookupColumns"}) {
             assertTrue(edm.contains(key + "=\""), "the .edm must carry the structured value [" + key + "] as an attribute");
         }
+
+        // The .edm must not contradict itself: the <relation> element restates the naming its FK
+        // <property> element carries, and a save applies the former over the latter. Structural over
+        // every relation in the file, so this holds for relation shapes no fixture here has yet (#6883).
+        assertEdmRelationsAgreeWithTheirProperties(edm);
+
+        // A relationship identity is unique within its owner - it is what the .schema emits as an FK's
+        // constraintName. The target-derived form was not: Product's `owner` and `reviewer` both point
+        // at Employee and both used to claim "Product_Employee".
+        assertRelationshipNamesAreUniquePerEntity(modelFromIntent);
+        assertRelationshipIdentityConvention(modelFromIntent);
 
         // 2. Rebuild the .model FROM the .edm the way the editor's save does: delete the oracle, then
         // PUT the .edm back through the workspace API (fires the ide-workspace-on-save transform). The
@@ -184,6 +255,122 @@ class EdmModelRoundTripIT extends IntegrationTest {
         // scalar that legitimately IS a JSON string (e.g. widgetDependsOnValueCases) is compared
         // value-to-value and never falsely flagged.
         assertEveryKeySurvives(modelFromIntent, modelFromEdm);
+    }
+
+    /**
+     * The {@code .edm} must not contradict itself. A to-one relation's identity and its lookup
+     * perspective are written twice - on the FK {@code <property>} element and again on the top-level
+     * {@code <relation>} element - and the save applies the {@code <relation>}'s copy over the
+     * property's, so a disagreement IS a silent rename on the first save (#6883). Asserted structurally
+     * over every relation in the file rather than as a list of known pairs, so a relation shape no
+     * fixture here has yet is covered too.
+     */
+    private void assertEdmRelationsAgreeWithTheirProperties(String edm) {
+        Document document = parseXml(edm);
+        NodeList relations = document.getElementsByTagName("relation");
+        assertTrue(relations.getLength() > 0, "fixture precondition: the .edm should carry <relation> elements");
+        for (int i = 0; i < relations.getLength(); i++) {
+            Element relation = (Element) relations.item(i);
+            String entityName = relation.getAttribute("entity");
+            String propertyName = relation.getAttribute("property");
+            Element property = edmProperty(document, entityName, propertyName);
+            String where = "the .edm's <relation> for [" + entityName + "." + propertyName + "] disagrees with its <property> on ";
+            // `name` is the attribute transform-edm.js reads; `relationName` is its twin, kept in step.
+            assertEquals(property.getAttribute("relationshipName"), relation.getAttribute("name"),
+                    where + "the relationship name - the save applies the <relation>'s value, renaming the relationship");
+            assertEquals(property.getAttribute("relationshipName"), relation.getAttribute("relationName"),
+                    where + "the relationship name (relationName)");
+            assertEquals(property.getAttribute("relationshipEntityPerspectiveName"),
+                    relation.getAttribute("relationshipEntityPerspectiveName"),
+                    where + "the lookup perspective - the save applies the <relation>'s value, repointing the generated lookup URL");
+            assertEquals(property.getAttribute("relationshipEntityName"), relation.getAttribute("referenced"),
+                    where + "the referenced entity");
+        }
+    }
+
+    /** The {@code <property>} element of the named entity, or a failure naming what was missing. */
+    private Element edmProperty(Document document, String entityName, String propertyName) {
+        NodeList entities = document.getElementsByTagName("entity");
+        for (int i = 0; i < entities.getLength(); i++) {
+            Element entity = (Element) entities.item(i);
+            if (!entityName.equals(entity.getAttribute("name"))) {
+                continue;
+            }
+            NodeList properties = entity.getElementsByTagName("property");
+            for (int j = 0; j < properties.getLength(); j++) {
+                Element property = (Element) properties.item(j);
+                if (propertyName.equals(property.getAttribute("name"))) {
+                    return property;
+                }
+            }
+            throw new AssertionError("the .edm's <relation> names property [" + propertyName + "] of [" + entityName
+                    + "], which that entity does not declare");
+        }
+        throw new AssertionError("the .edm's <relation> names entity [" + entityName + "], which the .edm does not declare");
+    }
+
+    /**
+     * A relationship identity is unique within its owning entity: it is what the generated
+     * {@code .schema} emits as the foreign key's {@code constraintName}. Deriving it from the TARGET
+     * collapses every relation an entity has to the same target onto one name - Product's {@code owner}
+     * and {@code reviewer} both point at Employee (#6883).
+     */
+    private void assertRelationshipNamesAreUniquePerEntity(JsonObject model) {
+        for (JsonElement e : model.getAsJsonObject("model")
+                                  .getAsJsonArray("entities")) {
+            JsonObject entity = e.getAsJsonObject();
+            JsonArray properties = entity.getAsJsonArray("properties");
+            if (properties == null) {
+                continue;
+            }
+            Set<String> seen = new HashSet<>();
+            for (JsonElement p : properties) {
+                JsonObject property = p.getAsJsonObject();
+                if (!property.has("relationshipEntityName") || !property.has("relationshipName")) {
+                    continue;
+                }
+                String name = property.get("relationshipName")
+                                      .getAsString();
+                assertTrue(seen.add(name), "[" + entity.get("name")
+                                                       .getAsString()
+                        + "] gives two relationships the same identity [" + name + "] - the .schema then emits two foreign keys"
+                        + " claiming the same constraintName");
+            }
+        }
+    }
+
+    /**
+     * The relationship identity and the cross-model lookup perspective the generator must settle on:
+     * the RELATION's name (unique within the owner, unlike the target's) and the perspective the
+     * target's OWNER model publishes it under (the only one the generated lookup URL can match). Pinned
+     * explicitly because the internal-consistency assertion above would also pass if both writers
+     * agreed on the wrong value.
+     */
+    private void assertRelationshipIdentityConvention(JsonObject model) {
+        JsonObject product = entity(model, "Product");
+        assertEquals("Product_Owner", property(product, "Owner").get("relationshipName")
+                                                                .getAsString(),
+                "a relationship is identified by its own name, not by its target");
+        assertEquals("Product_Reviewer", property(product, "Reviewer").get("relationshipName")
+                                                                      .getAsString(),
+                "a second relation to the same target gets its own identity");
+        assertEquals("Settings", property(product, "Currency").get("relationshipEntityPerspectiveName")
+                                                              .getAsString(),
+                "a cross-model target's perspective comes from its OWNER model, where Currency is a Setting");
+    }
+
+    /** External entities and DTDs off: this parses generated content, and nothing here needs them. */
+    private Document parseXml(String xml) {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setExpandEntityReferences(false);
+            return factory.newDocumentBuilder()
+                          .parse(new InputSource(new StringReader(xml)));
+        } catch (Exception ex) {
+            throw new AssertionError("the generated .edm is not well-formed XML", ex);
+        }
     }
 
     private void assertEntityStructuredEquals(JsonObject fromIntent, JsonObject fromEdm, String entityName, String key) {
@@ -291,14 +478,22 @@ class EdmModelRoundTripIT extends IntegrationTest {
                          .getAsJsonObject();
     }
 
-    private void writeIntent(String yaml) {
-        String path = PROJECT_PATH + "/app.intent";
+    private void writeIntent(String projectPath, String yaml) {
+        String path = projectPath + "/app.intent";
         IResource existing = repository.getResource(path);
         if (existing.exists()) {
             existing.setContent(yaml.getBytes(StandardCharsets.UTF_8));
         } else {
             repository.createResource(path, yaml.getBytes(StandardCharsets.UTF_8));
         }
+    }
+
+    private void generate(String project) {
+        String url = "/services/ide/intent/generate?workspace=" + WORKSPACE + "&project=" + project + "&path=app.intent";
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .post(url)
+                                                 .then()
+                                                 .statusCode(200));
     }
 
     private IResource resource(String fileName) {
@@ -311,8 +506,10 @@ class EdmModelRoundTripIT extends IntegrationTest {
 
     @AfterEach
     void cleanup() {
-        if (repository.hasCollection(PROJECT_PATH)) {
-            repository.removeCollection(PROJECT_PATH);
+        for (String path : new String[] {PROJECT_PATH, OWNER_PROJECT_PATH}) {
+            if (repository.hasCollection(path)) {
+                repository.removeCollection(path);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #6883.

`EdmIntentGenerator` wrote a to-one relation's identity **twice into the same `.edm`** — once on the `<property>` element, once on the top-level `<relation>` element — and derived the two independently, so they disagreed. Generate's `.model` takes the property's values; `transform-edm.js` rebuilds the `.model` from the relation's. An unmodified save through the Entity Data Modeler therefore renamed relationships and repointed lookups.

## What diverged

| attribute | `<property>` derived from | `<relation>` derived from | diverges when |
|---|---|---|---|
| `relationshipName` | the TARGET entity | the RELATION name | the relation is not named after its target |
| `relationshipEntityPerspectiveName` | the target's OWNER model | this model, locally | the target is cross-model (invisible locally → falls back to the entity name) |

The target-derived `relationshipName` is also **not unique within an entity**: a posting rule naming a dozen accounts emitted a dozen foreign keys claiming the same `constraintName` in the generated `.schema`.

## The fix

One computation per value, shared by all writers:

- `relationshipName(owner, relation)` — the relation-name form, unique per foreign key. `relationProperty`, `crossModelRelationProperty` and `relationLink` all call it.
- the perspective the caller **already resolved for the property** is passed into `relationLink` (same-model: the resolved one; cross-model: `info.perspectiveName()`). Resolving it inside `relationLink` cannot see an external target at all, which is what produced `api/currency/CurrencyController` where the owner publishes `api/settings/...`.

The two elements can no longer disagree by construction.

`transformRelation` keeps the **property's** own value and takes the `<relation>`'s only as a fallback. The property is the source of truth in the modeler too — `editor.js` writes the Relationship-properties dialog onto `cell.source.value.relationshipName` and derives the edge label from it — while `serializer.js` writes `<relation name>` from the source and target *entity* names and the perspective off the target *cell*, which for a cross-model projection is deliberately empty. So this also stops a real modeler save from clobbering them. `relationshipEntityName` stays unconditional: no writer puts it on the `<property>`, so the edge's `referenced` is the only live value.

## One correction to the issue

The duplicate `constraintName` exists in the generated **`.schema` artefact only**. `SchemasSynchronizer.parseImpl` drops a `.schema`'s foreign keys on purpose (#6794), so no database constraint was ever created, and none is renamed by this change. The issue's "renames live FK constraints on an already-deployed schema" is wrong. The perspective half is the one with a runtime symptom (a 404ing dropdown).

## Test

`EdmModelRoundTripIT` could not see any of this: every relation in its intent was named after its target, which makes both derivations produce the same string. Its intent now carries the shapes that break that coincidence —

- `Product.owner` and `Product.reviewer`, named for their **role**, both pointing at the **same** target (`Employee`);
- `Product.currency`, reaching into a second generated project whose `Currency` is a `function: Setting`, so its owner publishes it under `Settings`;

— and three new assertions:

1. **`assertEdmRelationsAgreeWithTheirProperties`** — structural over *every* `<relation>` in the generated `.edm`: its `name` / `relationName` / `relationshipEntityPerspectiveName` / `referenced` must equal the matching `<property>`'s. Asserted before a save is even attempted, so a relation shape no fixture has yet is covered too.
2. **`assertRelationshipNamesAreUniquePerEntity`** — no two relationships of one entity claim the same identity.
3. **`assertRelationshipIdentityConvention`** — pins *which* value the writers converged on, since (1) would also pass if both agreed on the wrong one.

The existing whole-entity `assertEveryKeySurvives` diff then covers the round-trip half.

Verified locally: fails against master on `[Product.Owner] expected: <Product_Employee> but was: <Product_Owner>`, passes with the fix. `engine-intent` unit suite green (793 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)