### PR TITLE
fix(harmonia): cap dialogs to the viewport and scroll their body

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/css/app.css
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/css/app.css
@@ -22,3 +22,22 @@ html, body { height: 100%; margin: 0; }
 :root {
   /* --primary: oklch(0.55 0.22 260); */
 }
+
+/*
+ * Cap Harmonia dialogs to the viewport and scroll their body.
+ * Harmonia's x-h-dialog is centred (top/left 50% + translate) with no max-height and
+ * no internal overflow, so a tall form dialog - e.g. the document line-item editor with
+ * many fields - grows past the screen and its header and Save/Cancel footer bleed off the
+ * top and bottom edges, unreachable. Capping the dialog and letting the content region
+ * (x-h-dialog-content) scroll keeps the header and footer pinned and on screen. Keyed on
+ * Harmonia's stable data-slot so it applies to every dialog on every shell.
+ */
+[data-slot="dialog"] {
+  max-height: calc(100vh - 2rem);
+}
+
+[data-slot="dialog"] [x-h-dialog-content] {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}


### PR DESCRIPTION
Fixes #6950

### Problem

A Harmonia dialog with enough fields to exceed the viewport height renders with its header pushed above the top edge and its **Save/Cancel footer pushed below the bottom edge** — both off-screen and unreachable. The dialog is vertically centered, so a body taller than the screen bleeds off both ends. The most visible case is the **document line-item editor** (the "Add line" dialog on a header-items entity such as a Sales Invoice), where the Save button cannot be clicked.

### Root cause

The shipped `codbex/harmonia` CSS (2.14.0) gives `x-h-dialog` a centered `position` with **no `max-height` and no `overflow`**:

```
bg-background fixed position-center z-50 vbox w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-4 shadow-xl sm:max-w-lg
```

`position-center` centers via `top:50%; left:50%; translate(-50%,-50%)`, so a body taller than the screen overflows off both the top and bottom. Additionally, **`x-h-dialog-content` is not a registered Harmonia directive** (the library registers only `h-dialog-overlay/-dialog/-header/-title/-close/-description/-footer`), so the `<div x-h-dialog-content>` wrappers used across the templates receive no styling and cannot scroll on their own.

This affects every Harmonia dialog on every shell; short dialogs (delete/print confirmations) simply never grow tall enough to trigger it.

### Fix

Cap `[data-slot="dialog"]` to the viewport and let the `x-h-dialog-content` region flex-grow and scroll, keeping the header and footer pinned and on screen. This is the same cap+scroll recipe the platform's Fundamental/BlimpKit IDE dialogs already use:

```css
.fd-dialog__content--no-mobile-stretch { max-height: calc(100vh - 6%); }
.fd-dialog__body                       { flex-grow: 1; overflow: auto; }
```

It is placed in the shared `application-core` app.css override layer (explicitly *"App-level overrides on top of Harmonia's compiled CSS"*) since Harmonia's compiled CSS does not bake it in. **One edit covers every dialog on every shell** — the application/builder/admin/partner/personal/monitoring/database shells and the generated per-project shell all load this file by absolute URL (`/services/web/application-core/shell/css/app.css`).

```css
[data-slot="dialog"] {
  max-height: calc(100vh - 2rem);
}
[data-slot="dialog"] [x-h-dialog-content] {
  flex: 1 1 auto;
  min-height: 0;
  overflow-y: auto;
}
```

Short dialogs are unaffected: below the cap, the `flex`/`overflow` rules are no-ops (no free space to distribute, no scrollbar shown).

Longer term, the cleaner home is an upstream `codbex/harmonia` change (cap `x-h-dialog` and register `x-h-dialog-content` with the scroll); this override is the correct fix for this repo in the meantime.

### Testing

- Verified manually: the document line-item ("Add line") dialog now stays within the viewport with a scrollable body and a reachable Save/Cancel footer.
- CSS-only change; no Java, no formatter/javadoc impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
