### PR TITLE
intent: extend the assistant's validation through a dry-run generation pass

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/agent/IntentAgentService.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/agent/IntentAgentService.java
@@ -19,6 +19,7 @@ import org.eclipse.dirigible.commons.config.DirigibleConfig;
 import org.eclipse.dirigible.components.intent.ai.AssistantGuide;
 import org.eclipse.dirigible.components.intent.ai.ModelClient;
 import org.eclipse.dirigible.components.intent.ai.ProposalRepairLoop;
+import org.eclipse.dirigible.components.intent.generator.IntentGenerationService;
 import org.eclipse.dirigible.components.intent.parser.IntentParser;
 import org.eclipse.dirigible.components.intent.parser.IntentValidationException;
 import org.slf4j.Logger;
@@ -70,9 +71,11 @@ class IntentAgentService {
             "Propose a complete, updated app.intent YAML for the developer to review as a diff.", inputSchema());
 
     private final ModelClient modelClient;
+    private final IntentGenerationService generationService;
 
-    IntentAgentService(ModelClient modelClient) {
+    IntentAgentService(ModelClient modelClient, IntentGenerationService generationService) {
         this.modelClient = modelClient;
+        this.generationService = generationService;
     }
 
     /**
@@ -125,8 +128,7 @@ class IntentAgentService {
      */
     AgentReply chat(AgentRequest request) {
         List<Map<String, Object>> messages = ModelClient.messages(request.history(), buildUserTurn(request));
-        ProposalRepairLoop loop =
-                new ProposalRepairLoop("yaml", "yaml", IntentAgentService::validationIssues, IntentAgentService::repairTurn);
+        ProposalRepairLoop loop = new ProposalRepairLoop("yaml", "yaml", this::validationIssues, IntentAgentService::repairTurn);
         ProposalRepairLoop.Outcome outcome = loop.run(messages, this::callModel);
 
         String reply = replyText(outcome);
@@ -197,21 +199,36 @@ class IntentAgentService {
     }
 
     /**
-     * Validate a proposed intent with the same parser that backs the editor's parse endpoint.
+     * Validate a proposed intent with the same parser that backs the editor's parse endpoint, and -
+     * when it parses - with a dry generation pass (dirigible #6956): the band the parser legitimately
+     * cannot see, a document that parses but whose generation would drop glue or be refused by a
+     * generation-time check, comes back to the repair loop instead of reaching the developer looking
+     * finished.
+     *
+     * <p>
+     * The dry run has no project context here (a proposal is not saved anywhere yet), so cross-model
+     * references resolve by convention and never produce a false "cannot be resolved" issue. A failure
+     * of the dry-run machinery itself must not fail the turn - the parse verdict alone is then the
+     * answer, exactly what this method returned before the dry run existed.
      *
      * @param proposedYaml the proposal
      * @return the validation issues; empty for a valid proposal
      */
-    private static List<String> validationIssues(String proposedYaml) {
+    private List<String> validationIssues(String proposedYaml) {
         try {
             IntentParser.parse(proposedYaml);
-            return List.of();
         } catch (IntentValidationException ex) {
             LOGGER.debug("Intent AI proposal failed structural validation", ex);
             return ex.getIssues();
         } catch (RuntimeException ex) {
             LOGGER.debug("Intent AI proposal is not parseable", ex);
             return List.of("the proposed YAML could not be parsed: " + ex.getMessage());
+        }
+        try {
+            return generationService.dryRun(proposedYaml);
+        } catch (RuntimeException ex) {
+            LOGGER.error("The dry generation pass over an AI proposal failed - accepting the parse verdict alone", ex);
+            return List.of();
         }
     }
 

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/ai/ProposalRepairLoop.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/ai/ProposalRepairLoop.java
@@ -35,8 +35,15 @@ public final class ProposalRepairLoop {
     /**
      * How many times an invalid proposal is sent back to the model for correction. Bounds the loop at
      * {@code 1 + MAX_REPAIR_ROUNDS} upstream calls per turn.
+     *
+     * <p>
+     * Raised from 2 once two things held (dirigible #6956): the upstream call is streamed with a
+     * generous outer bound instead of one 120-second window (#6955), so more rounds no longer multiply
+     * exposure to a wall-clock cliff; and the intent validator sees the generation layer as well as the
+     * parse, so later rounds have genuinely new defects to fix rather than restating one parse error.
+     * The loop still exits on the first clean round - four is a ceiling, not a target.
      */
-    public static final int MAX_REPAIR_ROUNDS = 2;
+    public static final int MAX_REPAIR_ROUNDS = 4;
 
     /** One upstream round-trip over the accumulated turns. */
     @FunctionalInterface

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/endpoint/IntentEndpoint.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/endpoint/IntentEndpoint.java
@@ -10,6 +10,7 @@
 package org.eclipse.dirigible.components.intent.endpoint;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 
 import jakarta.annotation.security.RolesAllowed;
@@ -42,6 +43,8 @@ import org.springframework.web.server.ResponseStatusException;
  * <li>{@code POST /services/ide/intent/parse} - body is the raw intent YAML; returns the parsed
  * {@link IntentModel} (drives the editor's live diagram), or {@code 422} with the full list of
  * structural issues.</li>
+ * <li>{@code POST /services/ide/intent/validate} - parse plus a write-nothing generation pass;
+ * returns the model together with everything generation would object to (dirigible #6956).</li>
  * <li>{@code POST /services/ide/intent/generate} - generates every derived model file into the
  * given workspace project (next to the intent file) and scrubs stale output; returns the written
  * and scrubbed file names.</li>
@@ -77,6 +80,60 @@ public class IntentEndpoint {
         } catch (IntentValidationException e) {
             return ResponseEntity.unprocessableEntity()
                                  .body(Map.of("issues", e.getIssues()));
+        }
+    }
+
+    /**
+     * Parse AND dry-run-generate an intent document - the full pre-flight the Builder's auto-apply gate
+     * needs (dirigible #6956). The parse-only endpoint above accepts everything the parser accepts,
+     * which includes documents whose generation would drop glue or be refused by a generation-time
+     * check; this one also runs the generation pass without writing anything and returns what it would
+     * object to.
+     *
+     * <p>
+     * The project coordinates are optional. With them, the dry run reads the real project (its
+     * {@code .settings}, developer-owned files, and cross-model dependencies resolving against the
+     * workspace/registry); without them it validates the document on its own, the way the AI
+     * assistant's server-side loop does - cross-model references then resolve by convention and are
+     * never reported as unresolvable.
+     *
+     * @param yaml the raw intent YAML
+     * @param workspace the workspace name, optional
+     * @param project the project name, optional
+     * @param path the intent file path within the project (naming fallback only), optional
+     * @return {@code {"model": ..., "issues": [...]}} - issues empty when generation raises nothing -
+     *         or {@code 422} with {@code {"issues": [...]}} when the document does not parse
+     */
+    @PostMapping(value = "/validate", consumes = MediaType.TEXT_PLAIN_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> validate(@RequestBody(required = false) String yaml,
+            @RequestParam(value = "workspace", required = false) String workspace,
+            @RequestParam(value = "project", required = false) String project,
+            @RequestParam(value = "path", required = false) String path) {
+        IntentModel model;
+        try {
+            model = IntentParser.parse(yaml);
+        } catch (IntentValidationException e) {
+            return ResponseEntity.unprocessableEntity()
+                                 .body(Map.of("issues", e.getIssues()));
+        }
+        String projectRoot = null;
+        if (workspace != null && !workspace.isBlank() && project != null && !project.isBlank()) {
+            Workspace workspaceObject = workspaceService.getWorkspace(workspace);
+            if (workspaceObject.exists()) {
+                Project projectObject = workspaceObject.getProject(project);
+                if (projectObject.exists()) {
+                    projectRoot = projectObject.getPath();
+                }
+            }
+        }
+        try {
+            List<String> issues = generationService.dryRun(yaml, projectRoot, project, workspace, path == null ? "app" : baseName(path));
+            return ResponseEntity.ok(Map.of("model", model, "issues", issues));
+        } catch (RuntimeException e) {
+            // The dry-run machinery failing is not the document's fault: answer with the parse verdict
+            // alone rather than blocking the caller on an internal error.
+            LOGGER.error("Intent dry-run validation failed for [{}/{}/{}]", workspace, project, path, e);
+            return ResponseEntity.ok(Map.of("model", model, "issues", List.of()));
         }
     }
 

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/endpoint/IntentEndpoint.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/endpoint/IntentEndpoint.java
@@ -113,7 +113,7 @@ public class IntentEndpoint {
         try {
             model = IntentParser.parse(yaml);
         } catch (IntentValidationException e) {
-            return ResponseEntity.unprocessableEntity()
+            return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
                                  .body(Map.of("issues", e.getIssues()));
         }
         String projectRoot = null;
@@ -131,10 +131,20 @@ public class IntentEndpoint {
             return ResponseEntity.ok(Map.of("model", model, "issues", issues));
         } catch (RuntimeException e) {
             // The dry-run machinery failing is not the document's fault: answer with the parse verdict
-            // alone rather than blocking the caller on an internal error.
-            LOGGER.error("Intent dry-run validation failed for [{}/{}/{}]", workspace, project, path, e);
+            // alone rather than blocking the caller on an internal error. The coordinates arrive in
+            // user-controlled URL parameters, so they are scrubbed before they reach the log.
+            LOGGER.error("Intent dry-run validation failed for [{}/{}/{}]", sanitizeForLog(workspace), sanitizeForLog(project),
+                    sanitizeForLog(path), e);
             return ResponseEntity.ok(Map.of("model", model, "issues", List.of()));
         }
+    }
+
+    /**
+     * Strip CR/LF and stray control characters from a value that arrives in a user-controlled request
+     * segment before it reaches the log, so a crafted request cannot forge log entries.
+     */
+    private static String sanitizeForLog(String value) {
+        return value == null ? "null" : value.replaceAll("[\\r\\n\\t]", "_");
     }
 
     /**
@@ -174,7 +184,8 @@ public class IntentEndpoint {
             return ResponseEntity.unprocessableEntity()
                                  .body(Map.of("issues", e.getIssues()));
         } catch (RuntimeException e) {
-            LOGGER.error("Intent generation failed for [{}/{}/{}]", workspace, project, path, e);
+            LOGGER.error("Intent generation failed for [{}/{}/{}]", sanitizeForLog(workspace), sanitizeForLog(project),
+                    sanitizeForLog(path), e);
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Generation failed: " + e.getMessage(), e);
         }
     }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/CalculatedActionStubGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/CalculatedActionStubGenerator.java
@@ -90,10 +90,12 @@ public class CalculatedActionStubGenerator implements IntentTargetGenerator {
             LOGGER.debug("Calculated action [{}] is not this project's to write - not scaffolding it", action);
             return;
         }
-        String path = context.getProjectRoot() + "/" + fileName;
-        if (context.getRepository()
-                   .getResource(path)
-                   .exists()) {
+        // No repository/project to look into (a dry run over an unsaved proposal): nothing can exist,
+        // so the stub "is produced" - and the dry-run context then discards the write.
+        boolean canLookUp = context.getRepository() != null && context.getProjectRoot() != null;
+        if (canLookUp && context.getRepository()
+                                .getResource(context.getProjectRoot() + "/" + fileName)
+                                .exists()) {
             return; // preserve the developer's implementation
         }
         String packageName = fileName.substring(0, fileName.lastIndexOf('/'))

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -643,7 +643,9 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                         + " own repository, which the [" + rollup.getModel() + "] model generates.";
                 LOGGER.warn(warning);
                 if (context != null) {
-                    context.addIssue(warning);
+                    // An ADVISORY, not an issue: no change to THIS document installs that guard, so the
+                    // assistant's repair loop must never be asked to fix it (dirigible #6956).
+                    context.addAdvisory(warning);
                 }
             }
             base.put("capacityField", withCapacity ? IntentNaming.pascalCase(rollup.getCapacity()) : "");

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentGenerationContext.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentGenerationContext.java
@@ -58,6 +58,14 @@ public final class IntentGenerationContext {
     private final IntentModel model;
     private final IRepository repository;
 
+    /**
+     * A validation-only pass: generators run and report exactly as they would for a real Generate, but
+     * nothing is written and nothing is scrubbed (dirigible #6956). Reads stay live - what already
+     * exists still decides what a generator would do - so the issues collected are the ones a real pass
+     * would raise.
+     */
+    private final boolean dryRun;
+
     /** The project's {@code .settings} (loaded or scaffolded by the service before generators run). */
     private IntentSettings settings;
 
@@ -71,14 +79,29 @@ public final class IntentGenerationContext {
      */
     private final java.util.List<String> issues = new java.util.ArrayList<>();
 
+    /**
+     * Non-fatal observations that no change to THIS document can address (e.g. a cross-model capacity
+     * guard that belongs to the child's own model). Kept apart from {@link #issues} so the assistant's
+     * repair loop is never asked to "fix" something that is not fixable here - a round spent on an
+     * unfixable advisory is a round not spent on a real defect - while the generate response still
+     * surfaces them to the developer.
+     */
+    private final java.util.List<String> advisories = new java.util.ArrayList<>();
+
     IntentGenerationContext(IntentModel model, String projectRoot, String projectName, String workspaceName, String fallbackName,
             IRepository repository) {
+        this(model, projectRoot, projectName, workspaceName, fallbackName, repository, false);
+    }
+
+    IntentGenerationContext(IntentModel model, String projectRoot, String projectName, String workspaceName, String fallbackName,
+            IRepository repository, boolean dryRun) {
         this.model = model;
         this.projectRoot = projectRoot;
         this.projectName = projectName;
         this.workspaceName = workspaceName;
         this.fallbackName = fallbackName;
         this.repository = repository;
+        this.dryRun = dryRun;
     }
 
     /**
@@ -90,6 +113,12 @@ public final class IntentGenerationContext {
      * @param content the full file content
      */
     public void writeModelFile(String fileName, String content) {
+        if (dryRun) {
+            // The name is still recorded - a dry run must report the same output set a real pass
+            // would produce - but the repository is never touched.
+            writtenFileNames.add(fileName);
+            return;
+        }
         String path = projectRoot + "/" + fileName;
         byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
         IResource existing = repository.getResource(path);
@@ -115,6 +144,10 @@ public final class IntentGenerationContext {
      * @param content the full file content to create when absent
      */
     public void writeModelFileIfAbsent(String fileName, String content) {
+        if (dryRun) {
+            writtenFileNames.add(fileName);
+            return;
+        }
         String path = projectRoot + "/" + fileName;
         IResource existing = repository.getResource(path);
         if (!existing.exists()) {
@@ -134,8 +167,11 @@ public final class IntentGenerationContext {
      *         absent and the generator should produce it
      */
     public boolean keepExistingModelFile(String fileName) {
-        if (!repository.getResource(projectRoot + "/" + fileName)
-                       .exists()) {
+        // No repository or no project to look into (a dry run over a proposal that belongs to no
+        // project yet): nothing can exist, so the generator should produce - which a dry run then
+        // discards, having exercised the build path.
+        if (repository == null || projectRoot == null || !repository.getResource(projectRoot + "/" + fileName)
+                                                                    .exists()) {
             return false;
         }
         writtenFileNames.add(fileName);
@@ -167,6 +203,34 @@ public final class IntentGenerationContext {
      */
     public java.util.List<String> getIssues() {
         return Collections.unmodifiableList(issues);
+    }
+
+    /**
+     * Record an observation no change to this document can address - surfaced to the developer, but
+     * never handed to the assistant's repair loop as something to fix.
+     *
+     * @param advisory a human-readable observation
+     */
+    public void addAdvisory(String advisory) {
+        advisories.add(advisory);
+    }
+
+    /**
+     * The advisories collected during this pass.
+     *
+     * @return an unmodifiable view of the advisories
+     */
+    public java.util.List<String> getAdvisories() {
+        return Collections.unmodifiableList(advisories);
+    }
+
+    /**
+     * Whether this pass is validation-only (nothing is written or scrubbed).
+     *
+     * @return {@code true} for a dry run
+     */
+    public boolean isDryRun() {
+        return dryRun;
     }
 
     public String getProjectName() {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentGenerationService.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentGenerationService.java
@@ -138,7 +138,70 @@ public class IntentGenerationService {
         List<String> scrubbed = scrubStaleModelFiles(projectRoot, context.getWrittenFileNames());
         List<Map<String, Object>> plan = buildCodeGenerationPlan(context.getSettings(), context.getWrittenFileNames());
         runCodeGenerations(plan, workspaceName, projectName);
-        return new GenerationResult(new ArrayList<>(context.getWrittenFileNames()), scrubbed, plan, context.getIssues());
+        // The developer-facing warnings carry BOTH kinds: the actionable issues and the advisories.
+        // Only the assistant's dry run keeps them apart (see dryRun below).
+        List<String> warnings = new ArrayList<>(context.getIssues());
+        warnings.addAll(context.getAdvisories());
+        return new GenerationResult(new ArrayList<>(context.getWrittenFileNames()), scrubbed, plan, warnings);
+    }
+
+    /**
+     * Run the generation pass for VALIDATION only: every generator executes and reports against the
+     * same context a real Generate would get, but nothing is written and nothing is scrubbed (dirigible
+     * #6956). This is the band the parser legitimately cannot see - a document that parses but whose
+     * generation would drop glue, or would be refused by a generation-time check.
+     *
+     * <p>
+     * A generator throwing {@link IntentValidationException} - fatal on a real Generate (422) - is
+     * collected here instead: the caller wants the complete list of what generation would object to,
+     * not the first objection.
+     *
+     * <p>
+     * The project coordinates may all be {@code null} - a proposal that belongs to no project yet, the
+     * AI assistant's case. Reads then find nothing (developer-owned files are treated as absent), and
+     * cross-model references resolve by naming convention rather than against a real owner model
+     * ({@code CrossModelSupport} skips its strict checks for unresolved targets) - deliberately, so a
+     * dependency that only exists in some workspace never produces a false "cannot be resolved" issue
+     * for the repair loop to burn a round on.
+     *
+     * @param yaml the raw {@code .intent} document; must already parse (the caller handles
+     *        {@link IntentValidationException} from the parse separately)
+     * @param projectRoot repository path of the target project root, or {@code null} when the document
+     *        belongs to no project
+     * @param projectName the target project name, or {@code null}
+     * @param workspaceName the workspace, or {@code null}
+     * @param fallbackName base name for single-file outputs when the YAML omits {@code name:}
+     * @return the actionable issues a real generation pass would report - advisories that no change to
+     *         this document can address are deliberately excluded
+     */
+    public List<String> dryRun(String yaml, String projectRoot, String projectName, String workspaceName, String fallbackName) {
+        IntentModel model = IntentParser.parse(yaml);
+        IntentGenerationContext context =
+                new IntentGenerationContext(model, projectRoot, projectName, workspaceName, fallbackName, repository, true);
+        context.setSettings(loadSettingsReadOnly(context));
+        for (IntentTargetGenerator generator : generators) {
+            try {
+                generator.generate(context);
+            } catch (IntentValidationException e) {
+                e.getIssues()
+                 .forEach(context::addIssue);
+            } catch (RuntimeException e) {
+                // The same isolation the real pass applies to a generator bug: one broken slice must
+                // not silence what the other generators have to say about the document.
+                LOGGER.error("Intent generator [{}] failed during a dry run", generator.name(), e);
+            }
+        }
+        return context.getIssues();
+    }
+
+    /**
+     * Validation-only pass for a document with no project context - the AI assistant's proposals.
+     *
+     * @param yaml the raw {@code .intent} document
+     * @return the actionable issues a real generation pass would report
+     */
+    public List<String> dryRun(String yaml) {
+        return dryRun(yaml, null, null, null, "app");
     }
 
     /**
@@ -214,20 +277,41 @@ public class IntentGenerationService {
      */
     private IntentSettings loadOrScaffoldSettings(IntentGenerationContext context) {
         String fileName = IntentNaming.baseName(context) + ".settings";
-        String path = context.getProjectRoot() + "/" + fileName;
-        var resource = repository.getResource(path);
-        if (resource.exists()) {
-            try {
-                return IntentSettings.parse(new String(resource.getContent(), java.nio.charset.StandardCharsets.UTF_8));
-            } catch (RuntimeException e) {
-                LOGGER.error("Failed to parse [{}] - falling back to defaults (not overwriting your file)", fileName, e);
-                return IntentSettings.scaffold(context.getModel());
-            }
+        IntentSettings existing = readSettings(context, fileName);
+        if (existing != null) {
+            return existing;
         }
         IntentSettings settings = IntentSettings.scaffold(context.getModel());
         context.writeModelFile(fileName, settings.toJson());
         LOGGER.info("Scaffolded initial settings [{}/{}]", context.getProjectRoot(), fileName);
         return settings;
+    }
+
+    /**
+     * The settings a dry run works with: the project's real {@code .settings} when there is a project
+     * to read them from, else an in-memory scaffold. Never writes - the scaffold-and-write of a first
+     * real Generate is exactly the side effect a dry run must not have.
+     */
+    private IntentSettings loadSettingsReadOnly(IntentGenerationContext context) {
+        IntentSettings existing =
+                context.getProjectRoot() == null ? null : readSettings(context, IntentNaming.baseName(context) + ".settings");
+        return existing != null ? existing : IntentSettings.scaffold(context.getModel());
+    }
+
+    /**
+     * The parsed project settings, or {@code null} when absent (or unreadable - defaults then apply).
+     */
+    private IntentSettings readSettings(IntentGenerationContext context, String fileName) {
+        var resource = repository.getResource(context.getProjectRoot() + "/" + fileName);
+        if (!resource.exists()) {
+            return null;
+        }
+        try {
+            return IntentSettings.parse(new String(resource.getContent(), java.nio.charset.StandardCharsets.UTF_8));
+        } catch (RuntimeException e) {
+            LOGGER.error("Failed to parse [{}] - falling back to defaults (not overwriting your file)", fileName, e);
+            return IntentSettings.scaffold(context.getModel());
+        }
     }
 
     /**

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/ServiceTaskHandlerGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/ServiceTaskHandlerGenerator.java
@@ -93,9 +93,12 @@ public class ServiceTaskHandlerGenerator implements IntentTargetGenerator {
                 }
                 String handler = IntentNaming.pascalCase(step.getName());
                 String fileName = "custom/" + handler + ".java";
-                if (context.getRepository()
-                           .getResource(context.getProjectRoot() + "/" + fileName)
-                           .exists()) {
+                // No repository/project to look into (a dry run over an unsaved proposal): nothing can
+                // exist, so the stub "is produced" - and the dry-run context then discards the write.
+                boolean canLookUp = context.getRepository() != null && context.getProjectRoot() != null;
+                if (canLookUp && context.getRepository()
+                                        .getResource(context.getProjectRoot() + "/" + fileName)
+                                        .exists()) {
                     continue; // preserve the developer's implementation
                 }
                 context.writeModelFile(fileName, stub(process.getName(), step.getName(), handler));

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGenerator.java
@@ -557,6 +557,9 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
         Map<String, Map<String, Object>> byName = new LinkedHashMap<>();
         try {
             IRepository repository = context.getRepository();
+            if (repository == null || context.getProjectRoot() == null) {
+                return byName; // no repository/project to read back from (a dry run over an unsaved proposal)
+            }
             IResource resource = repository.getResource(context.getProjectRoot() + "/" + baseName + ".model");
             if (!resource.exists()) {
                 return byName;

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/agent/IntentAgentServiceTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/agent/IntentAgentServiceTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.dirigible.components.intent.ai.ModelClient;
+import org.eclipse.dirigible.components.intent.generator.IntentGenerationService;
 import org.junit.jupiter.api.Test;
 
 import com.google.gson.JsonArray;
@@ -95,11 +96,12 @@ class IntentAgentServiceTest {
     @Test
     void repairRoundsAreBoundedAndTheOutstandingIssuesAreSurfaced() {
         ScriptedAgentService service = new ScriptedAgentService(proposal("Try 1.", INVALID_YAML), proposal("Try 2.", INVALID_YAML),
-                proposal("Try 3.", INVALID_YAML));
+                proposal("Try 3.", INVALID_YAML), proposal("Try 4.", INVALID_YAML), proposal("Try 5.", INVALID_YAML));
 
         AgentReply reply = service.chat(request());
 
-        assertEquals(3, service.calls.size(), "one initial call plus exactly two repair rounds");
+        assertEquals(1 + org.eclipse.dirigible.components.intent.ai.ProposalRepairLoop.MAX_REPAIR_ROUNDS, service.calls.size(),
+                "one initial call plus exactly the bounded repair rounds");
         assertEquals(INVALID_YAML, reply.proposedYaml(), "the last proposal is still returned for the editor to flag");
         assertTrue(reply.reply()
                         .contains("still fails intent validation"),
@@ -149,6 +151,40 @@ class IntentAgentServiceTest {
                           .isEmpty());
     }
 
+    @Test
+    void aProposalThatParsesButFailsGenerationIsSentBackForCorrection() {
+        // The band the parser cannot see (dirigible #6956): the proposal is structurally valid, but the
+        // generation pass would refuse or drop a piece of it. The dry run's issues must reach the
+        // repair loop exactly as a parse error does.
+        String generationIssue = "generates [audit-log] map [Vehicle] does not resolve against the source - not generated";
+        ScriptedGenerationService generation = new ScriptedGenerationService(List.of(List.of(generationIssue)));
+        ScriptedAgentService service =
+                new ScriptedAgentService(generation, proposal("First try.", VALID_YAML), proposal("Fixed.", VALID_YAML));
+
+        AgentReply reply = service.chat(request());
+
+        assertEquals(2, service.calls.size(), "the generation-layer issue triggers a repair round");
+        assertEquals(VALID_YAML, reply.proposedYaml());
+        List<Map<String, Object>> secondCall = service.calls.get(1);
+        String repairTurn = (String) secondCall.get(secondCall.size() - 1)
+                                               .get("content");
+        assertTrue(repairTurn.contains(generationIssue), "the dry run's issue text is sent back verbatim");
+    }
+
+    @Test
+    void aDryRunInfrastructureFailureDoesNotFailTheTurn() {
+        // The dry run judging the proposal is a bonus check on top of the parse - its own machinery
+        // breaking must degrade to the parse verdict, never to a failed turn.
+        ScriptedGenerationService generation = ScriptedGenerationService.failing(new IllegalStateException("no repository"));
+        ScriptedAgentService service = new ScriptedAgentService(generation, proposal("Added notes.", VALID_YAML));
+
+        AgentReply reply = service.chat(request());
+
+        assertEquals(1, service.calls.size());
+        assertEquals(VALID_YAML, reply.proposedYaml());
+        assertEquals("Added notes.", reply.reply(), "no validation note is appended");
+    }
+
     private static ModelClient.ModelReply proposal(String text, String yaml) {
         JsonObject input = new JsonObject();
         input.addProperty("explanation", text);
@@ -167,7 +203,11 @@ class IntentAgentServiceTest {
         private final List<List<Map<String, Object>>> calls = new ArrayList<>();
 
         private ScriptedAgentService(ModelClient.ModelReply... scripted) {
-            super(new ModelClient());
+            this(new ScriptedGenerationService(), scripted);
+        }
+
+        private ScriptedAgentService(IntentGenerationService generationService, ModelClient.ModelReply... scripted) {
+            super(new ModelClient(), generationService);
             this.replies = new ArrayDeque<>(List.of(scripted));
         }
 
@@ -175,6 +215,41 @@ class IntentAgentServiceTest {
         ModelClient.ModelReply callModel(List<Map<String, Object>> messages) {
             calls.add(List.copyOf(messages));
             return replies.pop();
+        }
+    }
+
+    /**
+     * Scripts the dry generation pass the same way the upstream model is scripted: each parseable
+     * proposal consumes the next issue list (empty once the script runs out). The real dry run is
+     * exercised by {@code IntentGenerationServiceDryRunTest}; here only the loop's wiring is under
+     * test.
+     */
+    private static final class ScriptedGenerationService extends IntentGenerationService {
+
+        private final Deque<List<String>> scriptedIssues;
+        private RuntimeException failure;
+
+        private ScriptedGenerationService(List<List<String>> scripted) {
+            super(List.of(), null, null);
+            this.scriptedIssues = new ArrayDeque<>(scripted);
+        }
+
+        private ScriptedGenerationService() {
+            this(List.of());
+        }
+
+        private static ScriptedGenerationService failing(RuntimeException failure) {
+            ScriptedGenerationService service = new ScriptedGenerationService();
+            service.failure = failure;
+            return service;
+        }
+
+        @Override
+        public List<String> dryRun(String yaml) {
+            if (failure != null) {
+                throw failure;
+            }
+            return scriptedIssues.isEmpty() ? List.of() : scriptedIssues.pop();
         }
     }
 }

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/assist/JavaAssistServiceTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/assist/JavaAssistServiceTest.java
@@ -89,7 +89,7 @@ class JavaAssistServiceTest {
         // assistant sees a compile error and asks for a correction. This is what makes batching
         // load-bearing rather than incidental - a custom class exists to use the generated ones.
         ScriptedAssistService alone = new ScriptedAssistService(proposal("Uses the rate.", COMPILES), proposal("Still uses it.", COMPILES),
-                proposal("And again.", COMPILES));
+                proposal("And again.", COMPILES), proposal("Once more.", COMPILES), proposal("Final try.", COMPILES));
         AssistContext lonely = new AssistContext("orders", "custom/Fees.java", "", null, List.of());
 
         AssistReply reply = alone.chat(lonely, "Use the base rate", List.of());
@@ -124,12 +124,14 @@ class JavaAssistServiceTest {
 
     @Test
     void repairRoundsAreBoundedAndTheOutstandingErrorsAreSurfaced() {
-        ScriptedAssistService service = new ScriptedAssistService(proposal("Try 1.", DOES_NOT_COMPILE),
-                proposal("Try 2.", DOES_NOT_COMPILE), proposal("Try 3.", DOES_NOT_COMPILE));
+        ScriptedAssistService service =
+                new ScriptedAssistService(proposal("Try 1.", DOES_NOT_COMPILE), proposal("Try 2.", DOES_NOT_COMPILE),
+                        proposal("Try 3.", DOES_NOT_COMPILE), proposal("Try 4.", DOES_NOT_COMPILE), proposal("Try 5.", DOES_NOT_COMPILE));
 
         AssistReply reply = service.chat(context(), "Charge twice the base rate", List.of());
 
-        assertEquals(3, service.calls.size(), "one initial call plus exactly two repair rounds");
+        assertEquals(1 + org.eclipse.dirigible.components.intent.ai.ProposalRepairLoop.MAX_REPAIR_ROUNDS, service.calls.size(),
+                "one initial call plus exactly the bounded repair rounds");
         assertEquals(DOES_NOT_COMPILE, reply.proposedSource(), "the last proposal is still returned for the developer to judge");
         assertFalse(reply.diagnostics()
                          .isEmpty());

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/IntentGenerationServiceDryRunTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/IntentGenerationServiceDryRunTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.eclipse.dirigible.components.intent.generator.action.ActionIntentGenerator;
+import org.eclipse.dirigible.components.intent.generator.apptest.AppTestIntentGenerator;
+import org.eclipse.dirigible.components.intent.generator.bpmn.BpmnIntentGenerator;
+import org.eclipse.dirigible.components.intent.generator.csvim.CsvimIntentGenerator;
+import org.eclipse.dirigible.components.intent.generator.edm.EdmIntentGenerator;
+import org.eclipse.dirigible.components.intent.generator.form.FormIntentGenerator;
+import org.eclipse.dirigible.components.intent.generator.generates.GeneratesIntentGenerator;
+import org.eclipse.dirigible.components.intent.generator.permission.PermissionIntentGenerator;
+import org.eclipse.dirigible.components.intent.generator.print.PrintIntentGenerator;
+import org.eclipse.dirigible.components.intent.generator.report.ReportIntentGenerator;
+import org.eclipse.dirigible.components.intent.generator.transition.TransitionsIntentGenerator;
+import org.eclipse.dirigible.repository.local.LocalRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The write-nothing generation pass behind the assistant's extended validation and the editor's
+ * {@code /validate} endpoint (dirigible #6956): the FULL generator chain runs and reports exactly
+ * as a real Generate would, but the repository is left byte-identical - and a document with no
+ * project context never produces a false cross-model "cannot be resolved" issue.
+ */
+class IntentGenerationServiceDryRunTest {
+
+    /**
+     * Parses cleanly, generates cleanly - and its generation-time warning is REMOVABLE: strip the
+     * {@code stage:} classifications and the event-driven create-from warns that its at-most-once guard
+     * cannot recognize a retired target. Exactly the band the parser cannot see.
+     */
+    private static final String CLEAN_YAML = """
+            name: fines
+            entities:
+              - name: FineStatus
+                function: Setting
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: DeclarationState
+                function: Setting
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: Fine
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: note, type: string }
+                relations:
+                  - { name: Status, kind: manyToOne, to: FineStatus, function: EntityStatus, init: 1 }
+              - name: Declaration
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: note, type: string }
+                relations:
+                  - { name: Fine, kind: manyToOne, to: Fine }
+                  - { name: State, kind: manyToOne, to: DeclarationState, function: EntityStatus, init: 1 }
+            generates:
+              - name: declaration-from-fine
+                from: Fine
+                to: Declaration
+                forEntity: Fine
+                event: { onTransition: Fine, when: "Status == POSTED" }
+                map:
+                  Fine: id
+                  Note: note
+            seeds:
+              - name: fine-statuses
+                entity: FineStatus
+                rows:
+                  - { id: 1, name: DRAFT }
+                  - { id: 2, name: POSTED }
+              - name: declaration-states
+                entity: DeclarationState
+                rows:
+                  - { id: 1, name: DRAFT,  stage: draft }
+                  - { id: 2, name: FILED,  stage: live }
+                  - { id: 3, name: VOIDED, stage: void }
+            """;
+
+    /** The same document with the {@code stage:} classifications stripped - generation must object. */
+    private static final String UNSTAGED_YAML = CLEAN_YAML.replaceAll(",\\s+stage: \\w+", "");
+
+    /** A document leaning on another model - which no project context can resolve. */
+    private static final String CROSS_MODEL_YAML = """
+            name: timesheets
+            uses:
+              - { model: projects }
+            entities:
+              - name: DayAllocation
+                fields:
+                  - { name: id,    type: integer, primaryKey: true, generated: true }
+                  - { name: hours, type: decimal }
+                relations:
+                  - { name: Project, kind: manyToOne, to: Project, model: projects }
+            rollups:
+              - { name: projectActualHours, entity: DayAllocation, via: Project, field: actualHours,
+                  op: sum, of: hours }
+            """;
+
+    private static IntentGenerationService service(LocalRepository repository) {
+        return new IntentGenerationService(List.of(new EdmIntentGenerator(), new GlueIntentGenerator(), new BpmnIntentGenerator(),
+                new FormIntentGenerator(), new ReportIntentGenerator(), new PrintIntentGenerator(), new CsvimIntentGenerator(),
+                new PermissionIntentGenerator(), new TransitionsIntentGenerator(), new GeneratesIntentGenerator(),
+                new ActionIntentGenerator(), new AppTestIntentGenerator(), new CalculatedActionStubGenerator(),
+                new ServiceTaskHandlerGenerator()), repository, null);
+    }
+
+    @Test
+    void aDryRunWithoutAProjectReportsWhatGenerationWouldObjectTo(@TempDir Path root) {
+        IntentGenerationService service = service(new LocalRepository(root.toString(), true));
+
+        List<String> issues = service.dryRun(UNSTAGED_YAML);
+
+        assertTrue(issues.stream()
+                         .anyMatch(issue -> issue.contains("declaration-from-fine") && issue.contains("stage:")),
+                "the generation-layer warning must surface through the dry run: " + issues);
+    }
+
+    @Test
+    void aCleanDocumentRaisesNoIssues(@TempDir Path root) {
+        IntentGenerationService service = service(new LocalRepository(root.toString(), true));
+
+        assertEquals(List.of(), service.dryRun(CLEAN_YAML));
+    }
+
+    @Test
+    void aDryRunWritesNothingAndScrubsNothing(@TempDir Path root) {
+        LocalRepository repository = new LocalRepository(root.toString(), true);
+        // A project that already exists, with a previously generated file the intent no longer
+        // declares - the exact thing a real pass would scrub - and no .settings, the exact thing a
+        // first real pass would scaffold.
+        String projectRoot = "/users/admin/workspace/fines";
+        repository.createResource(projectRoot + "/stale.form", "{}".getBytes(StandardCharsets.UTF_8));
+        repository.createResource(projectRoot + "/fines.intent", CLEAN_YAML.getBytes(StandardCharsets.UTF_8));
+        IntentGenerationService service = service(repository);
+        Map<String, byte[]> before = snapshot(root);
+
+        service.dryRun(CLEAN_YAML, projectRoot, "fines", "workspace", "fines");
+
+        Map<String, byte[]> after = snapshot(root);
+        assertEquals(before.keySet(), after.keySet(), "a dry run must create and delete nothing");
+        before.forEach((file, content) -> assertTrue(Arrays.equals(content, after.get(file)), "a dry run must not rewrite [" + file + "]"));
+    }
+
+    @Test
+    void aCrossModelDocumentWithoutAProjectProducesNoFalseResolutionIssues(@TempDir Path root) {
+        // The load-bearing filter (dirigible #6956): with no project context, a `uses:` dependency
+        // resolves by naming convention instead of failing "no model found in the workspace or the
+        // registry" - a false positive would teach the repair loop to "fix" correct YAML.
+        IntentGenerationService service = service(new LocalRepository(root.toString(), true));
+
+        List<String> issues = service.dryRun(CROSS_MODEL_YAML);
+
+        assertTrue(issues.stream()
+                         .noneMatch(issue -> issue.contains("cannot be resolved")),
+                "an unresolvable-only-because-there-is-no-project reference is not an issue: " + issues);
+    }
+
+    /** Every file under the repository root, relative path to content. */
+    private static Map<String, byte[]> snapshot(Path root) {
+        Map<String, byte[]> files = new LinkedHashMap<>();
+        try (Stream<Path> tree = Files.walk(root)) {
+            tree.filter(Files::isRegularFile)
+                .sorted()
+                .forEach(file -> {
+                    try {
+                        files.put(root.relativize(file)
+                                      .toString(),
+                                Files.readAllBytes(file));
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return files;
+    }
+}

--- a/components/resources/resources-builder/src/main/resources/META-INF/dirigible/builder/js/services/intentApi.js
+++ b/components/resources/resources-builder/src/main/resources/META-INF/dirigible/builder/js/services/intentApi.js
@@ -20,12 +20,13 @@
   const SHELLS = '/services/js/platform-core/extension-services/shells.js?extensionPoints=platform-shells';
   const PERSPECTIVES = '/services/js/platform-core/extension-services/perspectives.js?extensionPoints=application-perspectives';
 
-  // The agent endpoint makes up to three upstream model calls (the first draft plus two server-side
+  // The agent endpoint makes up to five upstream model calls (the first draft plus four server-side
   // repair rounds), each of them streamed and each reasoning over the COMPLETE app.intent it has to
   // re-emit - so there is no longer a fixed per-call ceiling to multiply, and the server's own outer
   // bound is 10 minutes per call. This is deliberately generous: aborting here reports a turn that is
-  // still being generated as a failure, and the user has no way to tell the two apart.
-  const AGENT_TIMEOUT_MS = 20 * 60 * 1000;
+  // still being generated as a failure, and the user has no way to tell the two apart. In practice
+  // the loop exits on the first clean round, so the worst case is rare by construction.
+  const AGENT_TIMEOUT_MS = 30 * 60 * 1000;
   const DEFAULT_TIMEOUT_MS = 60 * 1000;
 
   /** A failed call, carrying the status and the parsed body so callers can act on 412 / 422 / 502. */
@@ -98,6 +99,21 @@
     async parse(yaml) {
       const result = await call('POST', `${INTENT_BASE}/parse`, { body: yaml || '', contentType: 'text/plain' });
       return result.data;
+    },
+
+    /**
+     * The full pre-flight: parse PLUS a write-nothing generation pass (dirigible #6956). Returns
+     * `{model, issues}` - `issues` lists everything generation would drop or refuse, which the
+     * parse-only check cannot see; throws a BuilderHttpError whose `issues` holds the structural
+     * problems on 422. Passing the project lets the server read the real `.settings` and resolve
+     * cross-model dependencies against the workspace; without it the document is judged on its own.
+     */
+    async validate(yaml, project) {
+      const params = project
+        ? `?workspace=${seg(ws())}&project=${seg(project)}&path=${seg(App.config.intentFile)}`
+        : '';
+      const result = await call('POST', `${INTENT_BASE}/validate${params}`, { body: yaml || '', contentType: 'text/plain' });
+      return result.data || {};
     },
 
     /**

--- a/components/resources/resources-builder/src/main/resources/META-INF/dirigible/builder/js/stores/conversation.js
+++ b/components/resources/resources-builder/src/main/resources/META-INF/dirigible/builder/js/stores/conversation.js
@@ -204,14 +204,27 @@ document.addEventListener('alpine:init', () => {
      * Validate a proposal and, when it is sound, make it the app. An invalid proposal is NOT applied -
      * the server already spent its repair rounds on it, so the user is shown what is wrong and can
      * rephrase instead of ending up with a broken buffer.
+     *
+     * The check is the full pre-flight, not just a parse (dirigible #6956): a proposal that parses
+     * but whose generation would drop a piece of the model, or be refused by a generation-time check,
+     * is a model that LOOKS finished and then generates wrong - the worst thing this gate could
+     * accept. The current project (when it already exists) is passed so the server judges the
+     * proposal against the real `.settings` and cross-model dependencies.
      */
     async adopt(proposedYaml) {
       const intent = Alpine.store('intent');
       let model;
       try {
-        model = await App.services.intentApi.parse(proposedYaml);
+        const verdict = await App.services.intentApi.validate(proposedYaml, intent.project || undefined);
+        const issues = (verdict && Array.isArray(verdict.issues)) ? verdict.issues : [];
+        if (issues.length) {
+          this.say('error', 'That change parses, but generating it would not produce what it says, so it was not applied:\n'
+            + issues.map(i => '• ' + i).join('\n'));
+          return;
+        }
+        model = verdict.model;
       } catch (e) {
-        const issues = e.issues.length ? e.issues : ['The proposal could not be parsed.'];
+        const issues = e.issues && e.issues.length ? e.issues : ['The proposal could not be parsed.'];
         this.say('error', 'That change does not validate yet, so it was not applied:\n' + issues.map(i => '• ' + i).join('\n'));
         return;
       }


### PR DESCRIPTION
## Motivation

The intent assistant validates a proposal with the parser and nothing else, and the Builder shell's auto-apply gate re-checks it through the parse-only endpoint. Everything the parser accepts reaches the developer unexamined - including documents that parse and then **generate wrong**: glue silently dropped, or a generation-time check refusing what the parser cannot see. The generation layer already collects exactly the right issues (`IntentGenerationContext.addIssue` is where `reportDroppedGlue` and the cross-model checks land); what was missing was a way to run it **without writing**.

## Changes

**`IntentGenerationContext` - a `dryRun` mode.** Guards every write surface (`writeModelFile`, `writeModelFileIfAbsent`; `keepExistingModelFile` and the direct generator reads tolerate a missing repository/project). Reads stay live - what already exists still decides what a generator would do - and written file names are still recorded, so the pass reports the same output set a real Generate would produce.

Also splits off an **advisories** channel for observations no change to the document can address (the cross-model capacity-guard warning): the developer still sees them in the generate response, but the assistant's repair loop is never asked to "fix" something that is not fixable here - a round spent on an unfixable advisory is a round not spent on a real defect.

**`IntentGenerationService.dryRun(...)`.** The full generator chain against a dry-run context: nothing written, nothing scrubbed, no code generation, no settings scaffold. A generator throwing `IntentValidationException` - fatal on a real Generate - is *collected* here instead: the caller wants the complete list of objections, not the first one.

**The load-bearing filter.** With no project context (the assistant's case - a proposal is not saved anywhere yet), cross-model references resolve by naming convention (`CrossModelSupport` already degrades exactly this way for a null root) and the strict owner-model checks are skipped - so a dependency that only exists in some workspace never produces a false "cannot be resolved" issue that would teach the repair loop to "fix" correct YAML. The Builder's own path passes the real project and keeps the strict checks.

**`IntentAgentService.validationIssues`: parse, then dry run, concatenated.** The repair loop now sees the band the parser cannot. A failure of the dry-run machinery itself degrades to the parse verdict - never to a failed turn.

**`POST /services/ide/intent/validate`** - parse + dry run in one call, project coordinates optional. The Builder shell's `adopt()` gate now consumes it instead of `parse`, so a proposal that would generate wrong is not auto-applied; the user is told what generation would object to, in the same bubble style as a parse failure.

**`ProposalRepairLoop.MAX_REPAIR_ROUNDS` 2 → 4.** Deliberately after both preconditions: the call is streamed with a generous outer bound (#6955), so rounds no longer multiply exposure to a wall-clock cliff, and the validator now sees more than a parse error, so later rounds have genuinely new defects to fix. The loop still exits on the first clean round.

## Tests

- `IntentGenerationServiceDryRunTest` (new): the generation-layer warning surfaces through a project-less dry run; a clean document raises nothing; a dry run leaves the repository **byte-identical** (walked and compared); a `uses:` document with no project context produces **zero** false resolution issues.
- `IntentAgentServiceTest`: parse-ok-generation-fails triggers a repair round with the dry run's issue text sent back verbatim; a dry-run infrastructure failure does not fail the turn; the bounded-rounds test asserts against the constant.
- `JavaAssistServiceTest`: adapted to the raised bound (same loop).
- `engine-intent`: **948/948 green**. `IntentBuilderShellIT`: **3/3 green** against the built app - the full journey (proposal → client re-validation through `/validate` → auto-apply → publish) runs on the new gate.

Fixes #6956

🤖 Generated with [Claude Code](https://claude.com/claude-code)
