### PR TITLE
Monitoring Logs: read a log file as text/plain instead of failing content negotiation

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/api.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/api.js
@@ -96,7 +96,10 @@ App.services.api = {
     // X-Requested-With marks the call as programmatic for browsers without Sec-Fetch-Mode: the
     // server then answers an expired session with a PLAIN 401 (no Basic challenge), so the
     // browser's native login dialog never pops over a background poll.
-    const headers = { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' };
+    // A caller may pin the Accept header for THIS call ({ accept: 'text/plain' }) - e.g. the
+    // monitoring Logs page, whose file endpoint produces text/plain and answers 406 to a JSON-only
+    // Accept before the handler even runs. JSON stays the default.
+    const headers = { 'Accept': opts.accept || 'application/json', 'X-Requested-With': 'XMLHttpRequest' };
     if (!isForm) headers['Content-Type'] = 'application/json';
     // A caller may pin the request language for THIS call ({ language: 'bg' }) — e.g. Print, where the
     // chosen print language must drive the multilingual data overlay, not the UI locale. Absent the

--- a/components/resources/resources-monitoring/src/main/resources/META-INF/dirigible/monitoring/js/services/ops.js
+++ b/components/resources/resources-monitoring/src/main/resources/META-INF/dirigible/monitoring/js/services/ops.js
@@ -105,7 +105,7 @@ window.MonitoringOps = (() => {
     logFiles: () => get('/services/ide/logs/'),
 
     /** One log file, whole. It is never polled - the page tails what it loaded. */
-    logFile: (file) => get('/services/ide/logs/' + encodeURIComponent(file)),
+    logFile: (file) => App.services.api.get('/services/ide/logs/' + encodeURIComponent(file), { ...ABSOLUTE, accept: 'text/plain' }),
 
     /**
      * Run a read that must not take the page down with it. A monitoring screen exists to show what is


### PR DESCRIPTION
Fixes #6968.

The shell api helper (`application-core` `api.js`) hardwired `Accept: application/json`, while `LogsEndpoint` declares `produces = "text/plain"` for `GET /services/ide/logs/{file}` — content negotiation answered **406** before the handler ran, so the monitoring shell's Logs page showed "The file could not be read." for every file (the list endpoint is JSON and worked).

- `api.js`: per-call Accept override (`{ accept: 'text/plain' }`), JSON stays the default for everything else; the success path already falls back to raw text when the body is not JSON.
- `ops.js`: `logFile` requests `text/plain`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)