### PR TITLE
#6895 - The subset report guard reaches a one-hop path, a dotted filter and every measure

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -6752,66 +6752,142 @@ public final class IntentParser {
     }
 
     /**
-     * A report cannot reference a {@code subset} relation of its source: the stored value is the
-     * selected keys as ONE column ({@code "1,3"}), so a dimension over it would {@code GROUP BY} the
-     * literal list and a filter over it would compare against it - both well-formed SQL computing the
-     * wrong thing, with nothing at runtime to say so. Rejected at parse instead, naming the row-shaped
-     * alternative.
+     * A report cannot reference a {@code subset} relation: the stored value is the selected keys as ONE
+     * column ({@code "1,3"}), so a dimension over it would {@code GROUP BY} the literal list, a filter
+     * over it would compare against it and an aggregate over it would fold a comma-separated string -
+     * all well-formed SQL computing the wrong thing, with nothing at runtime to say so. Rejected at
+     * parse instead, naming the row-shaped alternative.
+     *
+     * <p>
+     * The reach matches the generator's: a {@code dimension}, a {@code measure} and every
+     * {@code filter} token resolve against the source's own relations AND, for a one-hop
+     * {@code relation.field} path, against the relations of the entity that relation points at
+     * (dirigible #6895). A cross-model target's relations live in the owner model, so such a path is
+     * left alone.
      */
     private static void validateSubsetReportReferences(IntentModel model, ReportIntent report, List<String> issues) {
-        EntityIntent source = null;
-        for (EntityIntent entity : model.getEntities()) {
-            if (entity.getName() != null && entity.getName()
-                                                  .equals(report.getSource())) {
-                source = entity;
-            }
-        }
+        EntityIntent source = isBlank(report.getSource()) ? null : entityByName(model, report.getSource());
         if (source == null) {
             return; // a missing / unknown source is reported separately
-        }
-        Set<String> subsets = new HashSet<>();
-        for (RelationIntent relation : source.getRelations()) {
-            if ("subset".equals(relation.getKind()) && !isBlank(relation.getName())) {
-                subsets.add(relation.getName()
-                                    .toLowerCase(Locale.ROOT));
-            }
-        }
-        if (subsets.isEmpty()) {
-            return;
         }
         String rowAlternative = " - the stored value is the selected keys as one column, so it cannot group, join or compare;"
                 + " author an explicit intermediate entity (manyToMany) when the set must be reported on";
         for (String dimension : report.getDimensions()) {
-            if (dimension == null || dimension.isBlank()) {
+            if (isBlank(dimension)) {
                 continue;
             }
-            // A dimension is `field`, `relation`, `relation.field` or a function form (`month(x)`,
-            // `year(x)`, `ageing(x, [...])`) - the referenced property's FIRST segment is what may
-            // name a subset relation.
-            String token = dimension.trim();
-            int open = token.indexOf('(');
-            if (open >= 0) {
-                token = token.substring(open + 1);
-            }
-            int cut = indexOfAny(token, '.', ',', ')');
-            String first = (cut >= 0 ? token.substring(0, cut) : token).trim();
-            if (subsets.contains(first.toLowerCase(Locale.ROOT))) {
-                issues.add("report [" + report.getName() + "] dimension [" + dimension.trim() + "] is a subset relation" + rowAlternative);
+            SubsetReference reference = subsetReferenced(model, source, referencedPath(dimension));
+            if (reference != null) {
+                issues.add("report [" + report.getName() + "] dimension [" + dimension.trim() + "] "
+                        + (reference.joinedEntity() == null ? "is a subset relation"
+                                : "references the subset relation [" + reference.name() + "]" + reference.on())
+                        + rowAlternative);
             }
         }
-        if (report.getFilter() != null && !report.getFilter()
-                                                 .isBlank()) {
-            // Identifier tokens not preceded by a dot are the first segments the generator rewrites.
-            java.util.regex.Matcher matcher = java.util.regex.Pattern.compile("(?<![.\\w])([A-Za-z_][A-Za-z0-9_]*)")
-                                                                     .matcher(report.getFilter());
+        for (String measure : report.getMeasures()) {
+            if (isBlank(measure)) {
+                continue;
+            }
+            SubsetReference reference = subsetReferenced(model, source, referencedPath(measure));
+            if (reference != null) {
+                issues.add("report [" + report.getName() + "] measure [" + measure.trim() + "] references the subset relation ["
+                        + reference.name() + "]" + reference.on() + rowAlternative);
+            }
+        }
+        if (!isBlank(report.getFilter())) {
+            // Identifier tokens not preceded by a dot are the first segments the generator rewrites; the
+            // optional second segment is the one-hop path it resolves against the joined entity.
+            java.util.regex.Matcher matcher =
+                    java.util.regex.Pattern.compile("(?<![.\\w])([A-Za-z_][A-Za-z0-9_]*)(?:\\.([A-Za-z_][A-Za-z0-9_]*))?")
+                                           .matcher(report.getFilter());
             while (matcher.find()) {
-                if (subsets.contains(matcher.group(1)
-                                            .toLowerCase(Locale.ROOT))) {
-                    issues.add("report [" + report.getName() + "] filter references the subset relation [" + matcher.group(1) + "]"
-                            + rowAlternative);
+                String path = matcher.group(2) == null ? matcher.group(1) : matcher.group(1) + "." + matcher.group(2);
+                SubsetReference reference = subsetReferenced(model, source, path);
+                if (reference != null) {
+                    issues.add("report [" + report.getName() + "] filter references the subset relation [" + reference.name() + "]"
+                            + reference.on() + rowAlternative);
                 }
             }
         }
+    }
+
+    /**
+     * A subset relation a report expression reaches: its name, and the joined entity it lives on -
+     * {@code null} when it is the report source's own relation.
+     */
+    private record SubsetReference(String name, String joinedEntity) {
+
+        /** The {@code on [Entity]} suffix naming where the relation lives, empty for the source's own. */
+        String on() {
+            return joinedEntity == null ? "" : " on [" + joinedEntity + "]";
+        }
+    }
+
+    /**
+     * The property path a report dimension or measure references: a function form ({@code month(x)},
+     * {@code ageing(x, [...])}, {@code sum(x)}) unwraps to its first argument, anything else is the
+     * expression itself.
+     */
+    private static String referencedPath(String expression) {
+        String token = expression.trim();
+        int open = token.indexOf('(');
+        if (open >= 0) {
+            token = token.substring(open + 1);
+        }
+        int cut = indexOfAny(token, ',', ')');
+        return (cut >= 0 ? token.substring(0, cut) : token).trim();
+    }
+
+    /**
+     * The subset relation a property path names, or {@code null} when it names none: the first segment
+     * against {@code source}'s own relations, then - for a {@code relation.field} path - the second
+     * segment against the relations of the entity {@code relation} points at.
+     */
+    private static SubsetReference subsetReferenced(IntentModel model, EntityIntent source, String path) {
+        if (isBlank(path)) {
+            return null;
+        }
+        int dot = path.indexOf('.');
+        String first = (dot > 0 ? path.substring(0, dot) : path).trim();
+        if (isSubsetRelation(source, first)) {
+            return new SubsetReference(first, null);
+        }
+        if (dot <= 0) {
+            return null;
+        }
+        RelationIntent hop = relationByName(source, first);
+        if (hop == null || isBlank(hop.getTo())) {
+            return null;
+        }
+        EntityIntent target = entityByName(model, hop.getTo());
+        if (target == null) {
+            return null; // a cross-model target's relations live in the owner model
+        }
+        String leaf = path.substring(dot + 1)
+                          .trim();
+        int next = leaf.indexOf('.');
+        String field = (next > 0 ? leaf.substring(0, next) : leaf).trim();
+        return isSubsetRelation(target, field) ? new SubsetReference(field, target.getName()) : null;
+    }
+
+    /** Whether the entity declares a {@code subset} relation under that name. */
+    private static boolean isSubsetRelation(EntityIntent entity, String name) {
+        RelationIntent relation = relationByName(entity, name);
+        return relation != null && "subset".equals(relation.getKind());
+    }
+
+    /** The entity's relation with that name, case-insensitively, or {@code null}. */
+    private static RelationIntent relationByName(EntityIntent entity, String name) {
+        if (entity.getRelations() == null || isBlank(name)) {
+            return null;
+        }
+        for (RelationIntent relation : entity.getRelations()) {
+            if (relation.getName() != null && relation.getName()
+                                                      .equalsIgnoreCase(name.trim())) {
+                return relation;
+            }
+        }
+        return null;
     }
 
     /** The first index of any of the given characters, or -1 when none occurs. */

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/SubsetIntentTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/SubsetIntentTest.java
@@ -49,6 +49,31 @@ class SubsetIntentTest {
                   - { id: 3, name: Corporate client }
             """;
 
+    /**
+     * The subset owner joined FROM a second entity - the one-hop {@code relation.field} reach a report
+     * dimension, filter or measure may take.
+     */
+    private static final String VISITS = """
+            name: schedules
+            entities:
+              - name: PayerType
+                kind: setting
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string, required: true }
+              - name: Schedule
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: title, type: string, required: true }
+                relations:
+                  - { name: payerTypes, kind: subset, to: PayerType, required: true }
+              - name: Visit
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                relations:
+                  - { name: schedule, kind: manyToOne, to: Schedule, required: true }
+            """;
+
     @Test
     void aMinimalSubsetParsesAndSurvivesUnexpanded() {
         IntentModel model = IntentParser.parse(SCHEDULES);
@@ -308,6 +333,68 @@ class SubsetIntentTest {
         assertTrue(ex.getMessage()
                      .contains("report [CorporateSchedules] filter references the subset relation [payerTypes]"),
                 ex.getMessage());
+    }
+
+    @Test
+    void aMeasureOverItIsRejected() {
+        String yaml = SCHEDULES + """
+                reports:
+                  - name: PayerTypeSpread
+                    source: Schedule
+                    dimensions: [title]
+                    measures: ["count(payerTypes)"]
+                """;
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+        assertTrue(ex.getMessage()
+                     .contains("report [PayerTypeSpread] measure [count(payerTypes)] references the subset relation [payerTypes]"),
+                ex.getMessage());
+    }
+
+    @Test
+    void aOneHopDimensionOverItIsRejected() {
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(VISITS + """
+                reports:
+                  - name: VisitsByPayerType
+                    source: Visit
+                    dimensions: [schedule.payerTypes]
+                    measures: ["count(*)"]
+                """));
+        assertTrue(ex.getMessage()
+                     .contains("report [VisitsByPayerType] dimension [schedule.payerTypes] references the subset relation"
+                             + " [payerTypes] on [Schedule]"),
+                ex.getMessage());
+        assertTrue(ex.getMessage()
+                     .contains("manyToMany"),
+                ex.getMessage());
+    }
+
+    @Test
+    void aOneHopFilterOverItIsRejected() {
+        String yaml = VISITS + """
+                reports:
+                  - name: CorporateVisits
+                    source: Visit
+                    dimensions: [id]
+                    measures: ["count(*)"]
+                    filter: "schedule.payerTypes == 3"
+                """;
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+        assertTrue(ex.getMessage()
+                     .contains("report [CorporateVisits] filter references the subset relation [payerTypes] on [Schedule]"),
+                ex.getMessage());
+    }
+
+    @Test
+    void aOneHopFieldOfTheJoinedEntityStaysAccepted() {
+        String yaml = VISITS + """
+                reports:
+                  - name: VisitsBySchedule
+                    source: Visit
+                    dimensions: [schedule.title]
+                    measures: ["count(*)"]
+                    filter: "schedule.title == 'Morning'"
+                """;
+        assertNotNull(IntentParser.parse(yaml), "a plain one-hop path to a joined field is what the generator resolves");
     }
 
     @Test


### PR DESCRIPTION
Fixes #6895.

`kind: subset` (#6894) lowers to ONE `VARCHAR` column carrying the selected keys as a comma-separated list, so a report that groups, filters or aggregates over it produces well-formed SQL computing the wrong thing — a `GROUP BY` over the literal `"1,3"`, a comparison against it, an aggregate folding a string — with nothing at runtime to say so. That is why `IntentParser.validateSubsetReportReferences` rejects it at parse. The guard had three holes:

1. **It only collected subsets of the report's own `source`.** A dimension may be `relation.field`, so a subset living on the *joined* entity was accepted: `dimensions: [campaign.channels]` grouped by `"1,3"`.
2. **The filter scan skipped dotted tokens** (the `(?<![.\w])` look-behind is deliberate for the first-segment rewrite), so `filter: "campaign.channels = 1"` passed for the same reason.
3. **`measures` were never inspected**, so `sum(channels)` / `count(channels)` reached the database and failed at query time with no authoring-time message.

## What changed

The guard now resolves a property path the way `ReportIntentGenerator.resolve` does — the first segment against the source's own relations, and a one-hop `relation.field` second segment against the relations of the entity that relation points at — and applies that resolution to **dimensions, measures and every filter token** (the filter regex gained an optional second segment). A cross-model target's relations live in the owner model, so such a path is left alone rather than guessed at.

The message is unchanged and still names the row-shaped alternative (author an explicit intermediate entity / `manyToMany`); it gains an `on [Entity]` clause when the relation lives on the joined entity, so the author knows which side to remodel.

The `subsets.isEmpty()` early return is gone — the issue's own example has no subset on the report source at all, only on the entity one hop away.

## Tests

`SubsetIntentTest` gains four cases — a rejected measure, a rejected one-hop dimension, a rejected one-hop filter, and the negative control that a plain one-hop path to a joined *field* (`schedule.title`, in both a dimension and a filter) still parses. The full `engine-intent` unit suite is green (831 tests); no IT fixture declares a `subset` relation, so nothing outside a model that authors one can be reached by this guard.