### PR TITLE
data-structures: an ANSI-quoted name is re-quoted per dialect, not wrapped again

### DIFF
--- a/modules/database/database-sql-mariadb/src/test/java/org/eclipse/dirigible/database/sql/dialects/mariadb/PreQuotedNameTest.java
+++ b/modules/database/database-sql-mariadb/src/test/java/org/eclipse/dirigible/database/sql/dialects/mariadb/PreQuotedNameTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.database.sql.dialects.mariadb;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.dirigible.database.sql.DataType;
+import org.eclipse.dirigible.database.sql.Modifiers;
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.junit.Test;
+
+/**
+ * A name the caller already quoted with the ANSI symbol - which is what every data-structure
+ * processor hands the builders - must be re-quoted with the backtick, not wrapped in it (#7021).
+ */
+public class PreQuotedNameTest {
+
+    /**
+     * Creates a table whose name and columns arrive ANSI-quoted.
+     */
+    @Test
+    public void createTableWithAnsiQuotedNames() {
+        String sql = SqlFactory.getNative(new MariaDBSqlDialect())
+                               .create()
+                               .table("\"T_NOTES\"")
+                               .column("\"ID\"", DataType.INTEGER, Modifiers.PRIMARY_KEY, Modifiers.NOT_NULL, Modifiers.NON_UNIQUE)
+                               .build();
+
+        assertEquals("CREATE TABLE `T_NOTES` ( `ID` INTEGER NOT NULL PRIMARY KEY )", sql);
+    }
+
+    /**
+     * Adds a column to a table whose name arrives ANSI-quoted.
+     */
+    @Test
+    public void alterTableAddColumnWithAnsiQuotedNames() {
+        String sql = SqlFactory.getNative(new MariaDBSqlDialect())
+                               .alter()
+                               .table("\"T_NOTES\"")
+                               .add()
+                               .column("\"COMPANY\"", DataType.VARCHAR, Modifiers.REGULAR, Modifiers.NULLABLE, Modifiers.NON_UNIQUE, "(20)")
+                               .build();
+
+        assertEquals("ALTER TABLE `T_NOTES` ADD `COMPANY` VARCHAR (20) ;", sql);
+    }
+
+    /**
+     * Adds a unique constraint to a table whose name arrives ANSI-quoted.
+     */
+    @Test
+    public void alterTableAddUniqueWithAnsiQuotedTableName() {
+        String sql = SqlFactory.getNative(new MariaDBSqlDialect())
+                               .alter()
+                               .table("\"T_NOTES\"")
+                               .add()
+                               .unique("Notes_Company_Number", new String[] {"COMPANY", "NUMBER"})
+                               .build();
+
+        assertEquals("ALTER TABLE `T_NOTES` ADD CONSTRAINT `Notes_Company_Number` UNIQUE ( `COMPANY` , `NUMBER` );", sql);
+    }
+
+    /**
+     * Drops a table whose name arrives ANSI-quoted.
+     */
+    @Test
+    public void dropTableWithAnsiQuotedName() {
+        String sql = SqlFactory.getNative(new MariaDBSqlDialect())
+                               .drop()
+                               .table("\"T_NOTES\"")
+                               .build();
+
+        assertEquals("DROP TABLE `T_NOTES`", sql);
+    }
+
+    /**
+     * A schema-qualified ANSI-quoted name keeps its parts separate.
+     */
+    @Test
+    public void dropSchemaQualifiedAnsiQuotedName() {
+        String sql = SqlFactory.getNative(new MariaDBSqlDialect())
+                               .drop()
+                               .table("\"MYSCHEMA\".\"T_NOTES\"")
+                               .build();
+
+        assertEquals("DROP TABLE `MYSCHEMA`.`T_NOTES`", sql);
+    }
+
+}

--- a/modules/database/database-sql-mysql/src/test/java/org/eclipse/dirigible/database/sql/dialects/mysql/PreQuotedNameTest.java
+++ b/modules/database/database-sql-mysql/src/test/java/org/eclipse/dirigible/database/sql/dialects/mysql/PreQuotedNameTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.database.sql.dialects.mysql;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.dirigible.database.sql.DataType;
+import org.eclipse.dirigible.database.sql.Modifiers;
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.junit.Test;
+
+/**
+ * A name the caller already quoted with the ANSI symbol - which is what every data-structure
+ * processor hands the builders - must be re-quoted with the backtick, not wrapped in it (#7021).
+ */
+public class PreQuotedNameTest {
+
+    /**
+     * Creates a table whose name and columns arrive ANSI-quoted.
+     */
+    @Test
+    public void createTableWithAnsiQuotedNames() {
+        String sql = SqlFactory.getNative(new MySQLSqlDialect())
+                               .create()
+                               .table("\"T_NOTES\"")
+                               .column("\"ID\"", DataType.INTEGER, Modifiers.PRIMARY_KEY, Modifiers.NOT_NULL, Modifiers.NON_UNIQUE)
+                               .build();
+
+        assertEquals("CREATE TABLE `T_NOTES` ( `ID` INTEGER NOT NULL PRIMARY KEY )", sql);
+    }
+
+    /**
+     * Adds a column to a table whose name arrives ANSI-quoted.
+     */
+    @Test
+    public void alterTableAddColumnWithAnsiQuotedNames() {
+        String sql = SqlFactory.getNative(new MySQLSqlDialect())
+                               .alter()
+                               .table("\"T_NOTES\"")
+                               .add()
+                               .column("\"COMPANY\"", DataType.VARCHAR, Modifiers.REGULAR, Modifiers.NULLABLE, Modifiers.NON_UNIQUE, "(20)")
+                               .build();
+
+        assertEquals("ALTER TABLE `T_NOTES` ADD `COMPANY` VARCHAR (20) ;", sql);
+    }
+
+    /**
+     * Adds a unique constraint to a table whose name arrives ANSI-quoted.
+     */
+    @Test
+    public void alterTableAddUniqueWithAnsiQuotedTableName() {
+        String sql = SqlFactory.getNative(new MySQLSqlDialect())
+                               .alter()
+                               .table("\"T_NOTES\"")
+                               .add()
+                               .unique("Notes_Company_Number", new String[] {"COMPANY", "NUMBER"})
+                               .build();
+
+        assertEquals("ALTER TABLE `T_NOTES` ADD CONSTRAINT `Notes_Company_Number` UNIQUE ( `COMPANY` , `NUMBER` );", sql);
+    }
+
+    /**
+     * Drops a table whose name arrives ANSI-quoted.
+     */
+    @Test
+    public void dropTableWithAnsiQuotedName() {
+        String sql = SqlFactory.getNative(new MySQLSqlDialect())
+                               .drop()
+                               .table("\"T_NOTES\"")
+                               .build();
+
+        assertEquals("DROP TABLE `T_NOTES`", sql);
+    }
+
+    /**
+     * A schema-qualified ANSI-quoted name keeps its parts separate.
+     */
+    @Test
+    public void dropSchemaQualifiedAnsiQuotedName() {
+        String sql = SqlFactory.getNative(new MySQLSqlDialect())
+                               .drop()
+                               .table("\"MYSCHEMA\".\"T_NOTES\"")
+                               .build();
+
+        assertEquals("DROP TABLE `MYSCHEMA`.`T_NOTES`", sql);
+    }
+
+}

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/AbstractSqlBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/AbstractSqlBuilder.java
@@ -26,6 +26,8 @@ public abstract class AbstractSqlBuilder implements ISqlBuilder {
      * The Regex find the content between single quotes.
      */
     private static final Pattern contentBetweenSingleQuotes = Pattern.compile("'([^']*?)'");
+    /** The ANSI escape symbol, the one every caller that pre-quotes a name uses. */
+    private static final char ANSI_ESCAPE_SYMBOL = '"';
     /** The dialect. */
     private final ISqlDialect dialect;
     /** The column pattern. */
@@ -82,18 +84,36 @@ public abstract class AbstractSqlBuilder implements ISqlBuilder {
     protected String encapsulate(String name, boolean isDataStructureName) {
         if (name == null)
             return null;
-        String escapeSymbol = String.valueOf(getEscapeSymbol());
+        char escapeChar = getEscapeSymbol();
+        String escapeSymbol = String.valueOf(escapeChar);
         if ("*".equals(name.trim())) {
             return name;
         }
-        if (!name.startsWith(escapeSymbol)) {
-            if (isDataStructureName || isColumn(name.trim())) {
-                name = escapeSymbol + name + escapeSymbol;
-            } else {
-                name = encapsulateMany(name);
-            }
+        if (name.startsWith(escapeSymbol)) {
+            return name;
+        }
+        if (isAnsiQuoted(name)) {
+            // Already quoted, but with the ANSI symbol rather than this dialect's - re-quote it instead of
+            // wrapping it again, which on the backtick dialects addressed a table literally named "T" (#7021).
+            return name.replace(ANSI_ESCAPE_SYMBOL, escapeChar);
+        }
+        if (isDataStructureName || isColumn(name.trim())) {
+            name = escapeSymbol + name + escapeSymbol;
+        } else {
+            name = encapsulateMany(name);
         }
         return name;
+    }
+
+    /**
+     * Checks whether the name is wrapped in the ANSI escape symbol - {@code "T"} or {@code "S"."T"}.
+     * The data-structure processors quote every name they pass down that way, whatever the dialect is.
+     *
+     * @param name the name
+     * @return true if the name is ANSI-quoted
+     */
+    private boolean isAnsiQuoted(String name) {
+        return name.length() > 1 && name.charAt(0) == ANSI_ESCAPE_SYMBOL && name.charAt(name.length() - 1) == ANSI_ESCAPE_SYMBOL;
     }
 
     /**


### PR DESCRIPTION
Fixes #7021

Every processor in `components/data/data-structures` hands the SQL builders a **pre-quoted** name (`"T_NOTES"`, `"COMPANY"`), and `AbstractSqlBuilder.encapsulate` left a name alone only when it already started with **the dialect's own** escape symbol. On the backtick dialects (MySQL, MariaDB) an ANSI-quoted name was therefore wrapped a second time, so the whole synchronizer layer - create, alter (column add/drop and the new unique reconciliation from #7019), drop - addressed a table literally named `"T_NOTES"`:

```
ALTER TABLE `"T_NOTES"` ADD CONSTRAINT `Notes_Company_Number` UNIQUE ( `COMPANY` , `NUMBER` );
-> Error 1146-42S02: Table 't."T_NOTES"' doesn't exist
```

## The fix

`encapsulate` now recognises a name wrapped in the ANSI `"` as **already quoted** and re-quotes it with the dialect's symbol when the two differ (`"S"."T"` -> `` `S`.`T` ``). This is the issue's second option: it fixes every caller at once - no processor changes - and matches what `MariaDBCreateViewBuilder` already does by hand for views. On the ANSI dialects (H2, PostgreSQL, MSSQL, HANA, Snowflake) the `startsWith(escapeSymbol)` branch still returns first, so nothing changes there.

## Tests

`PreQuotedNameTest` in both `database-sql-mysql` and `database-sql-mariadb`: create table, alter add column, alter add unique constraint, drop table, and a schema-qualified drop, each with the exact pre-quoted shape the processors emit. Neither database is in CI (H2 and PostgreSQL are), which is why this had no test catching it.

Existing dialect suites (H2, PostgreSQL, MSSQL, HANA, Snowflake, MySQL, MariaDB) and the `components/data` unit tests are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)