### PR TITLE
feat(db): user and schema DDL on the client SDK

### DIFF
--- a/components/api/api-database/src/main/java/org/eclipse/dirigible/components/api/db/DatabaseFacade.java
+++ b/components/api/api-database/src/main/java/org/eclipse/dirigible/components/api/db/DatabaseFacade.java
@@ -49,6 +49,7 @@ import org.eclipse.dirigible.components.database.helpers.FormattingParameters;
 import org.eclipse.dirigible.components.database.params.ParametersSetter;
 import org.eclipse.dirigible.database.persistence.processors.identity.PersistenceNextValueIdentityProcessor;
 import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.eclipse.dirigible.database.sql.builders.schema.CreateSchemaBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -971,6 +972,280 @@ public class DatabaseFacade implements InitializingBean {
                 throw ex;
             }
         });
+    }
+
+    // =========== Users and schemas ===========
+
+    /**
+     * Creates a database user in the default data source.
+     *
+     * @param userId the user id
+     * @param password the password
+     * @throws Throwable the throwable
+     */
+    public static void createUser(String userId, String password) throws Throwable {
+        createUser(userId, password, null);
+    }
+
+    /**
+     * Creates a database user.
+     *
+     * @param userId the user id
+     * @param password the password
+     * @param datasourceName the datasource name
+     * @throws Throwable the throwable
+     */
+    public static void createUser(String userId, String password, String datasourceName) throws Throwable {
+        DataSource dataSource = getDataSource(datasourceName);
+
+        LoggingExecutor.executeNoResultWithException(dataSource, () -> {
+
+            try (Connection connection = dataSource.getConnection()) {
+                String sql = SqlFactory.getNative(connection)
+                                       .create()
+                                       .user(userId, password)
+                                       .build();
+                executeStatements(connection, sql);
+            } catch (Exception ex) {
+                logger.error("Failed to create user [{}] in data source [{}].", userId, datasourceName, ex);
+                throw ex;
+            }
+        });
+    }
+
+    /**
+     * Sets the password of an existing database user in the default data source.
+     *
+     * @param userId the user id
+     * @param password the new password
+     * @throws Throwable the throwable
+     */
+    public static void setUserPassword(String userId, String password) throws Throwable {
+        setUserPassword(userId, password, null);
+    }
+
+    /**
+     * Sets the password of an existing database user.
+     *
+     * @param userId the user id
+     * @param password the new password
+     * @param datasourceName the datasource name
+     * @throws Throwable the throwable
+     */
+    public static void setUserPassword(String userId, String password, String datasourceName) throws Throwable {
+        DataSource dataSource = getDataSource(datasourceName);
+
+        LoggingExecutor.executeNoResultWithException(dataSource, () -> {
+
+            try (Connection connection = dataSource.getConnection()) {
+                String sql = SqlFactory.getNative(connection)
+                                       .alter()
+                                       .user(userId, password)
+                                       .build();
+                executeStatements(connection, sql);
+            } catch (Exception ex) {
+                logger.error("Failed to set the password of user [{}] in data source [{}].", userId, datasourceName, ex);
+                throw ex;
+            }
+        });
+    }
+
+    /**
+     * Drops a database user from the default data source.
+     *
+     * @param userId the user id
+     * @throws Throwable the throwable
+     */
+    public static void dropUser(String userId) throws Throwable {
+        dropUser(userId, null);
+    }
+
+    /**
+     * Drops a database user.
+     *
+     * @param userId the user id
+     * @param datasourceName the datasource name
+     * @throws Throwable the throwable
+     */
+    public static void dropUser(String userId, String datasourceName) throws Throwable {
+        DataSource dataSource = getDataSource(datasourceName);
+
+        LoggingExecutor.executeNoResultWithException(dataSource, () -> {
+
+            try (Connection connection = dataSource.getConnection()) {
+                String sql = SqlFactory.getNative(connection)
+                                       .drop()
+                                       .user(userId)
+                                       .build();
+                executeStatements(connection, sql);
+            } catch (Exception ex) {
+                logger.error("Failed to drop user [{}] in data source [{}].", userId, datasourceName, ex);
+                throw ex;
+            }
+        });
+    }
+
+    /**
+     * Whether a database user exists in the default data source.
+     *
+     * @param userId the user id
+     * @return true, if the user exists
+     * @throws Throwable the throwable
+     */
+    public static boolean existsUser(String userId) throws Throwable {
+        return existsUser(userId, null);
+    }
+
+    /**
+     * Whether a database user exists.
+     *
+     * @param userId the user id
+     * @param datasourceName the datasource name
+     * @return true, if the user exists
+     * @throws Throwable the throwable
+     */
+    public static boolean existsUser(String userId, String datasourceName) throws Throwable {
+        DataSource dataSource = getDataSource(datasourceName);
+
+        return LoggingExecutor.executeWithException(dataSource, () -> {
+
+            try (Connection connection = dataSource.getConnection()) {
+                return SqlFactory.getNative(connection)
+                                 .existsUser(connection, userId);
+            } catch (Exception ex) {
+                logger.error("Failed to check whether user [{}] exists in data source [{}].", userId, datasourceName, ex);
+                throw ex;
+            }
+        });
+    }
+
+    /**
+     * Creates a schema in the default data source.
+     *
+     * @param schema the schema
+     * @param owner the user to own the schema, or null to leave ownership to the database
+     * @throws Throwable the throwable
+     */
+    public static void createSchema(String schema, String owner) throws Throwable {
+        createSchema(schema, owner, null);
+    }
+
+    /**
+     * Creates a schema.
+     *
+     * @param schema the schema
+     * @param owner the user to own the schema, or null to leave ownership to the database
+     * @param datasourceName the datasource name
+     * @throws Throwable the throwable
+     */
+    public static void createSchema(String schema, String owner, String datasourceName) throws Throwable {
+        DataSource dataSource = getDataSource(datasourceName);
+
+        LoggingExecutor.executeNoResultWithException(dataSource, () -> {
+
+            try (Connection connection = dataSource.getConnection()) {
+                CreateSchemaBuilder builder = SqlFactory.getNative(connection)
+                                                        .create()
+                                                        .schema(schema);
+                if (null != owner) {
+                    builder.authorization(owner);
+                }
+                executeStatements(connection, builder.build());
+            } catch (Exception ex) {
+                logger.error("Failed to create schema [{}] in data source [{}].", schema, datasourceName, ex);
+                throw ex;
+            }
+        });
+    }
+
+    /**
+     * Drops a schema from the default data source.
+     *
+     * @param schema the schema
+     * @param cascade whether to drop the objects the schema contains as well
+     * @throws Throwable the throwable
+     */
+    public static void dropSchema(String schema, boolean cascade) throws Throwable {
+        dropSchema(schema, cascade, null);
+    }
+
+    /**
+     * Drops a schema.
+     *
+     * @param schema the schema
+     * @param cascade whether to drop the objects the schema contains as well
+     * @param datasourceName the datasource name
+     * @throws Throwable the throwable
+     */
+    public static void dropSchema(String schema, boolean cascade, String datasourceName) throws Throwable {
+        DataSource dataSource = getDataSource(datasourceName);
+
+        LoggingExecutor.executeNoResultWithException(dataSource, () -> {
+
+            try (Connection connection = dataSource.getConnection()) {
+                String sql = SqlFactory.getNative(connection)
+                                       .drop()
+                                       .schema(schema)
+                                       .cascade(cascade)
+                                       .build();
+                executeStatements(connection, sql);
+            } catch (Exception ex) {
+                logger.error("Failed to drop schema [{}] in data source [{}].", schema, datasourceName, ex);
+                throw ex;
+            }
+        });
+    }
+
+    /**
+     * Whether a schema exists in the default data source.
+     *
+     * @param schema the schema
+     * @return true, if the schema exists
+     * @throws Throwable the throwable
+     */
+    public static boolean existsSchema(String schema) throws Throwable {
+        return existsSchema(schema, null);
+    }
+
+    /**
+     * Whether a schema exists.
+     *
+     * @param schema the schema
+     * @param datasourceName the datasource name
+     * @return true, if the schema exists
+     * @throws Throwable the throwable
+     */
+    public static boolean existsSchema(String schema, String datasourceName) throws Throwable {
+        DataSource dataSource = getDataSource(datasourceName);
+
+        return LoggingExecutor.executeWithException(dataSource, () -> {
+
+            try (Connection connection = dataSource.getConnection()) {
+                return SqlFactory.getNative(connection)
+                                 .existsSchema(connection, schema);
+            } catch (Exception ex) {
+                logger.error("Failed to check whether schema [{}] exists in data source [{}].", schema, datasourceName, ex);
+                throw ex;
+            }
+        });
+    }
+
+    /**
+     * Executes what a builder produced, which on some dialects is more than one statement - creating a
+     * user on MSSQL is a server login and a database user, and dropping it removes both.
+     *
+     * @param connection the connection
+     * @param sql the generated statement, or several separated by a semicolon
+     * @throws SQLException the SQL exception
+     */
+    private static void executeStatements(Connection connection, String sql) throws SQLException {
+        for (String statement : sql.split(";")) {
+            if (!statement.isBlank()) {
+                try (PreparedStatement preparedStatement = connection.prepareStatement(statement.trim())) {
+                    preparedStatement.executeUpdate();
+                }
+            }
+        }
     }
 
     // =========== SQL ===========

--- a/components/api/api-modules-java/README.md
+++ b/components/api/api-modules-java/README.md
@@ -36,7 +36,7 @@ log.info("file size: {}", Files.size("/users/admin/workspace/proj/foo.txt"));
 | `core/context`                       | `sdk.core.Context`                                             |       |
 | `core/env`                           | `sdk.core.Env`                                                 |       |
 | `core/globals`                       | `sdk.core.Globals`                                             |       |
-| `db/database` + `db/sequence` + `db/query` + `db/insert` + `db/update` + `db/sql` + `db/procedure` | `sdk.db.Database` | One static facade with the full `DatabaseFacade` surface. |
+| `db/database` + `db/sequence` + `db/query` + `db/insert` + `db/update` + `db/sql` + `db/procedure` | `sdk.db.Database` | One static facade with the full `DatabaseFacade` surface. The user and schema DDL on it is **Java-only** - `createUser`, `setUserPassword`, `dropUser`, `existsUser`, `createSchema`, `dropSchema`, `existsSchema`, dialect-translated like the sequence DDL beside it, with no TS counterpart. `existsUser` is implemented for PostgreSQL, H2 and MSSQL and throws `SQLFeatureNotSupportedException` elsewhere. |
 | `db/store`                           | `sdk.db.Store`                                                 | Dynamic-entity Hibernate store. For typed `@Entity` CRUD on client classes, resolve `JavaEntityStore` via `BeanProvider`. |
 | `etcd/client`                        | `sdk.etcd.Client`                                              | Returns the raw `io.etcd.jetcd.KV`. |
 | `extensions/extensions`              | `sdk.extensions.Extensions`                                    | Java callers should prefer `List<...>` collection injection or `Extensions.find(Class<T>)`; see "Extension points" below. |

--- a/components/api/api-modules-java/pom.xml
+++ b/components/api/api-modules-java/pom.xml
@@ -91,6 +91,14 @@
             <artifactId>dirigible-components-api-database</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <!-- Database.getNativeSqlFactory and the user/schema DDL expose the SQL builders, so this is a
+            direct dependency rather than one inherited through api-database. -->
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-database-sql</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.eclipse.dirigible</groupId>
             <artifactId>dirigible-components-api-etcd</artifactId>

--- a/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/db/Database.java
+++ b/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/db/Database.java
@@ -40,6 +40,21 @@ import org.eclipse.dirigible.database.sql.SqlFactory;
  * <p>
  * Sequences ({@code nextval}, {@code createSequence}, {@code dropSequence}) work across H2,
  * PostgreSQL, Oracle, and MS SQL — the platform translates the call into the appropriate dialect.
+ *
+ * <p>
+ * Users and schemas ({@code createUser}, {@code setUserPassword}, {@code dropUser},
+ * {@code existsUser}, {@code createSchema}, {@code dropSchema}, {@code existsSchema}) are
+ * translated the same way, which is the point of having them here: an application that manages
+ * database principals — setting up the schemas and users it expects, or giving an isolated part of
+ * itself a database identity of its own — would otherwise hand-write the DDL of one database and
+ * stop working on the next. What "a user" means is not uniform, and the dialect absorbs that: on
+ * SQL Server one is a server login plus a database user, so creating it emits two statements and
+ * dropping it removes both.
+ *
+ * <p>
+ * {@code existsUser} has no portable answer and says so rather than guessing — SQL standardises
+ * {@code information_schema} for schemata but not for principals. It is implemented for PostgreSQL,
+ * H2 and SQL Server; elsewhere it throws {@link java.sql.SQLFeatureNotSupportedException}.
  */
 public final class Database {
 
@@ -167,6 +182,165 @@ public final class Database {
 
     public static void dropSequence(String sequence, String datasourceName) throws Throwable {
         DatabaseFacade.dropSequence(sequence, datasourceName);
+    }
+
+    /**
+     * Creates a database user in the default data source.
+     *
+     * @param userId the user id
+     * @param password the password
+     * @throws Throwable the throwable
+     */
+    public static void createUser(String userId, String password) throws Throwable {
+        DatabaseFacade.createUser(userId, password);
+    }
+
+    /**
+     * Creates a database user.
+     *
+     * @param userId the user id
+     * @param password the password
+     * @param datasourceName the datasource name
+     * @throws Throwable the throwable
+     */
+    public static void createUser(String userId, String password, String datasourceName) throws Throwable {
+        DatabaseFacade.createUser(userId, password, datasourceName);
+    }
+
+    /**
+     * Sets the password of an existing database user in the default data source.
+     *
+     * @param userId the user id
+     * @param password the new password
+     * @throws Throwable the throwable
+     */
+    public static void setUserPassword(String userId, String password) throws Throwable {
+        DatabaseFacade.setUserPassword(userId, password);
+    }
+
+    /**
+     * Sets the password of an existing database user.
+     *
+     * @param userId the user id
+     * @param password the new password
+     * @param datasourceName the datasource name
+     * @throws Throwable the throwable
+     */
+    public static void setUserPassword(String userId, String password, String datasourceName) throws Throwable {
+        DatabaseFacade.setUserPassword(userId, password, datasourceName);
+    }
+
+    /**
+     * Drops a database user from the default data source.
+     *
+     * @param userId the user id
+     * @throws Throwable the throwable
+     */
+    public static void dropUser(String userId) throws Throwable {
+        DatabaseFacade.dropUser(userId);
+    }
+
+    /**
+     * Drops a database user.
+     *
+     * @param userId the user id
+     * @param datasourceName the datasource name
+     * @throws Throwable the throwable
+     */
+    public static void dropUser(String userId, String datasourceName) throws Throwable {
+        DatabaseFacade.dropUser(userId, datasourceName);
+    }
+
+    /**
+     * Whether a database user exists in the default data source.
+     *
+     * @param userId the user id
+     * @return true, if the user exists
+     * @throws Throwable the throwable
+     */
+    public static boolean existsUser(String userId) throws Throwable {
+        return DatabaseFacade.existsUser(userId);
+    }
+
+    /**
+     * Whether a database user exists.
+     *
+     * @param userId the user id
+     * @param datasourceName the datasource name
+     * @return true, if the user exists
+     * @throws Throwable the throwable
+     */
+    public static boolean existsUser(String userId, String datasourceName) throws Throwable {
+        return DatabaseFacade.existsUser(userId, datasourceName);
+    }
+
+    /**
+     * Creates a schema in the default data source.
+     *
+     * @param schema the schema
+     * @param owner the user to own the schema, or null to leave ownership to the database
+     * @throws Throwable the throwable
+     */
+    public static void createSchema(String schema, String owner) throws Throwable {
+        DatabaseFacade.createSchema(schema, owner);
+    }
+
+    /**
+     * Creates a schema.
+     *
+     * @param schema the schema
+     * @param owner the user to own the schema, or null to leave ownership to the database
+     * @param datasourceName the datasource name
+     * @throws Throwable the throwable
+     */
+    public static void createSchema(String schema, String owner, String datasourceName) throws Throwable {
+        DatabaseFacade.createSchema(schema, owner, datasourceName);
+    }
+
+    /**
+     * Drops a schema from the default data source.
+     *
+     * @param schema the schema
+     * @param cascade whether to drop the objects the schema contains as well
+     * @throws Throwable the throwable
+     */
+    public static void dropSchema(String schema, boolean cascade) throws Throwable {
+        DatabaseFacade.dropSchema(schema, cascade);
+    }
+
+    /**
+     * Drops a schema.
+     *
+     * @param schema the schema
+     * @param cascade whether to drop the objects the schema contains as well
+     * @param datasourceName the datasource name
+     * @throws Throwable the throwable
+     */
+    public static void dropSchema(String schema, boolean cascade, String datasourceName) throws Throwable {
+        DatabaseFacade.dropSchema(schema, cascade, datasourceName);
+    }
+
+    /**
+     * Whether a schema exists in the default data source.
+     *
+     * @param schema the schema
+     * @return true, if the schema exists
+     * @throws Throwable the throwable
+     */
+    public static boolean existsSchema(String schema) throws Throwable {
+        return DatabaseFacade.existsSchema(schema);
+    }
+
+    /**
+     * Whether a schema exists.
+     *
+     * @param schema the schema
+     * @param datasourceName the datasource name
+     * @return true, if the schema exists
+     * @throws Throwable the throwable
+     */
+    public static boolean existsSchema(String schema, String datasourceName) throws Throwable {
+        return DatabaseFacade.existsSchema(schema, datasourceName);
     }
 
     public static SqlFactory getDefaultSqlFactory() {

--- a/components/engine/engine-intent/src/main/resources/java-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/java-assistant-guide.md
@@ -238,7 +238,7 @@ Import from here rather than from a platform-internal package.
 | Package | What is in it |
 |---|---|
 | `component` | `Component`, `Inject`, `Repository`, `Beans` |
-| `db` | `Entity`, `Table`, `Id`, `GeneratedValue`, `Column`, `Lob`, `Transient`, audit annotations, `CalculatedField`, `Store`, `Database`, `Translator`, `ValidationException` |
+| `db` | `Entity`, `Table`, `Id`, `GeneratedValue`, `Column`, `Lob`, `Transient`, audit annotations, `CalculatedField`, `Store`, `Database` (SQL, sequences, and the user / schema DDL: `createUser`, `setUserPassword`, `dropUser`, `existsUser`, `createSchema`, `dropSchema`, `existsSchema`), `Translator`, `ValidationException` |
 | `http` | `Controller`, `Get`/`Post`/`Put`/`Patch`/`Delete`, `Body`, `PathParam`, `QueryParam`, `Context`, `Request`, `Response`, `Upload`, `HttpClient` |
 | `job` | `Scheduled`, `JobHandler`, `Scheduler` |
 | `messaging` | `Listener`, `ListenerKind`, `MessageHandler`, `Producer`, `Consumer` |

--- a/modules/database/database-sql-h2/src/main/java/org/eclipse/dirigible/database/sql/dialects/h2/H2AlterBranchingBuilder.java
+++ b/modules/database/database-sql-h2/src/main/java/org/eclipse/dirigible/database/sql/dialects/h2/H2AlterBranchingBuilder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.database.sql.dialects.h2;
+
+import org.eclipse.dirigible.database.sql.ISqlDialect;
+import org.eclipse.dirigible.database.sql.builders.AlterBranchingBuilder;
+
+/**
+ * The H2 Alter Branching Builder.
+ */
+public class H2AlterBranchingBuilder extends AlterBranchingBuilder {
+
+    /**
+     * Instantiates a new H2 alter branching builder.
+     *
+     * @param dialect the dialect
+     */
+    public H2AlterBranchingBuilder(ISqlDialect dialect) {
+        super(dialect);
+    }
+
+    /**
+     * User.
+     *
+     * @param userId the user id
+     * @param password the new password
+     * @return the H2 alter user builder
+     */
+    @Override
+    public H2AlterUserBuilder user(String userId, String password) {
+        return new H2AlterUserBuilder(this.getDialect(), userId, password);
+    }
+
+}

--- a/modules/database/database-sql-h2/src/main/java/org/eclipse/dirigible/database/sql/dialects/h2/H2AlterUserBuilder.java
+++ b/modules/database/database-sql-h2/src/main/java/org/eclipse/dirigible/database/sql/dialects/h2/H2AlterUserBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.database.sql.dialects.h2;
+
+import org.eclipse.dirigible.database.sql.ISqlDialect;
+import org.eclipse.dirigible.database.sql.builders.user.AlterUserBuilder;
+
+/**
+ * The Class H2AlterUserBuilder.
+ */
+public class H2AlterUserBuilder extends AlterUserBuilder {
+
+    /**
+     * Instantiates a new H2 alter user builder.
+     *
+     * @param dialect the dialect
+     * @param userId the user id
+     * @param password the new password
+     */
+    public H2AlterUserBuilder(ISqlDialect dialect, String userId, String password) {
+        super(dialect, userId, password);
+    }
+
+    /**
+     * Generate alter user statement.
+     *
+     * <p>
+     * H2 spells the assignment out - {@code SET PASSWORD} - where PostgreSQL takes the bare
+     * {@code PASSWORD} the default builder emits.
+     *
+     * @param user the user
+     * @param pass the new password
+     * @return the string
+     */
+    @Override
+    protected String generateAlterUserStatement(String user, String pass) {
+        return "ALTER USER " + encapsulateIdentifier(user) + SPACE + "SET PASSWORD " + encapsulateLiteral(pass, getPasswordEscapeSymbol());
+    }
+}

--- a/modules/database/database-sql-h2/src/main/java/org/eclipse/dirigible/database/sql/dialects/h2/H2SqlDialect.java
+++ b/modules/database/database-sql-h2/src/main/java/org/eclipse/dirigible/database/sql/dialects/h2/H2SqlDialect.java
@@ -30,7 +30,7 @@ import org.eclipse.dirigible.database.sql.dialects.DefaultSqlDialect;
  * The H2 SQL Dialect.
  */
 public class H2SqlDialect extends
-        DefaultSqlDialect<SelectBuilder, InsertBuilder, UpdateBuilder, DeleteBuilder, CreateBranchingBuilder, AlterBranchingBuilder, DropBranchingBuilder, H2NextValueSequenceBuilder, H2LastValueIdentityBuilder> {
+        DefaultSqlDialect<SelectBuilder, InsertBuilder, UpdateBuilder, DeleteBuilder, CreateBranchingBuilder, H2AlterBranchingBuilder, DropBranchingBuilder, H2NextValueSequenceBuilder, H2LastValueIdentityBuilder> {
 
     /** The Constant FUNCTIONS. */
     public static final Set<String> FUNCTIONS = Collections.synchronizedSet(new HashSet<String>(Arrays.asList("abs", "acos", "asin", "atan",
@@ -107,6 +107,16 @@ public class H2SqlDialect extends
     }
 
     /**
+     * Alter.
+     *
+     * @return the H2 alter branching builder
+     */
+    @Override
+    public H2AlterBranchingBuilder alter() {
+        return new H2AlterBranchingBuilder(this);
+    }
+
+    /**
      * Exists schema.
      *
      * @param connection the connection
@@ -128,6 +138,29 @@ public class H2SqlDialect extends
             return true;
         }
         return false;
+    }
+
+    /**
+     * Exists user.
+     *
+     * @param connection the connection
+     * @param userId the user id
+     * @return true, if successful
+     * @throws SQLException the SQL exception
+     */
+    @Override
+    public boolean existsUser(Connection connection, String userId) throws SQLException {
+        String sql = new SelectBuilder(this).column("*")
+                                            .schema("INFORMATION_SCHEMA")
+                                            .from("USERS")
+                                            .where("USER_NAME = ?")
+                                            .build();
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, userId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        }
     }
 
 }

--- a/modules/database/database-sql-h2/src/test/java/org/eclipse/dirigible/database/sql/dialects/h2/UserTest.java
+++ b/modules/database/database-sql-h2/src/test/java/org/eclipse/dirigible/database/sql/dialects/h2/UserTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.database.sql.dialects.h2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.junit.Test;
+
+/**
+ * The Class UserTest.
+ */
+public class UserTest {
+
+    /**
+     * Creates the user.
+     */
+    @Test
+    public void createUser() {
+        String sql = SqlFactory.getNative(new H2SqlDialect())
+                               .create()
+                               .user("MY_USER", "s3cret")
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals("CREATE USER \"MY_USER\" PASSWORD 's3cret'", sql);
+    }
+
+    /**
+     * H2 spells the assignment out, where PostgreSQL takes the bare PASSWORD keyword.
+     */
+    @Test
+    public void alterUser() {
+        String sql = SqlFactory.getNative(new H2SqlDialect())
+                               .alter()
+                               .user("MY_USER", "rotated")
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals("ALTER USER \"MY_USER\" SET PASSWORD 'rotated'", sql);
+    }
+
+    /**
+     * Drop user.
+     */
+    @Test
+    public void dropUser() {
+        String sql = SqlFactory.getNative(new H2SqlDialect())
+                               .drop()
+                               .user("MY_USER")
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals("DROP USER \"MY_USER\"", sql);
+    }
+
+}

--- a/modules/database/database-sql-mssql/src/main/java/org/eclipse/dirigible/database/sql/dialects/mssql/MSSQLAlterBranchingBuilder.java
+++ b/modules/database/database-sql-mssql/src/main/java/org/eclipse/dirigible/database/sql/dialects/mssql/MSSQLAlterBranchingBuilder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.database.sql.dialects.mssql;
+
+import org.eclipse.dirigible.database.sql.ISqlDialect;
+import org.eclipse.dirigible.database.sql.builders.AlterBranchingBuilder;
+
+/**
+ * The MSSQL Alter Branching Builder.
+ */
+public class MSSQLAlterBranchingBuilder extends AlterBranchingBuilder {
+
+    /**
+     * Instantiates a new MSSQL alter branching builder.
+     *
+     * @param dialect the dialect
+     */
+    public MSSQLAlterBranchingBuilder(ISqlDialect dialect) {
+        super(dialect);
+    }
+
+    /**
+     * User.
+     *
+     * @param userId the user id
+     * @param password the new password
+     * @return the mssql alter user builder
+     */
+    @Override
+    public MSSQLAlterUserBuilder user(String userId, String password) {
+        return new MSSQLAlterUserBuilder(this.getDialect(), userId, password);
+    }
+
+}

--- a/modules/database/database-sql-mssql/src/main/java/org/eclipse/dirigible/database/sql/dialects/mssql/MSSQLAlterUserBuilder.java
+++ b/modules/database/database-sql-mssql/src/main/java/org/eclipse/dirigible/database/sql/dialects/mssql/MSSQLAlterUserBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.database.sql.dialects.mssql;
+
+import org.eclipse.dirigible.database.sql.ISqlDialect;
+import org.eclipse.dirigible.database.sql.builders.user.AlterUserBuilder;
+
+/**
+ * The Class MSSQLAlterUserBuilder.
+ */
+public class MSSQLAlterUserBuilder extends AlterUserBuilder {
+
+    /**
+     * Instantiates a new MSSQL alter user builder.
+     *
+     * @param dialect the dialect
+     * @param userId the user id
+     * @param password the new password
+     */
+    public MSSQLAlterUserBuilder(ISqlDialect dialect, String userId, String password) {
+        super(dialect, userId, password);
+    }
+
+    /**
+     * Generate alter user statement.
+     *
+     * <p>
+     * {@code ALTER LOGIN}, not {@code ALTER USER}: on SQL Server the password belongs to the server
+     * login, and the database user of the same name has none to change.
+     *
+     * @param user the user
+     * @param pass the new password
+     * @return the string
+     */
+    @Override
+    protected String generateAlterUserStatement(String user, String pass) {
+        return "ALTER LOGIN " + encapsulateIdentifier(user) + SPACE + "WITH PASSWORD ="
+                + encapsulateLiteral(pass, getPasswordEscapeSymbol());
+    }
+}

--- a/modules/database/database-sql-mssql/src/main/java/org/eclipse/dirigible/database/sql/dialects/mssql/MSSQLCreateUserBuilder.java
+++ b/modules/database/database-sql-mssql/src/main/java/org/eclipse/dirigible/database/sql/dialects/mssql/MSSQLCreateUserBuilder.java
@@ -20,12 +20,12 @@ public class MSSQLCreateUserBuilder extends CreateUserBuilder {
 
     @Override
     protected String generateCreateUserStatement(String user, String pass) {
-        // create server login
-        return "CREATE LOGIN " + getEscapeSymbol() + user + getEscapeSymbol() + SPACE + "WITH PASSWORD =" + getPasswordEscapeSymbol() + pass
-                + getPasswordEscapeSymbol() + "; "
+        String name = encapsulateIdentifier(user);
 
-                // create user mapped to the login
-                + "CREATE USER " + getEscapeSymbol() + user + getEscapeSymbol() + SPACE + "FOR LOGIN " + getEscapeSymbol() + user
-                + getEscapeSymbol();
+        // create server login
+        return "CREATE LOGIN " + name + SPACE + "WITH PASSWORD =" + encapsulateLiteral(pass, getPasswordEscapeSymbol()) + "; "
+
+        // create user mapped to the login
+                + "CREATE USER " + name + SPACE + "FOR LOGIN " + name;
     }
 }

--- a/modules/database/database-sql-mssql/src/main/java/org/eclipse/dirigible/database/sql/dialects/mssql/MSSQLDropBranchingBuilder.java
+++ b/modules/database/database-sql-mssql/src/main/java/org/eclipse/dirigible/database/sql/dialects/mssql/MSSQLDropBranchingBuilder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.database.sql.dialects.mssql;
+
+import org.eclipse.dirigible.database.sql.ISqlDialect;
+import org.eclipse.dirigible.database.sql.builders.DropBranchingBuilder;
+
+/**
+ * The MSSQL Drop Branching Builder.
+ */
+public class MSSQLDropBranchingBuilder extends DropBranchingBuilder {
+
+    /**
+     * Instantiates a new MSSQL drop branching builder.
+     *
+     * @param dialect the dialect
+     */
+    public MSSQLDropBranchingBuilder(ISqlDialect dialect) {
+        super(dialect);
+    }
+
+    /**
+     * User.
+     *
+     * @param userId the user id
+     * @return the mssql drop user builder
+     */
+    @Override
+    public MSSQLDropUserBuilder user(String userId) {
+        return new MSSQLDropUserBuilder(this.getDialect(), userId);
+    }
+
+}

--- a/modules/database/database-sql-mssql/src/main/java/org/eclipse/dirigible/database/sql/dialects/mssql/MSSQLDropUserBuilder.java
+++ b/modules/database/database-sql-mssql/src/main/java/org/eclipse/dirigible/database/sql/dialects/mssql/MSSQLDropUserBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.database.sql.dialects.mssql;
+
+import org.eclipse.dirigible.database.sql.ISqlDialect;
+import org.eclipse.dirigible.database.sql.builders.user.DropUserBuilder;
+
+/**
+ * The Class MSSQLDropUserBuilder.
+ */
+public class MSSQLDropUserBuilder extends DropUserBuilder {
+
+    /**
+     * Instantiates a new MSSQL drop user builder.
+     *
+     * @param dialect the dialect
+     * @param userId the user id
+     */
+    public MSSQLDropUserBuilder(ISqlDialect dialect, String userId) {
+        super(dialect, userId);
+    }
+
+    /**
+     * Generate drop user statement.
+     *
+     * <p>
+     * Both halves of what {@link MSSQLCreateUserBuilder} created. Dropping only the database user would
+     * leave the server login behind, and the next attempt to create the same user fails on a login that
+     * already exists.
+     *
+     * @param user the user
+     * @return the string
+     */
+    @Override
+    protected String generateDropUserStatement(String user) {
+        String name = encapsulateIdentifier(user);
+
+        return "DROP USER " + name + "; " + "DROP LOGIN " + name;
+    }
+}

--- a/modules/database/database-sql-mssql/src/main/java/org/eclipse/dirigible/database/sql/dialects/mssql/MSSQLSqlDialect.java
+++ b/modules/database/database-sql-mssql/src/main/java/org/eclipse/dirigible/database/sql/dialects/mssql/MSSQLSqlDialect.java
@@ -31,7 +31,7 @@ import java.util.Set;
  * The MSSQL SQL Dialect.
  */
 public class MSSQLSqlDialect extends
-        DefaultSqlDialect<MSSQLSelectBuilder, InsertBuilder, UpdateBuilder, DeleteBuilder, MSSQLCreateBranchingBuilder, AlterBranchingBuilder, DropBranchingBuilder, MSSQLNextValueSequenceBuilder, LastValueIdentityBuilder> {
+        DefaultSqlDialect<MSSQLSelectBuilder, InsertBuilder, UpdateBuilder, DeleteBuilder, MSSQLCreateBranchingBuilder, MSSQLAlterBranchingBuilder, MSSQLDropBranchingBuilder, MSSQLNextValueSequenceBuilder, LastValueIdentityBuilder> {
 
     public static final String FUNCTION_CURRENT_DATE = "CAST(GETDATE() AS DATE)"; //$NON-NLS-1$
     public static final String FUNCTION_CURRENT_TIME = "CAST(GETDATE() AS TIME)"; //$NON-NLS-1$
@@ -78,6 +78,26 @@ public class MSSQLSqlDialect extends
     @Override
     public MSSQLCreateBranchingBuilder create() {
         return new MSSQLCreateBranchingBuilder(this);
+    }
+
+    /**
+     * Alter.
+     *
+     * @return the mssql alter branching builder
+     */
+    @Override
+    public MSSQLAlterBranchingBuilder alter() {
+        return new MSSQLAlterBranchingBuilder(this);
+    }
+
+    /**
+     * Drop.
+     *
+     * @return the mssql drop branching builder
+     */
+    @Override
+    public MSSQLDropBranchingBuilder drop() {
+        return new MSSQLDropBranchingBuilder(this);
     }
 
     /**
@@ -174,6 +194,31 @@ public class MSSQLSqlDialect extends
 
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, schema);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        }
+    }
+
+    /**
+     * Exists user.
+     *
+     * <p>
+     * {@code sys.database_principals} holds the database user; the server login it maps to lives in
+     * {@code sys.server_principals}. The database user is what the schema is authorized to, so it is
+     * the one asked about here.
+     *
+     * @param connection the connection
+     * @param userId the user id
+     * @return true, if successful
+     * @throws SQLException the SQL exception
+     */
+    @Override
+    public boolean existsUser(Connection connection, String userId) throws SQLException {
+        String sql = "SELECT * FROM sys.database_principals WHERE name = ?";
+
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, userId);
             try (ResultSet resultSet = statement.executeQuery()) {
                 return resultSet.next();
             }

--- a/modules/database/database-sql-mssql/src/test/java/org/eclipse/dirigible/database/sql/dialects/mssql/UserTest.java
+++ b/modules/database/database-sql-mssql/src/test/java/org/eclipse/dirigible/database/sql/dialects/mssql/UserTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.database.sql.dialects.mssql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.junit.Test;
+
+/**
+ * The Class UserTest.
+ */
+public class UserTest {
+
+    /**
+     * A user is a server login plus a database user mapped to it.
+     */
+    @Test
+    public void createUser() {
+        String sql = SqlFactory.getNative(new MSSQLSqlDialect())
+                               .create()
+                               .user("MY_USER", "s3cret")
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals("CREATE LOGIN \"MY_USER\" WITH PASSWORD ='s3cret'; CREATE USER \"MY_USER\" FOR LOGIN \"MY_USER\"", sql);
+    }
+
+    /**
+     * The password belongs to the login, so rotating it is ALTER LOGIN and not ALTER USER.
+     */
+    @Test
+    public void alterUser() {
+        String sql = SqlFactory.getNative(new MSSQLSqlDialect())
+                               .alter()
+                               .user("MY_USER", "rotated")
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals("ALTER LOGIN \"MY_USER\" WITH PASSWORD ='rotated'", sql);
+    }
+
+    /**
+     * Both objects go, otherwise the login outlives the user and blocks the next create.
+     */
+    @Test
+    public void dropUser() {
+        String sql = SqlFactory.getNative(new MSSQLSqlDialect())
+                               .drop()
+                               .user("MY_USER")
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals("DROP USER \"MY_USER\"; DROP LOGIN \"MY_USER\"", sql);
+    }
+
+    /**
+     * The escaping applies on this dialect too.
+     */
+    @Test
+    public void createUserWithQuoteInPassword() {
+        String sql = SqlFactory.getNative(new MSSQLSqlDialect())
+                               .create()
+                               .user("MY_USER", "pa'ss")
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals("CREATE LOGIN \"MY_USER\" WITH PASSWORD ='pa''ss'; CREATE USER \"MY_USER\" FOR LOGIN \"MY_USER\"", sql);
+    }
+
+}

--- a/modules/database/database-sql-postgres/src/main/java/org/eclipse/dirigible/database/sql/dialects/postgres/PostgresSqlDialect.java
+++ b/modules/database/database-sql-postgres/src/main/java/org/eclipse/dirigible/database/sql/dialects/postgres/PostgresSqlDialect.java
@@ -214,4 +214,30 @@ public class PostgresSqlDialect extends
         return resultSet.next();
     }
 
+    /**
+     * Exists user.
+     *
+     * <p>
+     * {@code pg_roles} rather than {@code pg_user}: PostgreSQL merged users and groups into roles, and
+     * a role created without LOGIN is absent from {@code pg_user} while still occupying the name.
+     *
+     * @param connection the connection
+     * @param userId the user id
+     * @return true, if successful
+     * @throws SQLException the SQL exception
+     */
+    @Override
+    public boolean existsUser(Connection connection, String userId) throws SQLException {
+        String sql = new SelectBuilder(this).column("*")
+                                            .from("pg_roles")
+                                            .where("rolname = ?")
+                                            .build();
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, userId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        }
+    }
+
 }

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/ISqlDialect.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/ISqlDialect.java
@@ -155,6 +155,17 @@ public interface ISqlDialect<SELECT extends SelectBuilder, INSERT extends Insert
     Map<String, List<String>> uniqueConstraints(Connection connection, String table) throws SQLException;
 
     /**
+     * Check existence of a user (or role - the two are the same object on most databases).
+     *
+     * @param connection the current connection
+     * @param userId the user id
+     * @return true if the user exists and false otherwise
+     * @throws SQLException the SQL exception
+     */
+    @Override
+    boolean existsUser(Connection connection, String userId) throws SQLException;
+
+    /**
      * Checks if the database is capable of schema-level filtering statements (e.g. to reduce the
      * provisioned schemas down to those that the current user is entitled to see).
      *

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/ISqlFactory.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/ISqlFactory.java
@@ -152,6 +152,16 @@ public interface ISqlFactory<SELECT extends SelectBuilder, INSERT extends Insert
     Map<String, List<String>> uniqueConstraints(Connection connection, String table) throws SQLException;
 
     /**
+     * Check existence of a user (or role - the two are the same object on most databases).
+     *
+     * @param connection the current connection
+     * @param userId the user id
+     * @return true if the user exists and false otherwise
+     * @throws SQLException the SQL exception
+     */
+    public boolean existsUser(Connection connection, String userId) throws SQLException;
+
+    /**
      * Nextval.
      *
      * @param sequence the sequence

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/SqlFactory.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/SqlFactory.java
@@ -277,6 +277,19 @@ public class SqlFactory<SELECT extends SelectBuilder, INSERT extends InsertBuild
     }
 
     /**
+     * Exists user.
+     *
+     * @param connection the connection
+     * @param userId the user id
+     * @return true, if successful
+     * @throws SQLException the SQL exception
+     */
+    @Override
+    public boolean existsUser(Connection connection, String userId) throws SQLException {
+        return this.dialect.existsUser(connection, userId);
+    }
+
+    /**
      * Lastval.
      *
      * @param args the args

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/AbstractSqlBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/AbstractSqlBuilder.java
@@ -126,6 +126,44 @@ public abstract class AbstractSqlBuilder implements ISqlBuilder {
     }
 
     /**
+     * Quotes an identifier that comes from outside the platform, doubling any embedded escape symbol.
+     *
+     * <p>
+     * DDL takes no bind parameters, so an identifier reaches the statement by concatenation. Doubling
+     * is what keeps a name carrying the escape symbol from ending the quoted identifier early and
+     * having its remainder read as SQL. An already-quoted name is returned untouched, which is the same
+     * contract {@link #encapsulate(String, boolean)} offers.
+     *
+     * @param identifier the identifier
+     * @return the quoted identifier, or null when the identifier is null
+     */
+    protected String encapsulateIdentifier(String identifier) {
+        if (identifier == null) {
+            return null;
+        }
+        String escapeSymbol = String.valueOf(getEscapeSymbol());
+        if (identifier.length() > 1 && identifier.startsWith(escapeSymbol) && identifier.endsWith(escapeSymbol)) {
+            return identifier;
+        }
+        return escapeSymbol + identifier.replace(escapeSymbol, escapeSymbol + escapeSymbol) + escapeSymbol;
+    }
+
+    /**
+     * Quotes a string literal that comes from outside the platform, doubling any embedded quote symbol.
+     *
+     * @param literal the literal value
+     * @param quoteSymbol the symbol the dialect quotes literals with
+     * @return the quoted literal, or null when the literal is null
+     */
+    protected String encapsulateLiteral(String literal, char quoteSymbol) {
+        if (literal == null) {
+            return null;
+        }
+        String quote = String.valueOf(quoteSymbol);
+        return quote + literal.replace(quote, quote + quote) + quote;
+    }
+
+    /**
      * Gets the dialect.
      *
      * @return the dialect

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/AlterBranchingBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/AlterBranchingBuilder.java
@@ -13,6 +13,7 @@ import org.eclipse.dirigible.database.sql.ISqlDialect;
 import org.eclipse.dirigible.database.sql.SqlException;
 import org.eclipse.dirigible.database.sql.builders.sequence.AlterSequenceBuilder;
 import org.eclipse.dirigible.database.sql.builders.table.AlterTableBuilder;
+import org.eclipse.dirigible.database.sql.builders.user.AlterUserBuilder;
 
 /**
  * The Create Branching Builder.
@@ -36,6 +37,17 @@ public class AlterBranchingBuilder extends AbstractSqlBuilder {
      */
     public AlterTableBuilder table(String table) {
         return new AlterTableBuilder(getDialect(), table);
+    }
+
+    /**
+     * User.
+     *
+     * @param userId the user id
+     * @param password the new password
+     * @return the alter user builder
+     */
+    public AlterUserBuilder user(String userId, String password) {
+        return new AlterUserBuilder(this.getDialect(), userId, password);
     }
 
     /**

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/DropBranchingBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/DropBranchingBuilder.java
@@ -12,6 +12,7 @@ package org.eclipse.dirigible.database.sql.builders;
 import org.eclipse.dirigible.database.sql.ISqlDialect;
 import org.eclipse.dirigible.database.sql.SqlException;
 import org.eclipse.dirigible.database.sql.builders.schema.DropSchemaBuilder;
+import org.eclipse.dirigible.database.sql.builders.user.DropUserBuilder;
 import org.eclipse.dirigible.database.sql.builders.sequence.DropSequenceBuilder;
 import org.eclipse.dirigible.database.sql.builders.synonym.DropSynonymBuilder;
 import org.eclipse.dirigible.database.sql.builders.table.DropConstraintBuilder;
@@ -95,6 +96,16 @@ public class DropBranchingBuilder extends AbstractSqlBuilder {
      */
     public DropSynonymBuilder publicSynonym(String synonym) {
         return synonym(synonym);
+    }
+
+    /**
+     * User.
+     *
+     * @param userId the user id
+     * @return the drop user builder
+     */
+    public DropUserBuilder user(String userId) {
+        return new DropUserBuilder(this.getDialect(), userId);
     }
 
     /**

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/schema/CreateSchemaBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/schema/CreateSchemaBuilder.java
@@ -114,9 +114,7 @@ public class CreateSchemaBuilder extends AbstractCreateSqlBuilder {
         sql.append(SPACE)
            .append(AUTHORIZATION_KEYWORD)
            .append(SPACE)
-           .append(getEscapeSymbol())
-           .append(authorization)
-           .append(getEscapeSymbol());
+           .append(encapsulateIdentifier(authorization));
 
     }
 }

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/user/AlterUserBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/user/AlterUserBuilder.java
@@ -10,17 +10,17 @@
 package org.eclipse.dirigible.database.sql.builders.user;
 
 import org.eclipse.dirigible.database.sql.ISqlDialect;
-import org.eclipse.dirigible.database.sql.builders.AbstractCreateSqlBuilder;
+import org.eclipse.dirigible.database.sql.builders.AbstractSqlBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The Class CreateUserBuilder.
+ * The Class AlterUserBuilder - changes the password of an existing user.
  */
-public class CreateUserBuilder extends AbstractCreateSqlBuilder {
+public class AlterUserBuilder extends AbstractSqlBuilder {
 
     /** The Constant logger. */
-    private static final Logger logger = LoggerFactory.getLogger(CreateUserBuilder.class);
+    private static final Logger logger = LoggerFactory.getLogger(AlterUserBuilder.class);
 
     /** The user id. */
     private final String userId;
@@ -29,13 +29,13 @@ public class CreateUserBuilder extends AbstractCreateSqlBuilder {
     private final String password;
 
     /**
-     * Instantiates a new creates the user builder.
+     * Instantiates a new alter user builder.
      *
      * @param dialect the dialect
      * @param userId the user id
-     * @param password the password
+     * @param password the new password
      */
-    public CreateUserBuilder(ISqlDialect dialect, String userId, String password) {
+    public AlterUserBuilder(ISqlDialect dialect, String userId, String password) {
         super(dialect);
         this.userId = userId;
         this.password = password;
@@ -48,23 +48,27 @@ public class CreateUserBuilder extends AbstractCreateSqlBuilder {
      */
     @Override
     public String generate() {
-        // The user, never the statement: the statement carries the password in clear text, and a trace
-        // log is exactly the wrong place for it to end up.
-        logger.trace("generating a create user statement for [{}]", userId);
+        // The user, never the statement: the statement carries the new password in clear text, and a
+        // trace log is exactly the wrong place for it to end up.
+        logger.trace("generating an alter user statement for [{}]", userId);
 
-        return generateCreateUserStatement(userId, password);
+        return generateAlterUserStatement(userId, password);
     }
 
     /**
-     * Generate create user statement.
+     * Generate alter user statement.
+     *
+     * <p>
+     * A dialect whose credentials live on a different object than the user overrides this - see the
+     * MSSQL dialect, where the password belongs to the server login rather than to the database user.
      *
      * @param user the user
-     * @param pass the pass
+     * @param pass the new password
      * @return the string
      */
-    protected String generateCreateUserStatement(String user, String pass) {
+    protected String generateAlterUserStatement(String user, String pass) {
         StringBuilder sql = new StringBuilder();
-        sql.append("CREATE USER ")
+        sql.append("ALTER USER ")
            .append(encapsulateIdentifier(user))
            .append(SPACE)
            .append("PASSWORD ")
@@ -79,6 +83,15 @@ public class CreateUserBuilder extends AbstractCreateSqlBuilder {
      */
     protected char getPasswordEscapeSymbol() {
         return '\'';
+    }
+
+    /**
+     * Gets the user id.
+     *
+     * @return the user id
+     */
+    public String getUserId() {
+        return userId;
     }
 
 }

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/user/DropUserBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/user/DropUserBuilder.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.database.sql.builders.user;
+
+import org.eclipse.dirigible.database.sql.ISqlDialect;
+import org.eclipse.dirigible.database.sql.builders.AbstractDropSqlBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Class DropUserBuilder.
+ */
+public class DropUserBuilder extends AbstractDropSqlBuilder {
+
+    /** The Constant logger. */
+    private static final Logger logger = LoggerFactory.getLogger(DropUserBuilder.class);
+
+    /** The user id. */
+    private final String userId;
+
+    /**
+     * Instantiates a new drop user builder.
+     *
+     * @param dialect the dialect
+     * @param userId the user id
+     */
+    public DropUserBuilder(ISqlDialect dialect, String userId) {
+        super(dialect);
+        this.userId = userId;
+    }
+
+    /**
+     * Generate.
+     *
+     * @return the string
+     */
+    @Override
+    public String generate() {
+        String generated = generateDropUserStatement(userId);
+
+        // Safe to log in full - a drop statement carries an identifier and no credential.
+        logger.trace("generated: {}", generated);
+
+        return generated;
+    }
+
+    /**
+     * Generate drop user statement.
+     *
+     * <p>
+     * A dialect that creates a user as more than one object overrides this to remove all of them - see
+     * the MSSQL dialect, where a user is a database principal plus a server login.
+     *
+     * @param user the user
+     * @return the string
+     */
+    protected String generateDropUserStatement(String user) {
+        return "DROP USER " + encapsulateIdentifier(user);
+    }
+
+    /**
+     * Gets the user id.
+     *
+     * @return the user id
+     */
+    public String getUserId() {
+        return userId;
+    }
+
+}

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/DefaultSqlDialect.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/DefaultSqlDialect.java
@@ -390,6 +390,29 @@ public class DefaultSqlDialect<SELECT extends SelectBuilder, INSERT extends Inse
     }
 
     /**
+     * Exists user.
+     *
+     * <p>
+     * There is no portable answer: SQL standardises {@code information_schema} for schemata but not for
+     * principals, so every database keeps its users in a catalog of its own - {@code pg_roles},
+     * {@code sys.database_principals}, {@code mysql.user}. A dialect that knows where to look overrides
+     * this; the rest say so rather than guess, because a wrong "no" would have a caller create a user
+     * that already exists.
+     *
+     * @param connection the connection
+     * @param userId the user id
+     * @return true, if successful
+     * @throws SQLException the SQL exception
+     */
+    @Override
+    public boolean existsUser(Connection connection, String userId) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "Checking whether a user exists is not implemented for database [" + connection.getMetaData()
+                                                                                               .getDatabaseProductName()
+                        + "]");
+    }
+
+    /**
      * Checks if is schema filter supported.
      *
      * @return true, if is schema filter supported

--- a/modules/database/database-sql/src/test/java/org/eclipse/dirigible/database/sql/builders/user/UserTest.java
+++ b/modules/database/database-sql/src/test/java/org/eclipse/dirigible/database/sql/builders/user/UserTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.database.sql.builders.user;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.junit.Test;
+
+/**
+ * The Class UserTest.
+ */
+public class UserTest {
+
+    /**
+     * Creates the user.
+     */
+    @Test
+    public void createUser() {
+        String sql = SqlFactory.getDefault()
+                               .create()
+                               .user("MY_USER", "s3cret")
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals("CREATE USER \"MY_USER\" PASSWORD 's3cret'", sql);
+    }
+
+    /**
+     * Alter user.
+     */
+    @Test
+    public void alterUser() {
+        String sql = SqlFactory.getDefault()
+                               .alter()
+                               .user("MY_USER", "rotated")
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals("ALTER USER \"MY_USER\" PASSWORD 'rotated'", sql);
+    }
+
+    /**
+     * Drop user.
+     */
+    @Test
+    public void dropUser() {
+        String sql = SqlFactory.getDefault()
+                               .drop()
+                               .user("MY_USER")
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals("DROP USER \"MY_USER\"", sql);
+    }
+
+    /**
+     * A user name is quoted exactly once, whether or not the caller quoted it.
+     */
+    @Test
+    public void createUserAlreadyQuoted() {
+        String sql = SqlFactory.getDefault()
+                               .create()
+                               .user("\"MY_USER\"", "s3cret")
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals("CREATE USER \"MY_USER\" PASSWORD 's3cret'", sql);
+    }
+
+    /**
+     * An escape symbol inside a user name is doubled rather than ending the identifier.
+     */
+    @Test
+    public void createUserWithEscapeSymbolInName() {
+        String sql = SqlFactory.getDefault()
+                               .create()
+                               .user("ev\"il", "s3cret")
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals("CREATE USER \"ev\"\"il\" PASSWORD 's3cret'", sql);
+    }
+
+    /**
+     * A quote inside a password is doubled rather than ending the literal.
+     */
+    @Test
+    public void createUserWithQuoteInPassword() {
+        String sql = SqlFactory.getDefault()
+                               .create()
+                               .user("MY_USER", "pa'ss")
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals("CREATE USER \"MY_USER\" PASSWORD 'pa''ss'", sql);
+    }
+
+    /**
+     * The same protection on the alter path, which carries a password too.
+     */
+    @Test
+    public void alterUserWithQuoteInPassword() {
+        String sql = SqlFactory.getDefault()
+                               .alter()
+                               .user("MY_USER", "pa'ss")
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals("ALTER USER \"MY_USER\" PASSWORD 'pa''ss'", sql);
+    }
+
+    /**
+     * And on the drop path, which carries only an identifier.
+     */
+    @Test
+    public void dropUserWithEscapeSymbolInName() {
+        String sql = SqlFactory.getDefault()
+                               .drop()
+                               .user("ev\"il")
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals("DROP USER \"ev\"\"il\"", sql);
+    }
+
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/DatabaseUsersSdkIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/DatabaseUsersSdkIT.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
+/**
+ * End-to-end test for the user and schema DDL on {@code sdk.db.Database}: a client class creates a
+ * database user, rotates its password, creates a schema owned by it and drops both, without writing
+ * a line of SQL. The suite runs on H2 and on PostgreSQL, which is the point - the two spell these
+ * statements differently ({@code ALTER USER ... SET PASSWORD} against {@code ALTER USER ...
+ * PASSWORD}) and keep their principals in catalogs of their own.
+ */
+// One Dirigible boot for the whole class: the test cleans up after itself, so the per-method
+// context
+// reset inherited from IntegrationTest would only add boot time.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Tag("slow")
+class DatabaseUsersSdkIT extends IntegrationTest {
+
+    private static final String PROJECT = "db-users-it";
+    private static final String CONTROLLER_LOCATION = "/" + PROJECT + "/api/DatabaseUsersTestController.java";
+    private static final String CONTROLLER_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + CONTROLLER_LOCATION;
+    private static final String ENDPOINT = "/services/java/" + PROJECT + "/api/DatabaseUsersTestController";
+
+    private static final long ASSERTION_TIMEOUT_SECONDS = 30;
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @Test
+    void createsRotatesAndDropsAUserAndItsSchemaWithoutAnySql() {
+        publishController();
+
+        // One pass: the whole life cycle is asserted as a single string so a compile-readiness retry
+        // re-runs it from a clean state rather than half-way through.
+        restAssuredExecutor.execute(() -> assertEquals("absent,created,rotated,schema-created,schema-absent,absent", call("/lifecycle"),
+                "the user and schema life cycle must round-trip through the SDK"), ASSERTION_TIMEOUT_SECONDS);
+    }
+
+    @AfterEach
+    void cleanup() {
+        if (repository.hasResource(CONTROLLER_PATH)) {
+            repository.removeResource(CONTROLLER_PATH);
+            synchronizationProcessor.forceProcessSynchronizers();
+        }
+    }
+
+    private void publishController() {
+        repository.createResource(CONTROLLER_PATH, controllerSource().getBytes(StandardCharsets.UTF_8), false, "text/x-java", true);
+        synchronizationProcessor.forceProcessSynchronizers();
+    }
+
+    private static String call(String path) {
+        return given().when()
+                      .get(ENDPOINT + path)
+                      .then()
+                      .statusCode(200)
+                      .extract()
+                      .asString();
+    }
+
+    private static String controllerSource() {
+        return """
+                package api;
+
+                import java.util.ArrayList;
+                import java.util.List;
+
+                import org.eclipse.dirigible.sdk.db.Database;
+                import org.eclipse.dirigible.sdk.http.Controller;
+                import org.eclipse.dirigible.sdk.http.Get;
+
+                @Controller
+                public class DatabaseUsersTestController {
+
+                    private static final String USER = "IT_DB_USER";
+                    private static final String SCHEMA = "IT_DB_SCHEMA";
+
+                    @Get("/lifecycle")
+                    public String lifecycle() throws Throwable {
+                        // Leftovers from a previous run would make every step below lie.
+                        if (Database.existsSchema(SCHEMA)) {
+                            Database.dropSchema(SCHEMA, true);
+                        }
+                        if (Database.existsUser(USER)) {
+                            Database.dropUser(USER);
+                        }
+
+                        List<String> steps = new ArrayList<>();
+                        steps.add(Database.existsUser(USER) ? "present" : "absent");
+
+                        Database.createUser(USER, "S3cret-first");
+                        steps.add(Database.existsUser(USER) ? "created" : "missing");
+
+                        Database.setUserPassword(USER, "S3cret-second");
+                        steps.add(Database.existsUser(USER) ? "rotated" : "missing");
+
+                        Database.createSchema(SCHEMA, USER);
+                        steps.add(Database.existsSchema(SCHEMA) ? "schema-created" : "schema-missing");
+
+                        Database.dropSchema(SCHEMA, true);
+                        steps.add(Database.existsSchema(SCHEMA) ? "schema-present" : "schema-absent");
+
+                        Database.dropUser(USER);
+                        steps.add(Database.existsUser(USER) ? "present" : "absent");
+
+                        return String.join(",", steps);
+                    }
+                }
+                """;
+    }
+
+}


### PR DESCRIPTION
## Why

The SQL builders can create a user, create a schema and drop a schema — and nothing else about principals. `AlterBranchingBuilder` carries only `table` and `sequence`, `DropBranchingBuilder` has no user branch in any dialect, and there is no way to ask whether a user exists. The client SDK exposes none of it: `Database` offers sequence DDL and stops there.

So an application that manages database principals — setting up the schemas and users it expects, or giving an isolated part of itself a database identity of its own — writes the DDL of one database by hand and stops working on the next. That is what the dialects exist to prevent.

`DefaultDataSourceProvisioning` shows the shape of the gap from the inside: it uses `create().user(...)` and `create().schema(...).authorization(...)`, then drops to raw MSSQL text blocks the moment it needs anything else user-related.

## What

`sdk.db.Database` gains `createUser`, `setUserPassword`, `dropUser`, `existsUser`, `createSchema`, `dropSchema`, `existsSchema` — alongside the sequence DDL it already exposed, and built the same way: through `DatabaseFacade` onto the dialect's own builders.

**Java-only**, and recorded as such in the module README next to `sdk.bpm.ProcessStamps`, which sets the precedent. The facade underneath is the same one the GraalJS bridge binds, so a TS counterpart is a thin file over an unchanged surface if it is ever wanted — nothing here would move to add it.

Three builders were missing and are added:

- **`AlterUserBuilder`** — rotating a password. `AlterBranchingBuilder` previously had only `table` and `sequence`.
- **`DropUserBuilder`** — `DropBranchingBuilder` had no user branch in any dialect.
- **`existsUser`** on `ISqlFactory` / `ISqlDialect`, following the `existsSchema` precedent. SQL standardises `information_schema` for schemata but not for principals, so it is implemented for PostgreSQL (`pg_roles`), H2 (`INFORMATION_SCHEMA.USERS`) and MSSQL (`sys.database_principals`), and throws `SQLFeatureNotSupportedException` elsewhere rather than answering a wrong "no" — which would have a caller create a user that already exists. Deliberately **not** routed through `exists(conn, name, type)`: the default implementation ignores `type` and does a table metadata lookup.

## Dialect differences that are not cosmetic

- **MSSQL**: a user is a server login plus a database user. Dropping only the database user leaves the login behind and the next create fails on it, so `DROP USER` + `DROP LOGIN`. The password belongs to the login, so rotation is `ALTER LOGIN`, not `ALTER USER`.
- **H2**: writes `ALTER USER ... SET PASSWORD` where PostgreSQL takes the bare `PASSWORD` keyword.

Both are covered by builder unit tests asserting the generated string — MSSQL is not in CI (#6150), so that is the only coverage available for it.

## A quoting fix that comes with it

`CreateUserBuilder` and `CreateSchemaBuilder`'s `AUTHORIZATION` clause concatenated the escape character around values instead of escaping them, so a name or password carrying a quote ended the identifier or the literal early. DDL takes no bind parameters, so this is the only defence there is. `encapsulateIdentifier` / `encapsulateLiteral` on `AbstractSqlBuilder` now double an embedded quote, and tests pin it. `MSSQLCreateUserBuilder` gets the same fix, and `CREATE USER` loses a stray double space in passing.

`CreateUserBuilder` had no tests at all before this.

## Tests

- `database-sql` `builders/user/UserTest` — create / alter / drop plus the four escaping cases (JUnit 4, matching the module).
- `database-sql-h2` and `database-sql-mssql` `UserTest` — the dialect spellings.
- `DatabaseUsersSdkIT` — drives the whole life cycle (absent → created → rotated → schema created → schema dropped → user dropped) from a client class with **no SQL in it**. Passes on both H2 and PostgreSQL, which is the point.

`mvn formatter:validate` clean; javadoc builds clean under `-P release`.

## Note on scope

Left alone deliberately: MySQL/MariaDB inherit the generic `CREATE USER "x" PASSWORD 'y'`, which those two spell `IDENTIFIED BY`. That is a pre-existing bug in the default builder, not something this change introduces, and it deserves its own fix. No `GRANT`/`REVOKE` builders either — `DefaultDataSourceProvisioning`'s MSSQL privilege block would need them, but nothing here does.
