### PR TITLE
Shell: stamp <html lang> from the Region & Language store

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/locale.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/locale.js
@@ -33,6 +33,10 @@ document.addEventListener('alpine:init', () => {
       let saved = null;
       try { saved = localStorage.getItem(STORAGE_KEY); } catch (e) { /* storage unavailable */ }
       if (saved) this.value = saved;
+      // Stamp the document language BEFORE components mount: Harmonia's date/time/month pickers and
+      // x-h-date-format resolve their display locale as explicit -> <html lang> -> navigator.language,
+      // so without the stamp every date renders in the BROWSER's locale whatever this store says.
+      this.stamp();
       // Fire-and-forget: refresh the platform set (DIRIGIBLE_APPLICATION_LANGUAGES); on failure the
       // built-in default stands. A persisted value outside the set falls back to the first entry.
       fetch(LANGUAGES_URL, { credentials: 'same-origin', headers: { 'X-Requested-With': 'XMLHttpRequest' } })
@@ -40,8 +44,14 @@ document.addEventListener('alpine:init', () => {
         .then((codes) => {
           if (Array.isArray(codes) && codes.length) this.supported = codes;
           if (!this.supported.includes(this.value)) this.value = this.supported[0];
+          this.stamp();
         })
         .catch(() => { /* platform default stands */ });
+    },
+
+    // Keep the document language in sync with the effective value (guarded for non-browser runs).
+    stamp() {
+      try { document.documentElement.lang = this.value; } catch (e) { /* no document */ }
     },
 
     // The platform's supported data-language codes (never per-module).


### PR DESCRIPTION
Fixes #6971 — the store switched the i18n catalogs and the `Accept-Language` header but never set `document.documentElement.lang`, so Harmonia's locale-driven widgets (date/datetime/month pickers, `x-h-date-format`) resolved to `navigator.language` and rendered dates in the browser's locale regardless of the chosen language.

Stamps at store init (before Alpine components mount), re-stamps after the platform supported-set fetch corrects the value; `set()` reloads the page so init covers the change path. Guarded for non-browser contexts.

Related design note kept in the issue: pickers are locale-driven while list columns follow the instance's configured date PATTERN — with the stamp they now at least follow the same app language; pattern-driven pickers stay a separate ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)