### PR TITLE
fix(registry): close the watch service off the teardown thread (#6856)

### DIFF
--- a/components/core/core-registry/src/main/java/org/eclipse/dirigible/components/registry/watcher/LocalRegistryWatcher.java
+++ b/components/core/core-registry/src/main/java/org/eclipse/dirigible/components/registry/watcher/LocalRegistryWatcher.java
@@ -60,6 +60,12 @@ public class LocalRegistryWatcher implements DisposableBean {
     /** How long destroy() waits for the watch loop to leave before closing the service. */
     private static final long SHUTDOWN_TIMEOUT_SECONDS = 5;
 
+    /**
+     * How long we wait for the watch service's own {@code close()} before walking away from it - see
+     * {@link #closeWatchService()} for why walking away is the correct thing to do.
+     */
+    private static final long CLOSE_TIMEOUT_SECONDS = 2;
+
     /** The key to path map. */
     private final Map<WatchKey, Path> keyToPathMap = new HashMap<>();
 
@@ -508,23 +514,18 @@ public class LocalRegistryWatcher implements DisposableBean {
      * Destroy.
      *
      * <p>
-     * <b>Order matters: stop the watching thread FIRST, close the service second.</b> Closing the
-     * service while the thread sits in {@code take()} deadlocks on macOS, where the JDK has no native
-     * file-event source and falls back to {@code sun.nio.fs.PollingWatchService}: its {@code close()}
-     * walks the registered keys and locks each one while holding the key map, whereas the polling
-     * thread locks a key first and then the map - a lock-order inversion, and Spring's singleton
-     * teardown hangs for good (every {@code @DirtiesContext} integration test on a developer's Mac).
-     * Linux and Windows have native watchers and never showed it.
+     * <b>Order matters: stop the watching thread FIRST, close the service second</b> - clear
+     * {@code watching}, {@code shutdownNow()} to interrupt the blocking {@code take()} (the loop
+     * returns on the {@code InterruptedException}), wait briefly for the thread to actually be gone,
+     * and only then close the service, by which point none of OUR threads is inside it.
      *
      * <p>
-     * So: clear {@code watching}, {@code shutdownNow()} to interrupt the blocking {@code take()} (the
-     * loop returns on the {@code InterruptedException}), wait briefly for the thread to actually be
-     * gone, and only then close the service - by which point no one is inside it.
-     *
-     * @throws IOException Signals that an I/O exception has occurred.
+     * That ordering is necessary but <b>not</b> sufficient, and teardown must not hang on the part we
+     * cannot order - see {@link #closeWatchService()}. With the close offloaded there is nothing left
+     * here that can fail or block, so this no longer throws.
      */
     @Override
-    public void destroy() throws IOException {
+    public void destroy() {
         logger.info("Destroying Local Registry Watcher");
 
         watching = false;
@@ -551,16 +552,74 @@ public class LocalRegistryWatcher implements DisposableBean {
     }
 
     /**
-     * Close the watch service, if any. Split out of {@link #destroy()} because the re-initialization
-     * path runs on the watcher thread itself and must not shut down the executor it is running in.
+     * Close the watch service, if any - <b>never on the caller's thread</b>. Split out of
+     * {@link #destroy()} because the re-initialization path runs on the watcher thread itself and must
+     * not shut down the executor it is running in.
      *
-     * @throws IOException if the close fails
+     * <p>
+     * <b>Why the close is offloaded.</b> On macOS the JDK has no native file-event source and falls
+     * back to {@code sun.nio.fs.PollingWatchService}, which deadlocks against its own poller:
+     * {@code implClose()} takes the key map and then, per key, the key's monitor (via
+     * {@code PollingWatchKey.disable()}), while the poll task - {@code poll()}, a method synchronized
+     * on the key - takes the key's monitor and then the map, because a watched directory that has gone
+     * away sends it into {@code cancel()}, and {@code cancel()} locks the map. Whoever calls
+     * {@code close()} can therefore be parked forever by the service's own {@code FileSystemWatcher}
+     * thread, and Spring's singleton teardown hangs for good: every {@code @DirtiesContext} integration
+     * test on a developer's Mac, plus a locally started instance that never finishes shutting down.
+     * Linux and Windows have native watchers, which is why CI never showed it.
+     *
+     * <p>
+     * The inversion is entirely inside the JDK and both halves of it are the service's own: no ordering
+     * on our side can retire the poller, because it lives for as long as the service is open. Stopping
+     * OUR watch loop first (see {@link #destroy()}) was the fix attempted before, and it is not enough.
+     *
+     * <p>
+     * So close where a deadlock costs nothing: on a short-lived daemon thread, waited on only briefly.
+     * If the close does wedge, teardown proceeds and the JVM is free to exit anyway - the poller the
+     * service leaves behind is itself a daemon thread.
      */
-    private void closeWatchService() throws IOException {
+    private void closeWatchService() {
         WatchService service = this.watchService;
         this.watchService = null;
-        if (null != service) {
-            service.close();
+        if (null == service) {
+            return;
         }
+        if (!closeOffThread(service, CLOSE_TIMEOUT_SECONDS)) {
+            logger.warn(
+                    "The Local Registry watch service did not close within [{}]s - leaving it to the JVM."
+                            + " This is the JDK's polling watch service deadlocking against its own poller; teardown continues.",
+                    CLOSE_TIMEOUT_SECONDS);
+        }
+    }
+
+    /**
+     * Closes the given service on a short-lived daemon thread and waits at most {@code timeoutSeconds}
+     * for that close to finish - the whole point being that the caller walks away instead of hanging
+     * when it does not. Package-private and {@code static}: the JDK close that deadlocks cannot be
+     * provoked on demand, so this is the seam the shutdown test hands a close that never returns.
+     *
+     * @param service the service to close
+     * @param timeoutSeconds how long to wait for the close before giving up on it
+     * @return true if the close completed within the timeout, false if it was left running
+     */
+    static boolean closeOffThread(WatchService service, long timeoutSeconds) {
+        Thread closer = new Thread(() -> {
+            try {
+                service.close();
+            } catch (IOException | RuntimeException e) {
+                logger.warn("Failed to close the Local Registry watch service", e);
+            }
+        }, "dirigible-local-registry-watcher-close");
+        closer.setDaemon(true);
+        closer.start();
+
+        try {
+            closer.join(TimeUnit.SECONDS.toMillis(timeoutSeconds));
+        } catch (InterruptedException e) {
+            Thread.currentThread()
+                  .interrupt();
+            logger.warn("Interrupted while waiting for the Local Registry watch service to close", e);
+        }
+        return !closer.isAlive();
     }
 }

--- a/components/core/core-registry/src/test/java/org/eclipse/dirigible/components/registry/watcher/LocalRegistryWatcherShutdownTest.java
+++ b/components/core/core-registry/src/test/java/org/eclipse/dirigible/components/registry/watcher/LocalRegistryWatcherShutdownTest.java
@@ -11,41 +11,54 @@ package org.eclipse.dirigible.components.registry.watcher;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.dirigible.repository.api.IRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Shutting the watcher down must stop the watch loop and leave no thread behind.
+ * Shutting the watcher down must stop the watch loop, leave no thread of ours behind, and - above
+ * all - come back.
  *
  * <p>
- * The watch loop blocks in {@code WatchService.take()}. Closing the service from another thread
- * while it sits there deadlocks on macOS, where the JDK has no native file-event source and falls
- * back to {@code sun.nio.fs.PollingWatchService}: its {@code close()} locks each registered key
- * while holding the key map, while the polling thread locks a key first and then the map. Spring's
- * singleton teardown then hangs for good, which took out {@code @DirtiesContext} integration tests
- * on a developer's Mac. The fix is the ORDER: stop the loop, then close the service.
+ * The watch loop blocks in {@code WatchService.take()}, so shutdown stops the loop before it closes
+ * the service. That ordering is necessary but not sufficient: on macOS the JDK has no native
+ * file-event source and falls back to {@code sun.nio.fs.PollingWatchService}, which deadlocks
+ * against its OWN poller - {@code implClose()} takes the key map and then each key, while
+ * {@code poll()} (synchronized on the key) takes the key and then the map when a vanished directory
+ * sends it into {@code cancel()}. No ordering on our side can retire that poller, so whoever calls
+ * {@code close()} can be parked forever and Spring's singleton teardown hangs, which took out every
+ * {@code @DirtiesContext} integration test on a developer's Mac. Hence the close is offloaded to a
+ * daemon thread nobody waits on for long.
  *
  * <p>
- * <b>What this test does and does not prove.</b> The deadlock needs the polling thread to be inside
- * a poll at the moment of {@code close()} - a race a unit test cannot force (verified: the old
- * order still passes a pure timeout assertion). So this asserts the ORDERING'S OBSERVABLE EFFECTS,
- * which hold deterministically: {@code destroy()} returns, the watch loop is gone afterwards (not
- * merely signalled), it is idempotent, and the watcher can be initialized again. A hang, a
- * surviving watch thread, or a wedged second call all fail here. The deadlock itself was diagnosed
- * from a thread dump (lock-order inversion between {@code main} and {@code FileSystemWatcher}), not
- * from this test.
+ * <b>What these tests do and do not prove.</b> The deadlock needs the poller to be inside a poll at
+ * the moment of {@code close()} - a race a test cannot force (verified: the buggy versions still
+ * pass a pure timeout assertion). So the two halves are asserted separately, and both hold
+ * deterministically: {@link #destroyReturnsWhileTheWatchLoopIsBlockedInTake} covers the ordering's
+ * observable effects against a real watch service, and
+ * {@link #aCloseThatNeverReturnsDoesNotHoldUpTeardown} covers the close itself by handing shutdown
+ * a close that behaves the way the wedged JDK one does. The deadlock was diagnosed from a thread
+ * dump (lock-order inversion between {@code main} and {@code FileSystemWatcher}) and from the JDK
+ * sources, not from these tests.
  */
 class LocalRegistryWatcherShutdownTest {
 
@@ -73,7 +86,7 @@ class LocalRegistryWatcherShutdownTest {
                 "destroy() must stop the watch loop before closing the service - closing it underneath a blocking take()"
                         + " deadlocks against the JDK's polling watch service");
         // The loop must be GONE, not just told to stop: destroy() interrupts the blocking take() and
-        // waits for the thread, so nothing is left inside the service when it is closed.
+        // waits for the thread, so nothing of ours is left inside the service when it is closed.
         assertFalse(watcher.isWatching(), "the watch loop must have left before destroy() returned");
         // ...and it must have left because it was ASKED to (the interrupt), never because the service
         // was closed while it was blocked in take(). This is the ordering itself, asserted: the buggy
@@ -92,6 +105,37 @@ class LocalRegistryWatcherShutdownTest {
         assertFalse(watcher.isWatching(), "the re-initialized watch loop must also have left");
     }
 
+    /**
+     * The half no ordering can fix: a {@code close()} that never returns must not take teardown with
+     * it. This is the deadlocked JDK close, stood in for by one that parks forever - the real one
+     * cannot be provoked on demand.
+     */
+    @Test
+    void aCloseThatNeverReturnsDoesNotHoldUpTeardown() throws Exception {
+        ParkingWatchService service = new ParkingWatchService();
+
+        boolean closed = assertTimeoutPreemptively(SHUTDOWN_BOUND, () -> LocalRegistryWatcher.closeOffThread(service, 1),
+                "shutdown must walk away from a close that does not come back, not wait for it - waiting is the deadlock");
+
+        assertFalse(closed, "a close that never finished must be reported as unfinished, not as a clean close");
+        // Walking away is not skipping: the close is genuinely attempted, on a thread of its own.
+        assertTrue(service.closeEntered.await(SHUTDOWN_BOUND.toSeconds(), TimeUnit.SECONDS), "the close must have been attempted");
+        // ...and that thread must be a daemon, or the wedged close would keep the JVM from exiting -
+        // trading a hung teardown for a hung process is no fix at all.
+        assertTrue(service.closedOnDaemonThread.get(), "the close must run on a daemon thread so a wedged close cannot outlive the JVM");
+    }
+
+    /** Offloading the close must not mean losing it: a healthy service is still closed, and awaited. */
+    @Test
+    void aCloseThatCompletesIsAwaitedAndReported() throws Exception {
+        WatchService service = FileSystems.getDefault()
+                                          .newWatchService();
+
+        assertTrue(LocalRegistryWatcher.closeOffThread(service, SHUTDOWN_BOUND.toSeconds()),
+                "a close that completes must be reported as completed");
+        assertThrows(ClosedWatchServiceException.class, service::poll, "the watch service must really have been closed");
+    }
+
     /** Wait until the loop is actually inside take(), which is the state shutdown has to survive. */
     private static void awaitWatching(LocalRegistryWatcher watcher) throws InterruptedException {
         long deadline = System.nanoTime() + SETTLE.toNanos();
@@ -99,5 +143,48 @@ class LocalRegistryWatcherShutdownTest {
             Thread.sleep(50);
         }
         assertTrue(watcher.isWatching(), "the watch loop should be running before we try to stop it");
+    }
+
+    /**
+     * A watch service whose {@code close()} parks for good - what {@code PollingWatchService.close()}
+     * effectively does once its own poller has the key monitor it wants. Nothing else is used: this
+     * never gets registered with a path (a foreign watch service cannot be), it only gets closed.
+     */
+    private static final class ParkingWatchService implements WatchService {
+
+        private final CountDownLatch closeEntered = new CountDownLatch(1);
+
+        private final AtomicBoolean closedOnDaemonThread = new AtomicBoolean();
+
+        /** Never counted down - the point is that this close has no way out. */
+        private final CountDownLatch forever = new CountDownLatch(1);
+
+        @Override
+        public void close() {
+            closedOnDaemonThread.set(Thread.currentThread()
+                                           .isDaemon());
+            closeEntered.countDown();
+            try {
+                forever.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread()
+                      .interrupt();
+            }
+        }
+
+        @Override
+        public WatchKey poll() {
+            return null;
+        }
+
+        @Override
+        public WatchKey poll(long timeout, TimeUnit unit) {
+            return null;
+        }
+
+        @Override
+        public WatchKey take() {
+            throw new UnsupportedOperationException("not used: this service is only ever closed");
+        }
     }
 }


### PR DESCRIPTION
Fixes #6856.

## What was wrong

`LocalRegistryWatcher.destroy()` could still be parked forever by the JDK's own polling watch service. #6437 fixed the ordering of **our** watch loop, but the thread `close()` deadlocks against is the service's **own** poller, which exists for as long as the service is open and no ordering on our side can retire.

Confirmed against the Corretto 21.0.11 sources - both halves of the inversion belong to `sun.nio.fs.PollingWatchService`, which is what macOS falls back to for lack of a native file-event source:

| thread | takes | then wants |
| --- | --- | --- |
| whoever calls `close()` | the key map (`implClose()`) | each key's monitor, via `PollingWatchKey.disable()` |
| `FileSystemWatcher` (the service's own poller) | the key's monitor (`poll()` is `synchronized`) | the map - a vanished directory sends it into `cancel()`, which locks the map |

Spring's singleton teardown then hangs for good: every `@DirtiesContext` IT class wedges mid-run, and a locally started instance never finishes shutting down. Linux and Windows have native watchers, which is why CI stayed green.

## The fix

Close where a deadlock costs nothing: on a short-lived **daemon** thread, waited on for at most 2s. If the close does wedge, teardown proceeds and the JVM is still free to exit - the poller the service leaves behind is itself a daemon thread (`PollingWatchService` creates it with `setDaemon(true)`).

`destroy()` keeps stopping the watch loop first - that ordering is still necessary - and, with nothing left in it that can block or fail, no longer declares `throws IOException`. The offload lives in a package-private `closeOffThread(WatchService, long)` that reports whether the close finished; that is also the test seam, since the JDK close cannot be provoked into deadlocking on demand.

## Verification

Unit tests (`LocalRegistryWatcherShutdownTest`, 3 tests, all green):

- the pre-existing test still asserts the ordering and its observable effects, unchanged
- **new** `aCloseThatNeverReturnsDoesNotHoldUpTeardown` - hands shutdown a `WatchService` whose `close()` parks forever, and asserts shutdown returns, reports the close as unfinished, genuinely attempted it, and did so on a daemon thread
- **new** `aCloseThatCompletesIsAwaitedAndReported` - offloading does not lose a healthy close

Mutation-checked, so the new test is not a tautology: with the pre-fix inline close restored it fails with `execution timed out after 30000 ms`, while the other two still pass.

Integration tests on macOS 22.4 / Corretto 21.0.11, the environment where the issue reproduced twice:

- `IntentEngineIT` - 58 tests green, its `AFTER_CLASS` teardown completes
- `LocalNativeAppLifecycleIT` - 7 tests green with 7 watcher init/destroy cycles in one JVM (it inherits `AFTER_EACH_TEST_METHOD`), i.e. the shape that used to wedge on the second teardown, with no close-timeout warnings

The ITs show the real path running clean where it used to hang; they do not prove a deadlock was hit and survived, since that needs the poller to be inside a poll at the moment of `close()` - a race no test can force. That case is what the new unit test covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)