### PR TITLE
Personal controller: define the composed isMutable helper the /mutable endpoint calls

### DIFF
--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityMyController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityMyController.java.template
@@ -415,6 +415,16 @@ public class ${name}MyController {
 #end
 #end
     }
+    // The pre-check the generated UI gates its Edit affordances on: every guard this ${name} declares,
+    // in one answer.
+    private boolean isMutable(${name}Entity existing) {
+#if($immutableAlways)
+        return false;
+#else
+        return #if($immutableStatusProperty)isStatusMutable(existing)#{else}true#end#if($periodLock) && isPeriodOpen(existing.${periodLock.dateProperty})#end;
+#end
+    }
+
 #end
 #if($immutableStatusProperty && !$immutableAlways)
 


### PR DESCRIPTION
The `EntityMyController.java.template` emits the `/{id}/mutable` immutability pre-check endpoint under `#if($immutableAlways || $immutableStatusProperty)` but never defines `isMutable` — only the power controller template does. Any entity combining `personal:` with `immutable:` / `immutableWhen:` / `immutableInPeriod:` generates a My controller that fails to compile (`cannot find symbol: method isMutable`).

This mirrors the power controller's composed helper verbatim into the same `#if($immutableAlways || $immutableStatusProperty || $periodLock)` block that carries `requireMutable`.

Verified downstream: regenerating BusinessIntents `base-timesheets` (EmployeeTimesheet: `personal:` + `immutableWhen`) from a registry-patched 14.36.0 template produces exactly the missing 6-line helper and the module's AOT compile gate goes green.

Coverage follow-up (not in this PR): `IntentEmissionCoverageIT`'s fixtures have no entity combining `personal:` with an immutability keyword; adding one would catch this class at PR time.

Fixes #6962

🤖 Generated with [Claude Code](https://claude.com/claude-code)