### PR TITLE
fix(dependencies): report a declaration diagnostic once per change (#6827)

### DIFF
--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ProjectDependenciesCollector.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ProjectDependenciesCollector.java
@@ -21,11 +21,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 /**
  * Collects the maven dependency declarations from the project.json files of all projects in the
@@ -38,6 +41,9 @@ class ProjectDependenciesCollector {
 
     /** The repository. */
     private final IRepository repository;
+
+    /** The diagnostics the previous collection reported, joined - see {@link #report(List)}. */
+    private final AtomicReference<String> reported = new AtomicReference<>("");
 
     /**
      * Instantiates a new collector.
@@ -57,28 +63,44 @@ class ProjectDependenciesCollector {
         Set<MavenDependency> dependencies = new LinkedHashSet<>();
         Map<String, String> errors = new LinkedHashMap<>();
         Map<String, Set<String>> declaredBy = new LinkedHashMap<>();
+        List<Notice> notices = new ArrayList<>();
         ICollection registry = repository.getCollection(IRepositoryStructure.PATH_REGISTRY_PUBLIC);
-        if (!registry.exists()) {
-            return new DeclaredDependencies(dependencies, errors, declaredBy);
-        }
-        for (ICollection project : registry.getCollections()) {
-            IResource descriptor = project.getResource(ProjectMetadata.PROJECT_METADATA_FILE_NAME);
-            if (!descriptor.exists()) {
-                continue;
-            }
-            ProjectMetadata metadata;
-            try {
-                metadata = ProjectMetadataUtils.fromJson(new String(descriptor.getContent(), StandardCharsets.UTF_8));
-            } catch (RuntimeException e) {
-                LOGGER.warn("Ignoring the unparseable [{}] of project [{}]", ProjectMetadata.PROJECT_METADATA_FILE_NAME, project.getName(),
-                        e);
-                continue;
-            }
-            if (metadata != null) {
-                collectDeclared(project.getName(), metadata, dependencies, errors, declaredBy);
+        if (registry.exists()) {
+            for (ICollection project : registry.getCollections()) {
+                collectProject(project, dependencies, errors, declaredBy, notices);
             }
         }
+        report(notices);
         return new DeclaredDependencies(dependencies, errors, declaredBy);
+    }
+
+    /**
+     * Collects one registry project's declarations.
+     *
+     * @param project the registry project
+     * @param dependencies the collected dependencies to add to
+     * @param errors the declaration errors to add to
+     * @param declaredBy the declaring projects per coordinate to add to
+     * @param notices the diagnostics to add to
+     */
+    private void collectProject(ICollection project, Set<MavenDependency> dependencies, Map<String, String> errors,
+            Map<String, Set<String>> declaredBy, List<Notice> notices) {
+        IResource descriptor = project.getResource(ProjectMetadata.PROJECT_METADATA_FILE_NAME);
+        if (!descriptor.exists()) {
+            return;
+        }
+        ProjectMetadata metadata;
+        try {
+            metadata = ProjectMetadataUtils.fromJson(new String(descriptor.getContent(), StandardCharsets.UTF_8));
+        } catch (RuntimeException e) {
+            notices.add(Notice.warning(
+                    "Ignoring the unparseable [" + ProjectMetadata.PROJECT_METADATA_FILE_NAME + "] of project [" + project.getName() + "]",
+                    e));
+            return;
+        }
+        if (metadata != null) {
+            notices.addAll(collectDeclared(project.getName(), metadata, dependencies, errors, declaredBy));
+        }
     }
 
     /**
@@ -91,9 +113,11 @@ class ProjectDependenciesCollector {
      * @param dependencies the collected dependencies to add to
      * @param errors the declaration errors to add to
      * @param declaredBy the declaring projects per coordinate to add to
+     * @return the diagnostics of this project's declarations
      */
-    static void collectDeclared(String project, ProjectMetadata metadata, Set<MavenDependency> dependencies, Map<String, String> errors,
-            Map<String, Set<String>> declaredBy) {
+    static List<Notice> collectDeclared(String project, ProjectMetadata metadata, Set<MavenDependency> dependencies,
+            Map<String, String> errors, Map<String, Set<String>> declaredBy) {
+        List<Notice> notices = new ArrayList<>();
         for (ProjectMetadataDependency declared : metadata.getDependencies()) {
             String type = declared.getType();
             if (type == null || type.isBlank()) {
@@ -103,13 +127,15 @@ class ProjectDependenciesCollector {
                 continue; // consumed by the IDE workspace
             }
             if (!ProjectMetadataDependency.TYPE_MAVEN.equalsIgnoreCase(type)) {
-                LOGGER.warn("Ignoring the dependency of unknown type [{}] declared by project [{}]", type, project);
+                notices.add(Notice.warning("Ignoring the dependency of unknown type [" + type + "] declared by project [" + project + "]",
+                        null));
                 continue;
             }
             String id = declared.getId();
             if (id == null || id.isBlank()) {
-                errors.put(project, "Project [" + project + "] declares a maven dependency without an id (groupId:artifactId:version)");
-                LOGGER.error("Project [{}] declares a maven dependency without an id (groupId:artifactId:version)", project);
+                String message = "Project [" + project + "] declares a maven dependency without an id (groupId:artifactId:version)";
+                errors.put(project, message);
+                notices.add(Notice.error(message, null));
                 continue;
             }
             try {
@@ -120,7 +146,73 @@ class ProjectDependenciesCollector {
                           .add(project);
             } catch (IllegalArgumentException e) {
                 errors.put(id, "Project [" + project + "]: " + e.getMessage());
-                LOGGER.error("Invalid maven dependency [{}] declared by project [{}]", id, project, e);
+                notices.add(Notice.error("Invalid maven dependency [" + id + "] declared by project [" + project + "]", e));
+            }
+        }
+        return notices;
+    }
+
+    /**
+     * Logs this collection's diagnostics, but only when they differ from the previous collection's. The
+     * watcher re-collects the registry every few seconds, so a declaration this platform ignores or
+     * cannot resolve would otherwise re-log forever on an unmodified instance - which trains operators
+     * to ignore the log and buries the real dependency problems.
+     *
+     * @param notices the diagnostics of this collection
+     */
+    private void report(List<Notice> notices) {
+        String signature = notices.stream()
+                                  .map(Notice::message)
+                                  .collect(Collectors.joining("\n"));
+        if (signature.equals(reported.getAndSet(signature))) {
+            return;
+        }
+        notices.forEach(notice -> notice.log(LOGGER));
+    }
+
+    /**
+     * One declaration diagnostic. The message is materialized rather than left as an SLF4J format,
+     * because it doubles as the change-detection key {@link #report(List)} compares.
+     *
+     * @param error whether the declaration will not resolve, as opposed to one this platform merely
+     *        ignores
+     * @param message the message
+     * @param cause the throwable behind the diagnostic, null when there is none
+     */
+    record Notice(boolean error, String message, Throwable cause) {
+
+        /**
+         * A declaration this platform ignores.
+         *
+         * @param message the message
+         * @param cause the throwable behind the diagnostic, null when there is none
+         * @return the notice
+         */
+        static Notice warning(String message, Throwable cause) {
+            return new Notice(false, message, cause);
+        }
+
+        /**
+         * A declaration that will not resolve.
+         *
+         * @param message the message
+         * @param cause the throwable behind the diagnostic, null when there is none
+         * @return the notice
+         */
+        static Notice error(String message, Throwable cause) {
+            return new Notice(true, message, cause);
+        }
+
+        /**
+         * Logs the diagnostic.
+         *
+         * @param logger the logger
+         */
+        void log(Logger logger) {
+            if (error) {
+                logger.error(message, cause);
+            } else {
+                logger.warn(message, cause);
             }
         }
     }

--- a/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/DeclarationReportingTest.java
+++ b/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/DeclarationReportingTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import nl.altindag.log.LogCaptor;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.repository.local.LocalRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A declaration diagnostic is logged once per declaration change, not once per watcher tick
+ * (dirigible #6827). The watcher re-collects the registry every five seconds purely to compare the
+ * declaration fingerprint, so a diagnostic emitted by the collection itself repeats forever on an
+ * unmodified instance - which trains operators to ignore the log and buries the real dependency
+ * problems.
+ */
+class DeclarationReportingTest {
+
+    private IRepository repository;
+
+    private ProjectDependenciesCollector collector;
+
+    @BeforeEach
+    void setUp(@TempDir Path root) {
+        repository = new LocalRepository(root.toString(), true);
+        collector = new ProjectDependenciesCollector(repository);
+    }
+
+    @Test
+    void an_unknown_dependency_type_is_logged_once_across_repeated_collections() {
+        declare("my-project", """
+                { "guid": "my-project", "dependencies": [ { "type": "npm", "id": "left-pad@1.3.0" } ] }
+                """);
+
+        try (LogCaptor logCaptor = LogCaptor.forClass(ProjectDependenciesCollector.class)) {
+            collector.collect();
+            collector.collect();
+            collector.collect();
+
+            assertThat(logCaptor.getWarnLogs()).singleElement()
+                                               .satisfies(message -> assertThat(message).contains("npm")
+                                                                                        .contains("my-project"));
+        }
+    }
+
+    @Test
+    void a_changed_declaration_is_logged_again() {
+        declare("my-project", """
+                { "guid": "my-project", "dependencies": [ { "type": "npm", "id": "left-pad@1.3.0" } ] }
+                """);
+
+        try (LogCaptor logCaptor = LogCaptor.forClass(ProjectDependenciesCollector.class)) {
+            collector.collect();
+            declare("my-project", """
+                    { "guid": "my-project", "dependencies": [ { "type": "gem", "id": "rails" } ] }
+                    """);
+            collector.collect();
+
+            assertThat(logCaptor.getWarnLogs()).hasSize(2);
+            assertThat(logCaptor.getWarnLogs()
+                                .get(1)).contains("gem");
+        }
+    }
+
+    @Test
+    void a_declaration_error_is_logged_once_across_repeated_collections() {
+        declare("my-project", """
+                { "guid": "my-project", "dependencies": [ { "type": "maven", "id": "com.example:widget:[1.0,2.0)" } ] }
+                """);
+
+        try (LogCaptor logCaptor = LogCaptor.forClass(ProjectDependenciesCollector.class)) {
+            collector.collect();
+            collector.collect();
+
+            assertThat(logCaptor.getErrorLogs()).singleElement()
+                                                .satisfies(message -> assertThat(message).contains("com.example:widget:[1.0,2.0)"));
+        }
+    }
+
+    @Test
+    void a_typeless_project_dependency_never_reports() {
+        // the form the shipped platform templates carry - a plain project reference that predates
+        // typed dependencies
+        declare("template-application-rest-java", """
+                { "guid": "template-application-rest-java",
+                  "dependencies": [ { "guid": "template-application-dao-java" } ], "actions": [] }
+                """);
+
+        try (LogCaptor logCaptor = LogCaptor.forClass(ProjectDependenciesCollector.class)) {
+            collector.collect();
+            collector.collect();
+
+            assertThat(logCaptor.getWarnLogs()).isEmpty();
+            assertThat(logCaptor.getErrorLogs()).isEmpty();
+        }
+    }
+
+    /**
+     * Writes a project.json into the registry.
+     *
+     * @param project the project name
+     * @param descriptor the project.json content
+     */
+    private void declare(String project, String descriptor) {
+        repository.createResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + project + "/project.json",
+                descriptor.getBytes(StandardCharsets.UTF_8), false, "application/json", true);
+    }
+}

--- a/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/ProjectMetadataParsingTest.java
+++ b/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/ProjectMetadataParsingTest.java
@@ -9,8 +9,8 @@
  */
 package org.eclipse.dirigible.components.dependencies;
 
-import nl.altindag.log.LogCaptor;
 import org.eclipse.dirigible.components.dependencies.MavenDependency.Scope;
+import org.eclipse.dirigible.components.dependencies.ProjectDependenciesCollector.Notice;
 import org.eclipse.dirigible.components.project.ProjectMetadata;
 import org.eclipse.dirigible.components.project.ProjectMetadataDependency;
 import org.eclipse.dirigible.components.project.ProjectMetadataUtils;
@@ -101,13 +101,15 @@ class ProjectMetadataParsingTest {
         Map<String, String> errors = new LinkedHashMap<>();
         Map<String, Set<String>> declaredBy = new LinkedHashMap<>();
 
-        try (LogCaptor logCaptor = LogCaptor.forClass(ProjectDependenciesCollector.class)) {
-            ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies, errors,
-                    declaredBy);
+        List<Notice> notices = ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies,
+                errors, declaredBy);
 
-            assertThat(logCaptor.getWarnLogs()).anySatisfy(message -> assertThat(message).contains("npm")
-                                                                                         .contains("my-project"));
-        }
+        assertThat(notices).singleElement()
+                           .satisfies(notice -> {
+                               assertThat(notice.error()).isFalse();
+                               assertThat(notice.message()).contains("npm")
+                                                           .contains("my-project");
+                           });
         assertThat(dependencies).isEmpty();
         assertThat(errors).isEmpty();
     }
@@ -126,13 +128,11 @@ class ProjectMetadataParsingTest {
         Map<String, String> errors = new LinkedHashMap<>();
         Map<String, Set<String>> declaredBy = new LinkedHashMap<>();
 
-        try (LogCaptor logCaptor = LogCaptor.forClass(ProjectDependenciesCollector.class)) {
-            ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies, errors,
-                    declaredBy);
+        List<Notice> notices = ProjectDependenciesCollector.collectDeclared("my-project", ProjectMetadataUtils.fromJson(json), dependencies,
+                errors, declaredBy);
 
-            // the watcher re-collects every few seconds - a legacy guid entry must not spam the log
-            assertThat(logCaptor.getWarnLogs()).isEmpty();
-        }
+        // the watcher re-collects every few seconds - a legacy guid entry must not spam the log
+        assertThat(notices).isEmpty();
         assertThat(dependencies).isEmpty();
         assertThat(errors).isEmpty();
         assertThat(declaredBy).isEmpty();

--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/project.json
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/project.json
@@ -1,9 +1,5 @@
 {
     "guid": "template-application-rest-java",
-    "dependencies": [
-        {
-            "guid": "template-application-dao-java"
-        }
-    ],
+    "dependencies": [],
     "actions": []
 }


### PR DESCRIPTION
Fixes #6827.

## The defect

`DependenciesWatcher` re-collects the registry's `project.json` declarations every five seconds (a `fixedDelay` tick) purely to compare a cheap fingerprint — and `ProjectDependenciesCollector` logged its diagnostics as it collected. So any declaration the platform ignores (an unknown `type`) or cannot resolve (a `maven` entry with no `id`, a version range) re-logged **forever** on an unmodified instance.

A log line that repeats every five seconds is worse than no log line: it trains operators to ignore the log and buries the real dependency problems. That, not the wording of any single message, is what this fixes.

The first half of the issue — the legacy guid-only entry falling into the unknown-type branch — landed in #6910; this is the rest of the acceptance criteria.

## The change

`collectDeclared` now **returns** its diagnostics as data (`Notice(error, message, cause)`) instead of logging them, and `collect()` logs the set only when it differs from the previous collection's:

```java
private void report(List<Notice> notices) {
    String signature = notices.stream().map(Notice::message).collect(Collectors.joining("\n"));
    if (signature.equals(reported.getAndSet(signature))) {
        return;
    }
    notices.forEach(notice -> notice.log(LOGGER));
}
```

Once per declaration change, from whichever caller (boot resolution, the watcher, `POST /resolve`) collects first. The message is materialized rather than left as an SLF4J format because it doubles as the change-detection key; the throwable still travels with the notice, so every diagnostic that has a cause still logs its stack trace.

**Why the gate is keyed on the diagnostics and not on the declaration fingerprint:** an ignored declaration contributes nothing to `DeclaredDependencies.fingerprint()`, so a newly added `type: npm` entry would have been *silent* rather than merely *unrepeated* — a regression in diagnosability dressed up as a fix. Keyed on the notices, adding one warns exactly once and changing it warns again.

## The shipped descriptor

`template-application-rest-java/project.json` declared a dependency it does not have:

```json
"dependencies": [ { "guid": "template-application-dao-java" } ]
```

The template composes the DAO template through a JavaScript import in `template/template.js`; nothing reads that descriptor entry (the only consumer of a guid-only entry is `CloneCommand`, which would try to clone a null URL), and every sibling composite template — schema, UI-harmonia, angular — declares none. Corrected to `[]`. The typeless form itself stays silently tolerated per #6910, since it is valid legacy content in user projects.

## Tests

New `DeclarationReportingTest` drives the real collector against a `LocalRepository` registry — the watcher's actual scenario:

- an unknown type across three collections → **one** warn log
- the declaration then changed to a different unknown type → a **second** warn log
- a version-range `maven` entry across two collections → **one** error log
- the shipped typeless project reference across two collections → **no** warn, **no** error

`ProjectMetadataParsingTest` asserts on the returned notices instead of the log, keeping the parse-level contract where it belongs.

## Verification

- `mvn -pl components/core/core-dependencies test` — 43 tests, green
- `mvn -pl components/core/core-dependencies formatter:validate` — clean
- `mvn -pl components/core/core-dependencies -P release ... install` — javadoc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)