### PR TITLE
fix(intent): the .edm carries its document-level metadata, so a diagram save keeps it (#6882)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -701,9 +701,10 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
         if (notBlank(icon)) {
             body.put("icon", icon);
         }
-        // Data-language codes the app offers (intent `languages:`). Carried on the .model root (JSON
-        // only - the XML root renders no attributes); the Harmonia shell's Region & Language setting
-        // lists them and sends the choice as Accept-Language on every request.
+        // Data-language codes the app offers (intent `languages:`). Carried on the .model root, and as a
+        // JSON-string attribute of the .edm's <model> element so a diagram save cannot drop it (#6882);
+        // the Harmonia shell's Region & Language setting lists them and sends the choice as
+        // Accept-Language on every request.
         if (!model.getLanguages()
                   .isEmpty()) {
             body.put("languages", new ArrayList<>(model.getLanguages()));
@@ -2645,7 +2646,9 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
         List<Map<String, Object>> perspectives = (List<Map<String, Object>>) body.get("perspectives");
 
         StringBuilder sb = new StringBuilder(8192);
-        sb.append("<model>\n");
+        sb.append("<model");
+        appendDocumentAttributes(sb, body);
+        sb.append(">\n");
         sb.append(" <entities>\n");
         for (Map<String, Object> entity : entities) {
             sb.append("  <entity");
@@ -2696,6 +2699,52 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
         appendMxGraphModel(sb, document, entities);
         sb.append("</model>\n");
         return sb.toString();
+    }
+
+    /**
+     * The {@code .model} root keys that have their own ELEMENT in the {@code .edm} and so are not also
+     * written as an attribute of {@code <model>}.
+     */
+    private static final Set<String> DOCUMENT_ELEMENT_KEYS = Set.of("entities", "perspectives", "navigations");
+
+    /**
+     * Emit the DOCUMENT-level metadata as attributes of the {@code <model>} element: the identity
+     * scalars ({@code title}, {@code description}, {@code icon}) verbatim, and the structured values
+     * ({@code languages}, {@code widgets}, {@code customActionLabels}, {@code processTaskLabels}) as
+     * JSON strings - the same flat-attribute mechanism the entity/property level uses, for the same
+     * reason: a flat attribute survives both the mxGraph cell round-trip of a live editor save and the
+     * {@code transform-edm} regeneration, which a nested element would not.
+     *
+     * <p>
+     * Without this the {@code <model>} element carried NO attributes at all, so everything the
+     * {@code .model} said above its entities had no representation in the {@code .edm} and a save
+     * simply deleted it (#6882) - the entity/property half of the same defect was #6826. The loss was
+     * silent and the worst of it invisible: {@code languages} gone downgrades a multilingual
+     * application to monolingual, and the two label maps gone replaces every custom-action and
+     * user-task caption with its raw identifier.
+     *
+     * <p>
+     * A non-scalar with no entry in {@link #STRUCTURED_ATTRIBUTES} cannot be written and is REPORTED
+     * rather than dropped quietly - that silence is what let this ship. {@code EdmModelRoundTripIT}
+     * enumerates the whole document, so it fails on such a key too.
+     *
+     * @param sb the buffer
+     * @param body the {@code .model} root
+     */
+    private static void appendDocumentAttributes(StringBuilder sb, Map<String, Object> body) {
+        for (Map.Entry<String, Object> attr : body.entrySet()) {
+            String key = attr.getKey();
+            if (DOCUMENT_ELEMENT_KEYS.contains(key)) {
+                continue;
+            }
+            Object value = attr.getValue();
+            if ((value instanceof Iterable || value instanceof Map) && !STRUCTURED_ATTRIBUTES.contains(key)) {
+                LOGGER.warn("Document-level model value [{}] has no .edm representation and is lost when a diagram is saved -"
+                        + " add it to STRUCTURED_ATTRIBUTES (and to transform-edm.js's MODEL_STRUCTURED)", key);
+                continue;
+            }
+            appendModelAttribute(sb, key, value);
+        }
     }
 
     /**
@@ -3060,12 +3109,12 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
     }
 
     /**
-     * The entity/property attributes whose value is a List/Map. They are emitted into the {@code .edm}
-     * as a JSON string in a flat attribute (never dropped, never a nested element) so the {@code .edm}
-     * stays a lossless source for the derived {@code .model}: a flat attribute survives both the
-     * mxGraph cell-value round-trip of a live editor save and the {@code transform-edm} regeneration,
-     * which a nested element would not - #6826. {@code transform-edm.js} parses these keys back into
-     * objects.
+     * The document/entity/property attributes whose value is a List/Map. They are emitted into the
+     * {@code .edm} as a JSON string in a flat attribute (never dropped, never a nested element) so the
+     * {@code .edm} stays a lossless source for the derived {@code .model}: a flat attribute survives
+     * both the mxGraph cell-value round-trip of a live editor save and the {@code transform-edm}
+     * regeneration, which a nested element would not - #6826, and #6882 for the document level.
+     * {@code transform-edm.js} parses these keys back into objects.
      *
      * <p>
      * {@code uniqueConstraints} is deliberately NOT here: the composite-unique-key modeler feature owns
@@ -3073,8 +3122,8 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
      * {@code transform-edm} rebuilds into {@code uniqueConstraints}. Emitting it here too would write
      * it twice and round-trip it as a duplicate.
      */
-    private static final Set<String> STRUCTURED_ATTRIBUTES =
-            Set.of("rollupGuard", "checks", "labelParts", "aggregateKeys", "groupingKeys", "relatedEntities", "lookupColumns");
+    private static final Set<String> STRUCTURED_ATTRIBUTES = Set.of("rollupGuard", "checks", "labelParts", "aggregateKeys", "groupingKeys",
+            "relatedEntities", "lookupColumns", "languages", "widgets", "customActionLabels", "processTaskLabels");
 
     /**
      * Compact, non-HTML-escaping JSON for the structured {@code .edm} attributes. Compact so the value

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/js/editor.js
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/js/editor.js
@@ -1286,6 +1286,7 @@ angular.module('ui.entity-data.modeler', ['blimpKit', 'platformView', 'Workspace
 			codec.decode(doc.documentElement.getElementsByTagName('mxGraphModel')[0], $scope.graph.getModel());
 
 			deserializeFilter($scope.graph);
+			loadModelMetadata(doc, $scope.graph);
 			loadUniqueKeys(doc, $scope.graph);
 			loadPerspectives(doc, $scope.graph);
 			loadNavigations(doc, $scope.graph);
@@ -1430,6 +1431,27 @@ angular.module('ui.entity-data.modeler', ['blimpKit', 'platformView', 'Workspace
 							}
 							break;
 						}
+					}
+					break;
+				}
+			}
+		}
+
+		// The document-level metadata (title/description/icon, languages[], the custom-action and
+		// user-task label maps) rides on the <model> element's own attributes. Nothing in the modeler
+		// edits it, so it is stashed on the graph model verbatim and written back by serializer.js -
+		// a save that rebuilt <model> bare deleted all of it (#6882). Generic over the attributes, so
+		// a metadata key added later needs no change here.
+		function loadModelMetadata(doc, graph) {
+			if (!graph.getModel().metadata) {
+				graph.getModel().metadata = {};
+			}
+			for (let i = 0; i < doc.children.length; i++) {
+				let element = doc.children[i];
+				if (element.localName === "model") {
+					for (let j = 0; j < element.attributes.length; j++) {
+						let attribute = element.attributes[j];
+						graph.getModel().metadata[attribute.name] = attribute.value;
 					}
 					break;
 				}

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/js/serializer.js
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/js/serializer.js
@@ -64,9 +64,34 @@ function extraAttributes(obj, handled) {
 	return out;
 }
 
+// The <model> element's own attributes: the document-level metadata the .model carries ABOVE its
+// entities - title/description/icon, languages[], and the custom-action / user-task label maps. Nothing
+// in the modeler edits it, so it is written back verbatim from what was loaded (editor.js
+// loadModelMetadata). A save that rebuilt <model> bare deleted it, which silently downgraded a
+// multilingual application to monolingual and replaced every custom-action and user-task caption with
+// its raw identifier - #6882. Generic over the stashed attributes, so a key added later needs no change.
+function modelAttributes(graph) {
+	let metadata = graph.getModel().metadata;
+	if (!metadata) {
+		return '';
+	}
+	let out = '';
+	for (let key in metadata) {
+		if (!Object.prototype.hasOwnProperty.call(metadata, key)) {
+			continue;
+		}
+		let val = metadata[key];
+		if (val === null || val === undefined || val === '') {
+			continue;
+		}
+		out += ' ' + key + '="' + _.escape(val) + '"';
+	}
+	return out;
+}
+
 function createModel(graph) {
 	let model = [];
-	model.push('<model>\n');
+	model.push('<model' + modelAttributes(graph) + '>\n');
 	model.push(' <entities>\n');
 	let parent = graph.getDefaultParent();
 	let childCount = graph.model.getChildCount(parent);

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/template/transform-edm.js
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/template/transform-edm.js
@@ -16,13 +16,38 @@ import { XML } from "@aerokit/sdk/utils";
 
 // Structured (List/Map) attributes the EDM generator / serializer write as JSON strings in flat attributes
 // so the .edm stays lossless; parse them back into objects so the .model matches the intent's .model (#6826).
-// These two lists MUST mirror EdmIntentGenerator.STRUCTURED_ATTRIBUTES (Java) - a key handled on one side
-// but not the other round-trips as a JSON string (caught by EdmModelRoundTripIT's structural diff).
+// The three lists below MUST together mirror EdmIntentGenerator.STRUCTURED_ATTRIBUTES (Java) - a key
+// handled on one side but not the other round-trips as a JSON string (caught by EdmModelRoundTripIT's
+// structural diff).
 // uniqueConstraints is intentionally NOT here: the composite-unique-key feature emits it as a
 // <constraints>/<uniqueKey> section that transformUniqueKey (below) rebuilds, so parsing it here too would
 // duplicate it (#6826).
 const ENTITY_STRUCTURED = ['rollupGuard', 'checks', 'labelParts', 'aggregateKeys', 'groupingKeys', 'relatedEntities'];
 const PROPERTY_STRUCTURED = ['lookupColumns'];
+// Document level (#6882): the structured values the .model carries ABOVE its entities.
+const MODEL_STRUCTURED = ['languages', 'widgets', 'customActionLabels', 'processTaskLabels'];
+
+// The document-level metadata: every ATTRIBUTE of the <model> element, generically - so a future scalar
+// (a new title-like key) needs no change here, only serialization on the Java side. Before #6882 the
+// .model root was rebuilt with entities/perspectives/navigations and nothing else, so a diagram save
+// deleted title, description, icon, languages[] and the two label maps outright - silently downgrading a
+// multilingual application to monolingual and replacing every custom-action and user-task caption with
+// its raw identifier.
+function documentMetadata(rawModel) {
+    const metadata = {};
+    if (!rawModel) {
+        return metadata;
+    }
+    for (const key in rawModel) {
+        // XML.toJson prefixes an attribute with '-'; the child ELEMENTS (entities, perspectives, ...)
+        // have their own transforms below.
+        if (key.startsWith('-')) {
+            metadata[key.substring(1)] = rawModel[key];
+        }
+    }
+    parseStructured(metadata, MODEL_STRUCTURED);
+    return metadata;
+}
 
 function parseStructured(obj, keys) {
     for (const key of keys) {
@@ -51,7 +76,8 @@ export function transform(workspaceName, projectName, filePath) {
     let raw = JSON.parse(XML.toJson(contents));
 
     let root = {};
-    root.model = {};
+    // The document-level metadata first, so the regenerated .model reads like the generated one.
+    root.model = documentMetadata(raw.model);
     root.model.entities = [];
     root.model.perspectives = [];
     root.model.navigations = [];

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/EdmModelRoundTripIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/EdmModelRoundTripIT.java
@@ -86,6 +86,10 @@ class EdmModelRoundTripIT extends IntegrationTest {
     private static final String PROJECT_PATH = WORKSPACE_PATH + "/" + PROJECT;
     private static final String OWNER_PROJECT_PATH = WORKSPACE_PATH + "/" + OWNER_PROJECT;
     private static final String EDM_PUT_URL = "/services/ide/workspaces/" + WORKSPACE + "/" + PROJECT + "/rt.edm";
+    /** Declares every document-level value the .model root can carry. */
+    private static final String META_PROJECT = "edm-roundtrip-meta";
+    private static final String META_PROJECT_PATH = WORKSPACE_PATH + "/" + META_PROJECT;
+    private static final String META_EDM_PUT_URL = "/services/ide/workspaces/" + WORKSPACE + "/" + META_PROJECT + "/meta.edm";
 
     // The owner of the cross-model target. Currency is a SETTING, so its owner publishes it under the
     // "Settings" perspective - a perspective that is not the entity's name, which is the only shape in
@@ -165,6 +169,66 @@ class EdmModelRoundTripIT extends IntegrationTest {
             rollups:
               - { name: eventSeats, entity: Booking, via: Event, field: seatsTaken,
                   op: sum, of: seats, capacity: capacity, balance: seatsFree }
+            """;
+
+    // Every DOCUMENT-level value the .model root can carry, in one model: `description` and `icon`
+    // directly, `title` from the humanised name, `languages` (the multilingual switch), `widgets`
+    // (the dashboard tiles), `customActionLabels` (from the transition's button) and
+    // `processTaskLabels` (from the process and its userTask steps). The two label maps and the
+    // status seeds are what make the fixture bigger than it looks - a transition needs a classified
+    // status nomenclature to name a from/to.
+    private static final String META_INTENT_YAML = """
+            name: meta
+            description: Round-trip fixture for the document-level metadata
+            icon: receipt
+            languages: [en, bg]
+
+            entities:
+              - name: ClaimStatus
+                kind: setting
+                fields:
+                  - { name: id,   type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string,  required: true, length: 40 }
+
+              - name: Claim
+                fields:
+                  - { name: id,       type: integer, primaryKey: true, generated: true }
+                  - { name: number,   type: string,  length: 40 }
+                  - { name: filedOn,  type: date }
+                relations:
+                  - { name: Status, kind: manyToOne, to: ClaimStatus, function: EntityStatus, init: DRAFT }
+
+            transitions:
+              - name: VoidClaim
+                forEntity: Claim
+                from: [FILED]
+                setStatus: VOIDED
+                label: Void
+
+            processes:
+              - name: ClaimApproval
+                trigger: { onCreate: Claim }
+                steps:
+                  - name: review
+                    kind: userTask
+                    args: { assignee: manager }
+                  - name: done
+                    kind: end
+
+            widgets:
+              - name: OpenClaims
+                kind: kpi
+                url: /services/js/meta/custom/open-claims.js
+                label: Open Claims
+                icon: activity
+
+            seeds:
+              - name: claim-statuses
+                entity: ClaimStatus
+                rows:
+                  - { id: 1, name: DRAFT,  stage: draft }
+                  - { id: 3, name: FILED,  stage: live }
+                  - { id: 9, name: VOIDED, stage: void }
             """;
 
     @Autowired
@@ -255,6 +319,46 @@ class EdmModelRoundTripIT extends IntegrationTest {
         // scalar that legitimately IS a JSON string (e.g. widgetDependsOnValueCases) is compared
         // value-to-value and never falsely flagged.
         assertEveryKeySurvives(modelFromIntent, modelFromEdm);
+    }
+
+    /**
+     * The document level of the same contract (#6882): the {@code .model} rebuilt from an unmodified
+     * {@code .edm} save must still carry everything the {@code .model} said ABOVE its entities.
+     *
+     * <p>
+     * A separate fixture rather than more relations on the one above, because what it takes to make the
+     * document-level values exist at all - a classified status nomenclature for the transition to name,
+     * a process with a user task, dashboard widgets - has nothing to do with the structured entity
+     * values the other test is tuned for.
+     *
+     * <p>
+     * The assertion is the whole-document diff, not a list of the six keys the issue measured: a hand
+     * list is exactly what let the loss ship the first time.
+     */
+    @Test
+    void document_metadata_survives_the_edm_to_model_round_trip() {
+        writeIntent(META_PROJECT_PATH, META_INTENT_YAML);
+        generate(META_PROJECT);
+
+        JsonObject modelFromIntent = parseModel(contentOf(META_PROJECT_PATH, "meta.model"));
+        JsonObject document = modelFromIntent.getAsJsonObject("model");
+        // Fixture precondition: the model must actually carry each of them, or the diff proves nothing.
+        for (String key : new String[] {"title", "description", "icon", "languages", "widgets", "customActionLabels",
+                "processTaskLabels"}) {
+            assertTrue(document.has(key), "fixture precondition: the generated .model should carry document-level [" + key + "]");
+        }
+
+        byte[] edmBytes = resource(META_PROJECT_PATH, "meta.edm").getContent();
+        resource(META_PROJECT_PATH, "meta.model").delete();
+        restAssuredExecutor.execute(() -> given().contentType("application/octet-stream")
+                                                 .body(edmBytes)
+                                                 .when()
+                                                 .put(META_EDM_PUT_URL)
+                                                 .then()
+                                                 .statusCode(200));
+
+        assertTrue(resource(META_PROJECT_PATH, "meta.model").exists(), "the .edm -> .model transform must have regenerated meta.model");
+        assertEveryKeySurvives(modelFromIntent, parseModel(contentOf(META_PROJECT_PATH, "meta.model")));
     }
 
     /**
@@ -402,12 +506,30 @@ class EdmModelRoundTripIT extends IntegrationTest {
     private static final java.util.Set<String> ROUND_TRIP_EXCEPTIONS = java.util.Set.of("uniqueConstraints");
 
     /**
-     * Every entity/property key in the intent's .model must survive intact in the one rebuilt from the
-     * .edm.
+     * Every key the intent's .model carries must survive intact in the one rebuilt from the .edm -
+     * enumerated from the WHOLE document, not from its entities.
+     *
+     * <p>
+     * The walk used to start at {@code model.entities}, one level BELOW where the document-level
+     * metadata lives, which is exactly why #6882 shipped alongside a green round-trip test: the
+     * {@code .edm} had no representation for {@code title} / {@code description} / {@code icon} /
+     * {@code languages[]} / {@code customActionLabels} / {@code processTaskLabels}, and a save deleted
+     * all six without a single assertion noticing. Enumerating from the root means a document-level key
+     * added later cannot ship without {@code .edm} serialization either.
      */
     private void assertEveryKeySurvives(JsonObject fromIntent, JsonObject fromEdm) {
-        for (JsonElement e : fromIntent.getAsJsonObject("model")
-                                       .getAsJsonArray("entities")) {
+        JsonObject oracleDocument = fromIntent.getAsJsonObject("model");
+        JsonObject actualDocument = fromEdm.getAsJsonObject("model");
+        for (Map.Entry<String, JsonElement> member : oracleDocument.entrySet()) {
+            String key = member.getKey();
+            if ("entities".equals(key)) {
+                continue; // walked per entity below, so a mismatch names the entity and the attribute
+            }
+            assertTrue(actualDocument.has(key), "the model lost document-level [" + key + "] in the .edm -> .model round-trip");
+            assertEquals(member.getValue(), actualDocument.get(key),
+                    "the model's document-level [" + key + "] changed across the .edm -> .model round-trip");
+        }
+        for (JsonElement e : oracleDocument.getAsJsonArray("entities")) {
             JsonObject oracle = e.getAsJsonObject();
             String name = oracle.get("name")
                                 .getAsString();
@@ -497,16 +619,24 @@ class EdmModelRoundTripIT extends IntegrationTest {
     }
 
     private IResource resource(String fileName) {
-        return repository.getResource(PROJECT_PATH + "/" + fileName);
+        return resource(PROJECT_PATH, fileName);
+    }
+
+    private IResource resource(String projectPath, String fileName) {
+        return repository.getResource(projectPath + "/" + fileName);
     }
 
     private String contentOf(String fileName) {
-        return new String(resource(fileName).getContent(), StandardCharsets.UTF_8);
+        return contentOf(PROJECT_PATH, fileName);
+    }
+
+    private String contentOf(String projectPath, String fileName) {
+        return new String(resource(projectPath, fileName).getContent(), StandardCharsets.UTF_8);
     }
 
     @AfterEach
     void cleanup() {
-        for (String path : new String[] {PROJECT_PATH, OWNER_PROJECT_PATH}) {
+        for (String path : new String[] {PROJECT_PATH, OWNER_PROJECT_PATH, META_PROJECT_PATH}) {
             if (repository.hasCollection(path)) {
                 repository.removeCollection(path);
             }


### PR DESCRIPTION
Fixes #6882. **Stacked on #6891** (`fix/edm-relationship-name`) — both fix the same `.edm` → `.model` round-trip and both extend `EdmModelRoundTripIT`, so they would conflict as siblings. Base retargets to `master` once #6891 merges; review this diff only.

#6826 restored the round-trip for the structured **entity/property** values. The same defect class survived one level up: the `.edm` had **no representation for anything the `.model` says above its entities**. `<model>` carried zero attributes, and `transform-edm.js` rebuilt `root.model` from scratch with `entities`/`perspectives`/`navigations` and nothing else — so opening a diagram and saving it, **with no edit at all**, deleted:

`title` · `description` · `icon` · `languages[]` · `widgets[]` · `customActionLabels{}` · `processTaskLabels{}`

Unlike #6826, where the values reached the `.edm` and were skipped by the `Iterable`/`Map` guard, here there was nothing in the file to read back.

The worst of it is invisible until much later. `languages[]` is the multilingual switch, so **one save silently downgrades a multilingual application to monolingual** — no error, no warning, and the regression only shows when someone switches language in the running app and the strings do not change. The two label maps are the captions for custom actions and BPMN user tasks; losing them puts raw identifiers (`VoidSalesInvoice`, `creditHold`) in front of end users.

## The fix — all three writers

| file | change |
|---|---|
| `EdmIntentGenerator.renderEdmXml` | emits the metadata as attributes of `<model>` — scalars verbatim, structured values as JSON strings via the #6857 mechanism (a flat attribute survives both the mxGraph cell round-trip and the transform; a nested element would not) |
| `transform-edm.js` | reads **every** attribute of `<model>` back generically, then parses the structured ones the way `parseStructured` already does one level down |
| `serializer.js` + `editor.js` | writes those attributes back on the **modeler's own** save — `editor.js` stashes them on the graph model verbatim, next to the existing perspectives / navigations / uniqueKeys — so a real diagram save preserves them too, not only a byte-identical PUT |

A document-level non-scalar with no entry in `STRUCTURED_ATTRIBUTES` is now **reported** rather than dropped quietly. That silence is what let this ship.

`widgets[]` is included although the issue did not list it: the fixtures it measured declared no `widgets:`, but it is the same document-level `List` and was being lost identically.

## Test

`EdmModelRoundTripIT.assertEveryKeySurvives` started at `model.entities` — one level **below** where this loss happens, which is exactly why the defect shipped alongside a green round-trip test. Two changes:

1. **The walk is lifted to the whole document.** Every key of `model` is enumerated and asserted, so a document-level key added later cannot ship without `.edm` serialization either.
2. **A second test** drives a fixture that declares all seven values — a classified status nomenclature for its transition to name, a process with a user task, dashboard widgets, `languages: [en, bg]`, `description`, `icon` — generates, PUTs the `.edm` back unmodified, and asserts the rebuilt `.model` is leaf-identical. A whole-document structural diff, not a hand list of the six keys the issue measured; a hand list is what let this through the first time.

Both tests fail against master on `the model lost document-level [title]`.

Verified locally: `EdmModelRoundTripIT` (2) + `EdmUniqueKeyRoundTripIT` (1) + `IntentEngineIT` (57) = **60 green**; `engine-intent` unit suite green.

**Not covered by any automated test**, here as in #6857: the modeler-side `serializer.js` / `editor.js` pair, which only a real browser save exercises. They follow the established `extraAttributes` / `loadPerspectives` patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)