### PR TITLE
tests: quote the tenant schema and table in TenantActivationIT (fixes master on PostgreSQL)

### DIFF
--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantActivationIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantActivationIT.java
@@ -38,6 +38,7 @@ import org.eclipse.dirigible.components.initializers.synchronizer.Synchronizatio
 import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
 import org.eclipse.dirigible.components.tenants.service.TenantService;
 import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.eclipse.dirigible.database.sql.dialects.SqlDialectFactory;
 import org.eclipse.dirigible.repository.api.IRepository;
 import org.eclipse.dirigible.repository.api.IRepositoryStructure;
 import org.eclipse.dirigible.tests.base.IntegrationTest;
@@ -391,14 +392,23 @@ class TenantActivationIT extends IntegrationTest {
      * The assertion the whole test exists for: the per-tenant artefact is physically there, in the
      * schema the external provisioner created, reached through the data source the API registered.
      *
+     * <p>
+     * Both identifiers are quoted with the dialect's own escape symbol, because both were created
+     * quoted - the schema by {@link #createDatabaseUserAndSchema(String)} and the table by the
+     * platform's table processor. An unquoted name is folded by the database (down on PostgreSQL, up on
+     * H2), so it only happens to match on a database that folds the way the identifier was written.
+     *
      * @throws SQLException if the table cannot be read
      */
     private void assertPerTenantTableExists() throws SQLException {
         DirigibleDataSource tenantDataSource = dataSourcesManager.getDataSource(TENANT_ID + "_DefaultDB");
+        char escape = SqlDialectFactory.getDialect(tenantDataSource)
+                                       .getEscapeSymbol();
+        String qualifiedTable = escape + SCHEMA + escape + "." + escape + TABLE + escape;
         try (Connection connection = tenantDataSource.getConnection();
                 Statement statement = connection.createStatement();
-                ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM " + SCHEMA + "." + TABLE)) {
-            assertTrue(resultSet.next(), "table " + SCHEMA + "." + TABLE + " must exist in the tenant's schema");
+                ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM " + qualifiedTable)) {
+            assertTrue(resultSet.next(), "table " + qualifiedTable + " must exist in the tenant's schema");
         }
     }
 }


### PR DESCRIPTION
`TenantActivationIT` has failed **every master build** since the tenant provisioning API landed (#6993) - the `integration-tests-postgresql (slow)` shard, three errors, on each run:

```
org.postgresql.util.PSQLException: ERROR: relation "tenantactivationit.tenant_activation_it_orders" does not exist
  at TenantActivationIT.assertPerTenantTableExists(TenantActivationIT.java:400)
```

## Cause

The assertion the test exists for read the per-tenant table with an unquoted, schema-qualified name:

```java
statement.executeQuery("SELECT COUNT(*) FROM " + SCHEMA + "." + TABLE)
```

Both objects are created **quoted**: the schema by the test itself through the SQL dialect factory (`CreateSchemaBuilder` encapsulates the name), the table by the platform's `TableCreateProcessor` - the CI log shows `CREATE TABLE "TENANT_ACTIVATION_IT_ORDERS" ...` running against the tenant schema, so the artefact was there all along.

An unquoted reference is folded by the database - up on H2, down on PostgreSQL - so it only happens to match on a database that folds the way the identifier was written. H2 matched; PostgreSQL looked for `tenantactivationit.tenant_activation_it_orders` and found nothing.

## Fix

Quote both identifiers with the dialect's own escape symbol, the way `DBAsserter` already does for every other table assertion in the suite.

## Verification

Locally, against `postgres:16` with the CI's own `DIRIGIBLE_DATASOURCE_DEFAULT_*` settings:

- unfixed: `Tests run: 7, Failures: 0, Errors: 3` - the exact three CI errors, same message
- fixed: `Tests run: 7, Failures: 0, Errors: 0`
- fixed, on the default H2: `Tests run: 7, Failures: 0, Errors: 0`

`mvn formatter:validate` clean on the module.

Note: run 33507359017 additionally had one `ContextLockedParentHarmoniaIT` failure on the H2 `ui` shard - a one-off in that run only, unrelated to this, and not addressed here.