### PR TITLE
fix(csvim): a seed re-import no longer overwrites user-edited rows - upsert defaults to false

### DIFF
--- a/components/data/data-csvim/src/main/java/org/eclipse/dirigible/components/data/csvim/domain/CsvFile.java
+++ b/components/data/data-csvim/src/main/java/org/eclipse/dirigible/components/data/csvim/domain/CsvFile.java
@@ -115,10 +115,18 @@ public class CsvFile extends Artefact {
     @Column(name = "CSV_FILE_DISTINGUISH_EMPTY_FROM_NULL", columnDefinition = "BOOLEAN")
     @Expose
     private Boolean distinguishEmptyFromNull;
-    /** The upsert. */
+    /**
+     * Whether a re-import may UPDATE rows that already exist. Absent from the .csvim this is FALSE: a
+     * seed's default job is starter content - INSERT what is missing, never touch a row the user may
+     * have edited since. A re-import fires on any artefact hash change (a regenerated .csvim, a new CSV
+     * column), and with upsert on it rewrites every seeded PK row with the seed's values, binding NULL
+     * for the columns the CSV does not carry - which silently destroyed a production row edited long
+     * after its seeding (#6980). Release-maintained reference data (nomenclatures, translations) opts
+     * in explicitly with {@code "upsert": true}.
+     */
     @Column(name = "CSV_FILE_UPSERT", columnDefinition = "boolean", nullable = false)
     @Expose
-    private Boolean upsert = true; // default true
+    private Boolean upsert = false;
     /**
      * The csvim.
      */

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/csvim/CsvimIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/csvim/CsvimIntentGenerator.java
@@ -59,6 +59,14 @@ import org.springframework.stereotype.Component;
  * when the seed does not override it.
  *
  * <p>
+ * {@code upsert} is always emitted explicitly rather than left to the platform default, because the
+ * two seed kinds want opposite semantics: a language seed is release-maintained nomenclature whose
+ * re-import must keep updating deployed rows ({@code true}), while an entity or file seed is
+ * starter content whose rows the user owns after first import - a re-import must INSERT what is
+ * missing and never touch an existing row ({@code false}, the lesson of #6980). {@code upsert:} on
+ * the seed overrides either way.
+ *
+ * <p>
  * Idempotent: identical input always produces byte-identical output.
  */
 @Component
@@ -146,6 +154,15 @@ public class CsvimIntentGenerator implements IntentTargetGenerator {
      */
     static String renderCsvForTest(EntityIntent entity, SeedIntent seed) {
         return seed.isLanguageSeed() ? renderLanguageCsv(entity, seed) : renderCsv(orderedFieldsOf(entity), entity, seed);
+    }
+
+    /**
+     * Test seam: render a seed's .csvim declaration exactly like {@link #generate}. Public because the
+     * emission tests live beside {@link IntentGenerationContext}'s package-private constructor, one
+     * package up. Never use in production code.
+     */
+    public static String renderCsvimForTest(IntentGenerationContext context, SeedIntent seed, EntityIntent entity, String fileName) {
+        return renderCsvim(context, seed, entity, fileName);
     }
 
     private static String renderCsv(List<FieldIntent> fields, EntityIntent entity, SeedIntent seed) {
@@ -368,6 +385,7 @@ public class CsvimIntentGenerator implements IntentTargetGenerator {
         entry.put("delimField", FIELD_DELIM);
         entry.put("delimEnclosing", QUOTE_DELIM);
         entry.put("distinguishEmptyFromNull", true);
+        entry.put("upsert", seed.resolvedUpsert());
         entry.put("version", "1.0");
         Map<String, Object> document = new LinkedHashMap<>();
         document.put("files", List.of(entry));

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/SeedIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/SeedIntent.java
@@ -52,6 +52,14 @@ public class SeedIntent {
      * scrubbed by the intent regeneration.
      */
     private String file;
+    /**
+     * Optional: whether a re-import may UPDATE rows that already exist ({@code "upsert"} in the emitted
+     * {@code .csvim}). Omitted, the semantics follow the seed's nature: a language seed is
+     * release-maintained nomenclature and keeps updating ({@code true}); every other seed is starter
+     * content - INSERT what is missing, never touch a row the user may have edited since
+     * ({@code false}). Authors of release-maintained reference data declare {@code upsert: true}.
+     */
+    private Boolean upsert;
 
     public String getName() {
         return name;
@@ -129,5 +137,22 @@ public class SeedIntent {
     /** Whether this seed references an authored CSV file instead of inline rows. */
     public boolean isFileSeed() {
         return file != null && !file.isBlank();
+    }
+
+    public Boolean getUpsert() {
+        return upsert;
+    }
+
+    public void setUpsert(Boolean upsert) {
+        this.upsert = upsert;
+    }
+
+    /**
+     * The re-import semantics the emitted {@code .csvim} declares: the authored {@code upsert:} when
+     * present, otherwise {@code true} for a language seed (release-maintained translations) and
+     * {@code false} for everything else (starter content).
+     */
+    public boolean resolvedUpsert() {
+        return upsert != null ? upsert : isLanguageSeed();
     }
 }

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/CsvimUpsertEmissionTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/CsvimUpsertEmissionTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.dirigible.components.intent.generator.csvim.CsvimIntentGenerator;
+import org.eclipse.dirigible.components.intent.model.EntityIntent;
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.model.SeedIntent;
+import org.eclipse.dirigible.components.intent.parser.IntentParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The emitted .csvim always carries an explicit {@code upsert}, because the two seed kinds want
+ * opposite re-import semantics: starter content must never touch a row the user edited after the
+ * first import (#6980), while a language seed is release-maintained nomenclature that must keep
+ * updating. An authored {@code upsert:} overrides either way.
+ *
+ * <p>
+ * Lives in this package (not beside {@code CsvimIntentGeneratorTest}) because
+ * {@link IntentGenerationContext}'s constructor is package-private.
+ */
+class CsvimUpsertEmissionTest {
+
+    private static final String YAML = """
+            name: countries
+            entities:
+              - name: Country
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+            seeds:
+              - name: countries
+                entity: Country
+                rows:
+                  - { id: 34, name: Bulgaria }
+            """;
+
+    private static final String MULTILINGUAL_YAML = """
+            name: uoms
+            languages: [en, bg]
+            entities:
+              - name: UoM
+                kind: setting
+                multilingual: true
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string, required: true, length: 100 }
+            seeds:
+              - name: uoms-bg
+                entity: UoM
+                language: bg
+                rows:
+                  - { id: 1, name: "Килограм" }
+            """;
+
+    @Test
+    void entitySeedDeclaresCreateIfAbsentSemantics() {
+        IntentModel model = IntentParser.parse(YAML);
+        String csvim = renderCsvim(model, model.getSeeds()
+                                               .get(0));
+        assertTrue(csvim.contains("\"upsert\": false"),
+                "a starter seed's .csvim must pin upsert OFF so a re-import never stomps user-edited rows: " + csvim);
+    }
+
+    @Test
+    void languageSeedDeclaresReleaseMaintainedSemantics() {
+        IntentModel model = IntentParser.parse(MULTILINGUAL_YAML);
+        String csvim = renderCsvim(model, model.getSeeds()
+                                               .get(0));
+        assertTrue(csvim.contains("\"upsert\": true"),
+                "a language seed's .csvim must pin upsert ON - translations are release-maintained: " + csvim);
+    }
+
+    @Test
+    void authoredUpsertOverridesTheSeedKindDefault() {
+        IntentModel model = IntentParser.parse(YAML.replace("""
+                  - name: countries
+                    entity: Country
+                """, """
+                  - name: countries
+                    entity: Country
+                    upsert: true
+                """));
+        String csvim = renderCsvim(model, model.getSeeds()
+                                               .get(0));
+        assertTrue(csvim.contains("\"upsert\": true"), "upsert: true on the seed must override the starter-content default: " + csvim);
+    }
+
+    private static String renderCsvim(IntentModel model, SeedIntent seed) {
+        IntentGenerationContext context =
+                new IntentGenerationContext(model, "/users/admin/workspace/proj", "proj", "workspace", "proj", null);
+        EntityIntent entity = model.getEntities()
+                                   .stream()
+                                   .filter(e -> e.getName()
+                                                 .equals(seed.getEntity()))
+                                   .findFirst()
+                                   .orElseThrow();
+        return CsvimIntentGenerator.renderCsvimForTest(context, seed, entity, seed.getName());
+    }
+}

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/csvim/CsvimIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/csvim/CsvimIntentGeneratorTest.java
@@ -223,4 +223,5 @@ class CsvimIntentGeneratorTest {
                 34,Bulgaria
                 """, csv, "a seed that never references a relation must not gain FK columns");
     }
+
 }

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/CsvimReimportIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/CsvimReimportIT.java
@@ -88,7 +88,12 @@ class CsvimReimportIT extends IntegrationTest {
             }
             """;
 
-    /** The CSVIM fixture source - a stable pointer that is NEVER touched after the initial import. */
+    /**
+     * The CSVIM fixture source - a stable pointer that is NEVER touched after the initial import.
+     * Declares {@code "upsert": true} explicitly: this fixture exercises change DETECTION (the second
+     * sync must fire off a CSV-only edit), so it opts into update semantics; the default-semantics
+     * fixture below deliberately omits the key.
+     */
     private static final String CSVIM_SOURCE = """
             {
                 "files": [
@@ -100,11 +105,15 @@ class CsvimReimportIT extends IntegrationTest {
                         "useHeaderNames": true,
                         "delimField": ",",
                         "distinguishEmptyFromNull": true,
+                        "upsert": true,
                         "version": "1.0"
                     }
                 ]
             }
             """.formatted(PROJECT);
+
+    /** The same declaration WITHOUT {@code upsert} - the platform-default semantics under test. */
+    private static final String CSVIM_SOURCE_DEFAULT = CSVIM_SOURCE.replace("            \"upsert\": true,\n", "");
 
     /** The default data source name. */
     @Autowired
@@ -203,6 +212,39 @@ class CsvimReimportIT extends IntegrationTest {
     }
 
     /**
+     * The default semantics: a .csvim that never mentions {@code upsert} is starter content. A
+     * re-import (here: a changed seed value, which changes the tracked content) INSERTs the rows it
+     * does not find and never touches the ones it does - specifically not a row the user edited after
+     * the first import. This is the #6980 production shape: the seeded company row was renamed by the
+     * user, a later release changed the seed artefacts, and the re-import must not stomp the rename.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    void defaultReimportInsertsMissingRowsAndNeverTouchesExistingOnes() throws Exception {
+        write(TABLE_PATH, TABLE_SOURCE);
+        write(CSV_PATH, "CITY_ID,CITY_NAME\n1,Sofia");
+        write(CSVIM_PATH, CSVIM_SOURCE_DEFAULT);
+        synchronizationProcessor.forceProcessSynchronizers();
+
+        assertEquals("Sofia", cityName(1), "The initial import did not seed the row");
+
+        // the user makes the seeded row their own
+        try (Connection connection = dataSourceManager.getDefaultDataSource()
+                                                      .getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("UPDATE \"" + TABLE_NAME + "\" SET \"CITY_NAME\" = 'Sredets' WHERE \"CITY_ID\" = 1");
+        }
+
+        // a later release changes the seed: row 1 differs, row 2 is new
+        write(CSV_PATH, "CITY_ID,CITY_NAME\n1,Serdica\n2,Plovdiv");
+        synchronizationProcessor.forceProcessSynchronizers();
+
+        assertEquals("Sredets", cityName(1), "Without upsert the re-import must not touch an existing row");
+        assertEquals("Plovdiv", cityName(2), "Without upsert the re-import must still insert the rows it does not find");
+    }
+
+    /**
      * A changed value in a CSV that carries fewer columns than its table must be applied on re-import.
      *
      * @throws Exception the exception
@@ -216,6 +258,8 @@ class CsvimReimportIT extends IntegrationTest {
             try {
                 csvimProcessor.setStrictMode(false);
                 CsvFile csvFile = new CsvFile(null, "CSV_REIMPORT", null, "import", true, true, ",", "\"", null, false, null);
+                // update semantics are the explicit opt-in; this test exercises the update BINDING
+                csvFile.setUpsert(true);
 
                 csvimProcessor.process(csvFile, "R1,R2,R3\n1,r2_1,r3_1\n2,r2_2,r3_2".getBytes(), defaultDataSourceName);
 
@@ -253,6 +297,8 @@ class CsvimReimportIT extends IntegrationTest {
             try {
                 csvimProcessor.setStrictMode(false);
                 CsvFile csvFile = new CsvFile(null, "CSV_REIMPORT_NH", null, "import", false, false, ",", "\"", null, false, null);
+                // update semantics are the explicit opt-in; this test exercises the update BINDING
+                csvFile.setUpsert(true);
 
                 csvimProcessor.process(csvFile, "1,n2_1\n2,n2_2".getBytes(), defaultDataSourceName);
 


### PR DESCRIPTION
Fixes #6980.

## Problem

`CsvFile.upsert` defaulted **true**, so a `.csvim` that never mentions `upsert` got update-on-reimport semantics. A re-import fires on any artefact hash change (a regenerated `.csvim`, a new CSV column), and the update rewrites every seeded PK row with the seed's values - binding **NULL** for every table column the CSV does not carry.

Historically that update path threw `Parameter #N is not set` for any CSV narrower than its table (every audited entity), which *accidentally* protected user rows. Once the binding was fixed to bind by column name, the destructive default was fully armed: on a production instance, an upgrade whose release had touched the company seed files silently reverted the tenant's own company profile (PK 1, edited long after seeding) back to "My Company" and NULLed its VAT number, registration, manager, e-mail, phone and address.

## Fix

1. **`CsvFile.upsert` defaults to `false`** - absent `upsert`, a re-import INSERTs the rows it does not find and never touches the ones it does. A seed's default job is starter content; updating existing rows is a legitimate mode for release-maintained reference data, but it is the mode that destroys user data when applied to rows users own, so it is the explicit opt-in (`"upsert": true`), never the silent default.
2. **`CsvimIntentGenerator` always emits `upsert` explicitly**, because the two seed kinds want opposite semantics: `false` for entity/file seeds (starter content), `true` for language seeds (release-maintained translations that must keep updating). A new optional seed key `upsert:` overrides either way; the reflective unknown-key validation picks it up from the model field, so the DSL accepts it with no parser change.
3. **Tests**:
   - `CsvimReimportIT`: the two narrow-CSV binding tests and the CSV-edit change-detection test now opt into `upsert` explicitly - they test the update *binding* and re-import *triggering*, not the policy. A new test pins the new default in exactly the production shape: initial import → user edits the seeded row → the seed file changes → re-import must insert the new row and leave the edited one alone.
   - `CsvimUpsertEmissionTest` (in the `generator` package, beside the package-private `IntentGenerationContext` constructor): entity seed emits `"upsert": false`, language seed emits `"upsert": true`, authored `upsert: true` overrides.

Existing behavior that *relies* on updates is unaffected where it declared its intent; fixtures that relied on the silent default (the ITs above) now declare it - which is the point.

## Verification

- `data-csvim` + `engine-intent` unit tests: **942/942** green (includes the 3 new emission tests).
- `CsvimReimportIT`: **4/4** green against a full Dirigible boot.
- `mvn formatter:format` produces no reformatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)