### PR TITLE
fix(intent): the posting header comment must not name a channel it does not bind

### DIFF
--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Posting.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Posting.java.template
@@ -16,10 +16,9 @@ import org.eclipse.dirigible.sdk.utils.Json;
  * application.
  *
  * Contract (the accounting posting semantics, generalized):
- * - binds the moment the source's own publisher raises (a create is unsuffixed, a workflow status
- *   write publishes -transitioned, an enrichment listener announces its declared phase) and RE-LOADS
- *   the source by id - the payload is as-of the event and lacks later-step data such as a stamped
- *   document number;
+ * - binds the topic the source's own publisher raises when it ${moment} (see destination() below)
+ *   and RE-LOADS the source by id - the payload is as-of the event and lacks later-step data such as
+ *   a stamped document number;
  * - idempotent + resumable via the ${backRefProperty} back-reference: a redelivery of a complete post
  *   is a no-op, and a redelivery of a half-post (an item write failed after the target was saved)
  *   rebuilds the items so the post completes - so it never throws or leaves a half-post. Concurrent

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -2668,7 +2668,10 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         // status guard.
         String createPosting = contentOf("gen/events/emission/PaymentPostingPosting.java");
         assertTrue(createPosting.contains("-Payment\";"), "an onCreate posting must bind the source's bare create topic");
-        assertTrue(!createPosting.contains("-transitioned"), "an onCreate posting must not bind the -transitioned topic");
+        // Anchored on the destination()'s return literal, like the positive assertion above: what must
+        // not happen is BINDING the status channel, and a whole-file scan also trips on any prose that
+        // happens to name it.
+        assertTrue(!createPosting.contains("-transitioned\";"), "an onCreate posting must not bind the -transitioned topic");
         assertTrue(!createPosting.contains("source.Status"), "an onCreate posting without a when guard must not emit a status guard");
         assertTrue(createPosting.contains("target.Payment = source.Id;"), "the onCreate posting must stamp its back-reference");
 


### PR DESCRIPTION
Follow-up to #6933, which merged with `smoke-tests` red. **This is what turned it red.**

`IntentEmissionCoverageIT` asserts that an `onCreate` posting's generated file does not contain `-transitioned` anywhere:

```java
assertTrue(!createPosting.contains("-transitioned"), "an onCreate posting must not bind the -transitioned topic");
```

#6933 replaced `Posting.java.template`'s two-state `#if($isCreate)` header comment with an axis-neutral one that **enumerated every channel** - so every posting, including the `onCreate` ones, now carried that literal in its javadoc and the assertion tripped. The assertion was right: a generated handler should not talk about a channel it does not subscribe to.

## The fix

- The header comment names the **one** moment the handler binds, through the same pre-rendered `${moment}` the class summary already uses, and points at `destination()` for the topic itself. The reason a system status write publishes `-transitioned` rather than `-updated` belongs to the module guide, not to every generated file's header.
- The assertion is anchored on the `destination()`'s return literal (`-transitioned";`) to match its positive sibling one line above. What must not happen is *binding* the status channel; a whole-file scan also trips on prose that merely names it.

## Verification

`IntentEmissionCoverageIT`, `IntentEngineIT`, `EdmModelRoundTripIT` and `ModelGenerationIT` run together locally: 63 tests, all green (the same set reproduced the failure before the fix). `formatter:validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)