### PR TITLE
Harmonia print: fit wide tables to the page instead of clipping

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/basePage.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/basePage.js
@@ -106,12 +106,16 @@ function basePage() {
         '<th class="' + (c.number ? 'text-right' : '') + '">' + esc(this.columnHeader(c)) + '</th>').join('');
       const body = rows.map((r) => '<tr>' + columns.map((c) =>
         '<td class="' + (c.number ? 'text-right' : '') + '">' + esc(cellText(r, c)) + '</td>').join('') + '</tr>').join('');
+      // Fixed table layout + column-count font scaling so a wide table fits the page instead of
+      // overflowing and being clipped at the right edge (mirrors the server-side XslFoRenderer PDF
+      // path). Long unbreakable tokens (ids, IBANs) wrap inside the fixed cell.
+      const fontSize = Math.max(6, 10 - Math.max(0, columns.length - 3));
       const html = '<!doctype html><html><head><title>' + esc(title) + '</title><style>'
         + 'body{font-family:system-ui,-apple-system,sans-serif;margin:24px;color:#111}'
         + 'h1{font-size:18px;margin:0 0 4px}'
         + '.meta{font-size:11px;color:#555;margin:0 0 16px}'
-        + 'table{border-collapse:collapse;width:100%;font-size:12px}'
-        + 'th,td{border:1px solid #999;padding:4px 8px;text-align:left}'
+        + 'table{border-collapse:collapse;width:100%;table-layout:fixed;font-size:' + fontSize + 'pt}'
+        + 'th,td{border:1px solid #999;padding:2pt;text-align:left;overflow-wrap:anywhere;word-break:break-word}'
         + 'th{background:#eee}.text-right{text-align:right}'
         + '</style></head><body><h1>' + esc(title) + '</h1>'
         + '<p class="meta">' + rows.length + ' rows - ' + esc(new Date().toLocaleString()) + '</p>'

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report-file/report.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report-file/report.js.template
@@ -299,12 +299,15 @@ document.addEventListener('alpine:init', () => {
         const esc = (v) => String(v == null ? '' : v).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
         const th = cols.map(c => '<th class="' + this.alignClass(c) + '">' + esc(c) + '</th>').join('');
         const body = rows.map(r => '<tr>' + cols.map(c => '<td class="' + this.alignClass(c) + '">' + esc(this.cellText(c, r)) + '</td>').join('') + '</tr>').join('');
+        // Fixed table layout + column-count font scaling so a wide table fits the page instead of
+        // being clipped at the right edge (mirrors the server-side XslFoRenderer PDF path).
+        const fontSize = Math.max(6, 10 - Math.max(0, cols.length - 3));
         const html = '<!doctype html><html><head><title>' + esc(this.displayName) + '</title><style>'
           + 'body{font-family:system-ui,-apple-system,sans-serif;margin:24px;color:#111}'
           + 'h1{font-size:18px;margin:0 0 4px}'
           + '.meta{font-size:11px;color:#555;margin:0 0 16px}'
-          + 'table{border-collapse:collapse;width:100%;font-size:12px}'
-          + 'th,td{border:1px solid #999;padding:4px 8px;text-align:left}'
+          + 'table{border-collapse:collapse;width:100%;table-layout:fixed;font-size:' + fontSize + 'pt}'
+          + 'th,td{border:1px solid #999;padding:2pt;text-align:left;overflow-wrap:anywhere;word-break:break-word}'
           + 'th{background:#eee}.text-right{text-align:right}'
           + '</style></head><body><h1>' + esc(this.displayName) + '</h1>'
           + '<p class="meta">' + rows.length + ' rows' + (this.activeFilterCount ? ' (filtered)' : '') + ' - ' + esc(new Date().toLocaleString()) + '</p>'

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report/table-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report/table-page.js.template
@@ -75,12 +75,15 @@ document.addEventListener('alpine:init', () => {
         const cell = (col, row) => col.float ? this.displayNumber(row[col.key], col.pattern) : row[col.key];
         const th = this.printColumns.map(c => '<th class="' + (c.number ? 'text-right' : '') + '">' + esc(c.label) + '</th>').join('');
         const body = rows.map(r => '<tr>' + this.printColumns.map(c => '<td class="' + (c.number ? 'text-right' : '') + '">' + esc(cell(c, r)) + '</td>').join('') + '</tr>').join('');
+        // Fixed table layout + column-count font scaling so a wide table fits the page instead of
+        // being clipped at the right edge (mirrors the server-side XslFoRenderer PDF path).
+        const fontSize = Math.max(6, 10 - Math.max(0, this.printColumns.length - 3));
         const html = '<!doctype html><html><head><title>${name}</title><style>'
           + 'body{font-family:system-ui,-apple-system,sans-serif;margin:24px;color:#111}'
           + 'h1{font-size:18px;margin:0 0 4px}'
           + '.meta{font-size:11px;color:#555;margin:0 0 16px}'
-          + 'table{border-collapse:collapse;width:100%;font-size:12px}'
-          + 'th,td{border:1px solid #999;padding:4px 8px;text-align:left}'
+          + 'table{border-collapse:collapse;width:100%;table-layout:fixed;font-size:' + fontSize + 'pt}'
+          + 'th,td{border:1px solid #999;padding:2pt;text-align:left;overflow-wrap:anywhere;word-break:break-word}'
           + 'th{background:#eee}.text-right{text-align:right}'
           + '</style></head><body><h1>${name}</h1>'
           + '<p class="meta">' + rows.length + ' rows - ' + esc(new Date().toLocaleString()) + '</p>'


### PR DESCRIPTION
Closes #6973

### Problem
The list/master/report **Print** buttons build an HTML document and call `window.print()`. The stylesheet used `table{width:100%}` with the browser's default **auto** table-layout, where `width:100%` is only a *minimum*: the browser grows columns to fit content, and when the summed content width exceeds the page, the table overflows and the browser **clips** everything past the right edge. A wide entity like Sales Invoices (17 columns) loses roughly its right third. Confirmed from the produced PDF's metadata (`MediaBox 595x842`, `Producer: Skia/PDF`) — it is Chrome's own portrait print, not the server-side FOP path.

### Fix — mirror the server-side FOP renderer
No `@page`/landscape trick: the server-side `XslFoRenderer` prints portrait too and solves the identical "wide printed table" problem purely with fixed layout + font scaling. The browser print now does the same:

- **`table-layout:fixed; width:100%`** — the actual fix. Forces the table to exactly the page width so it cannot overflow; over-long content wraps into taller rows instead of being clipped.
- **Column-count font scaling**, same formula as `XslFoRenderer.java` (`Math.max(6, 10 - Math.max(0, columns - 3))`), so a wide table shrinks to stay compact (floors at 6pt).
- **`padding:2pt`** cells (matching FOP) and **`overflow-wrap:anywhere; word-break:break-word`** so space-less tokens (ids, IBANs like `BG12CODBEXTEXT23`) wrap inside their fixed cell.

### Scope
Fixed in all three copies of the print stylesheet:
- `application-core/.../pages/basePage.js` → `printRows` — the shared helper behind `printList()` on the **list / master / manage / my / partner** views. Because `application-core` is served once (not copied per project), this fixes every already-generated app after a rebuild, no regeneration needed.
- `template-application-ui-harmonia-java/.../report-file/report.js.template` → standalone report print.
- `template-application-ui-harmonia-java/.../report/table-page.js.template` → report table-view print.

The chart print (`chart-page.js`) prints an image, not a table, so it is unaffected. No other copies of the pattern exist (verified).

### Notes
- JS/`.template` only — no Java changed, so no formatter/javadoc impact.
- `IntentEmissionCoverageIT`'s `printRows(...)` / `printList()` call-site assertions are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)