### PR TITLE
build(deps): bump codbex__harmonia webjar from 2.14.0 to 2.14.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
         <bpmn-visualization.version>0.47.0</bpmn-visualization.version>
         <i18next.version>25.3.0</i18next.version>
         <alpinejs.version>3.15.11</alpinejs.version>
-        <harmonia.version>2.14.0</harmonia.version>
+        <harmonia.version>2.14.2</harmonia.version>
         <opensans.version>5.2.7</opensans.version>
         <lucide.version>1.8.0</lucide.version>
         <pinecone-router.version>7.5.2</pinecone-router.version>


### PR DESCRIPTION
Adopts and supersedes #6978 (Dependabot's bump to 2.14.1). 2.14.2 was published to Maven Central before that PR could land and is a strict superset of it; neither release carries a breaking change.

Both patch releases fix components the generated Harmonia stack drives with a **programmatically written model** - which is exactly what every edit form does when it loads a record.

**2.14.1 - Time Picker follows a model write.** The popup kept its previous selection while only the input text followed the model: opening it on edit highlighted the old time (or nothing), changing a single part was silently dropped because the selection never became complete, and once complete a pick recombined with the stale leftovers, writing a time mixed from two values. `x-h-time-picker` + `x-h-time-picker-input x-model="form.<prop>"` is what the manage, document, my/partner and form-builder templates emit for every time field.

**2.14.2 - Number Input.** With `x-model.number` bound, an entry the browser could not represent yet (a decimal separator its region settings reject) made the input report empty, the writeback wrote that back, and the whole entry disappeared under the cursor. A dropped separator keystroke is now reported through native custom validity instead of silently merging `123,5` into `1235`; the input defaults to `inputmode="decimal"` so iOS gets a separator key at all; and the step controls clamp to `min`/`max` when `step` is `any`. Every generated numeric field is precisely `x-h-input-number` > `input type="number" step="any" x-model.number` - in the manage/document/partner/my form views, the document line-item drafts, the admin editor, the report parameter strip and range filters, and the form builder.

### Verification

- `org.webjars.npm:codbex__harmonia:2.14.2` resolves from Maven Central; `components/resources/application-core` (the only module declaring the webjar) packages clean.
- The webjar is served version-less, so nothing references a versioned path - confirmed no `codbex__harmonia/2.` occurrences anywhere in the sources.
- `dist/` file inventory is unchanged and `harmonia.css` is byte-identical between 2.14.0 and 2.14.2 (the 2.13.0-style utility-class break would have shown here).
- A literal-token diff of `harmonia.min.js` **removes nothing** and adds only `"data-invalid-label"` and `"decimal"`, corroborating the changelog's "no breaking changes" - no template, CSS class, `data-*` hook or Selenide selector is affected.
- No source references the `step-up-trigger` / `step-down-trigger` data-slots whose (previously duplicated) assignment 2.14.2 corrects; the only hits are stale IT report artifacts under `tests/tests-integrations/build/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)