### PR TITLE
data-structures: the table alter path reconciles UNIQUE constraints with the model

### DIFF
--- a/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/synchronizer/table/TableAlterProcessor.java
+++ b/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/synchronizer/table/TableAlterProcessor.java
@@ -17,6 +17,10 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import org.eclipse.dirigible.components.data.structures.domain.TableConstraintUnique;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.dirigible.components.data.structures.domain.Table;
@@ -165,7 +169,154 @@ public class TableAlterProcessor {
                 executeAlterBuilder(connection, alterTableBuilder);
             }
         }
+        reconcileUniqueConstraints(connection, tableName, tableModel);
+    }
 
+    /**
+     * Brings the table's UNIQUE constraints in line with the model - the half of schema evolution the
+     * column pass above never covered (#7019). A key the model declares (a {@code unique} column or a
+     * composite {@code uniqueIndexes} entry) that the database lacks is ADDED; a UNIQUE the database
+     * enforces that the model no longer declares is DROPPED - the same policy the column pass applies
+     * to undeclared columns. Keys are compared as column SETS, so a differently named but equal key is
+     * left alone and a second run issues nothing. PRIMARY KEY and FOREIGN KEY constraints are never
+     * touched.
+     *
+     * <p>
+     * Fails soft: a database without an INFORMATION_SCHEMA view of its constraints skips the step (no
+     * change from before), and a statement the database refuses - duplicate rows already present, a
+     * foreign key that depends on the unique - is logged with the table and key, without failing the
+     * column reconciliation or the publish.
+     *
+     * @param connection the connection
+     * @param quotedTableName the table name as the alter builder wants it (quoted)
+     * @param tableModel the model
+     */
+    static void reconcileUniqueConstraints(Connection connection, String quotedTableName, Table tableModel) {
+        String tableName = DatabaseNameNormalizer.normalizeTableName(quotedTableName);
+        Map<String, List<String>> existing;
+        try {
+            existing = readUniqueConstraints(connection, tableName);
+        } catch (SQLException e) {
+            logger.warn("Unique constraints of table [{}] are not reconciled - the database exposes no INFORMATION_SCHEMA constraint"
+                    + " view: {}", tableName, e.getMessage());
+            return;
+        }
+        Map<Set<String>, DesiredUnique> desired = new LinkedHashMap<>();
+        for (TableColumn column : tableModel.getColumns()) {
+            if (column.isUnique() && !column.isPrimaryKey()) {
+                String columnName = DatabaseNameNormalizer.normalizeColumnName(column.getName())
+                                                          .toUpperCase();
+                desired.putIfAbsent(Set.of(columnName), new DesiredUnique(tableName + "_" + columnName + "_UNIQUE", List.of(columnName)));
+            }
+        }
+        if (tableModel.getConstraints() != null && tableModel.getConstraints()
+                                                             .getUniqueIndexes() != null) {
+            for (TableConstraintUnique unique : tableModel.getConstraints()
+                                                          .getUniqueIndexes()) {
+                if (unique.getColumns() == null || unique.getColumns().length == 0) {
+                    continue;
+                }
+                List<String> columns = new ArrayList<>(unique.getColumns().length);
+                for (String column : unique.getColumns()) {
+                    columns.add(DatabaseNameNormalizer.normalizeColumnName(column)
+                                                      .toUpperCase());
+                }
+                String name = unique.getName() != null && !unique.getName()
+                                                                 .isBlank() ? unique.getName()
+                                                                         : tableName + "_" + String.join("_", columns) + "_UNIQUE";
+                desired.putIfAbsent(new HashSet<>(columns), new DesiredUnique(name, columns));
+            }
+        }
+        Set<Set<String>> present = new HashSet<>();
+        for (Map.Entry<String, List<String>> constraint : existing.entrySet()) {
+            Set<String> columns = new HashSet<>(constraint.getValue());
+            if (desired.containsKey(columns)) {
+                present.add(columns);
+                continue;
+            }
+            logger.warn("Dropping unique constraint [{}] on table [{}] over {} - the model no longer declares it", constraint.getKey(),
+                    tableName, constraint.getValue());
+            AlterTableBuilder drop = SqlFactory.getNative(connection)
+                                               .alter()
+                                               .table(quotedTableName);
+            drop.drop()
+                .unique(constraint.getKey(), constraint.getValue()
+                                                       .toArray(new String[0]));
+            executeConstraintChange(connection, drop, tableName, constraint.getKey());
+        }
+        for (Map.Entry<Set<String>, DesiredUnique> key : desired.entrySet()) {
+            if (present.contains(key.getKey())) {
+                continue;
+            }
+            DesiredUnique unique = key.getValue();
+            logger.info("Adding unique constraint [{}] on table [{}] over {}", unique.name(), tableName, unique.columns());
+            AlterTableBuilder add = SqlFactory.getNative(connection)
+                                              .alter()
+                                              .table(quotedTableName);
+            add.add()
+               .unique(unique.name(), unique.columns()
+                                            .toArray(new String[0]));
+            executeConstraintChange(connection, add, tableName, unique.name());
+        }
+    }
+
+    /** A key the model wants: its constraint name and its columns in the declared order. */
+    private record DesiredUnique(String name, List<String> columns) {
+    }
+
+    /**
+     * The table's UNIQUE constraints as the database reports them through the standard
+     * INFORMATION_SCHEMA views (H2 and PostgreSQL both expose them): constraint name to its columns in
+     * ordinal order. Column names are upper-cased for the comparison with the model.
+     *
+     * @param connection the connection
+     * @param tableName the normalized (unquoted) table name
+     * @return constraint name to ordered columns
+     * @throws SQLException when the database has no such view
+     */
+    private static Map<String, List<String>> readUniqueConstraints(Connection connection, String tableName) throws SQLException {
+        String schema = connection.getSchema();
+        String sql = "SELECT tc.CONSTRAINT_NAME, kcu.COLUMN_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc"
+                + " JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu ON kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME"
+                + " AND kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME"
+                + " WHERE tc.CONSTRAINT_TYPE = 'UNIQUE' AND tc.TABLE_NAME = ?" + (schema != null ? " AND tc.TABLE_SCHEMA = ?" : "")
+                + " ORDER BY tc.CONSTRAINT_NAME, kcu.ORDINAL_POSITION";
+        Map<String, List<String>> constraints = new LinkedHashMap<>();
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, tableName);
+            if (schema != null) {
+                statement.setString(2, schema);
+            }
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    constraints.computeIfAbsent(resultSet.getString(1), name -> new ArrayList<>())
+                               .add(resultSet.getString(2)
+                                             .toUpperCase());
+                }
+            }
+        }
+        return constraints;
+    }
+
+    /**
+     * One ADD/DROP CONSTRAINT statement, fail-soft (see {@link #reconcileUniqueConstraints}).
+     *
+     * @param connection the connection
+     * @param builder the built statement
+     * @param tableName the table, for the log
+     * @param constraint the constraint, for the log
+     */
+    private static void executeConstraintChange(Connection connection, AlterTableBuilder builder, String tableName, String constraint) {
+        String sql = builder.build();
+        if (logger.isInfoEnabled()) {
+            logger.info(sql);
+        }
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            logger.error("Unique constraint [{}] on table [{}] could not be reconciled - the table's other changes stand. Statement: [{}]",
+                    constraint, tableName, sql, e);
+        }
     }
 
     /**

--- a/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/synchronizer/table/TableAlterProcessor.java
+++ b/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/synchronizer/table/TableAlterProcessor.java
@@ -182,10 +182,10 @@ public class TableAlterProcessor {
      * touched.
      *
      * <p>
-     * Fails soft: a database without an INFORMATION_SCHEMA view of its constraints skips the step (no
-     * change from before), and a statement the database refuses - duplicate rows already present, a
-     * foreign key that depends on the unique - is logged with the table and key, without failing the
-     * column reconciliation or the publish.
+     * Fails soft: a dialect without a catalog of unique constraints skips the step (no change from
+     * before), and a statement the database refuses - duplicate rows already present, a foreign key
+     * that depends on the unique - is logged with the table and key, without failing the column
+     * reconciliation or the publish.
      *
      * @param connection the connection
      * @param quotedTableName the table name as the alter builder wants it (quoted)
@@ -195,12 +195,19 @@ public class TableAlterProcessor {
         String tableName = DatabaseNameNormalizer.normalizeTableName(quotedTableName);
         Map<String, List<String>> existing;
         try {
-            existing = readUniqueConstraints(connection, tableName);
+            existing = SqlFactory.getNative(connection)
+                                 .uniqueConstraints(connection, tableName);
         } catch (SQLException e) {
-            logger.warn("Unique constraints of table [{}] are not reconciled - the database exposes no INFORMATION_SCHEMA constraint"
-                    + " view: {}", tableName, e.getMessage());
+            logger.warn("Unique constraints of table [{}] are not reconciled - the catalog read failed: {}", tableName, e.getMessage());
             return;
         }
+        if (existing == null) {
+            logger.info("Unique constraints of table [{}] are not reconciled - this database exposes no catalog of them", tableName);
+            return;
+        }
+        existing.replaceAll((name, columns) -> columns.stream()
+                                                      .map(String::toUpperCase)
+                                                      .toList());
         Map<Set<String>, DesiredUnique> desired = new LinkedHashMap<>();
         for (TableColumn column : tableModel.getColumns()) {
             if (column.isUnique() && !column.isPrimaryKey()) {
@@ -262,40 +269,6 @@ public class TableAlterProcessor {
 
     /** A key the model wants: its constraint name and its columns in the declared order. */
     private record DesiredUnique(String name, List<String> columns) {
-    }
-
-    /**
-     * The table's UNIQUE constraints as the database reports them through the standard
-     * INFORMATION_SCHEMA views (H2 and PostgreSQL both expose them): constraint name to its columns in
-     * ordinal order. Column names are upper-cased for the comparison with the model.
-     *
-     * @param connection the connection
-     * @param tableName the normalized (unquoted) table name
-     * @return constraint name to ordered columns
-     * @throws SQLException when the database has no such view
-     */
-    private static Map<String, List<String>> readUniqueConstraints(Connection connection, String tableName) throws SQLException {
-        String schema = connection.getSchema();
-        String sql = "SELECT tc.CONSTRAINT_NAME, kcu.COLUMN_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc"
-                + " JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu ON kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME"
-                + " AND kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME"
-                + " WHERE tc.CONSTRAINT_TYPE = 'UNIQUE' AND tc.TABLE_NAME = ?" + (schema != null ? " AND tc.TABLE_SCHEMA = ?" : "")
-                + " ORDER BY tc.CONSTRAINT_NAME, kcu.ORDINAL_POSITION";
-        Map<String, List<String>> constraints = new LinkedHashMap<>();
-        try (PreparedStatement statement = connection.prepareStatement(sql)) {
-            statement.setString(1, tableName);
-            if (schema != null) {
-                statement.setString(2, schema);
-            }
-            try (ResultSet resultSet = statement.executeQuery()) {
-                while (resultSet.next()) {
-                    constraints.computeIfAbsent(resultSet.getString(1), name -> new ArrayList<>())
-                               .add(resultSet.getString(2)
-                                             .toUpperCase());
-                }
-            }
-        }
-        return constraints;
     }
 
     /**

--- a/components/data/data-structures/src/test/java/org/eclipse/dirigible/components/data/structures/synchronizer/table/TableAlterProcessorTest.java
+++ b/components/data/data-structures/src/test/java/org/eclipse/dirigible/components/data/structures/synchronizer/table/TableAlterProcessorTest.java
@@ -15,6 +15,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
+import org.eclipse.dirigible.components.data.structures.domain.TableConstraints;
+import org.eclipse.dirigible.components.data.structures.domain.TableConstraintUnique;
+import java.util.Map;
+import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.ArrayList;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -74,6 +80,99 @@ class TableAlterProcessorTest {
                                 .contains("Incompatible change of table"),
                     exception.getMessage());
         }
+    }
+
+    /**
+     * #7019: a model that moves a key from one column to a composite gets exactly that on an existing
+     * table.
+     */
+    @Test
+    void aWithdrawnColumnUniqueIsDroppedAndTheDeclaredCompositeKeyIsAdded() throws SQLException {
+        try (Connection connection = connect("alter_unique_move")) {
+            createTable(connection, "\"COMPANY\" INTEGER, \"NUMBER\" VARCHAR(100) UNIQUE");
+            Table tableModel = modelWithCompositeKey();
+
+            TableAlterProcessor.execute(connection, tableModel);
+
+            Map<String, List<String>> uniques = uniqueConstraints(connection);
+            assertEquals(1, uniques.size(), "the single-column UNIQUE is gone and the composite key is there: " + uniques);
+            assertEquals(List.of("COMPANY", "NUMBER"), uniques.get("Notes_Company_Number"),
+                    "the declared name and column order: " + uniques);
+        }
+    }
+
+    @Test
+    void aDeclaredColumnUniqueIsAddedToAnExistingTable() throws SQLException {
+        try (Connection connection = connect("alter_unique_add")) {
+            createTable(connection, "\"CODE\" VARCHAR(20)");
+            Table tableModel = new Table("T_NOTES");
+            new TableColumn("ID", "INTEGER", null, tableModel);
+            new TableColumn("CODE", "VARCHAR", "20", true, false, null, null, null, true, false, tableModel);
+
+            TableAlterProcessor.execute(connection, tableModel);
+
+            Map<String, List<String>> uniques = uniqueConstraints(connection);
+            assertEquals(List.of(List.of("CODE")), new ArrayList<>(uniques.values()), "the model's unique column is enforced: " + uniques);
+        }
+    }
+
+    @Test
+    void aMatchingKeyIsKeptWhateverItsNameAndASecondRunChangesNothing() throws SQLException {
+        try (Connection connection = connect("alter_unique_idempotent")) {
+            createTable(connection,
+                    "\"COMPANY\" INTEGER, \"NUMBER\" VARCHAR(100), CONSTRAINT \"HAND_MADE\" UNIQUE (\"COMPANY\", \"NUMBER\")");
+            Table tableModel = modelWithCompositeKey();
+
+            TableAlterProcessor.execute(connection, tableModel);
+            TableAlterProcessor.execute(connection, tableModel);
+
+            Map<String, List<String>> uniques = uniqueConstraints(connection);
+            assertEquals(Map.of("HAND_MADE", List.of("COMPANY", "NUMBER")), uniques,
+                    "an equal key under another name is not churned, and the primary key is untouched");
+        }
+    }
+
+    @Test
+    void aRefusedConstraintChangeDoesNotFailTheAlter() throws SQLException {
+        try (Connection connection = connect("alter_unique_refused")) {
+            createTable(connection, "\"COMPANY\" INTEGER, \"NUMBER\" VARCHAR(100)");
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("INSERT INTO \"T_NOTES\" VALUES (1, 1, 'SI1'), (2, 1, 'SI1')");
+            }
+            Table tableModel = modelWithCompositeKey();
+
+            assertDoesNotThrow(() -> TableAlterProcessor.execute(connection, tableModel),
+                    "duplicate rows make the ADD fail - logged, not thrown");
+            assertTrue(uniqueConstraints(connection).isEmpty());
+        }
+    }
+
+    private static Table modelWithCompositeKey() {
+        Table tableModel = new Table("T_NOTES");
+        new TableColumn("ID", "INTEGER", null, tableModel);
+        new TableColumn("COMPANY", "INTEGER", null, tableModel);
+        new TableColumn("NUMBER", "VARCHAR", "100", tableModel);
+        TableConstraints constraints = new TableConstraints(tableModel);
+        tableModel.setConstraints(constraints);
+        constraints.getUniqueIndexes()
+                   .add(new TableConstraintUnique("Notes_Company_Number", null, new String[] {"COMPANY", "NUMBER"}, constraints, null,
+                           null));
+        return tableModel;
+    }
+
+    private static Map<String, List<String>> uniqueConstraints(Connection connection) throws SQLException {
+        Map<String, List<String>> uniques = new LinkedHashMap<>();
+        try (Statement statement = connection.createStatement();
+                ResultSet rs =
+                        statement.executeQuery("SELECT tc.CONSTRAINT_NAME, kcu.COLUMN_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc"
+                                + " JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu ON kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME"
+                                + " WHERE tc.CONSTRAINT_TYPE = 'UNIQUE' AND tc.TABLE_NAME = 'T_NOTES' ORDER BY tc.CONSTRAINT_NAME, kcu.ORDINAL_POSITION")) {
+            while (rs.next()) {
+                uniques.computeIfAbsent(rs.getString(1), name -> new ArrayList<>())
+                       .add(rs.getString(2));
+            }
+        }
+        return uniques;
     }
 
     private static Connection connect(String database) throws SQLException {

--- a/modules/database/database-sql-hana/src/main/java/org/eclipse/dirigible/database/sql/dialects/hana/HanaSqlDialect.java
+++ b/modules/database/database-sql-hana/src/main/java/org/eclipse/dirigible/database/sql/dialects/hana/HanaSqlDialect.java
@@ -23,6 +23,8 @@ import java.sql.*;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -315,6 +317,40 @@ public class HanaSqlDialect extends
             logger.debug("Assuming artifact [{}] in schema  [{}] of type [{}] does not exist", artefact, schema, type, ex);
             return false;
         }
+    }
+
+    /**
+     * HANA has no INFORMATION_SCHEMA; {@code SYS.CONSTRAINTS} lists every key column with the flags
+     * that tell a unique key from the primary key.
+     *
+     * @param connection the connection
+     * @param table the table
+     * @return constraint name to ordered columns
+     * @throws SQLException when the catalog read fails
+     */
+    @Override
+    public Map<String, List<String>> uniqueConstraints(Connection connection, String table) throws SQLException {
+        String schema = connection.getSchema();
+        try (PreparedStatement statement = connection.prepareStatement(uniqueConstraintsQuery(schema != null))) {
+            statement.setString(1, table);
+            if (schema != null) {
+                statement.setString(2, schema);
+            }
+            return readUniqueConstraints(statement);
+        }
+    }
+
+    /**
+     * The catalog query behind {@link #uniqueConstraints}; the current schema when the driver reports
+     * none.
+     *
+     * @param withSchema whether a schema parameter is bound
+     * @return the SQL
+     */
+    static String uniqueConstraintsQuery(boolean withSchema) {
+        return "SELECT CONSTRAINT_NAME, COLUMN_NAME FROM SYS.CONSTRAINTS WHERE TABLE_NAME = ? AND SCHEMA_NAME = "
+                + (withSchema ? "?" : "CURRENT_SCHEMA") + " AND IS_UNIQUE_KEY = 'TRUE' AND IS_PRIMARY_KEY = 'FALSE'"
+                + " ORDER BY CONSTRAINT_NAME, POSITION";
     }
 
     /**

--- a/modules/database/database-sql-hana/src/test/java/org/eclipse/dirigible/database/sql/dialects/hana/UniqueConstraintsCatalogTest.java
+++ b/modules/database/database-sql-hana/src/test/java/org/eclipse/dirigible/database/sql/dialects/hana/UniqueConstraintsCatalogTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.database.sql.dialects.hana;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * HANA has no INFORMATION_SCHEMA - the table alter path's unique-constraint reconciliation (#7019)
+ * reads SYS.CONSTRAINTS instead, keeping the primary key out of the picture.
+ */
+public class UniqueConstraintsCatalogTest {
+
+    @Test
+    public void readsUniqueKeysFromSysConstraintsWithoutThePrimaryKey() {
+        assertEquals(
+                "SELECT CONSTRAINT_NAME, COLUMN_NAME FROM SYS.CONSTRAINTS WHERE TABLE_NAME = ? AND SCHEMA_NAME = ?"
+                        + " AND IS_UNIQUE_KEY = 'TRUE' AND IS_PRIMARY_KEY = 'FALSE' ORDER BY CONSTRAINT_NAME, POSITION",
+                HanaSqlDialect.uniqueConstraintsQuery(true));
+    }
+
+    @Test
+    public void fallsBackToTheCurrentSchemaWhenTheDriverReportsNone() {
+        assertEquals(
+                "SELECT CONSTRAINT_NAME, COLUMN_NAME FROM SYS.CONSTRAINTS WHERE TABLE_NAME = ? AND SCHEMA_NAME = CURRENT_SCHEMA"
+                        + " AND IS_UNIQUE_KEY = 'TRUE' AND IS_PRIMARY_KEY = 'FALSE' ORDER BY CONSTRAINT_NAME, POSITION",
+                HanaSqlDialect.uniqueConstraintsQuery(false));
+    }
+}

--- a/modules/database/database-sql-mongodb/src/main/java/org/eclipse/dirigible/database/sql/dialects/mongodb/MongoDBSqlDialect.java
+++ b/modules/database/database-sql-mongodb/src/main/java/org/eclipse/dirigible/database/sql/dialects/mongodb/MongoDBSqlDialect.java
@@ -18,6 +18,8 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.dirigible.database.sql.DatabaseType;
@@ -177,4 +179,16 @@ public class MongoDBSqlDialect extends
         ExportImportUtil.importCollection(connection.unwrap(MongoDBConnection.class), table, input);
     }
 
+
+    /**
+     * A document store has no unique-constraint catalog to reconcile against.
+     *
+     * @param connection the connection
+     * @param table the table
+     * @return {@code null} - no catalog
+     */
+    @Override
+    public Map<String, List<String>> uniqueConstraints(Connection connection, String table) {
+        return null;
+    }
 }

--- a/modules/database/database-sql-snowflake/src/main/java/org/eclipse/dirigible/database/sql/dialects/snowflake/SnowflakeSqlDialect.java
+++ b/modules/database/database-sql-snowflake/src/main/java/org/eclipse/dirigible/database/sql/dialects/snowflake/SnowflakeSqlDialect.java
@@ -24,6 +24,8 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -213,4 +215,18 @@ public class SnowflakeSqlDialect extends
         return resultSet.next();
     }
 
+
+    /**
+     * Snowflake has TABLE_CONSTRAINTS but no KEY_COLUMN_USAGE - the columns of a key are only reachable
+     * through {@code SHOW UNIQUE KEYS}, which is not a query. Until that is wired, the table alter path
+     * leaves unique constraints alone here.
+     *
+     * @param connection the connection
+     * @param table the table
+     * @return {@code null} - no catalog
+     */
+    @Override
+    public Map<String, List<String>> uniqueConstraints(Connection connection, String table) {
+        return null;
+    }
 }

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/ISqlDialect.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/ISqlDialect.java
@@ -17,6 +17,8 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.sql.DataSource;
@@ -135,6 +137,22 @@ public interface ISqlDialect<SELECT extends SelectBuilder, INSERT extends Insert
      */
     @Override
     boolean existsSchema(Connection connection, String schema) throws SQLException;
+
+    /**
+     * The UNIQUE constraints of a table as the database catalog reports them - never the primary key,
+     * never a foreign key: constraint name to its columns in ordinal order. The table alter path
+     * reconciles these with the model, so the catalog read has to be the dialect's: INFORMATION_SCHEMA
+     * where the database has it, {@code SYS.CONSTRAINTS} on HANA, and so on.
+     *
+     * @param connection the current connection
+     * @param table the (unquoted) table name
+     * @return constraint name to ordered column names, empty when the table has none; {@code null} when
+     *         this database exposes no catalog of unique constraints at all - the caller then leaves
+     *         the table's constraints as they are
+     * @throws SQLException when the catalog read fails
+     */
+    @Override
+    Map<String, List<String>> uniqueConstraints(Connection connection, String table) throws SQLException;
 
     /**
      * Checks if the database is capable of schema-level filtering statements (e.g. to reduce the

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/ISqlFactory.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/ISqlFactory.java
@@ -11,6 +11,8 @@ package org.eclipse.dirigible.database.sql;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
 
 import org.eclipse.dirigible.database.sql.builders.AlterBranchingBuilder;
 import org.eclipse.dirigible.database.sql.builders.CreateBranchingBuilder;
@@ -136,6 +138,18 @@ public interface ISqlFactory<SELECT extends SelectBuilder, INSERT extends Insert
      * @throws SQLException the SQL exception
      */
     public boolean existsSchema(Connection connection, String schema) throws SQLException;
+
+    /**
+     * The UNIQUE constraints of a table as the database catalog reports them - never the primary key,
+     * never a foreign key: constraint name to its columns in ordinal order.
+     *
+     * @param connection the current connection
+     * @param table the (unquoted) table name
+     * @return constraint name to ordered column names, empty when the table has none; {@code null} when
+     *         this database exposes no catalog of unique constraints at all
+     * @throws SQLException when the catalog read fails
+     */
+    Map<String, List<String>> uniqueConstraints(Connection connection, String table) throws SQLException;
 
     /**
      * Nextval.

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/SqlFactory.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/SqlFactory.java
@@ -11,6 +11,8 @@ package org.eclipse.dirigible.database.sql;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
 
 import org.eclipse.dirigible.database.sql.builders.AlterBranchingBuilder;
 import org.eclipse.dirigible.database.sql.builders.CreateBranchingBuilder;
@@ -258,6 +260,20 @@ public class SqlFactory<SELECT extends SelectBuilder, INSERT extends InsertBuild
     @Override
     public boolean existsSchema(Connection connection, String schema) throws SQLException {
         return this.dialect.existsSchema(connection, schema);
+    }
+
+    /**
+     * Unique constraints of a table, from the dialect's catalog.
+     *
+     * @param connection the connection
+     * @param table the table
+     * @return constraint name to ordered columns, or {@code null} when the dialect has no catalog of
+     *         them
+     * @throws SQLException the SQL exception
+     */
+    @Override
+    public Map<String, List<String>> uniqueConstraints(Connection connection, String table) throws SQLException {
+        return this.dialect.uniqueConstraints(connection, table);
     }
 
     /**

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/table/AlterTableBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/table/AlterTableBuilder.java
@@ -253,8 +253,10 @@ public class AlterTableBuilder extends AbstractTableBuilder<AlterTableBuilder> {
                .append(SPACE)
                .append(KEYWORD_CONSTRAINT)
                .append(SPACE);
+            // Quoted like the ADD side names it: a unique key is created encapsulated (mixed case survives on
+            // PostgreSQL), so the drop must spell it the same way or it looks for a lower-cased stranger.
             this.getUniqueIndices()
-                .forEach(ui -> sql.append(ui.getName() + ", "));
+                .forEach(ui -> sql.append(encapsulate(ui.getName()) + ", "));
             sql.delete(sql.length() - 2, sql.length());
         }
     }
@@ -299,9 +301,11 @@ public class AlterTableBuilder extends AbstractTableBuilder<AlterTableBuilder> {
      * @param sql the sql
      */
     protected void generateUniqueIndices(StringBuilder sql) {
+        // ADD CONSTRAINT ... UNIQUE (...) - one clause per key, space-separated from the ADD and from each
+        // other, no trailing comma (the CREATE TABLE form's separator has no place in an ALTER).
         for (CreateTableUniqueIndexBuilder uniqueIndex : this.uniqueIndices) {
+            sql.append(SPACE);
             generateUniqueIndex(sql, uniqueIndex);
-            sql.append(COMMA);
         }
     }
 

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/DefaultSqlDialect.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/DefaultSqlDialect.java
@@ -33,6 +33,10 @@ import java.sql.*;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
 import java.util.Set;
 
 /**
@@ -333,6 +337,56 @@ public class DefaultSqlDialect<SELECT extends SelectBuilder, INSERT extends Inse
         statement.setString(1, schema);
         ResultSet resultSet = statement.executeQuery();
         return resultSet.next();
+    }
+
+    /**
+     * The standard INFORMATION_SCHEMA form - TABLE_CONSTRAINTS joined to KEY_COLUMN_USAGE - which H2,
+     * PostgreSQL, MySQL, MariaDB and SQL Server all expose. Scoped to the connection's schema (or,
+     * where the driver reports none - MySQL and MariaDB call it the catalog - to the catalog), so a
+     * same-named table in another schema does not leak in.
+     *
+     * @param connection the connection
+     * @param table the table
+     * @return constraint name to ordered columns
+     * @throws SQLException when the catalog read fails
+     */
+    @Override
+    public Map<String, List<String>> uniqueConstraints(Connection connection, String table) throws SQLException {
+        String schema = connection.getSchema();
+        if (schema == null) {
+            schema = connection.getCatalog();
+        }
+        String sql = "SELECT tc.CONSTRAINT_NAME, kcu.COLUMN_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc"
+                + " JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu ON kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME"
+                + " AND kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME"
+                + " WHERE tc.CONSTRAINT_TYPE = 'UNIQUE' AND tc.TABLE_NAME = ?" + (schema != null ? " AND tc.TABLE_SCHEMA = ?" : "")
+                + " ORDER BY tc.CONSTRAINT_NAME, kcu.ORDINAL_POSITION";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, table);
+            if (schema != null) {
+                statement.setString(2, schema);
+            }
+            return readUniqueConstraints(statement);
+        }
+    }
+
+    /**
+     * Collects a (constraint name, column name) result ordered by constraint and position into the
+     * {@link #uniqueConstraints} shape. Shared by the dialects' catalog queries.
+     *
+     * @param statement the prepared, bound statement
+     * @return constraint name to ordered columns
+     * @throws SQLException when the query fails
+     */
+    protected static Map<String, List<String>> readUniqueConstraints(PreparedStatement statement) throws SQLException {
+        Map<String, List<String>> constraints = new LinkedHashMap<>();
+        try (ResultSet resultSet = statement.executeQuery()) {
+            while (resultSet.next()) {
+                constraints.computeIfAbsent(resultSet.getString(1), name -> new ArrayList<>())
+                           .add(resultSet.getString(2));
+            }
+        }
+        return constraints;
     }
 
     /**

--- a/modules/database/database-sql/src/test/java/org/eclipse/dirigible/database/sql/builders/table/AlterTableTest.java
+++ b/modules/database/database-sql/src/test/java/org/eclipse/dirigible/database/sql/builders/table/AlterTableTest.java
@@ -120,4 +120,34 @@ public class AlterTableTest {
         assertEquals("ALTER TABLE \"ORDERS\" DROP CONSTRAINT FK1;", sql);
     }
 
+    /** Alter table add a unique key (the table alter processor's reconciliation form). */
+    @Test
+    public void alterTableAddUnique() {
+        String sql = SqlFactory.getDefault()
+                               .alter()
+                               .table("SALES_INVOICE")
+                               .add()
+                               .unique("SalesInvoice_Company_Number", new String[] {"SALES_INVOICE_COMPANY", "SALES_INVOICE_NUMBER"})
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals(
+                "ALTER TABLE \"SALES_INVOICE\" ADD CONSTRAINT \"SalesInvoice_Company_Number\" UNIQUE ( \"SALES_INVOICE_COMPANY\" , \"SALES_INVOICE_NUMBER\" );",
+                sql);
+    }
+
+    /** Alter table drop a unique key - the name quoted exactly as the ADD created it. */
+    @Test
+    public void alterTableDropUnique() {
+        String sql = SqlFactory.getDefault()
+                               .alter()
+                               .table("SALES_INVOICE")
+                               .drop()
+                               .unique("SalesInvoice_Company_Number", new String[] {"SALES_INVOICE_COMPANY", "SALES_INVOICE_NUMBER"})
+                               .build();
+
+        assertNotNull(sql);
+        assertEquals("ALTER TABLE \"SALES_INVOICE\" DROP CONSTRAINT \"SalesInvoice_Company_Number\";", sql);
+    }
+
 }


### PR DESCRIPTION
Fixes #7019

## What broke

`TableAlterProcessor` - the path every existing table takes on a republish - reconciled **columns only**. A unique key the model gained (a `unique` column, or a composite `constraints.uniqueIndexes` entry) was never created on an existing table; a key the model dropped was never removed. Evolving a key meant a hand-written `ALTER TABLE` on every tenant in every environment. That is exactly what #7017 (the `(Company, Number)` key for a partitioned document number) would have needed on staging and prod. Liquibase (`core-liquibase`) covers only the DIRIGIBLE_* SystemDB tables, not generated application tables in the tenant datasource.

## What changes

`TableAlterProcessor.reconcileUniqueConstraints`, run after the column pass:
- asks the **dialect** for the table's UNIQUE constraints (name → ordered columns) through a new `ISqlFactory.uniqueConstraints(connection, table)`; PRIMARY KEY and FOREIGN KEY are never touched:

  | dialect | catalog |
  |---|---|
  | H2, PostgreSQL, MySQL, MariaDB, SQL Server (`DefaultSqlDialect`) | `INFORMATION_SCHEMA.TABLE_CONSTRAINTS` ⋈ `KEY_COLUMN_USAGE`, scoped to the connection's schema, or to the catalog where the driver reports no schema (MySQL/MariaDB) |
  | HANA | `SYS.CONSTRAINTS` with `IS_UNIQUE_KEY = 'TRUE' AND IS_PRIMARY_KEY = 'FALSE'`, `CURRENT_SCHEMA` fallback |
  | Snowflake, MongoDB | `null` = no catalog, the table's keys are left alone (Snowflake has no `KEY_COLUMN_USAGE`; the columns of a key are only reachable via `SHOW UNIQUE KEYS`) |

- desired = every `unique` column as a one-column key + every `uniqueIndexes` entry, compared as **column sets**, so an equal key under another name is kept and a second run issues nothing;
- drops existing keys the model no longer declares (the same policy the column pass applies to undeclared columns), adds missing ones with the declared name (composite) or `<TABLE>_<COLUMN>_UNIQUE` (column-level);
- fails soft: a `null`/failed catalog read → the step is skipped (today's behaviour); a refused statement (duplicate rows already present, a foreign key depending on the unique) is logged with table and key and the rest of the alter stands.

`AlterTableBuilder`: the `ADD ... UNIQUE` form had never been used - it rendered `ADDCONSTRAINT` with a trailing comma; fixed. `DROP CONSTRAINT` for a unique now quotes the name, as the ADD that created it does (PostgreSQL keeps the mixed case, so an unquoted drop looked for a lower-cased stranger). The FK drop form is unchanged.

## Tests

- `AlterTableTest`: `alterTableAddUnique`, `alterTableDropUnique` (database-sql suite 112 green).
- `UniqueConstraintsCatalogTest` (HANA): the `SYS.CONSTRAINTS` query with a bound schema and with the `CURRENT_SCHEMA` fallback.
- `TableAlterProcessorTest` on H2: withdrawn column unique dropped + declared composite added; declared column unique added; a matching key under another name kept and a second run changes nothing; a refused change does not fail the alter (data-structures suite 13 green). All dialect modules build and their suites pass.
- The same four scenarios run against **PostgreSQL 16** in Docker through the processor with the PostgreSQL dialect: `T_NOTES_NUMBER_key` dropped, `"Notes_Company_Number"` added, idempotent, duplicate rows → `could not create unique index` logged and swallowed.
- **MariaDB 11** in Docker: the catalog read works (the native `NUMBER` unique is found through the catalog fallback), but the ALTER statements fail on a pre-existing defect unrelated to this change - every data-structures processor passes a pre-quoted `"NAME"`, which the backtick dialects wrap again. Filed as https://github.com/eclipse-dirigible/dirigible/issues/7021; the column add/drop path has the same problem there today.

Formatter validate clean on both modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

