### PR TITLE
feat(intent): a balance report can bucket turnovers by the corresponding account (#6908)

### DIFF
--- a/components/engine/engine-intent/README.md
+++ b/components/engine/engine-intent/README.md
@@ -556,6 +556,14 @@ reports:
     credit: credit
     dimensions: [account.code, account.name]
     filter: "journalEntry.status == 2"
+  - name: GeneralLedger
+    kind: balance
+    source: JournalEntryItem
+    date: journalEntry.entryDate              # its first hop is the document the lines share
+    debit: debit
+    credit: credit
+    dimensions: [account.code, account.name]
+    correspondence: account.code              # turnovers per corresponding account, allocated
 ```
 
 In `filter:`, reference relations via `relation.field` (translated to a JOIN); a bare relation

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/report/ReportIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/report/ReportIntentGenerator.java
@@ -162,6 +162,30 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
     /** A translation table is joined leniently - a row without a translation keeps its base value. */
     private static final String LANGUAGE_JOIN_TYPE = "LEFT";
 
+    /**
+     * The alias suffix of every table the {@code correspondence} axis joins - the counter-side line
+     * itself and whatever its bucket path resolves through. The same entity is joined twice in such a
+     * query (the line's own account AND the account it corresponded with), so without the suffix the
+     * second join would collide with the first on its alias and be dropped.
+     */
+    private static final String CORRESPONDENT_SUFFIX = "Correspondent";
+
+    /** The alias suffix of the correlated subquery that totals the document's counter side. */
+    private static final String DOCUMENT_TOTAL_SUFFIX = "DocumentTotal";
+
+    /**
+     * The correspondence axis is joined leniently - a line whose document has nothing on the counter
+     * side keeps its row (and its turnover) in one empty bucket.
+     */
+    private static final String CORRESPONDENCE_JOIN_TYPE = "LEFT";
+
+    /**
+     * The type the proportional allocation computes in. The cast is what makes the share a fraction:
+     * with {@code integer} debit/credit columns, {@code counter / total} would be integer division and
+     * truncate every allocated amount to zero.
+     */
+    private static final String ALLOCATION_TYPE = "DECIMAL(34,12)";
+
     /** The SQL type of a date-valued report parameter - a date picker on the report page. */
     private static final String DATE_TYPE = "DATE";
 
@@ -288,7 +312,7 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
         }
         StatementQuery statementQuery = null;
         if (balance) {
-            addBalanceMeasures(context, model, source, baseAlias, report, joins, columns);
+            addBalanceMeasures(context, model, source, baseAlias, baseTable, report, joins, columns);
         } else if (statement) {
             // The ledger references are resolved (and their joins registered) BEFORE the filter's, so
             // the emitted FROM introduces the statement's own tables first - the order the balance
@@ -472,31 +496,162 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
     }
 
     private static void addBalanceMeasures(IntentGenerationContext context, IntentModel model, EntityIntent source, String baseAlias,
-            ReportIntent report, Map<String, Join> joins, List<Map<String, Object>> columns) {
+            String baseTable, ReportIntent report, Map<String, Join> joins, List<Map<String, Object>> columns) {
         ColumnRef date = resolve(context, model, source, baseAlias, report.getDate()
                                                                           .trim());
         registerJoin(joins, date);
+        // The parser has already established that both amounts are fields of the SOURCE, so both sit on
+        // the base alias - which is what lets the correspondence axis qualify the same physical columns
+        // on the counter-side line below.
         ColumnRef debit = resolve(context, model, source, baseAlias, report.getDebit()
                                                                            .trim());
         registerJoin(joins, debit);
         ColumnRef credit = resolve(context, model, source, baseAlias, report.getCredit()
                                                                             .trim());
         registerJoin(joins, credit);
+        String debitAmount = "COALESCE(" + debit.qualified() + ", 0)";
+        String creditAmount = "COALESCE(" + credit.qualified() + ", 0)";
+        // The correspondence axis (the general ledger's "in correspondence with"): the counter-side
+        // lines of the same document become an extra grouping dimension, and each amount is allocated
+        // across them. It goes in BEFORE the totals so the dimension column precedes them in the
+        // SELECT, and its self-join precedes the joins its bucket path hangs off.
+        String correspondent = correspondenceAxis(context, model, source, baseAlias, baseTable, report, debit, credit, joins, columns);
+        if (correspondent != null) {
+            String counterDebit = "COALESCE(" + correspondent + "." + quote(debit.physicalColumn) + ", 0)";
+            String counterCredit = "COALESCE(" + correspondent + "." + quote(credit.physicalColumn) + ", 0)";
+            String documentDebit = documentTotal(source, baseAlias, baseTable, report, debit);
+            String documentCredit = documentTotal(source, baseAlias, baseTable, report, credit);
+            // A debit line corresponds with the CREDIT side of its document, so its share of a bucket is
+            // that bucket's credit over the document's total credit - and vice versa.
+            debitAmount = allocated(debitAmount, counterCredit, documentCredit);
+            creditAmount = allocated(creditAmount, counterDebit, documentDebit);
+        }
         String opening = date.qualified() + " < :fromDate";
         String period = date.qualified() + " >= :fromDate AND " + date.qualified() + " <= :toDate";
         String closing = date.qualified() + " <= :toDate";
-        addBalanceColumn(columns, debit, opening, "Opening Debit");
-        addBalanceColumn(columns, credit, opening, "Opening Credit");
-        addBalanceColumn(columns, debit, period, "Debit");
-        addBalanceColumn(columns, credit, period, "Credit");
-        addBalanceColumn(columns, debit, closing, "Closing Debit");
-        addBalanceColumn(columns, credit, closing, "Closing Credit");
+        addBalanceColumn(columns, debit, opening, debitAmount, "Opening Debit");
+        addBalanceColumn(columns, credit, opening, creditAmount, "Opening Credit");
+        addBalanceColumn(columns, debit, period, debitAmount, "Debit");
+        addBalanceColumn(columns, credit, period, creditAmount, "Credit");
+        addBalanceColumn(columns, debit, closing, debitAmount, "Closing Debit");
+        addBalanceColumn(columns, credit, closing, creditAmount, "Closing Credit");
     }
 
-    private static void addBalanceColumn(List<Map<String, Object>> columns, ColumnRef amount, String window, String alias) {
+    /**
+     * Register the {@code correspondence} self-join and emit its grouping column.
+     *
+     * <p>
+     * The counter-side account is NOT reachable from the source row - it sits on a sibling line of the
+     * same journal entry - so the axis is a self-join of the source table on the document the lines
+     * share, keyed by the FK of the first hop of {@code date}. The pairing is restricted to the
+     * OPPOSITE side (a debit line pairs with the credit lines and vice versa) so no bucket is emitted
+     * for a same-side sibling, and the line itself is excluded by primary key.
+     *
+     * <p>
+     * The join is LEFT on purpose: a document with nothing on the counter side (a single-line opening
+     * entry) would otherwise drop out of the report entirely, and its turnover would go missing from a
+     * report whose whole promise is that it reconciles with the plain balance. Such a line keeps one
+     * row with an empty bucket, and {@link #allocated} gives it the full amount.
+     *
+     * @return the alias of the counter-side line, or null when the report declares no correspondence
+     *         (or its document relation cannot be resolved)
+     */
+    private static String correspondenceAxis(IntentGenerationContext context, IntentModel model, EntityIntent source, String baseAlias,
+            String baseTable, ReportIntent report, ColumnRef debit, ColumnRef credit, Map<String, Join> joins,
+            List<Map<String, Object>> columns) {
+        if (!report.hasCorrespondence()) {
+            return null;
+        }
+        String documentColumn = documentColumn(source, report);
+        if (documentColumn == null) {
+            LOGGER.warn("Balance report [{}] declares correspondence but its date [{}] does not go through a to-one relation of [{}]"
+                    + " - the correspondence axis is skipped", report.getName(), report.getDate(), source.getName());
+            return null;
+        }
+        String correspondent = source.getName() + CORRESPONDENT_SUFFIX;
+        String keyColumn = keyColumn(source);
+        String baseDebit = "COALESCE(" + debit.qualified() + ", 0)";
+        String baseCredit = "COALESCE(" + credit.qualified() + ", 0)";
+        String counterDebit = "COALESCE(" + correspondent + "." + quote(debit.physicalColumn) + ", 0)";
+        String counterCredit = "COALESCE(" + correspondent + "." + quote(credit.physicalColumn) + ", 0)";
+        String on = correspondent + "." + quote(documentColumn) + " = " + baseAlias + "." + quote(documentColumn) + " AND " + correspondent
+                + "." + quote(keyColumn) + " <> " + baseAlias + "." + quote(keyColumn) + " AND ((" + baseDebit + " <> 0 AND "
+                + counterCredit + " <> 0) OR (" + baseCredit + " <> 0 AND " + counterDebit + " <> 0))";
+        joins.putIfAbsent(correspondent, new Join(baseTable, correspondent, on, CORRESPONDENCE_JOIN_TYPE));
+        String path = report.getCorrespondence()
+                            .trim();
+        ColumnRef bucket = resolve(context, model, source, correspondent, path, CORRESPONDENT_SUFFIX, CORRESPONDENCE_JOIN_TYPE);
+        registerJoin(joins, bucket);
+        columns.add(column(bucket.tableAlias, humanize("correspondent " + path.replace('.', ' ')), bucket.physicalColumn, bucket.reportType,
+                "NONE", true, bucket.translationExpression()));
+        return correspondent;
+    }
+
+    /**
+     * The document's total on the side named by {@code amount}, excluding the line itself - the
+     * denominator of the proportional allocation. A correlated scalar subquery rather than a joined
+     * derived table because the {@code .report} join model holds a plain table name (the editor quotes
+     * it), and a model the editor's builder cannot rebuild would open the report free-style.
+     *
+     * <p>
+     * It sums over ALL siblings, not only the joined ones: a same-side sibling contributes 0 on this
+     * side anyway, so the subquery equals the sum of the buckets the join actually produced - which is
+     * exactly what makes the shares add up to 1. It deliberately carries neither the report filter nor
+     * the lifecycle scope: the denominator is a fact about the document, not about the window.
+     */
+    private static String documentTotal(EntityIntent source, String baseAlias, String baseTable, ReportIntent report, ColumnRef amount) {
+        String alias = source.getName() + DOCUMENT_TOTAL_SUFFIX;
+        String documentColumn = documentColumn(source, report);
+        String keyColumn = keyColumn(source);
+        return "(SELECT SUM(COALESCE(" + alias + "." + quote(amount.physicalColumn) + ", 0)) FROM " + quote(baseTable) + " as " + alias
+                + " WHERE " + alias + "." + quote(documentColumn) + " = " + baseAlias + "." + quote(documentColumn) + " AND " + alias + "."
+                + quote(keyColumn) + " <> " + baseAlias + "." + quote(keyColumn) + ")";
+    }
+
+    /**
+     * The FK column on the source that groups its lines into one document - the first hop of the
+     * balance {@code date}, which is the relation to the journal entry / voucher. Null when the date is
+     * not such a path (the parser rejects that combination; generation only has to stay quiet).
+     */
+    private static String documentColumn(EntityIntent source, ReportIntent report) {
+        String date = report.getDate() == null ? ""
+                : report.getDate()
+                        .trim();
+        int dot = date.indexOf('.');
+        if (dot <= 0) {
+            return null;
+        }
+        RelationIntent relation = relationByName(source, date.substring(0, dot));
+        return relation == null ? null : column(source.getName(), relation.getName());
+    }
+
+    /** The source's primary-key column - how a line is excluded from its own correspondent bucket. */
+    private static String keyColumn(EntityIntent source) {
+        FieldIntent primaryKey = primaryKeyOf(source);
+        return column(source.getName(), primaryKey == null ? "id" : primaryKey.getName());
+    }
+
+    /**
+     * One line's amount allocated over the counter-side buckets of its document: the amount times the
+     * bucket's share ({@code counter / total}) - written as a product BEFORE the division so the result
+     * carries no avoidable rounding.
+     *
+     * <p>
+     * When the document has nothing on the counter side the total is 0 (or NULL, with no siblings at
+     * all), the division is NULL and the whole line falls back to its full amount in the one empty
+     * bucket the LEFT join left it. That fallback is what keeps the promise of this report shape: each
+     * account's totals across its correspondence buckets add up to the figures the plain balance report
+     * shows for the same window.
+     */
+    private static String allocated(String amount, String counter, String total) {
+        return "COALESCE(CAST(" + amount + " AS " + ALLOCATION_TYPE + ") * " + counter + " / NULLIF(" + total + ", 0), " + amount + ")";
+    }
+
+    private static void addBalanceColumn(List<Map<String, Object>> columns, ColumnRef amount, String window, String amountExpression,
+            String alias) {
         // COALESCE the amount: a one-sided ledger line (the exactlyOne debit/credit shape) holds
         // NULL on the other side, and SUM over all-NULL yields NULL instead of the 0 a balance shows.
-        String expression = "CASE WHEN " + window + " THEN COALESCE(" + amount.qualified() + ", 0) ELSE 0 END";
+        String expression = "CASE WHEN " + window + " THEN " + amountExpression + " ELSE 0 END";
         columns.add(column(amount.tableAlias, alias, amount.physicalColumn, "DECIMAL", "SUM", false, expression));
     }
 
@@ -957,6 +1112,18 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
      */
     private static ColumnRef resolve(IntentGenerationContext context, IntentModel model, EntityIntent source, String baseAlias,
             String reference) {
+        return resolve(context, model, source, baseAlias, reference, "", JOIN_TYPE);
+    }
+
+    /**
+     * Resolve a reference against {@code baseAlias}, aliasing every table it joins with
+     * {@code aliasSuffix} and joining it with {@code joinType}. Both are empty/INNER for an ordinary
+     * dimension; the correspondence axis resolves the same paths a second time against the counter-side
+     * line, where the suffix keeps the two sets of aliases apart and LEFT keeps a line whose document
+     * has no counter side.
+     */
+    private static ColumnRef resolve(IntentGenerationContext context, IntentModel model, EntityIntent source, String baseAlias,
+            String reference, String aliasSuffix, String joinType) {
         ColumnRef ref = new ColumnRef();
         int dot = reference.indexOf('.');
         if (dot > 0 && source != null) {
@@ -965,15 +1132,16 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
             RelationIntent relation = relationByName(source, relationName);
             if (relation != null && relation.getTo() != null) {
                 EntityIntent target = entityByName(model, relation.getTo());
-                String targetAlias = relation.getTo();
+                String targetName = relation.getTo();
+                String targetAlias = targetName + aliasSuffix;
                 ref.tableAlias = targetAlias;
-                ref.physicalColumn = column(targetAlias, fieldName);
+                ref.physicalColumn = column(targetName, fieldName);
                 FieldIntent targetField = fieldByName(target, fieldName);
                 // A cross-model target's fields are not in this model; string is the safe display type.
                 ref.reportType = targetField == null ? "CHARACTER VARYING" : reportType(targetField.getType());
                 ref.nullable = targetField == null || !targetField.isRequired();
                 ref.displayAlias = humanize(reference.replace('.', ' '));
-                ref.join = join(context, model, source, relation, target, targetAlias, baseAlias);
+                ref.join = join(context, model, source, relation, target, targetName, targetAlias, baseAlias, joinType);
                 translate(context, ref, target, crossModelInfo(context, model, relation), fieldName);
                 return ref;
             }
@@ -996,16 +1164,17 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
         if (relation != null && relation.getTo() != null
                 && ("manyToOne".equals(relation.getKind()) || "oneToOne".equals(relation.getKind()))) {
             EntityIntent target = entityByName(model, relation.getTo());
-            String targetAlias = relation.getTo();
+            String targetName = relation.getTo();
+            String targetAlias = targetName + aliasSuffix;
             // A cross-model target's label comes from the resolved owner model (its Name-like field).
             CrossModelSupport.TargetInfo info = crossModelInfo(context, model, relation);
             String labelField = info != null ? info.labelField() : labelFieldName(target);
             FieldIntent labeled = fieldByName(target, labelField);
             ref.tableAlias = targetAlias;
-            ref.physicalColumn = column(targetAlias, labelField);
+            ref.physicalColumn = column(targetName, labelField);
             ref.reportType = info != null ? "CHARACTER VARYING" : reportType(labeled == null ? null : labeled.getType());
             ref.displayAlias = humanize(reference);
-            ref.join = join(context, model, source, relation, target, targetAlias, baseAlias);
+            ref.join = join(context, model, source, relation, target, targetName, targetAlias, baseAlias, joinType);
             // The label of a multilingual nomenclature is exactly the value a list page shows
             // translated - this is the column the issue was raised about (dirigible #6544).
             translate(context, ref, target, info, labelField);
@@ -1066,8 +1235,10 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
         }
         String alias = ref.tableAlias + LANGUAGE_TABLE_SUFFIX;
         ref.languageColumn = property;
-        ref.languageJoin = new Join(table + LANGUAGE_TABLE_SUFFIX, alias, alias + "." + quote(LANGUAGE_ID_COLUMN) + " = " + ref.tableAlias
-                + "." + quote(keyColumn) + " AND " + alias + "." + quote(LANGUAGE_CODE_COLUMN) + " = " + LANGUAGE_PARAMETER, true);
+        ref.languageJoin = new Join(
+                table + LANGUAGE_TABLE_SUFFIX, alias, alias + "." + quote(LANGUAGE_ID_COLUMN) + " = " + ref.tableAlias + "."
+                        + quote(keyColumn) + " AND " + alias + "." + quote(LANGUAGE_CODE_COLUMN) + " = " + LANGUAGE_PARAMETER,
+                LANGUAGE_JOIN_TYPE);
     }
 
     /**
@@ -1117,20 +1288,27 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
         return "string".equals(t) || "text".equals(t) || "uuid".equals(t);
     }
 
+    /**
+     * The join a {@code relation.field} path needs. {@code targetName} is the target ENTITY - it names
+     * the physical table and prefixes its columns; {@code targetAlias} is only the SQL alias, and the
+     * two differ when the same entity is joined twice in one query (the correspondence axis joins the
+     * dimension's account and the counter-side account of the same document - see
+     * {@link #CORRESPONDENT_SUFFIX}).
+     */
     private static Join join(IntentGenerationContext context, IntentModel model, EntityIntent source, RelationIntent relation,
-            EntityIntent target, String targetAlias, String baseAlias) {
+            EntityIntent target, String targetName, String targetAlias, String baseAlias, String joinType) {
         String fkColumn = quote(column(source.getName(), relation.getName()));
         // A cross-model target's table and primary-key column come from the resolved owner model -
         // this model's intent-prefixed naming would point at a non-existent local table.
         CrossModelSupport.TargetInfo info = crossModelInfo(context, model, relation);
         if (info != null) {
             return new Join(info.tableDataName(), targetAlias,
-                    baseAlias + "." + fkColumn + " = " + targetAlias + "." + quote(info.keyColumn()));
+                    baseAlias + "." + fkColumn + " = " + targetAlias + "." + quote(info.keyColumn()), joinType);
         }
         FieldIntent targetPk = target == null ? null : primaryKeyOf(target);
-        String pkColumn = quote(column(targetAlias, targetPk == null ? "id" : targetPk.getName()));
-        return new Join(IntentNaming.tableName(context, targetAlias), targetAlias,
-                baseAlias + "." + fkColumn + " = " + targetAlias + "." + pkColumn);
+        String pkColumn = quote(column(targetName, targetPk == null ? "id" : targetPk.getName()));
+        return new Join(IntentNaming.tableName(context, targetName), targetAlias,
+                baseAlias + "." + fkColumn + " = " + targetAlias + "." + pkColumn, joinType);
     }
 
     /**
@@ -1251,8 +1429,9 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
             row.put("alias", join.alias);
             row.put("name", join.table);
             // A language join is LEFT: an untranslated row - or a caller with no language at all - must
-            // still appear, carrying the base value the SELECT's COALESCE then falls back to.
-            row.put("type", join.language ? LANGUAGE_JOIN_TYPE : JOIN_TYPE);
+            // still appear, carrying the base value the SELECT's COALESCE then falls back to. So is the
+            // correspondence axis, for the line whose document has nothing on the counter side.
+            row.put("type", join.type);
             row.put("condition", join.on);
             rows.add(row);
         }
@@ -1420,7 +1599,8 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
             if (relation != null && relation.getTo() != null) {
                 EntityIntent target = entityByName(model, relation.getTo());
                 String targetAlias = relation.getTo();
-                joins.putIfAbsent(targetAlias, join(context, model, source, relation, target, targetAlias, baseAlias));
+                joins.putIfAbsent(targetAlias,
+                        join(context, model, source, relation, target, targetAlias, targetAlias, baseAlias, JOIN_TYPE));
                 matcher.appendReplacement(dotted,
                         Matcher.quoteReplacement(targetAlias + "." + quote(column(targetAlias, matcher.group(2)))));
             } else {
@@ -1798,22 +1978,25 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
         }
     }
 
-    /** A join to a related entity's table - INNER, or LEFT for a language table. */
+    /**
+     * A join to another table - INNER by default; LEFT for a language table, and for the correspondent
+     * line of a correspondence balance report.
+     */
     private static final class Join {
         private final String table;
         private final String alias;
         private final String on;
-        private final boolean language;
+        private final String type;
 
         private Join(String table, String alias, String on) {
-            this(table, alias, on, false);
+            this(table, alias, on, JOIN_TYPE);
         }
 
-        private Join(String table, String alias, String on, boolean language) {
+        private Join(String table, String alias, String on, String type) {
             this.table = table;
             this.alias = alias;
             this.on = on;
-            this.language = language;
+            this.type = type;
         }
     }
 }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/ReportIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/ReportIntent.java
@@ -44,6 +44,22 @@ public class ReportIntent {
     /** {@code kind: balance}: the numeric source field holding the credit amount. */
     private String credit;
     /**
+     * {@code kind: balance}: an extra grouping dimension that buckets each ledger line by the accounts
+     * on the OPPOSITE side of the same document - the general ledger's "in correspondence with" axis
+     * (e.g. account 411's debit turnover split by the credit accounts it corresponded with). The
+     * correspondent line is a sibling row of the source, so this resolves like a dimension but against
+     * that sibling: a field of the source, a {@code relation.field} path or a bare to-one relation.
+     *
+     * <p>
+     * The document the lines share is the first hop of {@link #date} - the source's to-one relation to
+     * its journal entry / voucher - so a balance report declaring this must take its date over that
+     * relation. A compound entry (M debit lines against N credit lines) is allocated
+     * <b>proportionally</b> by the counter-side amounts, and a line with no counter side at all lands
+     * in one empty bucket, so each account's totals across the correspondence buckets still add up to
+     * the same figures the plain balance report shows for the same window.
+     */
+    private String correspondence;
+    /**
      * {@code kind: statement}: the account-code field the statement groups the ledger by - a
      * {@code string} field of the source or a one-hop {@code relation.field} path to it (e.g.
      * {@code account.code}). It is the code the {@link StatementLineIntent#getAccounts() line
@@ -157,6 +173,19 @@ public class ReportIntent {
 
     public void setCredit(String credit) {
         this.credit = credit;
+    }
+
+    public String getCorrespondence() {
+        return correspondence;
+    }
+
+    public void setCorrespondence(String correspondence) {
+        this.correspondence = correspondence;
+    }
+
+    /** Whether this balance report groups by the correspondent accounts of the same document. */
+    public boolean hasCorrespondence() {
+        return isBalance() && correspondence != null && !correspondence.isBlank();
     }
 
     public String getAccount() {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -6997,6 +6997,18 @@ public final class IntentParser {
                         + reference.name() + "]" + reference.on() + rowAlternative);
             }
         }
+        if (!isBlank(report.getCorrespondence())) {
+            // The correspondence bucket is a dimension read off a sibling line, so a subset relation is
+            // as wrong there as it is on a dimension - it would GROUP BY the stored key list.
+            SubsetReference reference = subsetReferenced(model, source, referencedPath(report.getCorrespondence()));
+            if (reference != null) {
+                issues.add("report [" + report.getName() + "] correspondence [" + report.getCorrespondence()
+                                                                                        .trim()
+                        + "] " + (reference.joinedEntity() == null ? "is a subset relation"
+                                : "references the subset relation [" + reference.name() + "]" + reference.on())
+                        + rowAlternative);
+            }
+        }
         if (!isBlank(report.getFilter())) {
             // Identifier tokens not preceded by a dot are the first segments the generator rewrites; the
             // optional second segment is the one-hop path it resolves against the joined entity.
@@ -7419,13 +7431,15 @@ public final class IntentParser {
      * {@code measures} because the six opening / period / closing totals ARE the measures.
      */
     private static void validateBalanceReport(IntentModel model, ReportIntent report, List<String> issues) {
-        boolean balanceInputs = report.getDate() != null || report.getDebit() != null || report.getCredit() != null;
+        boolean balanceInputs =
+                report.getDate() != null || report.getDebit() != null || report.getCredit() != null || report.getCorrespondence() != null;
         boolean statementInputs = report.getAccount() != null || !report.getLines()
                                                                         .isEmpty();
         if (report.getKind() == null || report.getKind()
                                               .isBlank()) {
             if (balanceInputs) {
-                issues.add("report [" + report.getName() + "] declares date/debit/credit but is not kind: balance or kind: statement");
+                issues.add("report [" + report.getName()
+                        + "] declares date/debit/credit/correspondence but is not kind: balance or kind: statement");
             }
             if (statementInputs) {
                 issues.add("report [" + report.getName() + "] declares account/lines but is not kind: statement");
@@ -7450,6 +7464,11 @@ public final class IntentParser {
                       .anyMatch(d -> d != null && !d.isBlank())) {
                 issues.add(prefix + " must not declare dimensions - its rows are the declared lines");
             }
+            if (report.getCorrespondence() != null) {
+                // Correspondence buckets one account's turnover by the accounts it faced; a statement has
+                // no account axis to bucket - its rows are the declared lines.
+                issues.add(prefix + " must not declare correspondence - the general ledger axis belongs to kind: balance");
+            }
         } else {
             if (report.getDimensions()
                       .stream()
@@ -7471,6 +7490,9 @@ public final class IntentParser {
             return; // the missing/unknown source is already reported
         }
         validateBalanceDate(model, source, report, issues, prefix);
+        if (!report.isStatement()) {
+            validateBalanceCorrespondence(model, source, report, issues, prefix);
+        }
         requireNumericBalanceField(source, report.getDebit(), "debit", issues, prefix);
         requireNumericBalanceField(source, report.getCredit(), "credit", issues, prefix);
         if (report.isStatement()) {
@@ -7485,6 +7507,65 @@ public final class IntentParser {
      * is the code the line selectors match with, so a numeric or date field cannot carry it, and a
      * cross-model target is checked at generation like every cross-model reference.
      */
+    /**
+     * {@code correspondence} - the general ledger's "in correspondence with" axis. The bucket is read
+     * off a SIBLING line of the same document, so two things have to hold that a plain dimension never
+     * needs: the source must reach its document (the first hop of {@code date}, which is where the
+     * sibling grouping key comes from) and it must have a primary key (a line does not correspond with
+     * itself, and self-exclusion is by key). The path itself resolves against the source entity - the
+     * sibling is another row of it - so it is checked exactly like a dimension.
+     */
+    private static void validateBalanceCorrespondence(IntentModel model, EntityIntent source, ReportIntent report, List<String> issues,
+            String prefix) {
+        String reference = report.getCorrespondence();
+        if (reference == null) {
+            return;
+        }
+        if (reference.isBlank()) {
+            issues.add(prefix + " correspondence is empty - name the path bucketing the counter-side lines,"
+                    + " e.g. correspondence: Account.number");
+            return;
+        }
+        reference = reference.trim();
+        String date = report.getDate() == null ? ""
+                : report.getDate()
+                        .trim();
+        int dateDot = date.indexOf('.');
+        if (dateDot <= 0 || toOneRelation(source, date.substring(0, dateDot)) == null) {
+            issues.add(prefix + " correspondence needs the document its lines share, which is the first hop of date - so date ["
+                    + report.getDate() + "] must be a <relation>.<field> path over a to-one relation of [" + source.getName()
+                    + "] to its journal entry / voucher");
+        }
+        if (source.getFields()
+                  .stream()
+                  .noneMatch(FieldIntent::isPrimaryKey)) {
+            issues.add(prefix + " correspondence needs a primaryKey on [" + source.getName()
+                    + "] - a line is excluded from its own correspondent bucket by key");
+        }
+        int dot = reference.indexOf('.');
+        if (dot > 0) {
+            String relationName = reference.substring(0, dot);
+            RelationIntent relation = toOneRelation(source, relationName);
+            if (relation == null) {
+                issues.add(
+                        prefix + " correspondence [" + reference + "] does not start with a to-one relation of [" + source.getName() + "]");
+                return;
+            }
+            if (relation.isCrossModel()) {
+                return; // like every cross-model reference, resolved at generation
+            }
+            EntityIntent target = entityByName(model, relation.getTo());
+            if (target != null && fieldByName(target, reference.substring(dot + 1)) == null) {
+                issues.add(prefix + " correspondence [" + reference + "] does not resolve to a field of [" + relation.getTo() + "]");
+            }
+            return;
+        }
+        if (fieldByName(source, reference) == null && toOneRelation(source, reference) == null) {
+            issues.add(
+                    prefix + " correspondence [" + reference + "] is neither a field nor a to-one relation of [" + source.getName() + "]");
+        }
+    }
+
     private static void validateStatementAccount(IntentModel model, EntityIntent source, ReportIntent report, List<String> issues,
             String prefix) {
         String reference = report.getAccount();

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -1918,6 +1918,46 @@ must be numeric fields of the source; at least one dimension; `measures` must be
 posted entries with a `filter` on the source's (or its master's) status FK — the report itself does
 not filter.
 
+##### correspondence - turnovers per corresponding account (the general ledger)
+
+**Use when:** the user needs the double-entry **general ledger** (главна книга) rather than the trial
+balance — per account, the turnover split by the accounts on the OPPOSITE side of the same document
+(account 411 Customers' debit turnover in correspondence with 702 Revenue and 4532 VAT on sales).
+
+```yaml
+reports:
+  - name: GeneralLedger
+    kind: balance
+    source: JournalEntryItem
+    date: journalEntry.entryDate           # its FIRST HOP is the document the lines share
+    debit: debit
+    credit: credit
+    dimensions: [account.code, account.name]
+    correspondence: account.code           # bucket the counter-side lines of the same entry by this
+    filter: "journalEntry.status == 2"
+```
+
+The correspondent account is not on the source row — it sits on a **sibling line of the same journal
+entry** — so `correspondence` is resolved a second time against that sibling and added as one more
+grouping dimension (`Correspondent Account Code`). It takes the same shapes a dimension does: a field
+of the source, a `relation.field` path, or a bare to-one relation. The document the lines share is
+the **first hop of `date`**, which is why a correspondence report must take its date over the
+relation to its journal entry / voucher rather than off a line-local date column.
+
+Amounts are allocated **proportionally**: a debit line's share of a bucket is that bucket's credit
+over the document's total credit, and the mirror image for a credit line. A simple entry (one line on
+at least one side) therefore attributes its full amount to the single counter-account, a compound
+entry (M debit lines against N credit lines) splits it by the counter-side amounts, and a line whose
+document has nothing on the counter side keeps its full amount in one **empty bucket** rather than
+disappearing. So each account's totals across its correspondence buckets add up to exactly the
+figures the plain balance report shows for the same window — that reconciliation is the property to
+check when in doubt.
+
+**Rules:** `correspondence` belongs to `kind: balance` only — a `kind: statement` report has no
+account axis to bucket (its rows are the declared lines) and declaring it there is an error. The
+source needs a `primaryKey` (a line is excluded from its own bucket by key), and a subset relation is
+as wrong here as it is on a dimension.
+
 #### reports[].kind: statement - the statutory financial statement
 
 **Use when:** the user needs a balance sheet, an income statement, or any other fixed line structure

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/report/CorrespondenceReconciliationTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/report/CorrespondenceReconciliationTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator.report;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.intent.generator.TestContexts;
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.parser.IntentParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The property the correspondence axis exists to keep, checked by RUNNING the generated SQL: each
+ * account's turnover summed across its correspondence buckets equals what the plain balance report
+ * shows for the same window. A general ledger that does not reconcile with the trial balance is
+ * worse than no general ledger, and the allocation arithmetic is the one part of this shape a
+ * string assertion cannot vouch for.
+ *
+ * <p>
+ * The ledger below is the four cases that matter: a simple entry (one line on each side), a
+ * compound one (one debit line against two credit lines - the proportional split), a fully compound
+ * one (two debit lines against two credit lines, where both sides are allocated at once), and a
+ * one-sided entry with no counter side at all (the empty bucket the LEFT join keeps).
+ */
+class CorrespondenceReconciliationTest {
+
+    private static final String LEDGER = """
+            name: ledger
+            entities:
+              - name: Account
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: code, type: string }
+              - name: JournalEntry
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: entryDate, type: date }
+                relations:
+                  - { name: items, kind: oneToMany, to: JournalEntryItem }
+              - name: JournalEntryItem
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: debit, type: decimal }
+                  - { name: credit, type: decimal }
+                relations:
+                  - { name: journalEntry, kind: manyToOne, to: JournalEntry, composition: true }
+                  - { name: account, kind: manyToOne, to: Account, required: true }
+            reports:
+              - name: Ledger
+                kind: balance
+                source: JournalEntryItem
+                date: journalEntry.entryDate
+                debit: debit
+                credit: credit
+                dimensions: [account.code]
+                #EXTRA#
+            """;
+
+    private static final String DDL = """
+            CREATE TABLE "LEDGER_ACCOUNT" ("ACCOUNT_ID" INTEGER PRIMARY KEY, "ACCOUNT_CODE" VARCHAR(20));
+            CREATE TABLE "LEDGER_JOURNAL_ENTRY" ("JOURNAL_ENTRY_ID" INTEGER PRIMARY KEY, "JOURNAL_ENTRY_ENTRY_DATE" DATE);
+            CREATE TABLE "LEDGER_JOURNAL_ENTRY_ITEM" ("JOURNAL_ENTRY_ITEM_ID" INTEGER PRIMARY KEY,
+                "JOURNAL_ENTRY_ITEM_DEBIT" DECIMAL(18,2), "JOURNAL_ENTRY_ITEM_CREDIT" DECIMAL(18,2),
+                "JOURNAL_ENTRY_ITEM_JOURNAL_ENTRY" INTEGER, "JOURNAL_ENTRY_ITEM_ACCOUNT" INTEGER);
+            INSERT INTO "LEDGER_ACCOUNT" VALUES (1, '411'), (2, '702'), (3, '4532'), (4, '412');
+            INSERT INTO "LEDGER_JOURNAL_ENTRY" VALUES (1, DATE '2026-03-01'), (2, DATE '2026-03-02'), (3, DATE '2026-03-03'),
+                (4, DATE '2026-03-04');
+            -- entry 1, simple: 411 debit 100 against 702 credit 100
+            INSERT INTO "LEDGER_JOURNAL_ENTRY_ITEM" VALUES (1, 100, NULL, 1, 1), (2, NULL, 100, 1, 2);
+            -- entry 2, compound: 411 debit 300 against 702 credit 200 and 4532 credit 100
+            INSERT INTO "LEDGER_JOURNAL_ENTRY_ITEM" VALUES (3, 300, NULL, 2, 1), (4, NULL, 200, 2, 2), (5, NULL, 100, 2, 3);
+            -- entry 3, one-sided: 411 debit 50 with nothing on the counter side
+            INSERT INTO "LEDGER_JOURNAL_ENTRY_ITEM" VALUES (6, 50, NULL, 3, 1);
+            -- entry 4, M against N: 411 debit 60 and 412 debit 40 against 702 credit 70 and 4532 credit 30
+            INSERT INTO "LEDGER_JOURNAL_ENTRY_ITEM" VALUES (7, 60, NULL, 4, 1), (8, 40, NULL, 4, 4),
+                (9, NULL, 70, 4, 2), (10, NULL, 30, 4, 3);
+            """;
+
+    @Test
+    void everyAccountsBucketsAddUpToItsPlainBalance() throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:correspondence;DB_CLOSE_DELAY=-1", "sa", "");
+                Statement statement = connection.createStatement()) {
+            statement.execute(DDL);
+
+            Map<String, BigDecimal> plain = totalsByAccount(statement, query(""), false);
+            Map<String, BigDecimal> allocated = totalsByAccount(statement, query("correspondence: account.code"), false);
+            assertEquals(plain, allocated, "the correspondence buckets must sum to the plain balance's debit turnover");
+            assertEquals(new BigDecimal("510.00"), plain.get("411"), "the debit turnover of 411 over the window");
+
+            Map<String, BigDecimal> credits = totalsByAccount(statement, query(""), true);
+            assertEquals(credits, totalsByAccount(statement, query("correspondence: account.code"), true),
+                    "and so must the credit turnover");
+
+            // The compound entry splits 411's 300 by the counter-side amounts, the simple one attributes
+            // its 100 whole, the one-sided entry's 50 lands in the empty bucket rather than vanishing, and
+            // entry 4 splits 411's 60 as 42 / 18 - the counter side's own 70:30 proportion.
+            Map<String, BigDecimal> buckets = debitBucketsOf(statement, query("correspondence: account.code"), "411");
+            assertEquals(new BigDecimal("342.00"), buckets.get("702"));
+            assertEquals(new BigDecimal("118.00"), buckets.get("4532"));
+            assertEquals(new BigDecimal("50.00"), buckets.get(null));
+        }
+    }
+
+    private static String query(String extra) {
+        IntentModel model = IntentParser.parse(LEDGER.replace("#EXTRA#", extra));
+        String query = (String) ReportIntentGenerator.buildForTest(TestContexts.context(model), model.getReports()
+                                                                                                     .get(0))
+                                                     .get("query");
+        // The window is a pair of named parameters the generated repository binds; bind them here.
+        return query.replace(":fromDate", "DATE '2026-01-01'")
+                    .replace(":toDate", "DATE '2026-12-31'");
+    }
+
+    /**
+     * The period debit (or credit) turnover per account code, summed over whatever rows the query
+     * emits.
+     */
+    private static Map<String, BigDecimal> totalsByAccount(Statement statement, String query, boolean credit) throws Exception {
+        Map<String, BigDecimal> totals = new LinkedHashMap<>();
+        try (ResultSet rows = statement.executeQuery(query)) {
+            while (rows.next()) {
+                String account = rows.getString("Account Code");
+                BigDecimal amount = rows.getBigDecimal(credit ? "Credit" : "Debit");
+                totals.merge(account, amount.setScale(2, RoundingMode.HALF_UP), BigDecimal::add);
+            }
+        }
+        return totals;
+    }
+
+    /** One account's period debit per correspondence bucket - null keyed for the empty bucket. */
+    private static Map<String, BigDecimal> debitBucketsOf(Statement statement, String query, String account) throws Exception {
+        Map<String, BigDecimal> buckets = new LinkedHashMap<>();
+        try (ResultSet rows = statement.executeQuery(query)) {
+            while (rows.next()) {
+                if (account.equals(rows.getString("Account Code"))) {
+                    buckets.merge(rows.getString("Correspondent Account Code"), rows.getBigDecimal("Debit")
+                                                                                    .setScale(2, RoundingMode.HALF_UP),
+                            BigDecimal::add);
+                }
+            }
+        }
+        return buckets;
+    }
+}

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/report/ReportEditorRoundTripTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/report/ReportEditorRoundTripTest.java
@@ -235,43 +235,79 @@ class ReportEditorRoundTripTest {
                         .toString());
     }
 
+    private static final String LEDGER = """
+            name: ledger
+            entities:
+              - name: Account
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: code, type: string }
+              - name: JournalEntry
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: entryDate, type: date }
+                relations:
+                  - { name: items, kind: oneToMany, to: JournalEntryItem }
+              - name: JournalEntryItem
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: debit, type: decimal }
+                  - { name: credit, type: decimal }
+                relations:
+                  - { name: journalEntry, kind: manyToOne, to: JournalEntry, composition: true }
+                  - { name: account, kind: manyToOne, to: Account, required: true }
+            reports:
+              - name: TrialBalance
+                kind: balance
+                source: JournalEntryItem
+                date: journalEntry.entryDate
+                debit: debit
+                credit: credit
+                dimensions: [account.code]
+                #EXTRA#
+            """;
+
+    private static Map<String, Object> ledgerReport(String extra) {
+        IntentModel model = IntentParser.parse(LEDGER.replace("#EXTRA#", extra));
+        return ReportIntentGenerator.buildForTest(TestContexts.context(model), model.getReports()
+                                                                                    .get(0));
+    }
+
     /** The balance windows are expressions too, so the accounting reports round-trip as well. */
     @Test
     void aBalanceReportRoundTrips() {
-        IntentModel model = IntentParser.parse("""
-                name: ledger
-                entities:
-                  - name: Account
-                    fields:
-                      - { name: id, type: integer, primaryKey: true, generated: true }
-                      - { name: code, type: string }
-                  - name: JournalEntry
-                    fields:
-                      - { name: id, type: integer, primaryKey: true, generated: true }
-                      - { name: entryDate, type: date }
-                    relations:
-                      - { name: items, kind: oneToMany, to: JournalEntryItem }
-                  - name: JournalEntryItem
-                    fields:
-                      - { name: id, type: integer, primaryKey: true, generated: true }
-                      - { name: debit, type: decimal }
-                      - { name: credit, type: decimal }
-                    relations:
-                      - { name: journalEntry, kind: manyToOne, to: JournalEntry, composition: true }
-                      - { name: account, kind: manyToOne, to: Account, required: true }
-                reports:
-                  - name: TrialBalance
-                    kind: balance
-                    source: JournalEntryItem
-                    date: journalEntry.entryDate
-                    debit: debit
-                    credit: credit
-                    dimensions: [account.code]
-                """);
-        Map<String, Object> document = ReportIntentGenerator.buildForTest(TestContexts.context(model), model.getReports()
-                                                                                                            .get(0));
+        Map<String, Object> document = ledgerReport("");
         assertRoundTrips(document);
         assertEquals(2, joins(document).size());
+    }
+
+    /**
+     * The general ledger's correspondence axis is the one report shape that joins a table to ITSELF and
+     * hangs a second copy of a dimension's join off that - all of it through the same {@code joins}
+     * rows and column {@code expression}s, so the builder still owns the query.
+     */
+    @Test
+    void aCorrespondenceBalanceReportRoundTrips() {
+        Map<String, Object> document = ledgerReport("correspondence: account.code");
+        assertRoundTrips(document);
+
+        List<Map<String, Object>> joins = joins(document);
+        assertEquals(4, joins.size());
+        Map<String, Object> self = joins.get(2);
+        assertEquals("JournalEntryItemCorrespondent", self.get("alias"));
+        assertEquals("LEDGER_JOURNAL_ENTRY_ITEM", self.get("name"));
+        // LEFT, so a document with nothing on the counter side keeps its line - and its turnover.
+        assertEquals("LEFT", self.get("type"));
+        // The self-join must be introduced BEFORE the join that hangs off its alias.
+        assertEquals("AccountCorrespondent", joins.get(3)
+                                                  .get("alias"));
+        assertEquals("LEFT", joins.get(3)
+                                  .get("type"));
+        assertNotEquals(joins.get(0)
+                             .get("alias"),
+                joins.get(3)
+                     .get("alias"),
+                "the two copies of the account join must not share an alias, or one of them is dropped");
     }
 
     /**

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/report/ReportIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/report/ReportIntentGeneratorTest.java
@@ -235,6 +235,102 @@ class ReportIntentGeneratorTest {
         assertTrue(!query.contains(" Status "), query);
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    void correspondenceBucketsTheCounterSideOfTheSameDocumentAndAllocatesProportionally() {
+        IntentModel model = IntentParser.parse(GENERAL_LEDGER_INTENT);
+        Map<String, Object> document = ReportIntentGenerator.buildForTest(TestContexts.context(model), model.getReports()
+                                                                                                            .get(0));
+        String query = (String) document.get("query");
+
+        // The counter-side line is a LEFT self-join on the document (the first hop of `date`), with the
+        // line itself excluded by key and the pairing restricted to the opposite side - so no bucket is
+        // emitted for a same-side sibling, and a document with no counter side keeps its row.
+        assertTrue(query.contains(
+                "LEFT JOIN \"LEDGER_JOURNAL_ENTRY_ITEM\" as JournalEntryItemCorrespondent ON JournalEntryItemCorrespondent.\"JOURNAL_ENTRY_ITEM_JOURNAL_ENTRY\" = JournalEntryItem.\"JOURNAL_ENTRY_ITEM_JOURNAL_ENTRY\""
+                        + " AND JournalEntryItemCorrespondent.\"JOURNAL_ENTRY_ITEM_ID\" <> JournalEntryItem.\"JOURNAL_ENTRY_ITEM_ID\""
+                        + " AND ((COALESCE(JournalEntryItem.\"JOURNAL_ENTRY_ITEM_DEBIT\", 0) <> 0 AND COALESCE(JournalEntryItemCorrespondent.\"JOURNAL_ENTRY_ITEM_CREDIT\", 0) <> 0)"
+                        + " OR (COALESCE(JournalEntryItem.\"JOURNAL_ENTRY_ITEM_CREDIT\", 0) <> 0 AND COALESCE(JournalEntryItemCorrespondent.\"JOURNAL_ENTRY_ITEM_DEBIT\", 0) <> 0))"),
+                query);
+        // The bucket path is resolved a SECOND time, against that line - so the account it joins must
+        // carry its own alias, or it would collide with the dimension's account and be dropped.
+        assertTrue(query.contains(
+                "LEFT JOIN \"LEDGER_ACCOUNT\" as AccountCorrespondent ON JournalEntryItemCorrespondent.\"JOURNAL_ENTRY_ITEM_ACCOUNT\" = AccountCorrespondent.\"ACCOUNT_ID\""),
+                query);
+        assertTrue(query.contains("AccountCorrespondent.\"ACCOUNT_CODE\" as \"Correspondent Account Code\""), query);
+        assertTrue(query.contains("GROUP BY Account.\"ACCOUNT_CODE\", Account.\"ACCOUNT_NAME\", AccountCorrespondent.\"ACCOUNT_CODE\""),
+                query);
+
+        // A debit line's share of a bucket is that bucket's CREDIT over the document's total credit
+        // (excluding the line itself); the cast makes the share a fraction rather than integer division,
+        // and the outer COALESCE gives a line with no counter side its full amount in the empty bucket.
+        String documentCredit =
+                "(SELECT SUM(COALESCE(JournalEntryItemDocumentTotal.\"JOURNAL_ENTRY_ITEM_CREDIT\", 0)) FROM \"LEDGER_JOURNAL_ENTRY_ITEM\" as JournalEntryItemDocumentTotal"
+                        + " WHERE JournalEntryItemDocumentTotal.\"JOURNAL_ENTRY_ITEM_JOURNAL_ENTRY\" = JournalEntryItem.\"JOURNAL_ENTRY_ITEM_JOURNAL_ENTRY\""
+                        + " AND JournalEntryItemDocumentTotal.\"JOURNAL_ENTRY_ITEM_ID\" <> JournalEntryItem.\"JOURNAL_ENTRY_ITEM_ID\")";
+        assertTrue(query.contains(
+                "SUM(CASE WHEN JournalEntry.\"JOURNAL_ENTRY_ENTRY_DATE\" >= :fromDate AND JournalEntry.\"JOURNAL_ENTRY_ENTRY_DATE\" <= :toDate"
+                        + " THEN COALESCE(CAST(COALESCE(JournalEntryItem.\"JOURNAL_ENTRY_ITEM_DEBIT\", 0) AS DECIMAL(34,12))"
+                        + " * COALESCE(JournalEntryItemCorrespondent.\"JOURNAL_ENTRY_ITEM_CREDIT\", 0) / NULLIF(" + documentCredit + ", 0),"
+                        + " COALESCE(JournalEntryItem.\"JOURNAL_ENTRY_ITEM_DEBIT\", 0)) ELSE 0 END) as \"Debit\""),
+                query);
+        // ... and a credit line's share is the mirror image - the bucket's DEBIT over the total debit.
+        assertTrue(query.contains(
+                "* COALESCE(JournalEntryItemCorrespondent.\"JOURNAL_ENTRY_ITEM_DEBIT\", 0) / NULLIF((SELECT SUM(COALESCE(JournalEntryItemDocumentTotal.\"JOURNAL_ENTRY_ITEM_DEBIT\", 0))"),
+                query);
+
+        // The correspondence bucket is a dimension: it groups, and it sits before the six totals.
+        List<Map<String, Object>> columns = (List<Map<String, Object>>) document.get("columns");
+        assertEquals(9, columns.size());
+        Map<String, Object> bucket = columns.get(2);
+        assertEquals("Correspondent Account Code", bucket.get("alias"));
+        assertEquals("AccountCorrespondent", bucket.get("table"));
+        assertEquals("NONE", bucket.get("aggregate"));
+        assertEquals(Boolean.TRUE, bucket.get("grouping"));
+        assertEquals("Debit", columns.get(5)
+                                     .get("alias"));
+    }
+
+    @Test
+    void correspondenceNeedsADocumentReachingDateAndAResolvablePath() {
+        IntentValidationException error = assertThrows(IntentValidationException.class, () -> IntentParser.parse("""
+                name: ledger
+                entities:
+                  - name: JournalEntryItem
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: entryDate, type: date }
+                      - { name: debit, type: decimal }
+                      - { name: credit, type: decimal }
+                reports:
+                  - name: GeneralLedger
+                    kind: balance
+                    source: JournalEntryItem
+                    date: entryDate
+                    debit: debit
+                    credit: credit
+                    dimensions: [debit]
+                    correspondence: account.code
+                """));
+        String message = error.getMessage();
+        // The document the lines share IS the first hop of `date`, so a line-local date has none.
+        assertTrue(message.contains("correspondence needs the document its lines share"), message);
+        assertTrue(message.contains("correspondence [account.code] does not start with a to-one relation of [JournalEntryItem]"), message);
+    }
+
+    /**
+     * A statement's rows are its declared lines, so it has no account axis to bucket - declaring the
+     * general ledger's correspondence there is a mistake, not a silently ignored key.
+     */
+    @Test
+    void correspondenceOnAStatementIsRejected() {
+        IntentValidationException error = assertThrows(IntentValidationException.class,
+                () -> IntentParser.parse(GENERAL_LEDGER_INTENT.replace("kind: balance", "kind: statement")));
+        assertTrue(error.getMessage()
+                        .contains("must not declare correspondence - the general ledger axis belongs to kind: balance"),
+                error.getMessage());
+    }
+
     private static final String LEDGER_INTENT = """
             name: ledger
             entities:
@@ -267,6 +363,14 @@ class ReportIntentGeneratorTest {
                 dimensions: [account.code, account.name]
                 filter: "credit == 0"
             """;
+
+    private static final String GENERAL_LEDGER_INTENT = LEDGER_INTENT.replace("""
+                dimensions: [account.code, account.name]
+                filter: "credit == 0"
+            """, """
+                dimensions: [account.code, account.name]
+                correspondence: account.code
+            """);
 
     @Test
     @SuppressWarnings("unchecked")
@@ -364,7 +468,7 @@ class ReportIntentGeneratorTest {
                     source: JournalEntryItem
                 """));
         String message = error.getMessage();
-        assertTrue(message.contains("declares date/debit/credit but is not kind: balance"), message);
+        assertTrue(message.contains("declares date/debit/credit/correspondence but is not kind: balance"), message);
         assertTrue(message.contains("unknown kind [pivot]"), message);
     }
 

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -220,6 +220,17 @@ class IntentEngineIT extends IntegrationTest {
                 debit: total
                 credit: creditSnapshot
                 dimensions: [customer]
+              # correspondence - the general ledger axis: the counter-side lines of the same document
+              # become one more bucket, and each amount is allocated proportionally across them. The
+              # document the lines share is the first hop of `date`.
+              - name: OrderItemCorrespondence
+                kind: balance
+                source: OrderItem
+                date: order.orderDate
+                debit: quantity
+                credit: creditSnapshot
+                dimensions: [order]
+                correspondence: order.orderDate
               # kind: statement - the statutory shape over the SAME signed ledger: instead of one row
               # per dimension value, a fixed line structure where each line is a formula over the
               # account codes, plus arithmetic over other lines. (The ledger here is the balance
@@ -376,7 +387,7 @@ class IntentEngineIT extends IntegrationTest {
                                                  .body("processes", hasSize(1))
                                                  .body("processes[0].steps", hasSize(6))
                                                  .body("forms", hasSize(1))
-                                                 .body("reports", hasSize(5))
+                                                 .body("reports", hasSize(6))
                                                  .body("permissions", hasSize(2))
                                                  .body("seeds[0].rows", hasSize(2)));
     }
@@ -621,7 +632,8 @@ class IntentEngineIT extends IntegrationTest {
                                                  .body("written",
                                                          hasItems("orders.edm", "orders.model", "OrderApproval.bpmn", "ApproveOrder.form",
                                                                  "OrdersByCustomer.report", "OrderBalance.report", "OrderStatement.report",
-                                                                 "orders.roles", "orders.glue", "countries.csvim", "countries.csv",
+                                                                 "OrderItemCorrespondence.report", "orders.roles", "orders.glue",
+                                                                 "countries.csvim", "countries.csv",
                                                                  "doc/Templates/Order/Print/en/standard.print", "orders.test"))
                                                  .body("scrubbed", hasSize(0))
                                                  // The model-to-code plan the editor replays: one entry per generated model with a
@@ -4168,10 +4180,25 @@ class IntentEngineIT extends IntegrationTest {
         assertTrue(balance.contains(
                 "SUM(CASE WHEN Order.\\\"ORDER_ORDER_DATE\\\" <= :toDate THEN COALESCE(Order.\\\"ORDER_TOTAL\\\", 0) ELSE 0 END) as \\\"Closing Debit\\\""),
                 "the closing debit should sum everything up to and including :toDate");
+
         assertTrue(balance.contains("\"name\": \"fromDate\"") && balance.contains("\"name\": \"toDate\""),
                 "the balance report should declare the two window parameters");
         assertTrue(balance.contains("\"initial\": \"1900-01-01\"") && balance.contains("\"initial\": \"9999-12-31\""),
                 "the window parameters should default to the all-time balance");
+        // correspondence - the counter-side lines of the same document as an extra grouping bucket.
+        String correspondence = contentOf("OrderItemCorrespondence.report");
+        assertTrue(correspondence.contains(
+                "LEFT JOIN \\\"ORDERS_ORDER_ITEM\\\" as OrderItemCorrespondent ON OrderItemCorrespondent.\\\"ORDER_ITEM_ORDER\\\" = OrderItem.\\\"ORDER_ITEM_ORDER\\\" AND OrderItemCorrespondent.\\\"ORDER_ITEM_ID\\\" <> OrderItem.\\\"ORDER_ITEM_ID\\\""),
+                "the correspondence axis should LEFT self-join the source on the document its lines share, excluding the line itself");
+        assertTrue(
+                correspondence.contains("as OrderCorrespondent ON OrderItemCorrespondent.\\\"ORDER_ITEM_ORDER\\\" = OrderCorrespondent."),
+                "the bucket path should be resolved against the counter-side line, under its own alias");
+        assertTrue(correspondence.contains("as \\\"Correspondent Order Order Date\\\""),
+                "the correspondence bucket should be emitted as a grouping column of its own");
+        assertTrue(
+                correspondence.contains("CAST(COALESCE(OrderItem.\\\"ORDER_ITEM_QUANTITY\\\", 0) AS DECIMAL(34,12))")
+                        && correspondence.contains("NULLIF((SELECT SUM(COALESCE(OrderItemDocumentTotal."),
+                "each amount should be allocated over the counter-side buckets of its own document");
 
         // kind: statement - the same window, but the rows are the declared lines: one subquery
         // reducing the ledger to a balance per account code, then one row per line reading it.


### PR DESCRIPTION
Closes #6908.

## The gap

The trial balance answers *how much moved on account 411*; the double-entry general ledger (главна книга) answers *against which accounts*. That second axis was the one a `kind: balance` report could not express — the correspondent account sits on a **sibling line of the same journal entry**, so no relation path from the source row reaches it.

## The declaration

```yaml
- name: GeneralLedger
  kind: balance
  source: JournalEntryItem
  date: journalEntry.entryDate           # its FIRST HOP is the document the lines share
  debit: debit
  credit: credit
  dimensions: [account.code, account.name]
  correspondence: account.code           # bucket the counter-side lines of the same entry by this
  filter: "journalEntry.status == 2"
```

`correspondence` takes the same shapes a dimension does (a field, a `relation.field` path, a bare to-one relation) and becomes one more grouping column — resolved a *second* time against the sibling line, under its own alias suffix so the two copies of the account join cannot collide.

## How

A **LEFT self-join** of the source on the document its lines share — the FK of the first hop of `date` — restricted to the opposite side (a debit line pairs with the credit lines and vice versa) and excluding the line itself by primary key. LEFT on purpose: a single-line entry with nothing on the counter side would otherwise drop out of the report and take its turnover with it.

Amounts are **allocated proportionally**: a debit line's share of a bucket is that bucket's credit over the document's total credit, and the mirror image for a credit line. So

- a **simple** entry attributes its full amount to the single counter-account,
- a **compound** one (M debit lines against N credit lines) splits it by the counter-side amounts,
- a line with **no counter side** keeps its full amount in one empty bucket.

Which is what makes each account's totals across its correspondence buckets add up to exactly the figures the plain balance report shows for the same window.

## Verification

That reconciliation is the property a general ledger is worthless without, and no assertion on a query string can vouch for the arithmetic — so `CorrespondenceReconciliationTest` **runs the generated SQL** against H2 over a ledger holding all four entry shapes (simple, one-against-two, two-against-two, one-sided) and checks that the allocated totals equal the plain balance's, per account, on both sides.

Alongside it: the SQL shape is pinned in `ReportIntentGeneratorTest`, the validation refusals (a line-local `date`, an unresolvable path, `correspondence` on a `kind: statement`, a subset relation) are covered too, `ReportEditorRoundTripTest` proves the report editor's builder still rebuilds the query — so declaring correspondence does not park the report in free-style (#6675) — and `IntentEngineIT` asserts the generated `.report` end to end.

`README.md` and the assistant guide document the axis, its `date` requirement and the reconciliation property to check when in doubt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)