### PR TITLE
intent: a partitioned document number gets a composite (per, number) key, never a single-column UNIQUE

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -1213,7 +1213,12 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
                                                                .toString()
                     : "2");
         }
-        if (field.isUnique()) {
+        // A partitioned document number (`number: { per: Company }`) is unique WITHIN its partition, by
+        // contract - identical numbers across partitions are correct. A single-column UNIQUE on the number
+        // would contradict that: the second company's first document renders the same string as the
+        // first company's and dies on the index (#7015). So `unique: true` on such a field is folded into
+        // the composite key over (partition, number) that buildUniqueConstraints synthesizes instead.
+        if (field.isUnique() && !isPartitionedNumber(field)) {
             p.put("dataUnique", "true");
         }
         if (field.getDefaultValue() != null && !field.getDefaultValue()
@@ -1831,39 +1836,84 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
      */
     private static List<Map<String, Object>> buildUniqueConstraints(EntityIntent entity) {
         List<Map<String, Object>> constraints = new ArrayList<>();
+        Set<Set<String>> declared = new HashSet<>();
         for (UniqueIntent unique : entity.getUnique()) {
             List<String> names = unique.getFields();
             if (names.size() < 2) {
                 continue; // reported by the parser
             }
-            List<Map<String, Object>> columns = new ArrayList<>(names.size());
-            StringBuilder constraintName = new StringBuilder(entity.getName());
-            for (String name : names) {
-                Map<String, Object> column = new LinkedHashMap<>();
-                column.put("name", IntentNaming.upperSnake(entity.getName()) + "_" + IntentNaming.upperSnake(name));
-                columns.add(column);
-                constraintName.append('_')
-                              .append(IntentNaming.pascalCase(name));
+            declared.add(keyOf(names));
+            constraints.add(uniqueConstraint(entity, names, unique.getMessage()));
+        }
+        // A partitioned document number is unique per partition (see propertyMap): the key the author
+        // means is (partition, number), synthesized here unless the author already spelled it out - in
+        // either column order, so a hand-written key is never doubled.
+        for (FieldIntent field : entity.getFields()) {
+            if (!isPartitionedNumber(field)) {
+                continue;
             }
-            Map<String, Object> constraint = new LinkedHashMap<>();
-            constraint.put("name", constraintName.toString());
-            constraint.put("columns", columns);
-            // The PROPERTY names, for the .edm twin: the modeler declares a key over properties (so a
-            // later dataName change follows it), and resolves them to columns when it rebuilds the
-            // .model. The columns above are what the schema template emits.
-            constraint.put("properties", names.stream()
-                                              .map(IntentNaming::pascalCase)
-                                              .collect(Collectors.joining(",")));
-            constraint.put("columnsCsv", columns.stream()
-                                                .map(column -> String.valueOf(column.get("name")))
-                                                .collect(Collectors.joining(",")));
-            constraint.put("message", notBlank(unique.getMessage()) ? unique.getMessage()
-                    : "A " + IntentNaming.humanize(entity.getName())
-                                         .toLowerCase(Locale.ROOT)
-                            + " with the same " + humanizeJoin(names) + " already exists");
-            constraints.add(constraint);
+            List<String> names = List.of(field.getNumber()
+                                              .getPer(),
+                    field.getName());
+            if (declared.add(keyOf(names))) {
+                constraints.add(uniqueConstraint(entity, names, null));
+            }
         }
         return constraints;
+    }
+
+    /** A {@code number:} field whose series is partitioned by a to-one ({@code per:}). */
+    private static boolean isPartitionedNumber(FieldIntent field) {
+        return field.getNumber() != null && notBlank(field.getNumber()
+                                                          .getPer());
+    }
+
+    /**
+     * The identity of a key - its member names, order-insensitive and in the property's canonical case.
+     */
+    private static Set<String> keyOf(List<String> names) {
+        Set<String> key = new HashSet<>();
+        for (String name : names) {
+            key.add(IntentNaming.pascalCase(name));
+        }
+        return key;
+    }
+
+    /**
+     * One composite key over the given fields / to-one relations, in the authored order.
+     *
+     * @param entity the entity
+     * @param names the member names (a field or a to-one relation each)
+     * @param message the authored violation message, or {@code null} for the default
+     * @return the constraint map the schema and REST templates consume
+     */
+    private static Map<String, Object> uniqueConstraint(EntityIntent entity, List<String> names, String message) {
+        List<Map<String, Object>> columns = new ArrayList<>(names.size());
+        StringBuilder constraintName = new StringBuilder(entity.getName());
+        for (String name : names) {
+            Map<String, Object> column = new LinkedHashMap<>();
+            column.put("name", IntentNaming.upperSnake(entity.getName()) + "_" + IntentNaming.upperSnake(name));
+            columns.add(column);
+            constraintName.append('_')
+                          .append(IntentNaming.pascalCase(name));
+        }
+        Map<String, Object> constraint = new LinkedHashMap<>();
+        constraint.put("name", constraintName.toString());
+        constraint.put("columns", columns);
+        // The PROPERTY names, for the .edm twin: the modeler declares a key over properties (so a
+        // later dataName change follows it), and resolves them to columns when it rebuilds the
+        // .model. The columns above are what the schema template emits.
+        constraint.put("properties", names.stream()
+                                          .map(IntentNaming::pascalCase)
+                                          .collect(Collectors.joining(",")));
+        constraint.put("columnsCsv", columns.stream()
+                                            .map(column -> String.valueOf(column.get("name")))
+                                            .collect(Collectors.joining(",")));
+        constraint.put("message", notBlank(message) ? message
+                : "A " + IntentNaming.humanize(entity.getName())
+                                     .toLowerCase(Locale.ROOT)
+                        + " with the same " + humanizeJoin(names) + " already exists");
+        return constraint;
     }
 
     /** {@code [tenant, application]} → {@code "tenant and application"}, for a default message. */

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -609,8 +609,12 @@ gives the field a platform-allocated, gap-free document number. The intent decla
   identically, else that artefact fails at publish.
 - `per` (optional) - a to-one relation of the entity whose value PARTITIONS the series (canonically
   `per: Company`): each partition value gets its own sequence, so two legal entities in one tenant
-  never share a counter. Identical numbers across partitions are correct. Never an `EntityStatus`
-  relation.
+  never share a counter. Identical numbers across partitions are correct - so the number's
+  uniqueness is COMPOSITE: the generator emits a `(per, number)` unique key for every partitioned
+  number, and a `unique: true` on the field is folded into it rather than emitted as a single-column
+  UNIQUE (which would make the second company's first document collide with the first company's).
+  A hand-declared entity-level `unique: [{ fields: [Company, number] }]` is honoured as-is, never
+  doubled. Never an `EntityStatus` relation.
 - `stampOn` - `create` (the generated repository allocates at insert) or `issue` (the document is
   created with a UUID placeholder and a generated delegate replaces it at the modeled issue step,
   idempotently - a re-issue after an amend keeps the number). Use `issue` for legal documents whose

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmPartitionedNumberUniqueTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmPartitionedNumberUniqueTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator.edm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.intent.parser.IntentParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A {@code number: { per: Company }} field is unique WITHIN its partition - identical numbers
+ * across partitions are the contract (#7015). So the number never carries a single-column UNIQUE;
+ * the key the author means is the composite (partition, number), synthesized unless declared by
+ * hand.
+ */
+class EdmPartitionedNumberUniqueTest {
+
+    private static final String BILLING =
+            """
+                    name: billing
+                    entities:
+                      - name: Company
+                        fields:
+                          - { name: id, type: integer, primaryKey: true, generated: true }
+                          - { name: name, type: string }
+                      - name: SalesInvoice
+                        fields:
+                          - { name: id, type: integer, primaryKey: true, generated: true }
+                          - { name: number, type: string, unique: true, length: 100, number: { series: Sales Invoice, per: Company, stampOn: issue } }
+                        relations:
+                          - { name: Company, kind: manyToOne, to: Company, required: true }
+                    """;
+
+    @Test
+    void aPartitionedNumberDropsItsSingleColumnUniqueForTheCompositeKey() {
+        Map<String, Object> number = property(BILLING, "SalesInvoice", "Number");
+        assertNull(number.get("dataUnique"),
+                "a single-column UNIQUE would make the second company's first number collide with the first's");
+        assertEquals("Company", number.get("numberPer"), "sanity: the partition marker is still there");
+
+        Map<String, Object> constraint = onlyConstraint(BILLING, "SalesInvoice");
+        assertEquals("SalesInvoice_Company_Number", constraint.get("name"));
+        assertEquals(List.of("SALES_INVOICE_COMPANY", "SALES_INVOICE_NUMBER"), columnNames(constraint),
+                "the partition's foreign-key column first, then the number - the shape a per-company range has");
+        assertEquals("Company,Number", constraint.get("properties"));
+        assertEquals("A sales invoice with the same company and number already exists", constraint.get("message"));
+    }
+
+    @Test
+    void thePartitionMakesTheKeyEvenWithoutUniqueTrue() {
+        String yaml = BILLING.replace("unique: true, ", "");
+        assertNull(property(yaml, "SalesInvoice", "Number").get("dataUnique"));
+        Map<String, Object> constraint = onlyConstraint(yaml, "SalesInvoice");
+        assertEquals(List.of("SALES_INVOICE_COMPANY", "SALES_INVOICE_NUMBER"), columnNames(constraint),
+                "the platform owns the number, so it owns its uniqueness - a silent duplicate within one company is never acceptable");
+    }
+
+    @Test
+    void anUnpartitionedNumberKeepsItsSingleColumnUnique() {
+        String yaml = BILLING.replace("per: Company, ", "");
+        Map<String, Object> number = property(yaml, "SalesInvoice", "Number");
+        assertEquals("true", number.get("dataUnique"), "one sequence for the whole tenant - the column itself is the key");
+        assertNull(entity(yaml, "SalesInvoice").get("uniqueConstraints"), "and there is nothing composite to synthesize");
+    }
+
+    @Test
+    void aHandDeclaredKeyIsHonouredAndNeverDoubled() {
+        String yaml = BILLING.replace("  - name: SalesInvoice\n", "  - name: SalesInvoice\n" + "    unique:\n"
+                + "      - { fields: [number, Company], message: \"This company already issued that number\" }\n");
+        Map<String, Object> constraint = onlyConstraint(yaml, "SalesInvoice");
+        assertEquals("SalesInvoice_Number_Company", constraint.get("name"), "the authored order and name win");
+        assertEquals(List.of("SALES_INVOICE_NUMBER", "SALES_INVOICE_COMPANY"), columnNames(constraint));
+        assertEquals("This company already issued that number", constraint.get("message"));
+    }
+
+    @Test
+    void theSynthesizedKeyReachesTheEdmTwin() {
+        String xml = EdmIntentGenerator.buildEdmXmlForTest(IntentParser.parse(BILLING), "billing");
+        assertTrue(xml.contains("<uniqueKey><entity>SalesInvoice</entity><name>SalesInvoice_Company_Number</name>"
+                + "<properties>Company,Number</properties>"), "the modeler round-trips the key like an authored one: " + xml);
+        assertTrue(!xml.contains("dataUnique=\"true\""), "and the number property carries no single-column UNIQUE: " + xml);
+    }
+
+    private static Map<String, Object> onlyConstraint(String yaml, String entityName) {
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> constraints = (List<Map<String, Object>>) entity(yaml, entityName).get("uniqueConstraints");
+        assertEquals(1, constraints == null ? 0 : constraints.size(), "exactly one key on " + entityName + ": " + constraints);
+        return constraints.get(0);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> columnNames(Map<String, Object> constraint) {
+        return ((List<Map<String, Object>>) constraint.get("columns")).stream()
+                                                                      .map(column -> String.valueOf(column.get("name")))
+                                                                      .toList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> property(String yaml, String entityName, String propertyName) {
+        List<Map<String, Object>> properties = (List<Map<String, Object>>) entity(yaml, entityName).get("properties");
+        return properties.stream()
+                         .filter(property -> propertyName.equals(property.get("name")))
+                         .findFirst()
+                         .orElseThrow(() -> new AssertionError("no property [" + propertyName + "] on [" + entityName + "]"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> entity(String yaml, String name) {
+        Map<String, Object> model = EdmIntentGenerator.buildModelJsonForTest(IntentParser.parse(yaml), "billing");
+        List<Map<String, Object>> entities = (List<Map<String, Object>>) ((Map<String, Object>) model.get("model")).get("entities");
+        return entities.stream()
+                       .filter(entity -> name.equals(entity.get("name")))
+                       .findFirst()
+                       .orElseThrow(() -> new AssertionError("no entity [" + name + "]"));
+    }
+}


### PR DESCRIPTION
Fixes #7015

## What broke

`number: { series: Sales Invoice, per: Company, stampOn: issue }` with `unique: true` on the field. The partition gives each company its own counter (and a new partition inherits the base counter, #6517), but the generator still emitted `dataUnique="true"`, so the schema put a **single-column UNIQUE** on `SALES_INVOICE_NUMBER`. Company 2's first invoice rendered `SI00000003` - the same string Company 1 already holds - and the Issue delegate's `updateProperty` died on the index. The invoice never left APPROVED.

The `.numbers`/`per:` contract is that identical numbers across partitions are correct, so the database key has to be composite.

## What changes

`EdmIntentGenerator`:
- `propertyMap` no longer emits `dataUnique` for a partitioned number, even with `unique: true`.
- `buildUniqueConstraints` synthesizes a composite key over `(per, number)` for every partitioned number - `unique: true` or not, the platform owns the number so it owns its uniqueness - and skips it when the author already declared that key by hand (order-insensitive match), so nothing is doubled.
- The key rides the existing composite-key path unchanged: `.model` `uniqueConstraints`, the `.edm` `<uniqueKey>` twin, the schema template's `constraints.uniqueIndexes`, and the REST controller's violation message (`A sales invoice with the same company and number already exists`).
- An unpartitioned number keeps its single-column UNIQUE exactly as before.

The assistant guide's `per:` bullet states the composite rule.

## Tests

`EdmPartitionedNumberUniqueTest` (5 new): partitioned + `unique: true` drops `dataUnique` and gets `SalesInvoice_Company_Number` over `[SALES_INVOICE_COMPANY, SALES_INVOICE_NUMBER]`; partitioned without `unique: true` gets the same key; unpartitioned keeps `dataUnique` and no key; a hand-declared `unique: [{ fields: [number, Company] }]` wins with its own order, name and message and is not doubled; the synthesized key reaches the `.edm` twin. `engine-intent` suite: 996 tests green, formatter clean.

## Migration on deployed modules

None by hand. The tables synchronizer used to add a new unique index but never drop a column-level UNIQUE the regenerated schema no longer declares - so an existing tenant would have needed a hand-written `ALTER`. That gap is #7019 / https://github.com/eclipse-dirigible/dirigible/pull/7020: the alter path now reconciles UNIQUE constraints with the model, so a tenant that carries the old single-column unique on the number gets it dropped and the composite key added on the module's next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

