### PR TITLE
docs: add GetMerged maintainer review scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Eclipse Dirigible™
 
 [![Build Status](https://github.com/eclipse/dirigible/actions/workflows/build.yml/badge.svg)](https://github.com/eclipse/dirigible/actions/workflows/build.yml)
+[![GetMerged Scorecard](https://getmerged.abhishekco.de/api/badge/eclipse-dirigible/dirigible)](https://getmerged.abhishekco.de/eclipse-dirigible/dirigible)
 [![Eclipse License](https://img.shields.io/badge/License-EPL%202.0-brightgreen.svg)](https://github.com/eclipse/dirigible/blob/master/LICENSE)
 [![Download Dirigible](https://img.shields.io/badge/download-releases-green.svg)](http://download.dirigible.io/)
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/eclipse-dirigible)](https://artifacthub.io/packages/search?org=dirigiblelabs)


### PR DESCRIPTION
Hey maintainers! 👋

I'm Abhishek, building [GetMerged](https://getmerged.abhishekco.de).

Like many developers, I spent years opening pull requests to popular open-source repos only to watch them sit unanswered for months. GitHub stars measure hype, not whether maintainers are actually active today.

I started GetMerged to fix that: we score projects based on real pull request review speed, newcomer acceptance, and merge rates.

Your project ranked in the **S-Tier** on our index with exceptional review turnaround. 

This PR adds your live GetMerged scorecard badge to `README.md` to signal to prospective contributors that their work won't get lost in a backlog.

[![GetMerged Scorecard](https://getmerged.abhishekco.de/api/badge/eclipse-dirigible/dirigible)](https://getmerged.abhishekco.de/eclipse-dirigible/dirigible)

*(Feel free to adjust the placement in your README or check your full scorecard at https://getmerged.abhishekco.de/eclipse-dirigible/dirigible)*
