### PR TITLE
data: a failed CREATE VIEW is recorded FAILED and retried on the next pass

### DIFF
--- a/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/synchronizer/ViewsSynchronizer.java
+++ b/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/synchronizer/ViewsSynchronizer.java
@@ -171,14 +171,21 @@ public class ViewsSynchronizer extends MultitenantBaseSynchronizer<View, Long> {
 
             switch (flow) {
                 case CREATE:
-                    if (ArtefactLifecycle.NEW.equals(view.getLifecycle())) {
+                    // A FAILED view is retried: its CREATE VIEW may have failed for a reason that heals
+                    // later - typically the tables it selects from belong to a module published on a
+                    // later pass (#6942). Recording the failure as CREATED-with-error parked the view
+                    // for good, since neither the CREATE nor the UPDATE gate matched it again.
+                    if (ArtefactLifecycle.NEW.equals(view.getLifecycle()) || ArtefactLifecycle.FAILED.equals(view.getLifecycle())) {
                         if (!SqlFactory.getNative(connection)
                                        .existsTable(connection, view.getName())) {
                             try {
                                 executeViewCreate(connection, view);
-                                callback.registerState(this, wrapper, ArtefactLifecycle.CREATED);
                             } catch (Exception e) {
-                                callback.registerState(this, wrapper, ArtefactLifecycle.CREATED, e);
+                                // FAILED keeps the view eligible for the next pass; returning false hands
+                                // it to the in-pass topological retry, exactly as the outer catch does.
+                                callback.addError(e.getMessage());
+                                callback.registerState(this, wrapper, ArtefactLifecycle.FAILED, e);
+                                return false;
                             }
                         } else {
                             if (logger.isWarnEnabled()) {

--- a/components/data/data-structures/src/test/java/org/eclipse/dirigible/components/data/structures/synchronizer/ViewsSynchronizerRetryTest.java
+++ b/components/data/data-structures/src/test/java/org/eclipse/dirigible/components/data/structures/synchronizer/ViewsSynchronizerRetryTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.data.structures.synchronizer;
+
+import org.eclipse.dirigible.components.base.artefact.ArtefactLifecycle;
+import org.eclipse.dirigible.components.base.artefact.ArtefactPhase;
+import org.eclipse.dirigible.components.base.artefact.topology.TopologyWrapper;
+import org.eclipse.dirigible.components.base.synchronizer.SynchronizerCallback;
+import org.eclipse.dirigible.components.data.sources.manager.DataSourcesManager;
+import org.eclipse.dirigible.components.data.structures.domain.View;
+import org.eclipse.dirigible.components.data.structures.service.ViewService;
+import org.eclipse.dirigible.components.database.DatabaseSystem;
+import org.eclipse.dirigible.components.database.DirigibleConnection;
+import org.eclipse.dirigible.components.database.DirigibleDataSource;
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * A CREATE VIEW that fails because its table does not exist yet is recorded FAILED and retried on a
+ * later pass - not parked as CREATED-with-error (#6942).
+ */
+class ViewsSynchronizerRetryTest {
+
+    /** The in-memory database of the test. */
+    private static final String JDBC_URL = "jdbc:h2:mem:views_synchronizer_retry;DB_CLOSE_DELAY=-1";
+
+    /** The table the view selects from. */
+    private static final String TABLE_NAME = "VIEW_RETRY_CITY";
+
+    /** The view under test. */
+    private static final String VIEW_NAME = "VIEW_RETRY_LINES";
+
+    /** The synchronizer under test. */
+    private ViewsSynchronizer synchronizer;
+
+    /**
+     * Wires the synchronizer over an in-memory database with a callback that persists the state the way
+     * the synchronization processor does.
+     *
+     * @throws SQLException the SQL exception
+     */
+    @BeforeEach
+    void setUp() throws SQLException {
+        DirigibleDataSource dataSource = mock(DirigibleDataSource.class);
+        when(dataSource.getConnection()).thenAnswer(invocation -> dirigibleConnection());
+        DataSourcesManager dataSourcesManager = mock(DataSourcesManager.class);
+        when(dataSourcesManager.getDefaultDataSource()).thenReturn(dataSource);
+        ViewService viewService = mock(ViewService.class);
+        when(viewService.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        synchronizer = new ViewsSynchronizer(viewService, dataSourcesManager);
+        SynchronizerCallback callback = mock(SynchronizerCallback.class);
+        doAnswer(invocation -> {
+            synchronizer.setStatus(artefact(invocation.getArgument(1)), invocation.getArgument(2), "");
+            return null;
+        }).when(callback)
+          .registerState(any(), any(TopologyWrapper.class), any(ArtefactLifecycle.class));
+        doAnswer(invocation -> {
+            Throwable cause = invocation.getArgument(3);
+            synchronizer.setStatus(artefact(invocation.getArgument(1)), invocation.getArgument(2), cause.getMessage());
+            return null;
+        }).when(callback)
+          .registerState(any(), any(TopologyWrapper.class), any(ArtefactLifecycle.class), any(Throwable.class));
+        synchronizer.setCallback(callback);
+    }
+
+    /**
+     * Drops what the test created.
+     *
+     * @throws SQLException the SQL exception
+     */
+    @AfterEach
+    void tearDown() throws SQLException {
+        execute("DROP VIEW IF EXISTS \"" + VIEW_NAME + "\"");
+        execute("DROP TABLE IF EXISTS \"" + TABLE_NAME + "\"");
+    }
+
+    /**
+     * The failed create leaves the view FAILED with its cause and not completed, so the pass retries
+     * it; once the table exists the same artefact is created and reads CREATED.
+     *
+     * @throws SQLException the SQL exception
+     */
+    @Test
+    void failedCreateIsRecordedFailedAndRetriedOnceTheTableExists() throws SQLException {
+        View view = new View("/report/lines.view", VIEW_NAME, "", null, "VIEW", null, "SELECT \"CITY_ID\" FROM \"" + TABLE_NAME + "\"");
+        view.setLifecycle(ArtefactLifecycle.NEW);
+        TopologyWrapper<View> wrapper = new TopologyWrapper<>(view, new HashMap<>(), synchronizer);
+
+        assertFalse(synchronizer.completeImpl(wrapper, ArtefactPhase.CREATE), "A failed create is not completed - the pass retries it");
+        assertEquals(ArtefactLifecycle.FAILED, view.getLifecycle(), "A failed create must read FAILED, not CREATED");
+        assertTrue(view.getError()
+                       .contains(TABLE_NAME),
+                "The error must name the failing statement, got: " + view.getError());
+        assertFalse(viewExists(), "No view can exist before its table does");
+
+        execute("CREATE TABLE \"" + TABLE_NAME + "\" (\"CITY_ID\" INT PRIMARY KEY)");
+
+        assertTrue(synchronizer.completeImpl(wrapper, ArtefactPhase.CREATE), "The retry over an existing table completes");
+        assertEquals(ArtefactLifecycle.CREATED, view.getLifecycle(), "The healed view must read CREATED");
+        assertEquals("", view.getError(), "The healed view must carry no stale error");
+        assertTrue(viewExists(), "The retry must create the view");
+    }
+
+    /**
+     * Opens a fresh connection to the in-memory database wearing the platform's connection type, which
+     * the SQL dialect lookup reads the database system from.
+     *
+     * @return the connection
+     * @throws SQLException the SQL exception
+     */
+    private static DirigibleConnection dirigibleConnection() throws SQLException {
+        Connection connection = DriverManager.getConnection(JDBC_URL, "sa", "");
+        DirigibleConnection dirigibleConnection = mock(DirigibleConnection.class, delegatesTo(connection));
+        doReturn(DatabaseSystem.H2).when(dirigibleConnection)
+                                   .getDatabaseSystem();
+        return dirigibleConnection;
+    }
+
+    /**
+     * Whether the view exists in the database.
+     *
+     * @return true when it exists
+     * @throws SQLException the SQL exception
+     */
+    private boolean viewExists() throws SQLException {
+        try (Connection connection = DriverManager.getConnection(JDBC_URL, "sa", "")) {
+            return SqlFactory.getNative(connection)
+                             .existsTable(connection, VIEW_NAME);
+        }
+    }
+
+    /**
+     * Executes a statement against the in-memory database.
+     *
+     * @param sql the statement
+     * @throws SQLException the SQL exception
+     */
+    private static void execute(String sql) throws SQLException {
+        try (Connection connection = DriverManager.getConnection(JDBC_URL, "sa", ""); Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+
+    /**
+     * Unwraps the artefact of a wrapper handed to the callback.
+     *
+     * @param wrapper the wrapper
+     * @return the view
+     */
+    private static View artefact(Object wrapper) {
+        return ((TopologyWrapper<?>) wrapper).getArtefact() instanceof View view ? view : null;
+    }
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/ViewOverLaterPublishedTableIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/java/ViewOverLaterPublishedTableIT.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api.java;
+
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.components.base.artefact.ArtefactLifecycle;
+import org.eclipse.dirigible.components.data.sources.manager.DataSourcesManager;
+import org.eclipse.dirigible.components.data.structures.domain.View;
+import org.eclipse.dirigible.components.data.structures.service.ViewService;
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A view whose SELECT reads another module's tables must come alive on the pass that creates those
+ * tables - the incremental-publish flow of #6942, where the report module is published before its
+ * owner.
+ *
+ * <p>
+ * The failed CREATE VIEW used to be recorded as CREATED-with-error, a state neither the CREATE nor
+ * the UPDATE gate matches, so the view stayed missing until its file was edited. It is now recorded
+ * FAILED, which the next pass retries.
+ */
+// One Dirigible boot for the class: the single scenario cleans up after itself.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class ViewOverLaterPublishedTableIT extends IntegrationTest {
+
+    /** The project publishing the view first. */
+    private static final String REPORT_PROJECT = "view-later-table-it-report";
+
+    /** The project publishing the table second. */
+    private static final String OWNER_PROJECT = "view-later-table-it-owner";
+
+    /** The registry-relative location of the view - how the synchronizer records it. */
+    private static final String VIEW_LOCATION = "/" + REPORT_PROJECT + "/views/lines.view";
+
+    /** The repository-absolute path of the view fixture. */
+    private static final String VIEW_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + VIEW_LOCATION;
+
+    /** The repository-absolute path of the table fixture. */
+    private static final String TABLE_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + OWNER_PROJECT + "/tables/city.table";
+
+    /** The table the view selects from. */
+    private static final String TABLE_NAME = "VIEW_LATER_CITY";
+
+    /** The view under test. */
+    private static final String VIEW_NAME = "VIEW_LATER_LINES";
+
+    /** The view fixture source. */
+    private static final String VIEW_SOURCE = """
+            {
+                "name": "%s",
+                "type": "VIEW",
+                "query": "SELECT \\"CITY_ID\\", \\"CITY_NAME\\" FROM \\"%s\\""
+            }
+            """.formatted(VIEW_NAME, TABLE_NAME);
+
+    /** The table fixture source. */
+    private static final String TABLE_SOURCE = """
+            {
+                "name": "%s",
+                "type": "TABLE",
+                "columns": [
+                    {
+                        "type": "INTEGER",
+                        "primaryKey": true,
+                        "nullable": false,
+                        "name": "CITY_ID"
+                    },
+                    {
+                        "type": "VARCHAR",
+                        "length": 40,
+                        "nullable": false,
+                        "name": "CITY_NAME"
+                    }
+                ]
+            }
+            """.formatted(TABLE_NAME);
+
+    /** The data source manager. */
+    @Autowired
+    private DataSourcesManager dataSourceManager;
+
+    /** The view service - the artefact state under assertion. */
+    @Autowired
+    private ViewService viewService;
+
+    /** The repository. */
+    @Autowired
+    private IRepository repository;
+
+    /** The synchronization processor. */
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    /**
+     * The first pass has nothing that can satisfy the view, so its in-pass retry is a dead end by
+     * design; keep that dead end short instead of paying the production interval ten times.
+     */
+    @BeforeAll
+    static void shortenCrossRetry() {
+        Configuration.set("DIRIGIBLE_SYNCHRONIZER_CROSS_RETRY_COUNT", "2");
+        Configuration.set("DIRIGIBLE_SYNCHRONIZER_CROSS_RETRY_INTERVAL_MILLIS", "100");
+    }
+
+    /**
+     * Publishing the view before the table it reads parks it FAILED with the cause; publishing the
+     * table heals it on that very pass.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    void viewOverTablesPublishedLaterHealsOnThePassThatCreatesThem() throws Exception {
+        write(VIEW_PATH, VIEW_SOURCE);
+        synchronizationProcessor.forceProcessSynchronizers();
+
+        View parked = view();
+        assertEquals(ArtefactLifecycle.FAILED, parked.getLifecycle(), "A CREATE VIEW over a missing table must be recorded FAILED");
+        assertTrue(parked.getError()
+                         .contains(TABLE_NAME),
+                "The recorded error must name the failing statement, got: " + parked.getError());
+        assertFalse(viewExists(), "The view cannot exist before its table does");
+
+        write(TABLE_PATH, TABLE_SOURCE);
+        synchronizationProcessor.forceProcessSynchronizers();
+
+        assertTrue(viewExists(), "The pass that creates the table must also create the view that was waiting for it");
+        View healed = view();
+        assertEquals(ArtefactLifecycle.CREATED, healed.getLifecycle(), "The healed view must read CREATED");
+        assertTrue(healed.getError() == null || healed.getError()
+                                                      .isBlank(),
+                "The healed view must carry no stale error, got: " + healed.getError());
+        assertEquals(0, rowCount(), "The view must be queryable");
+    }
+
+    /**
+     * Loads the single view artefact recorded for the fixture.
+     *
+     * @return the view
+     */
+    private View view() {
+        List<View> views = viewService.findByLocation(VIEW_LOCATION);
+        assertEquals(1, views.size(), "Exactly one view artefact is expected at " + VIEW_LOCATION);
+        return views.get(0);
+    }
+
+    /**
+     * Whether the view exists in the database.
+     *
+     * @return true when the view exists
+     * @throws Exception the exception
+     */
+    private boolean viewExists() throws Exception {
+        try (Connection connection = dataSourceManager.getDefaultDataSource()
+                                                      .getConnection()) {
+            return SqlFactory.getNative(connection)
+                             .existsTable(connection, VIEW_NAME);
+        }
+    }
+
+    /**
+     * Counts the rows the view returns.
+     *
+     * @return the row count
+     * @throws Exception the exception
+     */
+    private int rowCount() throws Exception {
+        try (Connection connection = dataSourceManager.getDefaultDataSource()
+                                                      .getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery("SELECT COUNT(*) FROM \"" + VIEW_NAME + "\"")) {
+            assertTrue(rs.next(), "COUNT(*) returned no row");
+            return rs.getInt(1);
+        }
+    }
+
+    /**
+     * Writes a fixture resource.
+     *
+     * @param path the path
+     * @param source the source
+     */
+    private void write(String path, String source) {
+        repository.createResource(path, source.getBytes(StandardCharsets.UTF_8), false, "text/plain", true);
+    }
+
+    /**
+     * Cleanup the fixture.
+     *
+     * @throws Exception the exception
+     */
+    @AfterEach
+    void cleanup() throws Exception {
+        for (String path : List.of(VIEW_PATH, TABLE_PATH)) {
+            if (repository.hasResource(path)) {
+                repository.removeResource(path);
+            }
+        }
+        synchronizationProcessor.forceProcessSynchronizers();
+        try (Connection connection = dataSourceManager.getDefaultDataSource()
+                                                      .getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("DROP VIEW IF EXISTS \"" + VIEW_NAME + "\"");
+            statement.execute("DROP TABLE IF EXISTS \"" + TABLE_NAME + "\"");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #6942

### What

`ViewsSynchronizer.completeImpl`, CREATE phase, recorded a failed `executeViewCreate` as **CREATED** with the error text attached - and the unconditional `registerState(CREATED)` that followed even wiped the text. Neither the CREATE gate (`NEW`) nor the UPDATE gate (`MODIFIED`) matches a CREATED artefact, so a view over tables that arrive on a later publish was parked for good: the log carried one error on the first pass and then stayed quiet while every consumer of the view failed with `Table "<VIEW>" not found`.

Now:

- a failed create registers **FAILED** with its cause and returns `false`, so the in-pass topological retry treats it like any other unsatisfied dependency (the same contract the method's outer `SQLException` catch already had);
- the CREATE gate admits `FAILED` as well as `NEW`, so the next pass - the one that creates the missing tables - creates the view; the DELETE gate already handled `FAILED`.

Same class as #6542 (csvim), and the same shape of fix its synchronizer carries.

### Tests

- `ViewsSynchronizerRetryTest` (data-structures, in-memory H2, no Spring): a view over a missing table completes `false` and reads FAILED naming the table; once the table exists the same artefact completes `true`, reads CREATED with no stale error, and the view exists.
- `ViewOverLaterPublishedTableIT` (HTTP-less, untagged so it runs in the PR smoke gate): publishes the `.view` first, asserts the FAILED artefact state and no view, then publishes the `.table` and asserts the view exists, is queryable and reads CREATED. The class shortens the cross-retry interval/count for its own run, since the first pass's in-pass retry is a dead end by design.

Locally: the quick build, both tests, the module's full unit suite and `formatter:validate` are green.

### Not touched

`TablesSynchronizer` records a failed `CREATE TABLE` the same way (CREATED-with-error). The issue is scoped to views and a table create rarely fails for a reason that heals, so it is left as is; worth a follow-up if it ever bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
