### PR TITLE
#6896 - The subset multi-select reaches the related register and the filtered option list; a missing options entity fails loudly

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -515,7 +515,8 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
                 // no <relation> element, so no diagram edge and no FK constraint can appear. The where:
                 // option filter rides the same optionsFilter scalars the to-one dropdowns use.
                 if ("subset".equals(relation.getKind())) {
-                    Map<String, Object> subsetProperty = subsetProperty(name, relation, byName.get(relation.getTo()));
+                    Map<String, Object> subsetProperty = subsetProperty(name, relation, byName.get(relation.getTo()),
+                            perspectiveFor(relation.getTo(), compositionParents, settingEntities));
                     putOptionsFilter(subsetProperty, relation, null);
                     properties.add(subsetProperty);
                     continue;
@@ -1341,8 +1342,16 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
      * template block already reads. {@code widgetPattern} is the server-side shape guard - the only
      * one, since no FK constrains the column; ascending order and de-duplication stay the client's
      * normalization.
+     *
+     * <p>
+     * {@code widgetOptionsEntityPerspectiveName} completes the option source the way
+     * {@code relationshipEntityPerspectiveName} completes a dropdown's: a consumer that cannot resolve
+     * the target itself - a {@code related:} register whose source entity is owned by ANOTHER model -
+     * needs the perspective to build the options controller's URL, and the target's own model is the
+     * only place that knows it (dirigible #6896).
      */
-    private static Map<String, Object> subsetProperty(String ownerEntity, RelationIntent relation, EntityIntent target) {
+    private static Map<String, Object> subsetProperty(String ownerEntity, RelationIntent relation, EntityIntent target,
+            String targetPerspective) {
         Map<String, Object> p = new LinkedHashMap<>();
         p.put("name", IntentNaming.pascalCase(relation.getName()));
         p.put("description", relation.getDescription() == null ? "" : relation.getDescription());
@@ -1367,6 +1376,7 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
         p.put("widgetLength", "20");
         p.put("widgetIsMajor", relation.isMajor() ? "true" : "false");
         p.put("widgetOptionsEntityName", relation.getTo());
+        p.put("widgetOptionsEntityPerspectiveName", targetPerspective);
         p.put("widgetDropDownKey", keyFieldName(target));
         p.put("widgetDropDownValue", labelFieldName(target));
         p.put("widgetPattern", "^\\d+(,\\d+)*$");
@@ -1979,9 +1989,10 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
     }
 
     /** The property keys a related register's column carries into the {@code .model}. */
-    private static final List<String> RELATED_COLUMN_KEYS = List.of("name", "widgetLabel", "dataName", "dataType", "dataScale",
-            "widgetType", "widgetPattern", "widgetDropDownKey", "widgetDropDownValue", "relationshipEntityName",
-            "relationshipEntityPerspectiveName", "widgetOptionsEntityName", "sensitiveProperty", "referencedModel");
+    private static final List<String> RELATED_COLUMN_KEYS =
+            List.of("name", "widgetLabel", "dataName", "dataType", "dataScale", "widgetType", "widgetPattern", "widgetDropDownKey",
+                    "widgetDropDownValue", "relationshipEntityName", "relationshipEntityPerspectiveName", "widgetOptionsEntityName",
+                    "widgetOptionsEntityPerspectiveName", "sensitiveProperty", "referencedModel");
 
     /**
      * Emits each entity's {@code related:} declarations as the {@code relatedEntities} model attribute

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmSubsetTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmSubsetTest.java
@@ -55,6 +55,8 @@ class EdmSubsetTest {
         assertEquals("512", property.get("dataLength"), "the length is not authorable, so headroom is the only safety valve");
         assertEquals("MULTISELECT", property.get("widgetType"));
         assertEquals("PayerType", property.get("widgetOptionsEntityName"), "the option source is the dedicated attribute");
+        assertEquals("PayerType", property.get("widgetOptionsEntityPerspectiveName"),
+                "a consumer that cannot resolve the target itself needs its perspective to reach the options controller");
         assertEquals("Id", property.get("widgetDropDownKey"));
         assertEquals("Name", property.get("widgetDropDownValue"));
         assertEquals("^\\d+(,\\d+)*$", property.get("widgetPattern"), "the server-side shape guard - the only one, no FK constrains it");
@@ -77,6 +79,33 @@ class EdmSubsetTest {
         assertFalse(edm.contains("<relation "), "a <relation> element would draw an FK edge and emit an FK constraint");
         assertTrue(edm.contains("widgetOptionsEntityName=\"PayerType\""), "the scalar attributes reach the .edm twin");
         assertTrue(edm.contains("widgetPattern=\"^\\d+(,\\d+)*$\""), "the regex survives into the XML verbatim");
+    }
+
+    /**
+     * The option source travels COMPLETE - entity plus perspective - the way a dropdown's does: a
+     * {@code related:} register whose source entity is owned by another model cannot resolve the target
+     * itself, and a settings lookup publishes under the shared Settings perspective rather than its own
+     * name (dirigible #6896).
+     */
+    @Test
+    void aSettingsLookupCarriesTheSharedSettingsPerspective() {
+        String yaml = """
+                name: schedules
+                entities:
+                  - name: PayerType
+                    kind: setting
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                  - name: Schedule
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                    relations:
+                      - { name: payerTypes, kind: subset, to: PayerType }
+                """;
+        Map<String, Object> property = propertyByName(entityByName(yaml, "Schedule"), "PayerTypes");
+
+        assertEquals("Settings", property.get("widgetOptionsEntityPerspectiveName"));
     }
 
     @Test

--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/ModelParameterProcessor.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/ModelParameterProcessor.java
@@ -11,6 +11,8 @@ package org.eclipse.dirigible.components.ide.template.service.model;
 
 import org.eclipse.dirigible.commons.api.helpers.NamingHelper;
 import org.eclipse.dirigible.commons.config.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -44,6 +46,9 @@ import static org.eclipse.dirigible.components.ide.template.service.model.ModelV
  * property pass to have completed, which is why they are separate sweeps rather than folded in.
  */
 final class ModelParameterProcessor {
+
+    /** The logger. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(ModelParameterProcessor.class);
 
     /** The name of the datasource used when neither the model nor the parameters name one. */
     private static final String DEFAULT_DATASOURCE_NAME_KEY = "DIRIGIBLE_DATABASE_DATASOURCE_NAME_DEFAULT";
@@ -491,9 +496,14 @@ final class ModelParameterProcessor {
      * of {@link #resolveDropdown}, never a widened gate: a multiselect is not a relation, so none of
      * the relation-only concerns there (projections, personal/partner identity, the add-new dialog, the
      * target repository) apply, and the two differ on exactly the inputs the whole method keys on -
-     * where the target's name and its perspective come from. An unresolvable target leaves the URLs
-     * unset, so the widget degrades to an empty select (the option-loading blocks gate on
-     * {@code widgetDropdownControllerUrl}), matching {@code resolveDropdown}'s convention.
+     * where the target's name and its perspective come from.
+     *
+     * <p>
+     * An unresolvable options entity FAILS the generation rather than degrading: the widget's view
+     * block is gated on the widget type while its option loading is gated on the owning entity carrying
+     * any option source at all, so a target that resolves to nothing used to emit a Refresh button
+     * calling a {@code loadOptions()} that was never generated - a dead widget with nothing anywhere to
+     * say why (dirigible #6896).
      *
      * @param property the property
      * @param entity the owning entity
@@ -505,20 +515,16 @@ final class ModelParameterProcessor {
         if (!"MULTISELECT".equals(str(property, "widgetType"))) {
             return;
         }
+        String owner = str(entity, "name") + "." + str(property, "name");
         String optionsEntity = str(property, "widgetOptionsEntityName");
         if (optionsEntity == null || optionsEntity.isEmpty()) {
-            return;
+            throw new IllegalArgumentException("Property [" + owner + "] is a multi-select but names no options entity"
+                    + " - it must name the lookup entity whose rows it offers.");
         }
-        Map<String, Object> target = findEntity(entities, optionsEntity);
-        if (target == null) {
-            return;
-        }
-        // The SETTING perspective rewrite happens in ModelGenerator at render time - AFTER this
-        // processor - so a settings target's raw perspectiveName would bake a URL the target never
-        // publishes under.
-        String perspective = "SETTING".equals(str(target, "type")) ? "Settings" : str(target, "perspectiveName");
-        if (perspective == null || perspective.isEmpty()) {
-            return;
+        String perspective = multiselectPerspective(findEntity(entities, optionsEntity));
+        if (perspective == null) {
+            throw new IllegalArgumentException("Property [" + owner + "] is a multi-select over [" + optionsEntity
+                    + "], which is not an entity of this model that publishes a controller - its options could never load.");
         }
         entity.put("hasDropdowns", Boolean.TRUE);
         String targetProject = str(parameters, "projectName");
@@ -536,6 +542,24 @@ final class ModelParameterProcessor {
                 "/services/java/" + targetProject + "/gen/" + javaGen + "/api/" + javaPerspective + "/" + optionsEntity + "Controller";
         property.put("widgetDropdownUrl", javaUrl);
         property.put("widgetDropdownControllerUrl", javaUrl);
+    }
+
+    /**
+     * The perspective a multi-select's options controller publishes under, or {@code null} when the
+     * target cannot serve options at all - unknown to this model, or an entity with no perspective of
+     * its own (a projection). The SETTING rewrite happens in ModelGenerator at render time - AFTER this
+     * processor - so a settings target's raw perspectiveName would bake a URL the target never
+     * publishes under.
+     *
+     * @param target the options entity, or null when it resolved to none
+     * @return the perspective, or null
+     */
+    private static String multiselectPerspective(Map<String, Object> target) {
+        if (target == null) {
+            return null;
+        }
+        String perspective = "SETTING".equals(str(target, "type")) ? "Settings" : str(target, "perspectiveName");
+        return perspective == null || perspective.isEmpty() ? null : perspective;
     }
 
     /**
@@ -880,7 +904,8 @@ final class ModelParameterProcessor {
 
     /**
      * Describes one register column: its heading, how the cell renders (number / float pattern / date)
-     * and, for a foreign key, where to fetch the referenced rows its label comes from.
+     * and, for a foreign key or a multi-select, where to fetch the referenced rows its label comes
+     * from.
      *
      * @param property the source property's metadata, as the model declares it
      * @param entities every entity in the model, for resolving a projection owner
@@ -913,6 +938,27 @@ final class ModelParameterProcessor {
             lookup.put("key", strOr(property, "widgetDropDownKey", "Id"));
             lookup.put("text", strOr(property, "widgetDropDownValue", "Name"));
             column.put("lookup", lookup);
+        } else if ("MULTISELECT".equals(widgetType) && truthy(property, "widgetOptionsEntityName")) {
+            // A subset column holds a KEY LIST ("1,3"), so the panel resolves EACH key through the
+            // options entity's rows and joins the labels - the same lookup shape as a foreign key,
+            // routed by the explicit `multi` flag (never by sniffing the value for commas). A subset
+            // cannot be cross-model, so the options entity belongs to the register SOURCE's project;
+            // its perspective travels on the property, the only place a source owned by another model
+            // can carry it.
+            String optionsEntity = str(property, "widgetOptionsEntityName");
+            String perspective =
+                    strOr(property, "widgetOptionsEntityPerspectiveName", multiselectPerspective(findEntity(entities, optionsEntity)));
+            if (perspective == null) {
+                LOGGER.warn("Register column [{}] is a multi-select over [{}], whose perspective this model cannot resolve"
+                        + " - the column renders the raw keys", name, optionsEntity);
+            } else {
+                Map<String, Object> lookup = new LinkedHashMap<>();
+                lookup.put("url", javaControllerUrl(sourceProject, sourceGenFolder, perspective, optionsEntity));
+                lookup.put("key", strOr(property, "widgetDropDownKey", "Id"));
+                lookup.put("text", strOr(property, "widgetDropDownValue", "Name"));
+                column.put("multi", Boolean.TRUE);
+                column.put("lookup", lookup);
+            }
         } else if ("Date".equals(dataType.typescript())) {
             column.put("date", Boolean.TRUE);
         } else if ("number".equals(dataType.typescript())) {

--- a/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/ModelParameterProcessorTest.java
+++ b/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/ModelParameterProcessorTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -372,6 +373,172 @@ class ModelParameterProcessorTest {
         ModelParameterProcessor.process(model(master, child), javaParameters());
 
         assertNull(child.get("masterLock"));
+    }
+
+    /**
+     * A multi-select (intent {@code kind: subset}) carries its option source as the dedicated
+     * {@code widgetOptionsEntityName}, never as relationship metadata - so the lookup URLs are built
+     * from that entity's own perspective.
+     */
+    @Test
+    void aMultiselectResolvesItsOptionSourceFromTheOptionsEntity() {
+        Map<String, Object> channels = property("Channels", "VARCHAR");
+        channels.put("widgetType", "MULTISELECT");
+        channels.put("widgetOptionsEntityName", "Channel");
+        channels.put("widgetDropDownKey", "Id");
+        channels.put("widgetDropDownValue", "Name");
+        Map<String, Object> lookupEntity = entity("Channel", "Channels", property("Id", "INTEGER"));
+        lookupEntity.put("type", "SETTING");
+        Map<String, Object> campaign = entity("Campaign", "Campaigns", channels);
+
+        ModelParameterProcessor.process(model(campaign, lookupEntity), javaParameters());
+
+        // A SETTING target publishes under the shared Settings perspective, not its own name (as the
+        // sanitized Java package segment it becomes).
+        assertEquals("/services/java/bookstore/gen/sales_order/api/settings/ChannelController",
+                channels.get("widgetDropdownControllerUrl"));
+        assertEquals(Boolean.TRUE, campaign.get("hasDropdowns"));
+    }
+
+    /**
+     * The dead-widget failure the guard exists for: the view block is gated on the widget TYPE while
+     * its option loading is gated on the entity carrying any option source at all, so an unresolvable
+     * target used to generate a Refresh button calling a method that was never emitted.
+     */
+    @Test
+    void aMultiselectWithoutAnOptionsEntityFailsTheGeneration() {
+        Map<String, Object> channels = property("Channels", "VARCHAR");
+        channels.put("widgetType", "MULTISELECT");
+        Map<String, Object> model = model(entity("Campaign", "Campaigns", channels));
+
+        IllegalArgumentException ex =
+                assertThrows(IllegalArgumentException.class, () -> ModelParameterProcessor.process(model, javaParameters()));
+        assertTrue(ex.getMessage()
+                     .contains("[Campaign.Channels] is a multi-select but names no options entity"),
+                ex.getMessage());
+    }
+
+    @Test
+    void aMultiselectOverAnUnknownOptionsEntityFailsTheGeneration() {
+        Map<String, Object> channels = property("Channels", "VARCHAR");
+        channels.put("widgetType", "MULTISELECT");
+        channels.put("widgetOptionsEntityName", "Chanel");
+        Map<String, Object> model = model(entity("Campaign", "Campaigns", channels));
+
+        IllegalArgumentException ex =
+                assertThrows(IllegalArgumentException.class, () -> ModelParameterProcessor.process(model, javaParameters()));
+        assertTrue(ex.getMessage()
+                     .contains("[Campaign.Channels] is a multi-select over [Chanel]"),
+                ex.getMessage());
+    }
+
+    /**
+     * A register column over a subset resolves EACH key through the options entity's rows, so it
+     * carries the {@code multi} flag beside the same lookup a foreign key gets - without it the
+     * register renders the raw key list.
+     */
+    @Test
+    void aRegisterColumnOverASubsetCarriesTheMultiLookup() {
+        Map<String, Object> column = property("Channels", "VARCHAR");
+        column.put("widgetType", "MULTISELECT");
+        column.put("widgetOptionsEntityName", "Channel");
+        column.put("widgetOptionsEntityPerspectiveName", "Settings");
+        column.put("widgetDropDownKey", "Id");
+        column.put("widgetDropDownValue", "Name");
+        Map<String, Object> campaign = entity("Campaign", "Campaigns", property("Id", "INTEGER"));
+        campaign.put("relatedEntities", List.of(register("CampaignCost", "Costs", column)));
+
+        ModelParameterProcessor.process(model(campaign), javaParameters());
+
+        Map<String, Object> resolved = registerColumn(campaign);
+        assertEquals(Boolean.TRUE, resolved.get("multi"));
+        assertEquals("/services/java/bookstore/gen/sales_order/api/settings/ChannelController", lookup(resolved).get("url"));
+        assertEquals("Id", lookup(resolved).get("key"));
+        assertEquals("Name", lookup(resolved).get("text"));
+    }
+
+    /**
+     * A register source generated before the perspective travelled on the property: the options entity
+     * is resolved in this model instead, which is where a same-model register's target always lives.
+     */
+    @Test
+    void aRegisterColumnOverASubsetFallsBackToThisModelsPerspective() {
+        Map<String, Object> column = property("Channels", "VARCHAR");
+        column.put("widgetType", "MULTISELECT");
+        column.put("widgetOptionsEntityName", "Channel");
+        Map<String, Object> lookupEntity = entity("Channel", "Channels", property("Id", "INTEGER"));
+        lookupEntity.put("type", "SETTING");
+        Map<String, Object> campaign = entity("Campaign", "Campaigns", property("Id", "INTEGER"));
+        campaign.put("relatedEntities", List.of(register("CampaignCost", "Costs", column)));
+
+        ModelParameterProcessor.process(model(campaign, lookupEntity), javaParameters());
+
+        Map<String, Object> resolved = registerColumn(campaign);
+        assertEquals(Boolean.TRUE, resolved.get("multi"));
+        assertEquals("/services/java/bookstore/gen/sales_order/api/settings/ChannelController", lookup(resolved).get("url"));
+    }
+
+    /**
+     * An options entity this model cannot resolve at all (a register source owned by another model,
+     * generated before the perspective travelled): the column renders the raw keys rather than a URL
+     * built on a guess.
+     */
+    @Test
+    void aRegisterColumnWhoseOptionsEntityIsUnresolvableCarriesNoLookup() {
+        Map<String, Object> column = property("Channels", "VARCHAR");
+        column.put("widgetType", "MULTISELECT");
+        column.put("widgetOptionsEntityName", "Channel");
+        Map<String, Object> campaign = entity("Campaign", "Campaigns", property("Id", "INTEGER"));
+        campaign.put("relatedEntities", List.of(register("CampaignCost", "Costs", column)));
+
+        ModelParameterProcessor.process(model(campaign), javaParameters());
+
+        Map<String, Object> resolved = registerColumn(campaign);
+        assertNull(resolved.get("multi"));
+        assertNull(resolved.get("lookup"));
+    }
+
+    /**
+     * Builds a related-records register declaration, as the model carries it.
+     *
+     * @param sourceEntity the referencing entity
+     * @param perspectiveName its perspective
+     * @param columns the property metadata of the columns it shows
+     * @return the register
+     */
+    @SafeVarargs
+    private static Map<String, Object> register(String sourceEntity, String perspectiveName, Map<String, Object>... columns) {
+        Map<String, Object> register = new LinkedHashMap<>();
+        register.put("entity", sourceEntity);
+        register.put("label", sourceEntity);
+        register.put("perspectiveName", perspectiveName);
+        register.put("primaryKey", "Id");
+        register.put("fkProperty", "Campaign");
+        register.put("properties", List.of(columns));
+        return register;
+    }
+
+    /**
+     * The single column of the single register of an entity.
+     *
+     * @param entity the entity carrying the register
+     * @return the resolved column descriptor
+     */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> registerColumn(Map<String, Object> entity) {
+        Map<String, Object> register = ((List<Map<String, Object>>) entity.get("relatedEntities")).get(0);
+        return ((List<Map<String, Object>>) register.get("columns")).get(0);
+    }
+
+    /**
+     * A resolved column's lookup descriptor.
+     *
+     * @param column the column
+     * @return the lookup
+     */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> lookup(Map<String, Object> column) {
+        return (Map<String, Object>) column.get("lookup");
     }
 
     /**

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/relatedPanel.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/relatedPanel.js
@@ -22,7 +22,9 @@
  * resolution and the cell formatting are the SAME, and are inherited from it rather than restated.
  *
  * `def` shape (from App.registerRelated): { entity, label, tkey, apiPath, appUrl, local, fkProperty,
- *   primaryKey, columns: [{ name, label, tkey, number, float, pattern, date, lookup, sensitive }] }.
+ *   primaryKey, columns: [{ name, label, tkey, number, float, pattern, date, lookup, multi, sensitive }] }.
+ * A `multi` column is a subset (`kind: subset`): its cell is a key list resolved through `lookup` per
+ * key — handled by the inherited detailPanel.cellValue, so nothing here is aware of it.
  * apiPath and appUrl are ABSOLUTE (the source may live in another project), so every call passes
  * { baseUrl: '' } and the row dialog opens the source's own application.
  */

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -442,10 +442,11 @@ document.addEventListener('alpine:init', () => {
 #end
 #end
 #foreach($property in $properties)
-#if($property.widgetOptionsFilterBy && $property.widgetType == "DROPDOWN" && $property.aggregate != "true")
+#if($property.widgetOptionsFilterBy && ($property.widgetType == "DROPDOWN" || $property.widgetType == "MULTISELECT") && $property.aggregate != "true")
       // Static option filter (intent `where:`): a header value stored outside the filter is absent from
-      // the filtered chooser list, so its label would not resolve on edit. Splice in that one row by id
-      // - the filter still governs what may be newly picked.
+      // the filtered chooser list, so its label would not resolve on edit. Splice in that row by id -
+      // the filter still governs what may be newly picked. A MULTISELECT holds SEVERAL keys, each of
+      // which may have fallen outside the filter.
       await this.ensureFilteredCurrent('${property.name}', '${property.widgetDropdownControllerUrl}', '${property.widgetDropDownKey}', '${property.widgetDropDownValue}');
 #end
 #end
@@ -866,19 +867,25 @@ document.addEventListener('alpine:init', () => {
         .map(r => ({ value: r[opts.key], text: '\u2003'.repeat(depthOf(r)) + String(r[opts.text] ?? '') }));
     },
 
-    // Static option filter (intent `where:`) label resolution for a HEADER dropdown: fetch a single
-    // out-of-filter row by id and prepend it to the chooser list so a value stored outside the filter
-    // still shows its label on edit. The filter still governs what the user can newly pick.
+    // Static option filter (intent `where:`) label resolution for a HEADER dropdown or multi-select:
+    // fetch each out-of-filter row by id and prepend it to the chooser list so a value stored outside
+    // the filter still shows its label on edit. The filter still governs what the user can newly pick.
+    // A MULTISELECT's model is an ARRAY of keys, so every stored key is checked - one that fell outside
+    // the filter would otherwise vanish from the trigger's label list while the record still stores it.
     async ensureFilteredCurrent(prop, url, key, text) {
       const current = this.form[prop];
-      if (current == null || current === '') return;
+      const values = (Array.isArray(current) ? current : [current]).filter(v => v != null && v !== '');
+      if (!values.length) return;
       const opts = this['options' + prop];
-      if (!Array.isArray(opts) || opts.some(o => String(o.value) === String(current))) return;
-      try {
-        const row = await App.services.api.get(url + '/' + encodeURIComponent(current), { baseUrl: '' });
-        if (row && row[key] != null) opts.unshift({ value: row[key], text: row[text] });
-      } catch (e) {
-        console.error('[${name}DocumentPage] failed to resolve the filtered current option for ' + prop, e);
+      if (!Array.isArray(opts)) return;
+      for (const value of values) {
+        if (opts.some(o => String(o.value) === String(value))) continue;
+        try {
+          const row = await App.services.api.get(url + '/' + encodeURIComponent(value), { baseUrl: '' });
+          if (row && row[key] != null) opts.unshift({ value: row[key], text: row[text] });
+        } catch (e) {
+          console.error('[${name}DocumentPage] failed to resolve the filtered current option for ' + prop, e);
+        }
       }
     },
 

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
@@ -301,11 +301,12 @@ document.addEventListener('alpine:init', () => {
 #end
 #end
 #foreach($property in $properties)
-#if($property.widgetOptionsFilterBy && $property.widgetType == "DROPDOWN")
+#if($property.widgetOptionsFilterBy && ($property.widgetType == "DROPDOWN" || $property.widgetType == "MULTISELECT"))
         // Static option filter (intent `where:`): a value stored before/outside the filter is absent
         // from the filtered chooser list, so its label would not resolve on edit. Splice in that one
         // row by id - the filter still governs what may be newly picked (mirrors the items dialog,
-        // which keeps the full set for label resolution alongside the filtered chooser set).
+        // which keeps the full set for label resolution alongside the filtered chooser set). A
+        // MULTISELECT holds SEVERAL keys, each of which may have fallen outside the filter.
         await this.ensureFilteredCurrent('${property.name}', '${property.widgetDropdownControllerUrl}', '${property.widgetDropDownKey}', '${property.widgetDropDownValue}');
 #end
 #end
@@ -387,19 +388,25 @@ document.addEventListener('alpine:init', () => {
         .map(r => ({ value: r[opts.key], text: '\u2003'.repeat(depthOf(r)) + String(r[opts.text] ?? '') }));
     },
 
-    // Static option filter (intent `where:`) label resolution: fetch a single out-of-filter row by id
-    // and prepend it to the chooser list so a value stored outside the filter still shows its label on
-    // edit. The filter still governs what the user can newly pick.
+    // Static option filter (intent `where:`) label resolution: fetch each out-of-filter row by id and
+    // prepend it to the chooser list so a value stored outside the filter still shows its label on
+    // edit. The filter still governs what the user can newly pick. A MULTISELECT's model is an ARRAY
+    // of keys, so every stored key is checked - one that fell outside the filter would otherwise
+    // vanish from the trigger's label list while the record still stores it.
     async ensureFilteredCurrent(prop, url, key, text) {
       const current = this.form[prop];
-      if (current == null || current === '') return;
+      const values = (Array.isArray(current) ? current : [current]).filter(v => v != null && v !== '');
+      if (!values.length) return;
       const opts = this['options' + prop];
-      if (!Array.isArray(opts) || opts.some(o => String(o.value) === String(current))) return;
-      try {
-        const row = await App.services.api.get(url + '/' + encodeURIComponent(current), { baseUrl: '' });
-        if (row && row[key] != null) opts.unshift({ value: row[key], text: row[text] });
-      } catch (e) {
-        console.error('[${name}FormPage] failed to resolve the filtered current option for ' + prop, e);
+      if (!Array.isArray(opts)) return;
+      for (const value of values) {
+        if (opts.some(o => String(o.value) === String(value))) continue;
+        try {
+          const row = await App.services.api.get(url + '/' + encodeURIComponent(value), { baseUrl: '' });
+          if (row && row[key] != null) opts.unshift({ value: row[key], text: row[text] });
+        } catch (e) {
+          console.error('[${name}FormPage] failed to resolve the filtered current option for ' + prop, e);
+        }
       }
     },
 

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/related/related-register.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/related/related-register.js.template
@@ -30,7 +30,9 @@ App.registerRelated('${name}', {
   primaryKey: '${register.primaryKey}',
   columns: [
 #foreach($column in $register.columns)
-    { name: '${column.name}', label: '${column.label}'#if($register.local && $column.dataName), tkey: '$projectName:${tprefix}.t.${column.dataName}'#end#if($column.lookup), lookup: { url: '${column.lookup.url}', key: '${column.lookup.key}', text: '${column.lookup.text}' }#end#if($column.date), date: true#end#if($column.float), number: true, float: true, pattern: '${column.pattern}'#elseif($column.number), number: true#end#if($column.sensitive), sensitive: true#end },
+## A subset column (intent `kind: subset`) holds a key LIST ("1,3"): the `multi` flag routes the cell
+## through the same lookup PER KEY and joins the labels - without it the register shows the raw ids.
+    { name: '${column.name}', label: '${column.label}'#if($register.local && $column.dataName), tkey: '$projectName:${tprefix}.t.${column.dataName}'#end#if($column.multi), multi: true#end#if($column.lookup), lookup: { url: '${column.lookup.url}', key: '${column.lookup.key}', text: '${column.lookup.text}' }#end#if($column.date), date: true#end#if($column.float), number: true, float: true, pattern: '${column.pattern}'#elseif($column.number), number: true#end#if($column.sensitive), sensitive: true#end },
 #end
   ],
 });

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/dialogs/js/details.js
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/dialogs/js/details.js
@@ -150,7 +150,24 @@ angular.module('edmDetails', ['blimpKit', 'platformView'])
             if (type === 'SETTING') return 'Settings';
             return 'Reports';
         }
+        // A multi-select's option source is the ONE thing the widget cannot work without: without it the
+        // generation has no controller to load the options from, and the widget would render as an empty
+        // select with a Refresh button that resolves nothing. Refused here rather than left to fail at
+        // generation time, where the model file is already written (#6896).
+        function optionsEntityMissing() {
+            return $scope.dialogType === 'property' && $scope.dataParameters.widgetType === 'MULTISELECT'
+                && !$scope.dataParameters.widgetOptionsEntityName;
+        }
         $scope.save = () => {
+            if (optionsEntityMissing()) {
+                Dialogs.showAlert({
+                    title: 'Options entity is required',
+                    message: 'A Multi Select property must name the lookup entity whose rows it offers.',
+                    type: AlertTypes.Error,
+                    preformatted: false,
+                });
+                return;
+            }
             if (!$scope.state.error) {
                 $scope.state.busyText = 'Saving';
                 $scope.state.isBusy = true;

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -286,6 +286,13 @@ class IntentEmissionCoverageIT extends IntegrationTest {
               # the table column and the detail pane, exactly like the list layout does.
               - name: Campaign
                 immutableWhen: "Status == 2"
+                # related over a source that carries a SUBSET column: the register's cell is a key
+                # list, so its lookup must resolve EACH key (the `multi` flag) - without it the
+                # register is the one surface that shows the raw "1,3" (#6896).
+                related:
+                  - entity: Bulletin
+                    label: Bulletins
+                    show: [title, channels]
                 fields:
                   - { name: id,   type: integer, primaryKey: true, generated: true }
                   - { name: name, type: string, required: true, length: 100 }
@@ -295,7 +302,10 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                   # never a link entity, never an FK. Campaign carries the unseeded REST round-trip
                   # (it is POSTed by the lock tests, so seeding it would collide with the identity
                   # sequence); the seeded carrier is Bulletin below.
-                  - { name: channels, kind: subset, to: Channel }
+                  # where: narrows the chooser to the active channels, which is also what makes a
+                  # STORED key that later fell outside the filter unresolvable - the form must splice
+                  # each such key back in for label resolution (#6896).
+                  - { name: channels, kind: subset, to: Channel, where: { active: true } }
 
               # The subset relation's lookup: a plain settings nomenclature the widget offers.
               - name: Channel
@@ -303,6 +313,7 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 fields:
                   - { name: id,   type: integer, primaryKey: true, generated: true }
                   - { name: name, type: string, required: true, length: 60 }
+                  - { name: active, type: boolean }
 
               # The SEEDED subset carrier, never POSTed: proves the seed's relation key lands as
               # the quoted csv column and CSVIM imports it (the silent-zero failure this IT exists for).
@@ -312,6 +323,9 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                   - { name: title, type: string, required: true, length: 100 }
                 relations:
                   - { name: channels, kind: subset, to: Channel }
+                  # The incoming association Campaign's register filters by (optional, so the seeded
+                  # rows stay valid without naming a campaign).
+                  - { name: campaign, kind: manyToOne, to: Campaign }
 
               # locksWithMaster: false - the deliberate post-lock collection (#6700). It is the
               # negative control for the inherited lock below: notes keep their writes after the
@@ -1304,9 +1318,9 @@ class IntentEmissionCoverageIT extends IntegrationTest {
               - name: channels
                 entity: Channel
                 rows:
-                  - { id: 1, name: Email }
-                  - { id: 2, name: Social }
-                  - { id: 3, name: Print }
+                  - { id: 1, name: Email,  active: true }
+                  - { id: 2, name: Social, active: true }
+                  - { id: 3, name: Print,  active: true }
               # The subset value is seeded by the relation's authored name, in the normative
               # shape - a quoted csv cell ("1,3"); the second row proves an omitted set stays null.
               - name: bulletins
@@ -1731,11 +1745,23 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 "the multiselect options must load from the lookup's controller under the Settings perspective");
         assertTrue(subsetFormPage.contains(".split(',')") && subsetFormPage.contains(".join(',')"),
                 "the form must split the stored csv on load and join it back to the normative shape on save");
+        // where: on a subset - a stored key that later fell outside the filter has no option, so its
+        // label would silently drop out of the trigger's list while the record still stores it (#6896).
+        assertTrue(subsetFormPage.contains("ensureFilteredCurrent('Channels'"),
+                "a filtered subset must splice its stored out-of-filter keys back in for label resolution");
         // The seeded value column: the relation-name key emits the quoted csv cell (the cell carries
         // the field delimiter, so an unquoted emission would shear the row apart).
         String bulletinsCsv = contentOf("bulletins.csv");
         assertTrue(bulletinsCsv.contains("BULLETIN_CHANNELS"), "a seed row's subset key must emit the value column into the seed CSV");
         assertTrue(bulletinsCsv.contains("\"1,3\""), "the subset seed cell must be quoted - it carries the field delimiter");
+        // ... and the register of the records referencing Campaign renders that same value as LABELS:
+        // the column carries the `multi` flag beside the options lookup, which is what routes the cell
+        // through the lookup per key instead of printing the raw list (#6896).
+        String campaignRegister = contentOf("gen/emission/js/components/pages/Campaign/Campaign.related.js");
+        assertTrue(campaignRegister.contains("name: 'Channels'") && campaignRegister.contains("multi: true"),
+                "a register column over a subset must carry the multi flag, got: " + campaignRegister);
+        assertTrue(campaignRegister.contains("lookup: { url: '" + API + "/settings/ChannelController'"),
+                "a register column over a subset must carry the options entity's lookup, got: " + campaignRegister);
         assertTrue(entryRepository.contains("EntryLineRepository"),
                 "aggregate: true must make the master repository recompute totals from its items child");
 


### PR DESCRIPTION
Fixes #6896.

`kind: subset` (#6894) lowers to ONE `VARCHAR` column holding the selected lookup keys plus a `MULTISELECT` widget. #6894 wired label resolution and the array-bound select into the manage form, the list, the master + detail panel, the document header and line-item dialog, the `my`/`partner` mirrors and the CSV export. Four surfaces in the same family were missed — the widget or its label resolution was not wired, and each failed silently.

## 1 + 2. A `related:` register rendered the raw key list — and the key it needed was unconsumed

`ModelParameterProcessor.relatedColumn` gated a column's `lookup` on `("DROPDOWN" | "DOCUMENT_STATUS") && relationshipEntityName`, which a subset property deliberately never carries, and `related-register.js.template` never emitted `multi:`. So the one surface that showed `1,3` where every other showed `Email, Print`.

The register column now gets the same `lookup` shape plus `multi: true`; the runtime side needed nothing (`relatedPanel` spreads `detailPanel`, so it inherits the `multi` branch of `cellValue`).

Building that URL needs the options entity's **perspective**, and `widgetOptionsEntityName` alone cannot give it: a register whose source entity is owned by ANOTHER model reads the source's property metadata out of that model's `.model`, where the target is not declared. So `EdmIntentGenerator.subsetProperty` now emits `widgetOptionsEntityPerspectiveName` beside it — the exact mirror of a dropdown's `relationshipEntityName` + `relationshipEntityPerspectiveName` pair — and it joins `RELATED_COLUMN_KEYS`. That answers the issue's second point: the previously unconsumed key now feeds the fix, rather than coming back out. A same-model register resolves the perspective locally as a fallback, so a `.model` generated before this change still renders labels; a target this model cannot resolve at all logs a warning and renders the raw keys rather than a URL built on a guess.

## 3. A `where:` filter silently dropped a stored key from the display

`ensureFilteredCurrent` — the splice-in that keeps a stored, out-of-filter value resolvable — was gated on `widgetType == "DROPDOWN"`, while a `MULTISELECT` loads its options through the same filtered `/search`. It now takes a multi-value model (every stored key checked, each missing one fetched by id), and the call site is gated on both widget types. Manage form and document header.

## 4. An unresolvable options entity yielded a Refresh button calling a method that was never generated

`resolveMultiselect` returned early without setting `hasDropdowns`, while the `MULTISELECT` view block — including `@click="loadOptions()"` — is gated on the widget type. The generation now **fails**, naming the property and the entity: either the property names no options entity, or it names one that publishes no controller. That is safe by construction — `MULTISELECT` is one day old and only intent's `subset` produces it, so no existing model can hit it — and it is the honest boundary for a widget whose option source is the one thing it cannot work without.

The modeler is fixed at the same point: `save()` refuses a Multi Select property with no options entity (the label said `required="true"`, the control carried no validation, and nothing downstream complained). I did not add `ng-required` to the `bk-select` — BlimpKit ships as a webjar so I could not verify the directive honours it, and an inert attribute that *looks* like validation is worse than none; the dialog has no `<form>`/`$invalid` gate anyway, so the refusal in `save()` is the mechanism that works.

## Tests

- `ModelParameterProcessorTest`: the register lookup and its `multi` flag, the same-model perspective fallback, the raw-key degradation when nothing resolves, and both generation failures.
- `EdmSubsetTest`: the perspective travels on the property, and a `kind: setting` lookup carries the shared `Settings` perspective rather than its own name.
- `IntentEmissionCoverageIT` (smoke set): Campaign gains a `related:` register over Bulletin showing its subset column — asserting `multi: true` + the options lookup URL — and its subset relation gains a `where:` filter, asserting the form emits `ensureFilteredCurrent('Channels', …)`. **Run locally: green (127 s).**
- `engine-intent` (828) and `ide-template` (83) unit suites green; `formatter:validate` clean with the cache wiped; `-P release` javadoc has no `error:`.

## One observation, not fixed here

#6894 removed the explicit `widgetDropDownMultiSelect` emission from `editor-entity/js/serializer.js` but left the attribute in `PROPERTY_HANDLED`, so the generic lossless pass skips it too: a legacy `.edm` carrying that attribute now loses it on a modeler save. Retiring the attribute looks deliberate, so I left it alone rather than widen this PR — say the word and I will drop it from `PROPERTY_HANDLED` so the generic pass preserves it.