### PR TITLE
fix(harmonia): print data in the chosen print language, not the UI locale (#6945)

### DIFF
--- a/components/engine/engine-document/CLAUDE.md
+++ b/components/engine/engine-document/CLAUDE.md
@@ -47,10 +47,17 @@ uploaded). The Print button asks which to use when several exist.
   (404 with a clear message when absent), then `DocumentParser → DataBinder → XslFoRenderer →
   PDFFacade.generate(fo, "<data/>")`.
 
-**The client supplies the data.** The Harmonia document page POSTs the record + items it already
-loaded, with dropdown FKs resolved to display labels (`printPayload()` in
-`document-page.js.template`). Deliberate: no server-side entity fetching, no auth forwarding, and
-the printout matches exactly what the user sees. The JSON body is parsed with a **plain Gson**
+**The client feeds this endpoint from a server-side feeder, not from its own screen state.** The
+Harmonia document/manage page first GETs the generated `…PrintFeeder/{id}` (client-Java), which
+loads the record + its related graph through the generated repositories and returns the nested
+`{ document, items }` payload — so `{{document.<Relation>.<Field>}}` resolves and validations, events
+and the **multilingual translation overlay** all apply. The page then POSTs that payload here. The
+feeder is called as the logged-in user (auth + tenant are the caller's). **Language:** the print
+dialog's chosen language drives BOTH halves — it is the `?lang=` that selects the CMS template folder
+(labels) AND is sent as the feeder GET's `Accept-Language` (via `api.get(url, { language: lang })`),
+because the repositories' multilingual overlay reads `User.getLanguage()`/`Accept-Language`; without
+that pin the nomenclature VALUES would translate to the UI locale while the template is in the print
+language (dirigible #6945). The JSON body is parsed with a **plain Gson**
 (`ToNumberPolicy.LONG_OR_DOUBLE`) — never `JsonHelper`/`GsonHelper` (the `@Expose` trap; and
 LONG_OR_DOUBLE keeps integers integral while decimals arrive as `Double`, which `DataBinder`
 formats in the form money pattern `### ### ### ##0.00`).

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/api.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/api.js
@@ -98,7 +98,10 @@ App.services.api = {
     // browser's native login dialog never pops over a background poll.
     const headers = { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' };
     if (!isForm) headers['Content-Type'] = 'application/json';
-    const language = this.language();
+    // A caller may pin the request language for THIS call ({ language: 'bg' }) — e.g. Print, where the
+    // chosen print language must drive the multilingual data overlay, not the UI locale. Absent the
+    // override, the app's single language flag (the Region & Language store) applies as before.
+    const language = opts.language !== undefined ? opts.language : this.language();
     if (language) headers['Accept-Language'] = language;
 
     let r;

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -281,8 +281,11 @@ document.addEventListener('alpine:init', () => {
         // graph through the repositories and returns the { document, items } payload the template binds
         // - so {{document.<Relation>.<Field>}} resolves. It is the auditable source of what a print
         // receives; the browser calls it as the logged-in user (auth + tenant + i18n are the caller's).
+        // Pin the feeder's language to the CHOSEN print language, not the UI locale: the repositories'
+        // multilingual overlay reads Accept-Language, so without this the nomenclature values (Payment
+        // Method, Status, ...) would render in the UI locale while the template is in the print language.
         const payload = await App.services.api.get(
-          '/services/java/${projectName}/gen/events/${javaGenFolderName}/${name}PrintFeeder/' + encodeURIComponent(this.id), { baseUrl: '' });
+          '/services/java/${projectName}/gen/events/${javaGenFolderName}/${name}PrintFeeder/' + encodeURIComponent(this.id), { baseUrl: '', language: lang });
         const response = await fetch('/services/print/${name}?lang=' + encodeURIComponent(lang), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
@@ -717,8 +717,11 @@ document.addEventListener('alpine:init', () => {
         // graph through the repositories and returns the { document, items } payload the template binds
         // - so {{document.<Relation>.<Field>}} resolves. It is called as the logged-in user (auth +
         // tenant + i18n are the caller's).
+        // Pin the feeder's language to the CHOSEN print language, not the UI locale: the repositories'
+        // multilingual overlay reads Accept-Language, so without this the nomenclature values (Payment
+        // Method, Status, ...) would render in the UI locale while the template is in the print language.
         const payload = await App.services.api.get(
-          '/services/java/${projectName}/gen/events/${javaGenFolderName}/${name}PrintFeeder/' + encodeURIComponent(this.id), { baseUrl: '' });
+          '/services/java/${projectName}/gen/events/${javaGenFolderName}/${name}PrintFeeder/' + encodeURIComponent(this.id), { baseUrl: '', language: lang });
         const response = await fetch('/services/print/${name}?lang=' + encodeURIComponent(lang), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Problem

Fixes #6945.

Printing a document (or a record from the manage form) in a language different from the current UI language produced a PDF whose **labels** were in the chosen print language but whose **nomenclature values** (Payment Method, Sent Method, Status, ...) were in the UI locale. The two halves of the document disagreed — e.g. a Bulgarian Sales Invoice template (ФАКТУРА, ПАДЕЖ) still reading "E-mail" / "Bank transfer" / "SENT".

## Root cause

The Harmonia Print flow has two language selectors that were not kept in sync:

1. **Template (labels)** — the chosen print `lang` is passed as `POST /services/print/{entity}?lang=bg`, which selects the CMS template folder `Templates/<Entity>/Print/bg/`. ✅
2. **Data (nomenclature values)** — the `{document, items}` payload is fetched from the generated `…PrintFeeder/{id}` endpoint first. The feeder loads each related nomenclature through its generated repository, which overlays translations via `Translator` using `User.getLanguage()` → the request's **`Accept-Language`** header.

The feeder is fetched through the shared `App.services.api.get(...)`, which always sets `Accept-Language` to the **UI locale store** (`codbex.harmonia.language`), never the print-dialog `lang`. So the data translated to the UI language while the template was in the print language.

## Fix

Pin the feeder GET's `Accept-Language` to the chosen print language, so the multilingual overlay resolves data in the same language as the template — using the mechanism the rest of the platform already uses.

- `application-core` `services/api.js`: `request()` honors an opt-in `{ language }` per-call override; absent it, the Region & Language store applies exactly as before (backward compatible).
- `document-page.js.template` and `form-page.js.template`: the print feeder fetch passes `{ language: lang }`.
- Refreshed the `engine-document` guide, which still described the pre-feeder "client supplies the data" design.

## Scope / notes

- The **interactive UI print dialog** is what #6945 reports and what this fixes.
- The server-side mail path (`attach: print`/`report` in `Send.java`/`Notification.java`) calls the feeder in a background listener where there is no request-scoped `Accept-Language`; it selects the template language via an expression but the feeder data stays in the base language. That is the same bug class but a different (in-process, thread-local) fix and is intentionally out of scope here.

## Verification

Manual (no JS test harness): generate an app with a multilingual nomenclature and a `bg` print template, keep UI = English, print → Bulgarian; the nomenclature values now render in Bulgarian ("Банков превод", "Изпратена"). English-UI/English-print is byte-identical to before.

Reminder: `api.js` is bundled into the fat jar — a locally running instance needs `application-core` + `build/application` repackaged and a restart to reflect the change; target apps need regeneration to pick up the template edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)