### PR TITLE
Print languages: backend-neutral codes from the CMS, malformed Accept-Language degrades instead of throwing

### DIFF
--- a/components/api/api-security/src/main/java/org/eclipse/dirigible/components/api/security/UserFacade.java
+++ b/components/api/api-security/src/main/java/org/eclipse/dirigible/components/api/security/UserFacade.java
@@ -399,7 +399,17 @@ public class UserFacade {
             if (language == null || language.isEmpty()) {
                 language = ANY_LANGUAGE;
             }
-            List<Locale.LanguageRange> ranges = Locale.LanguageRange.parse(language);
+            List<Locale.LanguageRange> ranges;
+            try {
+                ranges = Locale.LanguageRange.parse(language);
+            } catch (IllegalArgumentException e) {
+                // The header is client-controlled: a malformed value must degrade to "no language
+                // preference", never turn every localized read on this request into a 500.
+                if (logger.isWarnEnabled()) {
+                    logger.warn("Malformed Accept-Language header [{}] - ignoring it", language);
+                }
+                return "";
+            }
             return ranges == null || ranges.isEmpty() ? ""
                     : ranges.get(0)
                             .getRange();

--- a/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/CmsStore.java
+++ b/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/CmsStore.java
@@ -95,7 +95,15 @@ class CmsStore {
         for (CmisObject child : printFolder.get()
                                            .getChildren()) {
             if (child instanceof CmisFolder) {
-                languages.add(child.getName());
+                // The S3 CMS names a child folder with its trailing separator (en/) while the
+                // internal CMS does not - normalize so the language CODE contract is backend-neutral.
+                String code = child.getName();
+                while (code.endsWith(PATH_SEPARATOR)) {
+                    code = code.substring(0, code.length() - 1);
+                }
+                if (!code.isEmpty()) {
+                    languages.add(code);
+                }
             }
         }
         return languages;


### PR DESCRIPTION
Fixes #6967 — two halves, both needed:

1. **`CmsStore.listLanguages`** strips the trailing path separator the S3 CMS keeps on child folder names (`CmisS3Folder.getName()` → `en/`), so `GET /services/print/{entity}/languages` serves the same clean codes on every CMS backend.
2. **`UserFacade.getLanguage`** catches `IllegalArgumentException` from `Locale.LanguageRange.parse` — the header is client-controlled, and a malformed value must degrade to "no language preference" (warn + empty) rather than turn every localized repository read on the request into a 500.

Observed in production-shaped staging (S3 CMS, 14.36.0): Print → any language → `SalesInvoicePrintFeeder#feed threw: range=en/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)