### PR TITLE
intent: force a requirement-coverage self-audit in the proposal contract

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/agent/AgentCoverage.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/agent/AgentCoverage.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.agent;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * One line of the proposal's requirement-coverage audit (dirigible #6997): a discrete requirement
+ * from the developer's request, mapped to the construct(s) of the proposed YAML that carry it -
+ * {@code "boundary"} when a boundaries entry carries it instead, {@code "none"} when the proposal
+ * does not carry it at all.
+ *
+ * @param requirement the requirement, in the developer's own words
+ * @param construct what carries it, or {@code "boundary"} / {@code "none"}
+ */
+record AgentCoverage(String requirement, String construct) {
+
+    /** Whether the proposal, by its own audit, does not carry this requirement. */
+    boolean uncovered() {
+        return StringUtils.isBlank(construct) || "none".equalsIgnoreCase(construct.trim());
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/agent/AgentReply.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/agent/AgentReply.java
@@ -19,6 +19,9 @@ import java.util.List;
  *        {@code null}
  * @param boundaries the requirements the proposal could <em>not</em> express, each naming the
  *        extension point that carries it; empty when the request fit entirely inside the DSL
+ * @param coverage the proposal's requirement-by-requirement audit of the request (dirigible #6997)
+ *        - which construct carries each requirement; empty when the reply proposed nothing or came
+ *        from a contract without the audit
  */
-record AgentReply(String reply, String proposedYaml, List<AgentBoundary> boundaries) {
+record AgentReply(String reply, String proposedYaml, List<AgentBoundary> boundaries, List<AgentCoverage> coverage) {
 }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/agent/IntentAgentService.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/agent/IntentAgentService.java
@@ -82,17 +82,40 @@ class IntentAgentService {
      * The proposal's shape. {@code boundaries} is the structured half of the honesty contract: a
      * requirement the DSL cannot express must arrive as data the editor can render distinctly and the
      * developer can forward verbatim, not buried in prose that reads like the rest of the answer.
+     *
+     * <p>
+     * {@code coverage} is the completeness half (dirigible #6997): a REQUIRED requirement-by-
+     * requirement mapping of the request onto the proposal. The server cannot verify the mapping - both
+     * sides are prose - but demanding the enumeration makes the model walk the request while it still
+     * holds the pen, so an omission stops being a thing nobody looked at and becomes a hole in a list
+     * the model itself is writing. The mapping then reaches the developer as structure.
      */
     private static Map<String, Object> inputSchema() {
         Map<String, Object> properties = new LinkedHashMap<>();
         properties.put("explanation", Map.of("type", "string", "description", "A short, plain explanation of what changed and why."));
         properties.put("yaml", Map.of("type", "string", "description", "The COMPLETE updated app.intent YAML document."));
+        properties.put("coverage",
+                Map.of("type", "array", "description",
+                        "EVERY discrete requirement in the developer's request, one entry each, mapped to what carries it. "
+                                + "Enumerate the request first, then map: a requirement you cannot map to a construct is a defect to fix "
+                                + "before proposing, not a footnote. For a small edit the list is small - it is never empty.",
+                        "items", coverageItemSchema()));
         properties.put("boundaries",
                 Map.of("type", "array", "description",
                         "Every requirement this proposal could NOT express in the intent - one entry each, "
                                 + "including ones the proposal omits entirely. Empty when the request fit inside the DSL.",
                         "items", boundaryItemSchema()));
-        return Map.of("type", "object", "properties", properties, "required", List.of("explanation", "yaml"));
+        return Map.of("type", "object", "properties", properties, "required", List.of("explanation", "yaml", "coverage"));
+    }
+
+    private static Map<String, Object> coverageItemSchema() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("requirement", Map.of("type", "string", "description", "One discrete requirement, in the developer's own words."));
+        properties.put("construct", Map.of("type", "string", "description",
+                "The construct(s) of the proposed YAML that carry it, named precisely (e.g. \"generates: log-no-match (defaults: reason)\"). "
+                        + "Use \"boundary\" when a boundaries entry carries it instead, and \"none\" when the proposal does not carry it "
+                        + "- never leave a requirement out of this list to avoid saying \"none\"."));
+        return Map.of("type", "object", "properties", properties, "required", List.of("requirement", "construct"));
     }
 
     private static Map<String, Object> boundaryItemSchema() {
@@ -136,7 +159,44 @@ class IntentAgentService {
                     .isEmpty()) {
             reply += "\n\nNote: this proposal still fails intent validation:\n" + ProposalRepairLoop.bulleted(outcome.issues());
         }
-        return new AgentReply(reply, outcome.proposal(), boundaries(outcome.reply()));
+        List<AgentCoverage> coverage = coverage(outcome.reply());
+        List<String> uncovered = coverage.stream()
+                                         .filter(AgentCoverage::uncovered)
+                                         .map(AgentCoverage::requirement)
+                                         .toList();
+        if (!uncovered.isEmpty()) {
+            // The model's own audit found holes and proposed anyway - make them impossible to miss,
+            // exactly the way outstanding validation issues are surfaced (dirigible #6997).
+            reply += "\n\nNote: by the proposal's own coverage audit, these requirements are NOT carried by it:\n"
+                    + ProposalRepairLoop.bulleted(uncovered);
+        }
+        return new AgentReply(reply, outcome.proposal(), boundaries(outcome.reply()), coverage);
+    }
+
+    /**
+     * The requirement-coverage audit, in the order the model listed it (dirigible #6997). A malformed
+     * entry is dropped rather than failing the turn, and an absent audit is an empty list - an older
+     * transcript replayed against this contract must still answer.
+     */
+    private static List<AgentCoverage> coverage(ModelClient.ModelReply reply) {
+        JsonObject input = reply.toolInput();
+        if (input == null || !input.has("coverage") || !input.get("coverage")
+                                                             .isJsonArray()) {
+            return List.of();
+        }
+        List<AgentCoverage> coverage = new ArrayList<>();
+        for (JsonElement element : input.getAsJsonArray("coverage")) {
+            if (!element.isJsonObject()) {
+                continue;
+            }
+            JsonObject entry = element.getAsJsonObject();
+            String requirement = member(entry, "requirement");
+            if (StringUtils.isBlank(requirement)) {
+                continue;
+            }
+            coverage.add(new AgentCoverage(requirement, member(entry, "construct")));
+        }
+        return coverage;
     }
 
     /**

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -24,15 +24,47 @@ Treat it as the contract: anything you propose must parse and validate against i
 - **Only use the capabilities below.** If a request needs something not expressible here, never invent
   syntax - and never quietly substitute the nearest expressible thing. Report it as a boundary; the
   section "What is deliberately not intent" tells you how.
-- **Account for every requirement.** Before you answer, list the requirements in the developer's
-  message. Each one must end up either **modeled** in the YAML or **reported as a boundary**. A
-  requirement that is plain modeling the DSL supports - a log table is just an entity - must be
-  modeled; dropping it is a defect, not a boundary.
+- **Account for every requirement - in the `coverage` array, not only in your head.** Before you
+  answer, list the discrete requirements in the developer's message. Each one must end up either
+  **modeled** in the YAML or **reported as a boundary**, and every one of them appears in the tool
+  call's required `coverage` array (see "The coverage audit" below). A requirement that is plain
+  modeling the DSL supports - a log table is just an entity - must be modeled; dropping it is a
+  defect, not a boundary.
 - **Propose, don't assume.** When the request is broad ("build me a CRM"), propose a small, coherent
   starting set of blocks and ask before expanding. When it is specific, make just that change.
 - **Your output is validated.** What you produce is parsed by the real `IntentParser`; if it reports
   issues, fix exactly those and try again. Prefer being correct over being clever.
 - **Be concise.** Short replies: a one-line rationale, not a recital of the file.
+
+## The coverage audit - every proposal carries its own checklist
+
+Every `propose_intent` call REQUIRES a `coverage` array: one entry per discrete requirement in the
+developer's request, mapped to what carries it. This is not paperwork - it is the step that catches
+the failure nothing else can. The parser judges the shape of what you wrote; the generation dry-run
+judges what your document would produce; **neither can see a requirement you left out**, and neither
+can you, unless you walk the request line by line while you still hold the pen. That is what the
+enumeration forces.
+
+Work in this order:
+
+1. **Enumerate first.** Read the request and write down each discrete requirement in the developer's
+   own words - including the ones stated as emphasis ("**every** log entry must ...") and the ones
+   inside conditions ("if the driver cannot be identified ...").
+2. **Map each one** to the construct(s) of your proposed YAML that carry it, named precisely:
+
+   ```json
+   { "requirement": "every log entry records the plate and violation moment it checked",
+     "construct":   "generates: log-no-match / log-multiple-matches / log-driver-identified / log-declaration-created (map: plateNumberChecked, violationAtChecked)" }
+   ```
+
+3. **A requirement you cannot map is a defect to fix, not a footnote.** Go back and model it. Only
+   when the DSL genuinely does not express it does it become a `boundaries` entry - and its coverage
+   entry then says `"construct": "boundary"`.
+4. **Never satisfy the list by shrinking it.** `"construct": "none"` is the honest last resort and is
+   surfaced to the developer as a loud warning; leaving the requirement out of the list entirely is
+   the one dishonest move, because it is invisible.
+
+For a small edit ("rename the field") the list has one entry. It is never empty on a proposal.
 
 ## What is deliberately not intent - and where it goes instead
 

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/agent/IntentAgentServiceTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/agent/IntentAgentServiceTest.java
@@ -152,6 +152,79 @@ class IntentAgentServiceTest {
     }
 
     @Test
+    void theCoverageAuditReachesTheEditorAsStructure() {
+        // The completeness contract (dirigible #6997): the requirement-by-requirement mapping arrives
+        // as data, a malformed entry is dropped, and an uncovered requirement is impossible to miss -
+        // it is appended to the reply the way outstanding validation issues are.
+        JsonObject input = new JsonObject();
+        input.addProperty("explanation", "Added the notes field.");
+        input.addProperty("yaml", VALID_YAML);
+        JsonArray coverage = new JsonArray();
+        JsonObject covered = new JsonObject();
+        covered.addProperty("requirement", "members carry free-text notes");
+        covered.addProperty("construct", "entities: Member (fields: notes)");
+        coverage.add(covered);
+        JsonObject uncovered = new JsonObject();
+        uncovered.addProperty("requirement", "every note edit is recorded in an audit log");
+        uncovered.addProperty("construct", "none");
+        coverage.add(uncovered);
+        JsonObject malformed = new JsonObject();
+        malformed.addProperty("construct", "no requirement named");
+        coverage.add(malformed);
+        input.add("coverage", coverage);
+
+        ScriptedAgentService service = new ScriptedAgentService(new ModelClient.ModelReply("Here you go.", input));
+
+        AgentReply reply = service.chat(request());
+
+        assertEquals(2, reply.coverage()
+                             .size(),
+                "a malformed entry is dropped rather than failing the turn");
+        assertEquals("entities: Member (fields: notes)", reply.coverage()
+                                                              .get(0)
+                                                              .construct());
+        assertTrue(reply.reply()
+                        .contains("NOT carried by it"),
+                "the uncovered requirement is announced in the reply");
+        assertTrue(reply.reply()
+                        .contains("every note edit is recorded in an audit log"));
+    }
+
+    @Test
+    void aFullyCoveredProposalAppendsNoWarning() {
+        JsonObject input = new JsonObject();
+        input.addProperty("explanation", "Added notes.");
+        input.addProperty("yaml", VALID_YAML);
+        JsonArray coverage = new JsonArray();
+        JsonObject covered = new JsonObject();
+        covered.addProperty("requirement", "members carry free-text notes");
+        covered.addProperty("construct", "entities: Member (fields: notes)");
+        coverage.add(covered);
+        input.add("coverage", coverage);
+
+        ScriptedAgentService service = new ScriptedAgentService(new ModelClient.ModelReply("Added notes.", input));
+
+        AgentReply reply = service.chat(request());
+
+        assertEquals(1, reply.coverage()
+                             .size());
+        assertEquals("Added notes.", reply.reply(), "a clean audit adds nothing to the reply");
+    }
+
+    @Test
+    void aReplyWithoutACoverageAuditStillAnswers() {
+        // An older transcript replayed against the new contract, or a plain-text answer: absence is
+        // an empty list, never a failure.
+        ScriptedAgentService service = new ScriptedAgentService(proposal("Added notes.", VALID_YAML));
+
+        AgentReply reply = service.chat(request());
+
+        assertTrue(reply.coverage()
+                        .isEmpty());
+        assertEquals("Added notes.", reply.reply());
+    }
+
+    @Test
     void aProposalThatParsesButFailsGenerationIsSentBackForCorrection() {
         // The band the parser cannot see (dirigible #6956): the proposal is structurally valid, but the
         // generation pass would refuse or drop a piece of it. The dry run's issues must reach the

--- a/components/resources/resources-builder/src/main/resources/META-INF/dirigible/builder/js/stores/conversation.js
+++ b/components/resources/resources-builder/src/main/resources/META-INF/dirigible/builder/js/stores/conversation.js
@@ -175,6 +175,10 @@ document.addEventListener('alpine:init', () => {
         // nobody noticing. It is stored as its own message, so it is in the record too.
         this.reportBoundaries(reply.boundaries);
 
+        // The proposal's own requirement audit (dirigible #6997): where each sentence of the request
+        // landed - and, prominently, the ones it landed nowhere.
+        this.reportCoverage(reply.coverage);
+
         if (reply.proposedYaml) await this.adopt(reply.proposedYaml);
       } finally {
         await this.flush();
@@ -197,6 +201,26 @@ document.addEventListener('alpine:init', () => {
             + (boundary.suggestedClass ? ' (' + boundary.suggestedClass + ', to be written by hand)' : ''));
         }
         this.say('boundary', lines.join('\n'));
+      }
+    },
+
+    /**
+     * Render the proposal's requirement-coverage audit (dirigible #6997). Requirements the proposal
+     * does NOT carry get the boundary treatment - each its own unmissable message - because a silent
+     * omission is exactly the failure this audit exists to make loud. The rest of the mapping is one
+     * quiet note: a reviewer sees at a glance which sentence of the request landed where.
+     */
+    reportCoverage(coverage) {
+      const entries = (coverage || []).filter(c => c && c.requirement);
+      if (!entries.length) return;
+      const uncovered = entries.filter(c => !c.construct || c.construct.trim().toLowerCase() === 'none');
+      for (const miss of uncovered) {
+        this.say('boundary', 'Not carried by the proposal: ' + miss.requirement);
+      }
+      const mapped = entries.filter(c => !uncovered.includes(c));
+      if (mapped.length) {
+        this.say('note', 'Requirement coverage:\n'
+          + mapped.map(c => '• ' + c.requirement + ' → ' + c.construct).join('\n'));
       }
     },
 

--- a/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/js/editor.js
+++ b/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/js/editor.js
@@ -447,6 +447,28 @@ editorView.controller('IntentEditorController', ($scope, $http, ViewParameters, 
         }
     };
 
+    /**
+     * Render the proposal's requirement-coverage audit (dirigible #6997). A requirement the proposal
+     * does NOT carry gets the boundary treatment - its own unmissable bubble - because a silent
+     * omission is exactly the failure the audit exists to make loud. The rest of the mapping is one
+     * quiet bubble: which sentence of the request landed on which construct.
+     */
+    const reportCoverage = (coverage) => {
+        const entries = (coverage || []).filter((c) => c && c.requirement);
+        if (!entries.length) return;
+        const uncovered = entries.filter((c) => !c.construct || c.construct.trim().toLowerCase() === 'none');
+        for (const miss of uncovered) {
+            $scope.chat.messages.push({ role: 'boundary', text: 'Not carried by the proposal: ' + miss.requirement });
+        }
+        const mapped = entries.filter((c) => !uncovered.includes(c));
+        if (mapped.length) {
+            $scope.chat.messages.push({
+                role: 'assistant',
+                text: 'Requirement coverage:\n' + mapped.map((c) => '• ' + c.requirement + ' → ' + c.construct).join('\n'),
+            });
+        }
+    };
+
     /** Where a suggested class lives in this project - the same custom/ mapping the stub generator uses. */
     const customFileFor = (suggestedClass) => {
         if (!suggestedClass) return null;
@@ -491,6 +513,7 @@ editorView.controller('IntentEditorController', ($scope, $http, ViewParameters, 
                      $scope.chat.turns.push({ role: 'assistant', content: reply });
                  }
                  reportBoundaries(response.data && response.data.boundaries);
+                 reportCoverage(response.data && response.data.coverage);
                  if (response.data && response.data.proposedYaml) {
                      proposedYaml = response.data.proposedYaml;
                      $scope.chat.proposalPending = true;


### PR DESCRIPTION
## Motivation

The one defect class no validation layer can catch is the requirement a proposal **silently leaves out**. The parser judges shape; the dry-run generation pass (#6998) judges what IS in the document; the `boundaries` contract reports only what the model *noticed* it could not express - an omission it did not notice is invisible by construction. That is exactly how a specification's "**Every** log entry, regardless of its event, must ..." became three missing audit rules that parsed and generated cleanly, and reached the developer looking finished (issue #6997 has the full case).

An external agent does not miss these because its loop contains a step the one-shot tool contract had no equivalent for: before finishing, it re-reads the specification and audits its own output against it. This PR makes that audit part of the contract.

## Changes

**`propose_intent` gains a REQUIRED `coverage` array.** Every discrete requirement of the request, mapped to the construct(s) of the proposed YAML that carry it - `"boundary"` when a boundaries entry carries it instead, `"none"` as the honest last resort. The server cannot verify the mapping (both sides are prose); the point is that **schema-forced enumeration makes the model walk the request requirement-by-requirement while it still holds the pen** - an omission stops being a thing nobody looked at and becomes a hole in a list the model itself is writing. The same mechanism that makes a pre-flight checklist work.

**`IntentAgentService`** parses the audit into `AgentReply.coverage` (malformed entries dropped, absence tolerated - an older transcript replays fine) and announces uncovered requirements in the reply text the way outstanding validation issues already are.

**Both UIs render it.** The Builder shell and the intent editor give an uncovered requirement the boundary treatment - its own unmissable message - and render the rest of the mapping as one quiet note, so a reviewer sees at a glance which sentence of their request landed on which construct.

**The guide teaches the discipline** ("The coverage audit" section): enumerate first, map each requirement, treat an unmappable one as a defect to fix before proposing, and never satisfy the list by shrinking it - `"none"` is surfaced loudly, while leaving a requirement off the list is the one dishonest move.

## Tests

`IntentAgentServiceTest`: the audit arrives as structure with malformed entries dropped; an uncovered requirement is announced in the reply; a fully covered proposal appends nothing; a reply without an audit still answers. `engine-intent`: **956/956 green** (the count master reached with #6998).

Fixes #6997

🤖 Generated with [Claude Code](https://claude.com/claude-code)

