### PR TITLE
intent: a `when` guard may be a list of comparisons - their AND - to tell converging paths apart

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -900,7 +900,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             // !$eventOnly, so a .glue written before this key existed keeps rendering the endpoint it
             // always did (a regeneration from an older glue file must not silently drop the button).
             e.put("eventOnly", !g.hasButton());
-            putGeneratesEvent(g, e, fromPk);
+            putGeneratesEvent(g, e, fromPk, source, context);
             putSupersededTarget(g, e, model, crossModel ? null : byName.get(g.getTo()), context);
             // Cross-model source: the gen folder and the project that owns the source's topics/views.
             e.put("crossModelSource", crossModelSource);
@@ -1092,7 +1092,8 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
      * @param e the glue entry being built
      * @param fromPk the source's primary-key property name
      */
-    private static void putGeneratesEvent(GeneratesIntent g, Map<String, Object> e, String fromPk) {
+    private static void putGeneratesEvent(GeneratesIntent g, Map<String, Object> e, String fromPk, EntityIntent source,
+            IntentGenerationContext context) {
         e.put("hasEvent", g.isEventDriven());
         if (!g.isEventDriven()) {
             e.put("isCreate", false);
@@ -1101,6 +1102,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             e.put("appendMode", false);
             e.put("guardProperty", "");
             e.put("guardValue", "");
+            e.put("guardCondition", "");
             e.put("backRefProperty", "");
             return;
         }
@@ -1118,20 +1120,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         // The cardinality (#6800): `append` drops the existing-target lookup in the create-from, so
         // every delivery of the event creates a row. It is the absence of a guard, not another guard.
         e.put("appendMode", g.isAppendMode());
-        String guardProperty = "";
-        String guardValue = "";
-        Object whenValue = g.getEvent()
-                            .get("when");
-        if (whenValue != null) {
-            java.util.regex.Matcher when = java.util.regex.Pattern.compile("\\s*(\\w+)\\s*==\\s*(\\d+)\\s*")
-                                                                  .matcher(String.valueOf(whenValue));
-            if (when.matches()) {
-                guardProperty = IntentNaming.pascalCase(when.group(1));
-                guardValue = when.group(2);
-            }
-        }
-        e.put("guardProperty", guardProperty);
-        e.put("guardValue", guardValue);
+        putGeneratesGuard(g, e, source, context);
         String backReference = "";
         for (Map.Entry<String, String> mapping : g.getMap()
                                                   .entrySet()) {
@@ -1146,6 +1135,79 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                     + "] as its value) - it is the at-most-once guard against an event redelivery"));
         }
         e.put("backRefProperty", backReference);
+    }
+
+    /** One entry of a `when` guard: the numeric status comparison, or a string-field comparison. */
+    private static final java.util.regex.Pattern WHEN_STATUS_TERM = java.util.regex.Pattern.compile("\\s*(\\w+)\\s*==\\s*(\\d+)\\s*");
+    private static final java.util.regex.Pattern WHEN_STRING_TERM =
+            java.util.regex.Pattern.compile("\\s*(\\w+)\\s*(==|!=)\\s*(?:'([^']*)'|\"([^\"]*)\"|([A-Za-z_][A-Za-z0-9_\\-]*))\\s*");
+
+    /**
+     * The event guard, rendered for the listener template (dirigible #6957). A scalar {@code when} is
+     * the status comparison it always was; a LIST is an implicit AND of one status comparison plus
+     * comparisons against the source's own string fields - which is how a consumer binds to one of two
+     * paths that converge on a single status (the automatic route stamped by a lookup's {@code
+     * outcome:} trace field versus the manual one).
+     *
+     * <p>
+     * Emits {@code guardCondition} - the complete Java condition over the RE-LOADED {@code source} -
+     * and keeps {@code guardProperty}/{@code guardValue} (the status term) for the javadoc line and
+     * older templates. A string term against a field the developer can edit gets an actionable warning
+     * (never a refusal): a guard on an editable field means a UI edit silently changes which
+     * automations fire, and the fix - {@code readOnly: true} on the trace field - is one line.
+     */
+    private static void putGeneratesGuard(GeneratesIntent g, Map<String, Object> e, EntityIntent source, IntentGenerationContext context) {
+        String guardProperty = "";
+        String guardValue = "";
+        List<String> conditions = new ArrayList<>();
+        Object whenValue = g.getEvent()
+                            .get("when");
+        List<?> terms = whenValue instanceof List<?> list ? list : whenValue == null ? List.of() : List.of(whenValue);
+        for (Object term : terms) {
+            java.util.regex.Matcher status = WHEN_STATUS_TERM.matcher(String.valueOf(term));
+            if (status.matches()) {
+                String property = IntentNaming.pascalCase(status.group(1));
+                if (guardProperty.isEmpty()) {
+                    guardProperty = property;
+                    guardValue = status.group(2);
+                }
+                conditions.add("source." + property + " != null && source." + property + " == " + status.group(2));
+                continue;
+            }
+            java.util.regex.Matcher text = WHEN_STRING_TERM.matcher(String.valueOf(term));
+            if (!text.matches()) {
+                continue; // parser already reported it
+            }
+            String property = IntentNaming.pascalCase(text.group(1));
+            String literal = text.group(3) != null ? text.group(3) : text.group(4) != null ? text.group(4) : text.group(5);
+            String equals = "java.util.Objects.equals(source." + property + ", " + NotificationSupport.quote(literal) + ")";
+            conditions.add("==".equals(text.group(2)) ? equals : "!" + equals);
+            warnIfGuardFieldIsEditable(g, text.group(1), source, context);
+        }
+        e.put("guardProperty", guardProperty);
+        e.put("guardValue", guardValue);
+        e.put("guardCondition", String.join(" && ", conditions));
+    }
+
+    /**
+     * A string guard reads a trace the PLATFORM wrote (a lookup's {@code outcome:}); one the user can
+     * edit turns "how did this record get here" into "what does the field say today". Actionable, not
+     * fatal: {@code readOnly: true} on the field is the one-line fix.
+     */
+    private static void warnIfGuardFieldIsEditable(GeneratesIntent g, String fieldName, EntityIntent source,
+            IntentGenerationContext context) {
+        if (source == null || context == null) {
+            return;
+        }
+        for (FieldIntent field : source.getFields()) {
+            if (fieldName.equalsIgnoreCase(field.getName()) && !field.isReadOnly()) {
+                String warning = "generates [" + g.getName() + "] event when guards [" + field.getName() + "] of [" + source.getName()
+                        + "], which is not readOnly - a user edit of that field silently changes whether this rule fires;"
+                        + " mark it `readOnly: true` so only the platform (a lookup's outcome:) writes it";
+                LOGGER.warn(warning);
+                context.addIssue(warning);
+            }
+        }
     }
 
     /**

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/NotificationSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/NotificationSupport.java
@@ -308,6 +308,29 @@ public final class NotificationSupport {
         return "==".equals(matcher.group(2)) ? equals : "!" + equals;
     }
 
+    /**
+     * A {@code when} guard that may be the scalar comparison or a LIST of them - an implicit AND
+     * (dirigible #6957). Each element renders through {@link #guard(String)}; an element that does not
+     * parse contributes nothing ({@code true}), exactly as the scalar always degraded, so a list is
+     * never stricter than what its author could say with scalars.
+     *
+     * @param when the guard - a comparison string, a list of them, or {@code null}
+     * @return a Java boolean expression
+     */
+    public static String guard(Object when) {
+        if (!(when instanceof List<?> terms)) {
+            return guard(when == null ? null : String.valueOf(when));
+        }
+        List<String> conditions = new java.util.ArrayList<>();
+        for (Object term : terms) {
+            String condition = guard(term == null ? null : String.valueOf(term));
+            if (!"true".equals(condition)) {
+                conditions.add(condition);
+            }
+        }
+        return conditions.isEmpty() ? "true" : String.join(" && ", conditions);
+    }
+
     private static String literalToJava(String rhs) {
         if (rhs.length() >= 2 && (rhs.startsWith("'") && rhs.endsWith("'") || rhs.startsWith("\"") && rhs.endsWith("\""))) {
             return quote(rhs.substring(1, rhs.length() - 1));

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/TriggerSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/TriggerSupport.java
@@ -40,11 +40,13 @@ public final class TriggerSupport {
         return EventBinding.kind(process.getTrigger());
     }
 
-    /** The optional {@code when} guard expression on the trigger, or null. */
-    public static String triggerWhen(ProcessIntent process) {
-        Object value = process.getTrigger()
-                              .get("when");
-        return value == null ? null : value.toString();
+    /**
+     * The optional {@code when} guard on the trigger, or null - a comparison string, or a list of them
+     * meaning their AND (dirigible #6957); {@code NotificationSupport.guard(Object)} renders either.
+     */
+    public static Object triggerWhen(ProcessIntent process) {
+        return process.getTrigger()
+                      .get("when");
     }
 
     /**

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -221,6 +221,21 @@ public final class IntentParser {
             java.util.regex.Pattern.compile("\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*(==|!=)\\s*(.+?)\\s*");
 
     /**
+     * One entry of a create-from's {@code when} guard list (dirigible #6957) that carries the status:
+     * the same numeric comparison the scalar form always was (a status NAME is already a seed id here -
+     * {@code StatusSymbolResolver} runs before the typed mapping).
+     */
+    private static final java.util.regex.Pattern WHEN_STATUS_TERM = java.util.regex.Pattern.compile("\\s*(\\w+)\\s*==\\s*(\\d+)\\s*");
+
+    /**
+     * One entry of a create-from's {@code when} guard list comparing a STRING field of the source to a
+     * literal - quoted, or a bare word (letters, digits, {@code _}, {@code -}; a lookup's outcome
+     * values such as {@code found} or {@code notFound-notRouted} need no quotes).
+     */
+    private static final java.util.regex.Pattern WHEN_STRING_TERM =
+            java.util.regex.Pattern.compile("\\s*(\\w+)\\s*(==|!=)\\s*(?:'([^']*)'|\"([^\"]*)\"|([A-Za-z_][A-Za-z0-9_\\-]*))\\s*");
+
+    /**
      * Plain Gson for the YAML-Map -> JSON -> POJO round-trip. The platform's {@code JsonHelper} /
      * {@code GsonHelper} cannot be used here: they are configured with
      * {@code excludeFieldsWithoutExposeAnnotation()}, which silently maps every un-annotated model
@@ -1787,7 +1802,10 @@ public final class IntentParser {
         }
         Object when = resolve.getEvent()
                              .get("when");
-        if (when != null) {
+        if (when instanceof List) {
+            issues.add(subject + " when does not take a list here - the ANDed list form (dirigible #6957) is available"
+                    + " on generates events and process triggers");
+        } else if (when != null) {
             java.util.regex.Matcher matcher = RESOLVE_WHEN.matcher(when.toString());
             if (!matcher.matches()) {
                 issues.add(subject + " when [" + when + "] must be `<Field> == <value>` or `<Field> != <value>`");
@@ -5943,7 +5961,10 @@ public final class IntentParser {
                 validatePhaseBinding(posting.getEvent(), subject, alias != null ? null : byName.get(source), issues);
                 Object when = posting.getEvent()
                                      .get("when");
-                if (onTransition != null) {
+                if (when instanceof List) {
+                    issues.add(subject + " event when does not take a list here - the ANDed list form (dirigible #6957) is available"
+                            + " on generates events and process triggers");
+                } else if (onTransition != null) {
                     if (when == null || !String.valueOf(when)
                                                .matches("\\s*\\w+\\s*==\\s*\\d+\\s*")) {
                         issues.add(subject + " event requires `when: \"<Property> == <status seed id>\"`");
@@ -6593,14 +6614,7 @@ public final class IntentParser {
                 issues.add(subject + " event source [" + declared + "] is not the from entity [" + g.getFrom()
                         + "] - a create-from reads the source from:, the event only says when");
             }
-            Object when = event.get("when");
-            if (onTransition != null && (when == null || !String.valueOf(when)
-                                                                .matches("\\s*\\w+\\s*==\\s*\\d+\\s*"))) {
-                issues.add(subject + " event requires `when: \"<Property> == <status seed id or name>\"`");
-            } else if (when != null && !String.valueOf(when)
-                                              .matches("\\s*\\w+\\s*==\\s*\\d+\\s*")) {
-                issues.add(subject + " event when [" + when + "] must be `<Property> == <status seed id or name>`");
-            }
+            validateGeneratesWhen(event.get("when"), onTransition != null, subject, crossModelSource ? null : source, issues);
         }
         // The back-reference: the target's own to-one back to the source, written from the source's
         // primary key. Required in BOTH cardinalities - the at-most-once guard under `once`, the row's
@@ -6664,11 +6678,91 @@ public final class IntentParser {
             issues.add(subject + " event " + kind + " names a process that runs on [" + triggerEntity + "], not on the from entity ["
                     + g.getFrom() + "] - a step event is about the record its process runs on, which is the record the create-from reads");
         }
-        Object when = g.getEvent()
-                       .get("when");
-        if (when != null && !String.valueOf(when)
-                                   .matches("\\s*\\w+\\s*==\\s*\\d+\\s*")) {
-            issues.add(subject + " event when [" + when + "] must be `<Property> == <status seed id or name>`");
+        validateGeneratesWhen(g.getEvent()
+                               .get("when"),
+                false, subject, entityByName(model, g.getFrom()), issues);
+    }
+
+    /**
+     * A create-from's {@code when} guard (dirigible #6957): a single comparison string - the status
+     * guard {@code <Property> == <seed id>} exactly as before - or a LIST of comparison strings,
+     * implicitly ANDed. A list carries at most one status/numeric comparison plus any number of
+     * comparisons against the source's own STRING fields ({@code ==} or {@code !=}, the literal quoted
+     * or a bare word), which is what lets a consumer tell apart two paths that converge on one status:
+     * the {@code resolves:} lookup stamps its {@code outcome:} trace field, and
+     * {@code ["Status == DRIVER_IDENTIFIED", "resolution == found"]} fires only on the automatic one.
+     *
+     * <p>
+     * The list is deliberately AND-only and equality-only - encoding the restriction in the shape
+     * instead of growing an expression grammar - and duplicate properties are refused, since a second
+     * comparison on the same property is either redundant or always-false.
+     */
+    private static void validateGeneratesWhen(Object when, boolean requireStatusGuard, String subject, EntityIntent source,
+            List<String> issues) {
+        if (when == null) {
+            if (requireStatusGuard) {
+                issues.add(subject + " event requires `when: \"<Property> == <status seed id or name>\"`");
+            }
+            return;
+        }
+        if (when instanceof String scalar) {
+            if (!scalar.matches("\\s*\\w+\\s*==\\s*\\d+\\s*")) {
+                issues.add(requireStatusGuard ? subject + " event requires `when: \"<Property> == <status seed id or name>\"`"
+                        : subject + " event when [" + when + "] must be `<Property> == <status seed id or name>`");
+            }
+            return;
+        }
+        if (!(when instanceof List<?> terms)) {
+            issues.add(subject + " event when must be a comparison string or a list of them");
+            return;
+        }
+        if (terms.isEmpty()) {
+            issues.add(subject + " event when list must not be empty");
+            return;
+        }
+        int statusTerms = 0;
+        Set<String> guarded = new HashSet<>();
+        for (Object term : terms) {
+            if (!(term instanceof String comparison)) {
+                issues.add(subject + " event when list entries must be comparison strings, not [" + term + "]");
+                continue;
+            }
+            java.util.regex.Matcher numeric = WHEN_STATUS_TERM.matcher(comparison);
+            java.util.regex.Matcher text = WHEN_STRING_TERM.matcher(comparison);
+            String property;
+            if (numeric.matches()) {
+                statusTerms++;
+                property = numeric.group(1);
+            } else if (text.matches()) {
+                property = text.group(1);
+                FieldIntent field = source == null ? null : fieldByName(source, property);
+                if (source != null && field == null) {
+                    issues.add(subject + " event when [" + comparison + "] references [" + property + "], which is not a field of ["
+                            + source.getName() + "] - a string comparison guards one of the source's own fields (a lookup's `outcome:`"
+                            + " trace field, typically)");
+                    continue;
+                }
+                if (field != null && field.getType() != null && !"string".equals(field.getType()) && !"text".equals(field.getType())) {
+                    issues.add(subject + " event when [" + comparison + "] compares [" + property + "] to a string, but it is a ["
+                            + field.getType() + "] field - only the source's string/text fields can carry a literal guard");
+                    continue;
+                }
+            } else {
+                issues.add(subject + " event when [" + comparison
+                        + "] must be `<Property> == <status seed id or name>` or `<StringField> ==|!= <literal>`");
+                continue;
+            }
+            if (!guarded.add(property.toLowerCase(Locale.ROOT))) {
+                issues.add(subject + " event when guards [" + property + "] twice - a second comparison on the same property is either"
+                        + " redundant or can never hold");
+            }
+        }
+        if (requireStatusGuard && statusTerms == 0) {
+            issues.add(subject + " event when list must include the status guard `<Property> == <status seed id or name>`");
+        }
+        if (statusTerms > 1) {
+            issues.add(subject + " event when declares more than one numeric comparison - one status guard plus string-field"
+                    + " comparisons are supported");
         }
     }
 

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/StatusSymbolResolver.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/StatusSymbolResolver.java
@@ -221,8 +221,7 @@ final class StatusSymbolResolver {
             // the guard could never hold and the process silently never started (#6862).
             Map<?, ?> trigger = asMap(process.get("trigger"));
             if (trigger != null && trigger.get("when") != null) {
-                put(trigger, "when", rewriteExpression(text(trigger, "when"), statusRelationName(triggerEntity), statusOf(triggerEntity),
-                        subject + " trigger when"));
+                rewriteWhen(trigger, statusRelationName(triggerEntity), statusOf(triggerEntity), subject + " trigger when");
             }
             // `setRelationField: <Relation>` + `value:` writes an id of THAT relation's target - the
             // status in the canonical case, but the same shape serves any nomenclature FK.
@@ -255,7 +254,9 @@ final class StatusSymbolResolver {
             // A cross-model source's nomenclature is seeded in its own model; name it as such rather
             // than reporting the entity as unknown.
             Target status = text(event, "model") != null ? new Target(source, text(event, "model")) : statusOf(source);
-            put(event, "when", rewriteExpression(text(event, "when"), statusRelationName(source), status, subject));
+            if (event.get("when") instanceof String) { // a list `when` is refused by the parser; do not mangle it into a string here
+                put(event, "when", rewriteExpression(text(event, "when"), statusRelationName(source), status, subject));
+            }
         }
     }
 
@@ -277,7 +278,7 @@ final class StatusSymbolResolver {
             Target status = text(generate, "fromUses") != null ? new Target(source, text(generate, "fromUses")) : statusOf(source);
             Map<?, ?> event = asMap(generate.get("event"));
             if (event != null && event.get("when") != null) {
-                put(event, "when", rewriteExpression(text(event, "when"), statusRelationName(source), status, subject + " event when"));
+                rewriteWhen(event, statusRelationName(source), status, subject + " event when");
             }
             putResolved(generate, "sourceStatus", status, subject + " sourceStatus");
             putResolved(generate, "sourceStatusOnRetire", status, subject + " sourceStatusOnRetire");
@@ -298,7 +299,7 @@ final class StatusSymbolResolver {
             String record = event.get("onCreate") != null ? text(event, "onCreate") : text(event, "onUpdate");
             Target status = statusOf(record);
             String subject = "resolve [" + text(resolve, "name") + "]";
-            if (event.get("when") != null) {
+            if (event.get("when") instanceof String) { // a list `when` is refused by the parser; do not mangle it into a string here
                 put(event, "when", rewriteExpression(text(event, "when"), statusRelationName(record), status, subject + " event when"));
             }
             for (String outcome : List.of("found", "notFound", "ambiguous")) {
@@ -451,6 +452,27 @@ final class StatusSymbolResolver {
             return null;
         }
         return resolveSymbol(token, target, subject);
+    }
+
+    /**
+     * Rewrite a {@code when} guard in place - a scalar comparison string, or a LIST of them (implicit
+     * AND, dirigible #6957): each element is rewritten independently, so a status name resolves to its
+     * seed id while the elements guarding other properties (a string trace field such as a lookup's
+     * {@code outcome:}) pass through untouched.
+     */
+    @SuppressWarnings("unchecked")
+    private void rewriteWhen(Map<?, ?> owner, String statusRelation, Target target, String subject) {
+        Object value = owner.get("when");
+        if (value instanceof List<?> list) {
+            List<Object> mutable = (List<Object>) list;
+            for (int i = 0; i < mutable.size(); i++) {
+                if (mutable.get(i) instanceof String term) {
+                    mutable.set(i, rewriteExpression(term, statusRelation, target, subject));
+                }
+            }
+        } else if (value instanceof String expression) {
+            put(owner, "when", rewriteExpression(expression, statusRelation, target, subject));
+        }
     }
 
     /**

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -1735,6 +1735,33 @@ generates:
     process and its steps belong to the model that declares them). `when:` stays optional here: the step
     IS the moment. Use it when the follow-up document belongs to a point in a flow rather than to a
     status - and as the route around a source whose write does not publish a transition.
+- **`when:` may be a LIST of comparisons - their AND - to guard by HOW the status was reached.** When a
+  status converges from more than one path (a `resolves:` lookup routes to it automatically, an
+  officer's task sets it manually), a bare status guard fires on both. The lookup's `outcome:` trace
+  field stamps the provenance (`found` / `notFound` / `ambiguous`), and a list `when` reads it:
+
+  ```yaml
+  # SUCCESS log only for the AUTOMATIC identification - the manual path (same status,
+  # outcome stamped notFound/ambiguous by the earlier failed lookup) does not fire it.
+  - name: log-driver-identified
+    from: Fine
+    to: FineLog
+    event:
+      onTransition: Fine
+      mode: append
+      when:
+        - "Status == DRIVER_IDENTIFIED"
+        - "resolution == found"
+  ```
+
+  One status comparison (mandatory for `onTransition`, by seeded name or id) plus any number of
+  `<StringField> ==|!= <literal>` terms against the source's OWN string fields (the literal quoted or a
+  bare word). AND only, equality only, one comparison per property - and guard only fields the platform
+  writes (`readOnly: true`, like a lookup's `outcome:` target): a user-editable guard field means a UI
+  edit silently changes which automations fire, and Generate warns about it. The document that must
+  exist once regardless of path (the Declaration) keeps the bare converged-status guard; only the rules
+  that record HOW it happened need the extra term. The manual path's own log binds `onStepCompleted` on
+  the officer's task, which needs no guard at all.
 - **`map:` must copy the source's `id` onto the target's to-one back to the source** - in BOTH
   cardinalities. Under the default `mode: once` it is the at-most-once guard: before creating anything the
   create-from looks for a target that already back-references this source and returns it instead, so an

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueWhenListTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueWhenListTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.intent.parser.IntentParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The rendered guard of a {@code when} list (issue #6957): every term of the AND evaluates against
+ * the RE-LOADED source - the numeric status comparison exactly as the scalar always did, the string
+ * terms null-safely via {@code Objects.equals} - and a string term against a field the developer
+ * can edit gets an actionable warning, because such a guard means a UI edit silently changes which
+ * automations fire.
+ */
+class GlueWhenListTest {
+
+    private static final String HEAD = """
+            name: fines
+            entities:
+              - name: FineStatus
+                function: Setting
+                fields:
+                  - { name: id,   type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: Fine
+                fields:
+                  - { name: id,         type: integer, primaryKey: true, generated: true }
+                  - { name: note,       type: string }
+                  - { name: resolution, type: string, readOnly: true }
+                  - { name: verdict,    type: string }
+                relations:
+                  - { name: Status, kind: manyToOne, to: FineStatus, function: EntityStatus, init: 1 }
+              - name: FineLog
+                fields:
+                  - { name: id,   type: integer, primaryKey: true, generated: true }
+                  - { name: note, type: string }
+                relations:
+                  - { name: Fine, kind: manyToOne, to: Fine }
+            seeds:
+              - name: fine-statuses
+                entity: FineStatus
+                rows:
+                  - { id: 1, name: NEW }
+                  - { id: 2, name: IDENTIFIED }
+            generates:
+              - name: log-identified
+                from: Fine
+                to: FineLog
+                forEntity: Fine
+            """;
+
+    private static IntentGenerationContext context() {
+        return new IntentGenerationContext(null, "/users/admin/workspace/fines", "fines", "workspace", "fines", null);
+    }
+
+    @Test
+    void aScalarWhenRendersTheGuardItAlwaysDid() {
+        Map<String, Object> g = GlueIntentGenerator.buildGeneratesForTest(IntentParser.parse(HEAD + """
+                    event: { onTransition: Fine, when: "Status == IDENTIFIED" }
+                    map:
+                      Fine: id
+                """), context())
+                                                   .get(0);
+
+        assertEquals("Status", g.get("guardProperty"));
+        assertEquals("2", g.get("guardValue"));
+        assertEquals("source.Status != null && source.Status == 2", g.get("guardCondition"));
+    }
+
+    @Test
+    void aListWhenRendersTheConjunctionOverTheReloadedSource() {
+        Map<String, Object> g = GlueIntentGenerator.buildGeneratesForTest(IntentParser.parse(HEAD + """
+                    event:
+                      onTransition: Fine
+                      when:
+                        - "Status == IDENTIFIED"
+                        - "resolution == found"
+                    map:
+                      Fine: id
+                """), context())
+                                                   .get(0);
+
+        assertEquals("Status", g.get("guardProperty"), "the status term still names the javadoc's status");
+        assertEquals("2", g.get("guardValue"));
+        assertEquals("source.Status != null && source.Status == 2 && java.util.Objects.equals(source.Resolution, \"found\")",
+                g.get("guardCondition"));
+    }
+
+    @Test
+    void anExcludingStringTermRendersNegated() {
+        Map<String, Object> g = GlueIntentGenerator.buildGeneratesForTest(IntentParser.parse(HEAD + """
+                    event:
+                      onTransition: Fine
+                      when:
+                        - "Status == 2"
+                        - "resolution != 'ambiguous'"
+                    map:
+                      Fine: id
+                """), context())
+                                                   .get(0);
+
+        assertEquals("source.Status != null && source.Status == 2 && !java.util.Objects.equals(source.Resolution, \"ambiguous\")",
+                g.get("guardCondition"));
+    }
+
+    @Test
+    void guardingAnEditableFieldWarnsWithTheOneLineFix() {
+        IntentGenerationContext context = context();
+
+        GlueIntentGenerator.buildGeneratesForTest(IntentParser.parse(HEAD + """
+                    event:
+                      onTransition: Fine
+                      when:
+                        - "Status == 2"
+                        - "verdict == found"
+                    map:
+                      Fine: id
+                """), context);
+
+        assertTrue(context.getIssues()
+                          .stream()
+                          .anyMatch(issue -> issue.contains("[verdict]") && issue.contains("readOnly")),
+                "an editable guard field must be called out: " + context.getIssues());
+    }
+
+    @Test
+    void guardingTheReadOnlyTraceFieldDoesNotWarn() {
+        IntentGenerationContext context = context();
+
+        GlueIntentGenerator.buildGeneratesForTest(IntentParser.parse(HEAD + """
+                    event:
+                      onTransition: Fine
+                      when:
+                        - "Status == 2"
+                        - "resolution == found"
+                    map:
+                      Fine: id
+                """), context);
+
+        assertTrue(context.getIssues()
+                          .isEmpty(),
+                "a platform-written trace field is the intended guard: " + context.getIssues());
+    }
+
+    @Test
+    void aProcessTriggerListWhenRendersTheJoinedGuardExpression() {
+        List<Map<String, Object>> triggers = GlueIntentGenerator.buildTriggersForTest(IntentParser.parse(HEAD + """
+                    event: { onCreate: Fine }
+                    map:
+                      Fine: id
+                processes:
+                  - name: ManualIdentification
+                    trigger:
+                      onTransition: Fine
+                      when:
+                        - "Status == IDENTIFIED"
+                        - "resolution == found"
+                    steps:
+                      - { name: done, kind: end }
+                """));
+
+        assertEquals("java.util.Objects.equals(entity.Status, 2) && java.util.Objects.equals(entity.Resolution, \"found\")", triggers.get(0)
+                                                                                                                                     .get("guardExpression"));
+    }
+}

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/WhenListIntentTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/WhenListIntentTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The list form of a create-from's {@code when} guard (issue #6957): an implicit AND of the status
+ * comparison plus comparisons against the source's own string fields, which is what lets a consumer
+ * tell apart two paths converging on one status - the automatic {@code resolves:} route stamped by
+ * its {@code outcome:} trace field versus a manual task. AND-only, equality-only, one comparison
+ * per property - the restriction is encoded in the SHAPE, so there is no expression grammar to
+ * grow.
+ */
+class WhenListIntentTest {
+
+    /** The fines shape of the motivating case: a status lifecycle plus a readOnly trace field. */
+    private static final String HEAD = """
+            name: fines
+            entities:
+              - name: FineStatus
+                function: Setting
+                fields:
+                  - { name: id,   type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: Fine
+                fields:
+                  - { name: id,         type: integer, primaryKey: true, generated: true }
+                  - { name: note,       type: string }
+                  - { name: amount,     type: decimal }
+                  - { name: resolution, type: string, readOnly: true }
+                relations:
+                  - { name: Status, kind: manyToOne, to: FineStatus, function: EntityStatus, init: 1 }
+              - name: FineLog
+                fields:
+                  - { name: id,   type: integer, primaryKey: true, generated: true }
+                  - { name: note, type: string }
+                relations:
+                  - { name: Fine, kind: manyToOne, to: Fine }
+            seeds:
+              - name: fine-statuses
+                entity: FineStatus
+                rows:
+                  - { id: 1, name: NEW }
+                  - { id: 2, name: IDENTIFIED }
+            generates:
+              - name: log-identified
+                from: Fine
+                to: FineLog
+                forEntity: Fine
+            """;
+
+    @Test
+    void aListWhenParsesAndItsStatusNameResolvesToTheSeedId() {
+        IntentModel model = IntentParser.parse(HEAD + """
+                    event:
+                      onTransition: Fine
+                      when:
+                        - "Status == IDENTIFIED"
+                        - "resolution == found"
+                    map:
+                      Fine: id
+                """);
+
+        Object when = model.getGenerates()
+                           .get(0)
+                           .getEvent()
+                           .get("when");
+        assertTrue(when instanceof List<?>, "the list survives into the typed model, got: " + when);
+        List<?> terms = (List<?>) when;
+        assertEquals("Status == 2", terms.get(0), "the status NAME resolves to its seed id inside the list");
+        assertEquals("resolution == found", terms.get(1), "the string term passes through the symbol resolver untouched");
+    }
+
+    @Test
+    void quotedLiteralsParseTheSameAsBareWords() {
+        IntentParser.parse(HEAD + """
+                    event:
+                      onTransition: Fine
+                      when:
+                        - "Status == 2"
+                        - "resolution == 'notFound-notRouted'"
+                    map:
+                      Fine: id
+                """);
+    }
+
+    @Test
+    void aStringTermMayAlsoExclude() {
+        IntentParser.parse(HEAD + """
+                    event:
+                      onTransition: Fine
+                      when:
+                        - "Status == 2"
+                        - "resolution != ambiguous"
+                    map:
+                      Fine: id
+                """);
+    }
+
+    @Test
+    void anOnTransitionListWithoutTheStatusGuardIsRefused() {
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(HEAD + """
+                    event:
+                      onTransition: Fine
+                      when:
+                        - "resolution == found"
+                    map:
+                      Fine: id
+                """));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(issue -> issue.contains("must include the status guard")),
+                "got: " + ex.getIssues());
+    }
+
+    @Test
+    void anEmptyListIsRefused() {
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(HEAD + """
+                    event:
+                      onTransition: Fine
+                      when: []
+                    map:
+                      Fine: id
+                """));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(issue -> issue.contains("when list must not be empty")),
+                "got: " + ex.getIssues());
+    }
+
+    @Test
+    void aSecondComparisonOnTheSamePropertyIsRefused() {
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(HEAD + """
+                    event:
+                      onTransition: Fine
+                      when:
+                        - "Status == 2"
+                        - "resolution == found"
+                        - "resolution != ambiguous"
+                    map:
+                      Fine: id
+                """));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(issue -> issue.contains("guards [resolution] twice")),
+                "got: " + ex.getIssues());
+    }
+
+    @Test
+    void twoNumericComparisonsAreRefused() {
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(HEAD + """
+                    event:
+                      onTransition: Fine
+                      when:
+                        - "Status == 2"
+                        - "id == 7"
+                    map:
+                      Fine: id
+                """));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(issue -> issue.contains("more than one numeric comparison")),
+                "got: " + ex.getIssues());
+    }
+
+    @Test
+    void aStringTermOnANonStringFieldIsRefused() {
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(HEAD + """
+                    event:
+                      onTransition: Fine
+                      when:
+                        - "Status == 2"
+                        - "amount == found"
+                    map:
+                      Fine: id
+                """));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(issue -> issue.contains("[amount]") && issue.contains("decimal")),
+                "got: " + ex.getIssues());
+    }
+
+    @Test
+    void aStringTermOnAnUnknownPropertyIsRefused() {
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(HEAD + """
+                    event:
+                      onTransition: Fine
+                      when:
+                        - "Status == 2"
+                        - "verdict == found"
+                    map:
+                      Fine: id
+                """));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(issue -> issue.contains("[verdict], which is not a field of [Fine]")),
+                "got: " + ex.getIssues());
+    }
+
+    @Test
+    void aProcessTriggerAcceptsAListWhen() {
+        IntentParser.parse(HEAD + """
+                    event: { onCreate: Fine }
+                    map:
+                      Fine: id
+                processes:
+                  - name: ManualIdentification
+                    trigger:
+                      onTransition: Fine
+                      when:
+                        - "Status == IDENTIFIED"
+                        - "resolution == found"
+                    steps:
+                      - { name: done, kind: end }
+                """);
+    }
+
+    @Test
+    void aResolveRefusesAListWhen() {
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse("""
+                name: fines
+                entities:
+                  - name: Driver
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: Vehicle
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: Assignment
+                    fields:
+                      - { name: id,        type: integer, primaryKey: true, generated: true }
+                      - { name: validFrom, type: timestamp }
+                      - { name: validTo,   type: timestamp }
+                    relations:
+                      - { name: vehicle, kind: manyToOne, to: Vehicle }
+                      - { name: driver,  kind: manyToOne, to: Driver }
+                  - name: Fine
+                    fields:
+                      - { name: id,   type: integer, primaryKey: true, generated: true }
+                      - { name: kind, type: string }
+                      - { name: at,   type: timestamp }
+                    relations:
+                      - { name: vehicle, kind: manyToOne, to: Vehicle }
+                      - { name: driver,  kind: manyToOne, to: Driver }
+                resolves:
+                  - name: lookup
+                    event:
+                      onCreate: Fine
+                      when: ["kind == speeding"]
+                    set: driver
+                    from: Assignment
+                    match: { vehicle: vehicle }
+                    between: { start: validFrom, end: validTo, value: at }
+                """));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(issue -> issue.contains("does not take a list here")),
+                "got: " + ex.getIssues());
+    }
+}

--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/GlueGenerator.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/GlueGenerator.java
@@ -627,8 +627,11 @@ class GlueGenerator {
                 // the at-most-once check reads, plus whether a button is contributed at all. The axis and
                 // the cardinality (issue #6800): the topic suffix the listener binds - a lifecycle one or
                 // a step-scoped one - and whether the create-from keeps its at-most-once lookup at all.
-                "fromPk", "eventOnly", "hasEvent", "isCreate", "guardProperty", "guardValue", "backRefProperty", "isStep", "stepProcess",
-                "stepName", "appendMode",
+                // guardCondition (issue #6957) is the COMPLETE pre-rendered guard - the status term AND
+                // any string-field terms of a `when` list; the property/value pair stays beside it for
+                // the javadoc and for a .glue written before the condition existed.
+                "fromPk", "eventOnly", "hasEvent", "isCreate", "guardProperty", "guardValue", "guardCondition", "backRefProperty", "isStep",
+                "stepProcess", "stepName", "appendMode",
                 // The state half of that guard (issue #6814): which of the target's statuses retire it, so
                 // a cancelled or voided document stops blocking its replacement. Gated on the boolean - a
                 // .glue written before this key existed keeps the existence-only guard it always had.

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/GenerateOnEvent.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/GenerateOnEvent.java.template
@@ -59,7 +59,16 @@ public class ${className}GenerateOnEvent implements MessageHandler {
         if (payload == null || payload.${fromPk} == null) {
             return;
         }
-#if($guardProperty != "")
+#if($guardCondition && $guardCondition != "")
+        gen.${fromGenFolder}.data.${fromJavaPerspective}.${fromEntity}Entity source =
+                new gen.${fromGenFolder}.data.${fromJavaPerspective}.${fromEntity}Repository().findById(payload.${fromPk});
+        ## The complete pre-rendered guard - the status comparison AND any string-field terms of the
+        ## intent's `when` list (issue #6957), all evaluated against the re-loaded source.
+        if (source == null || !(${guardCondition})) {
+            return;
+        }
+#elseif($guardProperty != "")
+        ## A .glue written before guardCondition existed: render the single status guard it always had.
         gen.${fromGenFolder}.data.${fromJavaPerspective}.${fromEntity}Entity source =
                 new gen.${fromGenFolder}.data.${fromJavaPerspective}.${fromEntity}Repository().findById(payload.${fromPk});
         if (source == null || source.${guardProperty} == null || source.${guardProperty} != ${guardValue}) {

--- a/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/js/intent-diagrams.js
+++ b/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/js/intent-diagrams.js
@@ -426,7 +426,10 @@ window.IntentDiagrams = (() => {
     // and it carries its `when` guard: two rules bound to the same transition are told apart by their
     // guards, which is precisely what the picture has to make visible.
     const generatesTrigger = (event) => {
-        const guard = event.when ? ' ' + event.when : '';
+        // `when` may be a LIST of ANDed comparisons (issue #6957) - the card joins them, so "which
+        // path fires me" stays readable at a glance.
+        const when = Array.isArray(event.when) ? event.when.join(' && ') : event.when;
+        const guard = when ? ' ' + when : '';
         if (event.onTransition) return 'on transition' + guard;
         if (event.onCreate) return 'on create' + guard;
         if (event.onPhase) return 'on phase ' + (event.phase || '');

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -2878,7 +2878,8 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertTrue(generateOnEvent.contains("implements MessageHandler"), "the event-driven create-from must be a message handler");
         assertTrue(generateOnEvent.contains("-Slip-transitioned"),
                 "an onTransition create-from must bind the source's -transitioned topic");
-        assertTrue(generateOnEvent.contains("source.Status != 2"), "the listener must guard on the status the seeded name resolved to");
+        assertTrue(generateOnEvent.contains("!(source.Status != null && source.Status == 2)"),
+                "the listener must guard on the status the seeded name resolved to");
         assertTrue(generateOnEvent.contains("new VoucherFromSlipGenerate().create("),
                 "the listener must delegate to the create-from rather than re-implement the mapping");
         assertFalse(generateOnEvent.contains("VoucherLineEntity"), "the listener must carry no mapping of its own");

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -3093,10 +3093,72 @@ class IntentEngineIT extends IntegrationTest {
         // its guard still steps over the retired document - which is what mints the replacement once the
         // reopen has re-published the source's transition.
         String onEvent = codeOf("gen/events/reissue/InvoiceFromProformaGenerateOnEvent.java");
-        assertTrue(onEvent.contains("source.Status != 2"), "the trigger still qualifies on the status the source is returned to");
+        assertTrue(onEvent.contains("!(source.Status != null && source.Status == 2)"),
+                "the trigger still qualifies on the status the source is returned to");
         String generate = codeOf("gen/events/reissue/InvoiceFromProformaGenerate.java");
         assertTrue(generate.contains("if (candidate.Status == null || !(candidate.Status == 3 || candidate.Status == 4)) {"),
                 "the at-most-once guard must step over the retired target the reopen reacts to");
+    }
+
+    @Test
+    void generates_when_list_guards_the_listener_by_status_and_trace_field() {
+        // Issue #6957: a status two paths converge on (a resolves: lookup routes to it, an officer's
+        // task sets it manually) is indistinguishable to a bare status guard - the SUCCESS log fires on
+        // both. A `when` LIST is the AND of the status comparison and the lookup's own readOnly
+        // `outcome:` trace field, so the rule fires only on the path that stamped it.
+        String yaml = """
+                name: fineflow
+                entities:
+                  - name: FineStatus
+                    kind: setting
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string, required: true, length: 100 }
+                  - name: Fine
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: note, type: string }
+                      - { name: resolution, type: string, readOnly: true }
+                    relations:
+                      - { name: Status, kind: manyToOne, to: FineStatus, function: EntityStatus, init: 1 }
+                  - name: FineLog
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: note, type: string }
+                    relations:
+                      - { name: Fine, kind: manyToOne, to: Fine }
+                generates:
+                  - name: log-identified
+                    from: Fine
+                    to: FineLog
+                    forEntity: Fine
+                    event:
+                      onTransition: Fine
+                      mode: append
+                      when:
+                        - "Status == IDENTIFIED"
+                        - "resolution == found"
+                    map: { Fine: id }
+                seeds:
+                  - name: fine-statuses
+                    entity: FineStatus
+                    rows:
+                      - { id: 1, name: NEW }
+                      - { id: 2, name: IDENTIFIED }
+                """;
+        writeIntent(yaml);
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .post(GENERATE_URL)
+                                                 .then()
+                                                 .statusCode(200));
+
+        generateFromModel("template-application-events-java/template/template.js", "fineflow.glue");
+        String onEvent = codeOf("gen/events/fineflow/LogIdentifiedGenerateOnEvent.java");
+        assertTrue(
+                onEvent.contains(
+                        "!(source.Status != null && source.Status == 2 && java.util.Objects.equals(source.Resolution, \"found\"))"),
+                "every term of the when list must guard the re-loaded source, got: " + onEvent);
+        assertTrue(onEvent.contains("-Fine-transitioned"), "the list form must not change the topic the listener binds");
     }
 
     @Test


### PR DESCRIPTION
## Motivation

When a status can be reached by more than one path - a `resolves:` lookup routes to `DRIVER_IDENTIFIED` automatically, an officer's task sets the same status manually - nothing could bind a consumer to only ONE of those paths: `event.when` was a single status comparison, so "append a `DRIVER_IDENTIFICATION_SUCCESS` row on **automatic** identification" also fired on the manual route. Splitting the status does not compose (the downstream at-most-once create-from needs ONE converged status, #6813), and the lookup's `outcome:` trace field - which stamps exactly the provenance needed - could not be guarded on. Issue #6957.

## The design: a LIST `when`, implicit AND

```yaml
- name: log-driver-identified
  from: Fine
  to: FineLog
  event:
    onTransition: Fine
    mode: append
    when:
      - "Status == DRIVER_IDENTIFIED"
      - "resolution == found"
```

Each element is the single comparison the grammar always had; the list means their AND. **The restriction is encoded in the shape, not policed by a grammar**: a list cannot express `||`, `!=` on the status, or parentheses, so there is no expression language to grow one operator at a time (the `when`-dialect drift #6907 came from exactly that). One status comparison (mandatory for `onTransition`, seeded name or id) plus `<StringField> ==|!= <literal>` terms against the source's OWN string fields, the literal quoted or a bare word. Scalar `when` is untouched everywhere.

Accepted on **`generates` events** and **process `trigger.when`** (which already rendered string comparisons through `NotificationSupport.guard`); every other `when` site refuses a list with a message that says where the form is available.

## What guards the guard

- **Parser**: empty list, a second comparison on the same property, more than one numeric term, a term against a non-string field or an unknown property - all refused with the fix in the message; an `onTransition` list must include the status guard.
- **`StatusSymbolResolver`** rewrites the status NAME per element and leaves string terms alone; the sites that do not take lists no longer risk mangling one into a stringified `[a, b]`.
- **Generation warns on a proxy that can lie**: a string term against a field that is not `readOnly` gets an actionable issue ("a user edit silently changes whether this rule fires; mark it `readOnly: true`") - the dry-run/repair loop (#6956) surfaces it to the assistant, and the fix is one line. A platform-written trace field (`resolves:` `outcome:`) warns nothing.
- **Runtime semantics are the existing ones**: the listener re-loads the source by id and evaluates every term against that snapshot - the same contract the single guard always had. The template renders the pre-built `guardCondition` and keeps the old `guardProperty`/`guardValue` branch, so a `.glue` written before this change regenerates byte-compatibly.
- **The binder passes it through**: `GlueGenerator.bindGenerate` (ide-template) whitelists template parameters explicitly, so `guardCondition` is added there - the first IT run caught exactly this hole: unit tests proved the emitter and the template separately, and only the glue → binder → template chain showed the key being dropped.
- **The diagram (#6954)** joins the list on the create-from card, so "which path fires me" is visible at a glance.
- **The guide** documents the form with the auto-vs-manual pattern, including which rule keeps the bare converged guard (the at-most-once document) and which needs the extra term (the trail rows).

## Tests

- `WhenListIntentTest` (11): parse + resolve-inside-list + the full refusal matrix (empty, duplicate property, two numerics, non-string field, unknown property, list on `resolves:`), trigger acceptance.
- `GlueWhenListTest` (6): rendered `guardCondition` for scalar/list/negated terms, the editable-field warning and its readOnly silence, the trigger's joined `guardExpression`.
- `IntentEngineIT.generates_when_list_guards_the_listener_by_status_and_trace_field`: the REAL Velocity template renders the conjunction into the generated listener; the two existing on-event assertions follow the new (equivalent) rendering.
- `engine-intent`: **973/973** green; `IntentEngineIT` + `IntentEmissionCoverageIT`: **61/61** green against the built application.

Fixes #6957

🤖 Generated with [Claude Code](https://claude.com/claude-code)
