### PR TITLE
fix(engine-java): one long string literal must not turn synchronization off platform-wide (#6936)

### DIFF
--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/synchronizer/BaseSynchronizer.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/synchronizer/BaseSynchronizer.java
@@ -54,6 +54,21 @@ public abstract class BaseSynchronizer<A extends Artefact, ID> implements Synchr
             span.setStatus(io.opentelemetry.api.trace.StatusCode.ERROR, "Exception occurred during synchronization");
 
             throw e;
+        } catch (StackOverflowError e) {
+            // Analysing ONE definition must never end the synchronization pass. A stack overflow in a
+            // parser is a property of that definition - a pathological source, a deeply nested document
+            // - not of the JVM: the stack has already unwound here and every other definition parses
+            // fine. Left to propagate, it escapes the whole run, and since the same file is parsed
+            // again on the next pass the job never completes again: no schema, no seeds, no compile, no
+            // routing, while HTTP keeps answering 200. Reported as a broken definition instead: the
+            // pass completes, the failure is logged and listed with the run's errors, and the
+            // definition is re-parsed on every later pass so a corrected source heals itself.
+            span.recordException(e);
+            span.setStatus(io.opentelemetry.api.trace.StatusCode.ERROR, "Stack overflow occurred during synchronization");
+
+            logger.error("Stack overflow while parsing [{}] by [{}]", location, this, e);
+            throw new ParseException("Stack overflow while parsing [" + location + "] - the definition is too large or too deeply "
+                    + "nested for the parser", 0);
         } finally {
             span.end();
         }

--- a/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/synchronizer/BaseSynchronizerParseTest.java
+++ b/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/synchronizer/BaseSynchronizerParseTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.synchronizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+
+import java.text.ParseException;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.eclipse.dirigible.components.base.artefact.Artefact;
+import org.eclipse.dirigible.components.base.artefact.ArtefactLifecycle;
+import org.eclipse.dirigible.components.base.artefact.ArtefactPhase;
+import org.eclipse.dirigible.components.base.artefact.ArtefactService;
+import org.eclipse.dirigible.components.base.artefact.topology.TopologyWrapper;
+import org.eclipse.dirigible.components.open.telemetry.OpenTelemetryProvider;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import io.opentelemetry.api.OpenTelemetry;
+
+/**
+ * Guards how {@link BaseSynchronizer#parse(String, byte[])} contains a failure of the parser it
+ * delegates to. The unit under test is the boundary, not any concrete synchronizer.
+ */
+class BaseSynchronizerParseTest {
+
+    private static final String LOCATION = "/project/Big.java";
+
+    /**
+     * A {@link StackOverflowError} from a parser is a property of the one definition being analysed. If
+     * it propagates it ends the whole synchronization run - and because the same definition is parsed
+     * again on every later pass, no pass ever completes again while the server keeps answering 200. It
+     * must arrive as the ordinary "this definition is broken" signal the processor already handles.
+     */
+    @Test
+    void a_stack_overflow_from_the_parser_is_reported_as_a_broken_definition() {
+        ParseException thrown = withNoopTelemetry(() -> assertThrows(ParseException.class, () -> synchronizerFailingWith(() -> {
+            throw new StackOverflowError();
+        }).parse(LOCATION, new byte[0])));
+
+        assertTrue(thrown.getMessage()
+                         .contains(LOCATION),
+                "the failing definition must be named: " + thrown.getMessage());
+    }
+
+    /** Everything else keeps its existing contract - the containment is not a blanket catch. */
+    @Test
+    void a_runtime_exception_from_the_parser_still_propagates() {
+        IllegalStateException thrown =
+                withNoopTelemetry(() -> assertThrows(IllegalStateException.class, () -> synchronizerFailingWith(() -> {
+                    throw new IllegalStateException("boom");
+                }).parse(LOCATION, new byte[0])));
+
+        assertEquals("boom", thrown.getMessage());
+    }
+
+    /** {@code OpenTelemetryProvider} resolves its tracer from the Spring context, which no test has. */
+    private static <T> T withNoopTelemetry(Supplier<T> body) {
+        try (MockedStatic<OpenTelemetryProvider> telemetry = mockStatic(OpenTelemetryProvider.class)) {
+            telemetry.when(OpenTelemetryProvider::get)
+                     .thenReturn(OpenTelemetry.noop());
+            return body.get();
+        }
+    }
+
+    private static BaseSynchronizer<TestArtefact, Long> synchronizerFailingWith(Runnable failure) {
+        return new BaseSynchronizer<>() {
+
+            @Override
+            protected List<TestArtefact> parseImpl(String location, byte[] content) {
+                failure.run();
+                return List.of();
+            }
+
+            @Override
+            public ArtefactService<TestArtefact, Long> getService() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isAccepted(String type) {
+                return true;
+            }
+
+            @Override
+            public List<TestArtefact> retrieve(String location) {
+                return List.of();
+            }
+
+            @Override
+            public void setStatus(TestArtefact artefact, ArtefactLifecycle lifecycle, String message) {
+                // Not exercised by the parse boundary.
+            }
+
+            @Override
+            protected boolean completeImpl(TopologyWrapper<TestArtefact> wrapper, ArtefactPhase flow) {
+                return true;
+            }
+
+            @Override
+            protected void cleanupImpl(TestArtefact artefact) {
+                // Not exercised by the parse boundary.
+            }
+
+            @Override
+            public void setCallback(SynchronizerCallback callback) {
+                // Not exercised by the parse boundary.
+            }
+
+            @Override
+            public String getFileExtension() {
+                return ".test";
+            }
+
+            @Override
+            public String getArtefactType() {
+                return "test";
+            }
+        };
+    }
+
+    private static final class TestArtefact extends Artefact {
+    }
+
+}

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/JavaSourceParser.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/JavaSourceParser.java
@@ -18,17 +18,19 @@ import java.util.regex.Pattern;
  *
  * <p>
  * We deliberately avoid pulling in a full Java parser; the synchronizer only needs the binary class
- * name to key the artefact and request a compilation unit by name. Comments and string literals are
+ * name to key the artefact and request a compilation unit by name. Comments and literals are
  * stripped first so {@code //}- and {@code /* *}/-embedded {@code package} tokens don't trip up the
  * matcher.
+ *
+ * <p>
+ * The stripping is a single linear character scan, not a set of regex passes, for two reasons. A
+ * regex alternation under a quantifier ({@code "(?:\\.|[^"\\])*"}) costs Java's engine one stack
+ * frame per iteration, so a long enough string literal - a generated report's multi-kilobyte SQL
+ * constant full of escaped identifier quotes - overflows the thread stack; and running the comment
+ * passes before the literal pass gets the nesting backwards, so a {@code /*} inside a string
+ * literal opened a comment that swallowed real code up to the next {@code *}{@code /} in the file.
  */
 public final class JavaSourceParser {
-
-    // Strip /* ... */ block comments (non-greedy, multi-line) and // line comments.
-    private static final Pattern BLOCK_COMMENT = Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL);
-    private static final Pattern LINE_COMMENT = Pattern.compile("//[^\\n]*");
-    private static final Pattern STRING_LITERAL = Pattern.compile("\"(?:\\\\.|[^\"\\\\])*\"");
-    private static final Pattern CHAR_LITERAL = Pattern.compile("'(?:\\\\.|[^'\\\\])'");
 
     private static final Pattern PACKAGE_DECL = Pattern.compile("(?m)^\\s*package\\s+([a-zA-Z_$][\\w$]*(?:\\.[a-zA-Z_$][\\w$]*)*)\\s*;");
 
@@ -66,16 +68,98 @@ public final class JavaSourceParser {
         return new ParsedSource(packageName, simpleName, fqn);
     }
 
+    /**
+     * Replace every comment and literal with an inert placeholder, in one left-to-right pass. Each
+     * construct is recognised where it starts, so a comment opener inside a literal is literal text and
+     * a quote inside a comment is comment text - the ordering a set of independent regex passes cannot
+     * express. Line structure outside block comments is preserved, which is what the {@code (?m)^\s*}
+     * anchor of {@link #PACKAGE_DECL} reads.
+     *
+     * @param source raw Java source
+     * @return the source with comments and literals neutralised
+     */
     private static String stripCommentsAndLiterals(String source) {
-        String s = BLOCK_COMMENT.matcher(source)
-                                .replaceAll(" ");
-        s = LINE_COMMENT.matcher(s)
-                        .replaceAll(" ");
-        s = STRING_LITERAL.matcher(s)
-                          .replaceAll("\"\"");
-        s = CHAR_LITERAL.matcher(s)
-                        .replaceAll("' '");
-        return s;
+        int length = source.length();
+        StringBuilder stripped = new StringBuilder(length);
+        int index = 0;
+        while (index < length) {
+            char current = source.charAt(index);
+            char following = index + 1 < length ? source.charAt(index + 1) : '\0';
+            if (current == '/' && following == '/') {
+                index = skipLineComment(source, index);
+                stripped.append(' ');
+            } else if (current == '/' && following == '*') {
+                index = skipBlockComment(source, index);
+                stripped.append(' ');
+            } else if (current == '"' && following == '"' && index + 2 < length && source.charAt(index + 2) == '"') {
+                index = skipTextBlock(source, index);
+                stripped.append("\"\"");
+            } else if (current == '"') {
+                index = skipQuoted(source, index, '"');
+                stripped.append("\"\"");
+            } else if (current == '\'') {
+                index = skipQuoted(source, index, '\'');
+                stripped.append("' '");
+            } else {
+                stripped.append(current);
+                index++;
+            }
+        }
+        return stripped.toString();
+    }
+
+    /** Index of the terminating newline, which the caller keeps, or the end of the source. */
+    private static int skipLineComment(String source, int start) {
+        int index = start + 2;
+        while (index < source.length() && source.charAt(index) != '\n') {
+            index++;
+        }
+        return index;
+    }
+
+    /** Index just past the closing delimiter, or the end of an unterminated comment. */
+    private static int skipBlockComment(String source, int start) {
+        int end = source.indexOf("*/", start + 2);
+        return end < 0 ? source.length() : end + 2;
+    }
+
+    /** Index just past the closing triple quote, or the end of an unterminated text block. */
+    private static int skipTextBlock(String source, int start) {
+        int length = source.length();
+        int index = start + 3;
+        while (index < length) {
+            char current = source.charAt(index);
+            if (current == '\\') {
+                index += 2;
+            } else if (current == '"' && index + 2 < length && source.charAt(index + 1) == '"' && source.charAt(index + 2) == '"') {
+                return index + 3;
+            } else {
+                index++;
+            }
+        }
+        return length;
+    }
+
+    /**
+     * Index just past the closing quote of a string or character literal. Neither may span a line, so
+     * an unterminated one stops at the newline rather than consuming the rest of the source.
+     */
+    private static int skipQuoted(String source, int start, char quote) {
+        int length = source.length();
+        int index = start + 1;
+        while (index < length) {
+            char current = source.charAt(index);
+            if (current == '\\') {
+                index += 2;
+            } else if (current == quote) {
+                return index + 1;
+            } else if (current == '\n') {
+                return index;
+            } else {
+                index++;
+            }
+        }
+        return length;
     }
 
     /** Parsed coordinates of a Java source. */

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/runtime/JavaSourceParserTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/runtime/JavaSourceParserTest.java
@@ -11,6 +11,7 @@ package org.eclipse.dirigible.engine.java.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -60,6 +61,57 @@ class JavaSourceParserTest {
                                           .simpleName());
         assertEquals("E", JavaSourceParser.parse("enum E { A, B }")
                                           .simpleName());
+    }
+
+    @Test
+    void parses_a_source_carrying_a_very_long_escaped_string_literal() {
+        // The shape that killed synchronization platform-wide: a generated report repository whose
+        // QUERY constant is one single-line SQL string full of escaped identifier quotes. The
+        // regex-based stripper spent one stack frame per escape and overflowed the thread stack from a
+        // few hundred escapes on - and the StackOverflowError escaped the whole SynchronizationJob.
+        StringBuilder literal = new StringBuilder("\"SELECT ");
+        for (int i = 0; i < 20_000; i++) {
+            literal.append("\\\"COLUMN_")
+                   .append(i)
+                   .append("\\\", ");
+        }
+        literal.append("1\"");
+        String source = "package gen.report;\n" + "public final class BigQueryRepository {\n" + "    static final String QUERY = " + literal
+                + ";\n" + "}\n";
+        assertTrue(source.length() > 100_000, "the literal must be well past any plausible stack budget");
+
+        JavaSourceParser.ParsedSource p = JavaSourceParser.parse(source);
+
+        assertEquals("gen.report.BigQueryRepository", p.fqn());
+    }
+
+    @Test
+    void a_comment_opener_inside_a_string_literal_does_not_open_a_comment() {
+        // Stripping comments before literals got the nesting backwards: the unterminated /* inside the
+        // annotation value paired with the javadoc's */ and swallowed the type declaration with it.
+        JavaSourceParser.ParsedSource p = JavaSourceParser.parse("""
+                package real.pkg;
+                @SuppressWarnings("/*")
+                public class Target {
+                    /** Javadoc. */
+                    void m() {}
+                }
+                """);
+
+        assertEquals("real.pkg", p.packageName());
+        assertEquals("Target", p.simpleName());
+    }
+
+    @Test
+    void ignores_a_type_declaration_inside_a_text_block() {
+        // A text block is a literal too - scanned as a pair of empty strings it leaks its content into
+        // the code stream, and content that happens to declare a type wins the first-match race.
+        String source = "package real.pkg;\n" + "@SuppressWarnings(\"\"\"\n" + "        class Fake {}\n" + "        \"\"\")\n"
+                + "public class Target {}\n";
+
+        JavaSourceParser.ParsedSource p = JavaSourceParser.parse(source);
+
+        assertEquals("Target", p.simpleName());
     }
 
     @Test

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaEngineIT.java
@@ -110,6 +110,16 @@ class JavaEngineIT extends IntegrationTest {
     }
 
     @Test
+    void a_multi_kilobyte_escaped_string_literal_does_not_stop_synchronization() {
+        // The source shape of a generated report repository: one single-line SQL constant carrying a
+        // few thousand escaped identifier quotes. Parsing it used to overflow the stack, and the
+        // StackOverflowError escaped the whole SynchronizationJob - so this asserts far more than one
+        // file: if the pass had died, nothing would ever be compiled or registered again.
+        writeAndSync(handlerWithLongQueryConstant());
+        assertEndpointReturns(200, "hello from long-query");
+    }
+
+    @Test
     void broken_definition_self_heals_without_a_byte_change() {
         // A duplicate FQN breaks the SECOND source's parse (definition state BROKEN) - one
         // deterministic instance of the "transient parse failure" class. The regression this guards:
@@ -195,6 +205,34 @@ class JavaEngineIT extends IntegrationTest {
                     }
                 }
                 """.formatted(tag);
+    }
+
+    /**
+     * The same handler plus a ~36 KB single-line string constant full of escaped quotes. Kept under
+     * javac's 64 KB limit for a constant-pool string, which is the only ceiling on how far this can go.
+     */
+    private static String handlerWithLongQueryConstant() {
+        StringBuilder columns = new StringBuilder();
+        for (int i = 0; i < 2_000; i++) {
+            columns.append("\\\"COLUMN_")
+                   .append(i)
+                   .append("\\\", ");
+        }
+        return """
+                package demo;
+                import jakarta.servlet.http.HttpServletRequest;
+                import jakarta.servlet.http.HttpServletResponse;
+                import org.eclipse.dirigible.engine.java.handler.JavaHandler;
+                public class Hello implements JavaHandler {
+                    static final String QUERY = "SELECT %s 1";
+                    @Override
+                    public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
+                        response.setContentType("application/json");
+                        response.getWriter()
+                                .write("{\\"message\\": \\"hello from long-query\\", \\"length\\": " + QUERY.length() + "}");
+                    }
+                }
+                """.formatted(columns);
     }
 
 }


### PR DESCRIPTION
Fixes #6936.

`JavaSourceParser` stripped comments and literals with three regex passes, and `STRING_LITERAL` was the alternation-in-a-loop shape - Java's engine recurses one stack frame per iteration of `(?:\\.|[^"\\])*`, so a long enough literal overflows the thread stack. A generated report repository whose `QUERY` constant is a multi-kilobyte single-line SQL string full of escaped identifier quotes reliably did.

**The blast radius was the whole instance.** The `StackOverflowError` escaped the parser, killed the `SynchronizationJob` run, and every later run died at the same file - no schema, no seeds, no compile, no controller registration - while HTTP kept answering 200.

## What changed

**1. The stripping is one linear character scan.** The unrolled-loop regex the issue suggests only moves the cliff. Measured on this JVM, `"[^"\\]*(?:\\.[^"\\]*)*"` still recurses once per *escape* rather than per character:

| escaped quotes in the literal | old pattern | unrolled pattern | scan |
| --- | --- | --- | --- |
| 200 | ok | ok | ok |
| 400 | **StackOverflowError** | ok | ok |
| 1600 | StackOverflowError | **StackOverflowError** | ok |
| 25600 | StackOverflowError | StackOverflowError | ok |

So the regression test the issue asks for (a 100 KB escaped-quote literal parses) fails on the unrolled form too. A scan has no per-character recursion at all.

It also fixes the pass **order**, which was wrong independently of size: comments were stripped *before* literals, so a `/*` inside a string literal opened a comment that swallowed real code up to the next `*/` in the file (`@SuppressWarnings("/*")` above a class with a javadoc'd method loses its type declaration). Each construct is now recognised where it starts, and text blocks are recognised as literals too.

**2. `BaseSynchronizer.parse` contains a `StackOverflowError` and reports it as a broken definition.** A stack overflow while analysing ONE definition is a property of that definition, not of the JVM - the stack has already unwound and every other definition parses fine. The pass now completes, names the bad file, lists it with the run's errors, and re-parses it on every later pass so a corrected source heals itself. Every synchronizer parses through this one boundary, so the containment is not specific to `.java`; `RuntimeException` keeps its existing contract (the catch is not a blanket one).

## Tests

- `JavaSourceParserTest`: a 100 KB escaped-quote literal parses; a comment opener inside a string literal stays literal; a type declaration inside a text block is not taken as the primary type. **All three fail on the old parser** (two errors + one wrong name).
- `BaseSynchronizerParseTest` (new): the parse boundary turns a `StackOverflowError` into a `ParseException` naming the location, and still lets a `RuntimeException` through. The first test fails without the containment.
- `JavaEngineIT`: publishes a handler carrying a ~36 KB escaped-quote constant (under javac's 64 KB constant-pool ceiling) and asserts it compiles and serves - if the pass had died, nothing would be registered at all.

Verified locally: `formatter:validate` clean on all three modules, `-P release` javadoc clean on both changed modules, full unit suites of `core-base` + `engine-java` green (30 classes), `JavaEngineIT` green (6 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)