### PR TITLE
Stop warning about typeless project-to-project dependencies

### DIFF
--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ProjectDependenciesCollector.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ProjectDependenciesCollector.java
@@ -82,8 +82,9 @@ class ProjectDependenciesCollector {
     }
 
     /**
-     * Collects one project's maven declarations - git entries keep their meaning elsewhere, and unknown
-     * types are tolerated with a warning so an older platform accepts a newer descriptor.
+     * Collects one project's maven declarations - git and typeless project-to-project entries keep
+     * their meaning elsewhere, and unknown types are tolerated with a warning so an older platform
+     * accepts a newer descriptor.
      *
      * @param project the project name
      * @param metadata the parsed project.json
@@ -95,6 +96,9 @@ class ProjectDependenciesCollector {
             Map<String, Set<String>> declaredBy) {
         for (ProjectMetadataDependency declared : metadata.getDependencies()) {
             String type = declared.getType();
+            if (type == null || type.isBlank()) {
+                continue; // the classic project-to-project (guid) dependency, consumed by the IDE workspace
+            }
             if (ProjectMetadataDependency.TYPE_GIT.equalsIgnoreCase(type)) {
                 continue; // consumed by the IDE workspace
             }

--- a/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/ProjectMetadataParsingTest.java
+++ b/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/ProjectMetadataParsingTest.java
@@ -25,9 +25,9 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * The project.json parsing contract of the maven dependency type - maven entries parse, git entries
- * keep their exact current meaning, and unknown types are tolerated with a warning so an older
- * platform accepts a newer descriptor.
+ * The project.json parsing contract of the maven dependency type - maven entries parse, git and
+ * typeless project-to-project entries keep their exact current meaning, and unknown types are
+ * tolerated with a warning so an older platform accepts a newer descriptor.
  */
 class ProjectMetadataParsingTest {
 
@@ -110,6 +110,32 @@ class ProjectMetadataParsingTest {
         }
         assertThat(dependencies).isEmpty();
         assertThat(errors).isEmpty();
+    }
+
+    @Test
+    void a_typeless_project_dependency_is_skipped_without_a_warning() {
+        String json = """
+                {
+                    "guid": "my-project",
+                    "dependencies": [
+                        { "guid": "template-application-dao-java" }
+                    ]
+                }
+                """;
+        Set<MavenDependency> dependencies = new LinkedHashSet<>();
+        Map<String, String> errors = new LinkedHashMap<>();
+        Map<String, Set<String>> declaredBy = new LinkedHashMap<>();
+
+        try (LogCaptor logCaptor = LogCaptor.forClass(ProjectDependenciesCollector.class)) {
+            ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies, errors,
+                    declaredBy);
+
+            // the watcher re-collects every few seconds - a legacy guid entry must not spam the log
+            assertThat(logCaptor.getWarnLogs()).isEmpty();
+        }
+        assertThat(dependencies).isEmpty();
+        assertThat(errors).isEmpty();
+        assertThat(declaredBy).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
### Problem

A registry project that declares the classic `guid`-only dependency logs a warning on every dependencies-watcher tick:

```
[WARN] o.e.d.c.d.ProjectDependenciesCollector - Ignoring the dependency of unknown type [null] declared by project [template-application-rest-java]
```

`ProjectDependenciesCollector.collectDeclared` recognized only `git` (skipped) and `maven` (resolved), so a typeless entry — the historical project-to-project dependency, which carries no `"type"` field — fell into the unknown-type branch introduced for forward compatibility with newer descriptors.

`DependenciesWatcher.watch()` runs on a `fixedDelay = 5_000`, re-collecting the whole registry each tick, so the warning repeats indefinitely. `template-application-rest-java/project.json` declares exactly such a dependency:

```json
"dependencies": [ { "guid": "template-application-dao-java" } ]
```

Nothing is functionally wrong — guid dependencies were never meant to be Maven-resolved, and no declaration is being dropped. The descriptor is valid; the log line is a false positive and pure noise.

### Change

A null or blank `type` now short-circuits before the type check, the same way `git` does. Genuinely unknown types such as `npm` still warn, so the forward-compatibility behaviour is preserved.

### Test

Added `a_typeless_project_dependency_is_skipped_without_a_warning`, which asserts via `LogCaptor` that a `{ "guid": "..." }` entry yields no warn logs and no collected dependencies, errors, or `declaredBy` entries — the exact descriptor shape that was spamming the log.

Full `core-dependencies` module: 39 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
