### PR TITLE
fix: stack Harmonia form fields full-width below sm in narrow FK-add dialog (#6995)

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
@@ -44,10 +44,10 @@
          (display:contents keeps the grid layout intact). -->
     <fieldset :disabled="!mutable" style="display: contents;">
 #end
-    <div class="grid grid-cols-12 gap-4" style="max-width: 900px">
+    <div class="grid grid-cols-1 sm:grid-cols-12 gap-4" style="max-width: 900px">
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement && !$property.sensitiveProperty && $property.name != "ProcessId" && $property.name != "ProcessIds" && (!$property.auditType || $property.auditType == "NONE") && $property.name != "Name" && $property.name != "$!{personalProperty}" && $property.isReadOnlyProperty != "true" && $property.widgetType != "DOCUMENT_STATUS" && !($property.widgetType == "DOCUMENT_NUMBER" && $property.numberSeries) && $property.aggregate != "true")
-      <div x-h-field style="grid-column: span #if($property.widgetType == "MULTISELECT")12#elseif($property.widgetSize && $property.widgetSize != "")${property.widgetSize}#{else}6#end"#visibleGate($property)>
+      <div x-h-field class="#if($property.widgetType == "MULTISELECT")col-span-full#elseif($property.widgetSize && $property.widgetSize != "")sm:col-span-${property.widgetSize}#{else}sm:col-span-6#end"#visibleGate($property)>
         <label x-h-label>
           <span x-text="T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end')"></span>#if($property.isRequiredProperty == "true") <span class="text-destructive">*</span>#end
         </label>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template
@@ -46,10 +46,10 @@
          keeps the grid layout intact - the same trick the manage form's preview mode uses). -->
     <fieldset :disabled="!mutable" style="display: contents;">
 #end
-    <div class="grid grid-cols-12 gap-4" style="max-width: 900px">
+    <div class="grid grid-cols-1 sm:grid-cols-12 gap-4" style="max-width: 900px">
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement && !$property.sensitiveProperty && $property.name != "ProcessId" && $property.name != "ProcessIds" && (!$property.auditType || $property.auditType == "NONE") && $property.name != "Name" && $property.name != $skipOwnerFk && $property.name != $skipParentFk && $property.isReadOnlyProperty != "true" && $property.widgetType != "DOCUMENT_STATUS")
-      <div x-h-field style="grid-column: span #if($property.widgetType == "MULTISELECT")12#elseif($property.widgetSize && $property.widgetSize != "")${property.widgetSize}#{else}6#end"#visibleGate($property)>
+      <div x-h-field class="#if($property.widgetType == "MULTISELECT")col-span-full#elseif($property.widgetSize && $property.widgetSize != "")sm:col-span-${property.widgetSize}#{else}sm:col-span-6#end"#visibleGate($property)>
         <label x-h-label>
           <span x-text="T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end')"></span>#if($property.isRequiredProperty == "true") <span class="text-destructive">*</span>#end
         </label>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
@@ -44,10 +44,10 @@
          (display:contents keeps the grid layout intact). -->
     <fieldset :disabled="!mutable" style="display: contents;">
 #end
-    <div class="grid grid-cols-12 gap-4" style="max-width: 900px">
+    <div class="grid grid-cols-1 sm:grid-cols-12 gap-4" style="max-width: 900px">
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement && !$property.sensitiveProperty && $property.name != "ProcessId" && $property.name != "ProcessIds" && (!$property.auditType || $property.auditType == "NONE") && $property.name != "Name" && $property.name != "$!{partnerProperty}" && $property.isReadOnlyProperty != "true" && $property.widgetType != "DOCUMENT_STATUS" && !($property.widgetType == "DOCUMENT_NUMBER" && $property.numberSeries) && $property.aggregate != "true")
-      <div x-h-field style="grid-column: span #if($property.widgetType == "MULTISELECT")12#elseif($property.widgetSize && $property.widgetSize != "")${property.widgetSize}#{else}6#end"#visibleGate($property)>
+      <div x-h-field class="#if($property.widgetType == "MULTISELECT")col-span-full#elseif($property.widgetSize && $property.widgetSize != "")sm:col-span-${property.widgetSize}#{else}sm:col-span-6#end"#visibleGate($property)>
         <label x-h-label>
           <span x-text="T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end')"></span>#if($property.isRequiredProperty == "true") <span class="text-destructive">*</span>#end
         </label>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-form-view.html.template
@@ -46,10 +46,10 @@
          keeps the grid layout intact - the same trick the manage form's preview mode uses). -->
     <fieldset :disabled="!mutable" style="display: contents;">
 #end
-    <div class="grid grid-cols-12 gap-4" style="max-width: 900px">
+    <div class="grid grid-cols-1 sm:grid-cols-12 gap-4" style="max-width: 900px">
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement && !$property.sensitiveProperty && $property.name != "ProcessId" && $property.name != "ProcessIds" && (!$property.auditType || $property.auditType == "NONE") && $property.name != "Name" && $property.name != $skipOwnerFk && $property.name != $skipParentFk && $property.isReadOnlyProperty != "true" && $property.widgetType != "DOCUMENT_STATUS")
-      <div x-h-field style="grid-column: span #if($property.widgetType == "MULTISELECT")12#elseif($property.widgetSize && $property.widgetSize != "")${property.widgetSize}#{else}6#end"#visibleGate($property)>
+      <div x-h-field class="#if($property.widgetType == "MULTISELECT")col-span-full#elseif($property.widgetSize && $property.widgetSize != "")sm:col-span-${property.widgetSize}#{else}sm:col-span-6#end"#visibleGate($property)>
         <label x-h-label>
           <span x-text="T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end')"></span>#if($property.isRequiredProperty == "true") <span class="text-destructive">*</span>#end
         </label>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -93,7 +93,7 @@
 #if($property.widgetSize)#set($span = $property.widgetSize)#else#set($span = "6")#end
 #if($property.widgetType == "TEXTAREA" || $property.widgetType == "CHECKBOX" || $property.widgetType == "MULTISELECT")#set($span = "12")#end
 #if($lookup)#set($span = "12")#end
-      <div x-h-field#if($span == "12") class="col-span-full"#else style="grid-column: span ${span};"#end#visibleGate($property) :data-invalid="!!errors.${property.name}">
+      <div x-h-field#if($span == "12") class="col-span-full"#else class="sm:col-span-${span}"#end#visibleGate($property) :data-invalid="!!errors.${property.name}">
 #if($property.widgetType == "CHECKBOX")
         <div class="hbox items-center gap-3">
           <span x-h-checkbox><input type="checkbox" id="f_${property.name}" x-model="form.${property.name}"#if($readonly) disabled#end /></span>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
@@ -112,7 +112,7 @@
 #if($property.widgetType == "TEXTAREA" || $property.widgetType == "CHECKBOX" || $property.widgetType == "MULTISELECT")#set($span = "12")#end
 #if($lookup)#set($span = "12")#end
       <!-- ${property.name} (${property.widgetType}) -->
-      <div x-h-field#if($span == "12") class="col-span-full"#else style="grid-column: span ${span};"#end#visibleGate($property) :data-invalid="!!errors.${property.name}">
+      <div x-h-field#if($span == "12") class="col-span-full"#else class="sm:col-span-${span}"#end#visibleGate($property) :data-invalid="!!errors.${property.name}">
 #if($property.widgetType == "CHECKBOX")
         <div class="hbox items-center gap-3">
           <span x-h-checkbox>


### PR DESCRIPTION
### What
Generated Harmonia create/edit forms sized each field with an **unconditional** width — inline `style="grid-column: span 4|6|12"` (or `class="col-span-full"`) — while the field grid itself is responsive (`grid-cols-1 sm:grid-cols-12`).

When such a form opens inside the shared runtime's FK-add / detail-panel dialog (the "New &lt;Entity&gt;" modal reached from a combobox's "+ New" or a detail panel's Add), the dialog iframe is ~478px — below the `sm` breakpoint (640px) — so the grid collapses to a single track. But the fields still declare `span 4/6/12`. In a single-track grid those inline spans spawn **implicit columns**, and `col-span-full` (`grid-column: 1 / -1`) then resolves to only the first *explicit* track. Result: a full-width field renders narrow, shares a row with the next field, and its "+ New" button clips.

Fixes #6995.

### How
Switch the field width from the unconditional inline span to the responsive **`sm:col-span-N`** class (utilities already shipped in codbex-harmonia's CSS; `sm` = 640px):

- Below `sm`: no `col-span` class applies, so every field falls back to the single `grid-cols-1` track — full width, no implicit columns, no overlap, no clipped controls.
- At `sm`+: `sm:col-span-N` reproduces the authored 3/4/6/12 spans exactly as before.

The Personal/Partner form templates additionally had a **non-responsive** `grid-cols-12` wrapper; those are made responsive (`grid-cols-1 sm:grid-cols-12`) for the same reason.

No CSS, no Java, no shared-shell changes — only the six Velocity form templates in `template-application-ui-harmonia-java`:
- `perspective/manage/form-view.html.template`
- `perspective/document/document-view.html.template`
- `my/my-form-view.html.template`, `my/my-document-view.html.template`
- `partner/partner-form-view.html.template`, `partner/partner-document-view.html.template`

### Verification
- Regenerated + republished the `customer-payments` sample against a running instance with the fix: the served `CustomerPayment-form.html` went from **9** `grid-column: span` occurrences to **0**, and now carries **12** `sm:col-span-*` / `col-span-full` classes (e.g. `<div x-h-field class="sm:col-span-6" ...>`).
- In the narrow FK-add dialog the fields stack full-width in a single column (no overlap, no clipped "+ New"); the full-page form (≥640px) keeps the authored spans unchanged.
- `ModelGenerationIT` renders every template twice and is the regression harness for these edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
