### PR TITLE
tests: pin the register-lookup assertions to the hoisted-operand shape (fixes master)

### DIFF
--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -930,16 +930,19 @@ class IntentEngineIT extends IntegrationTest {
                 lookup.contains("@Component") && lookup.contains("class AssignSalesRepResolve implements MessageHandler")
                         && lookup.contains("return \"intent-test-Order-Order\""),
                 "the lookup should be a @Component MessageHandler bound to the record's create topic");
-        assertTrue(lookup.contains("new CustomerAssignmentRepository().findAll(Criteria.create().eq(\"Customer\", entity.Customer))"),
+        // Every operand is hoisted into a local before it is null-tested and bound, so a path is walked
+        // once; a bare property - which is what this lookup declares - hoists the record's own column.
+        assertTrue(lookup.contains("Object key0 = entity.Customer;"), "the match key should be hoisted into a local");
+        assertTrue(lookup.contains("new CustomerAssignmentRepository().findAll(Criteria.create().eq(\"Customer\", key0))"),
                 "the lookup should query the register with a typed Criteria built from the match keys");
         assertTrue(
-                lookup.contains("Long at = millis(entity.OrderDate)") && lookup.contains("Long from = millis(row.ValidFrom)")
-                        && lookup.contains("Long to = endExclusive(row.ValidTo)"),
+                lookup.contains("Object on = entity.OrderDate;") && lookup.contains("Long at = millis(on)")
+                        && lookup.contains("Long from = millis(row.ValidFrom)") && lookup.contains("Long to = endExclusive(row.ValidTo)"),
                 "the lookup should compare the record's date against both period bounds");
         assertTrue(lookup.contains("if (entity.SalesRep != null)"),
                 "an already-resolved record should be skipped, so a manual correction is never overwritten");
         assertTrue(
-                lookup.contains("stamp(entity.Id, \"found\", resolved)") && lookup.contains("\"notFound\"")
+                lookup.contains("stamp(entity, \"found\", resolved, java.util.Map.of())") && lookup.contains("\"notFound\"")
                         && lookup.contains("\"ambiguous\""),
                 "all three outcomes should be generated - an ambiguous register is never resolved by picking one");
         // The RESULT - the relation and the trace - is one targeted update. The routing status is a


### PR DESCRIPTION
`IntentEngineIT.glue_template_generates_the_trigger_and_resolver_handlers` still asserted the generated register lookup as it read before #7032, so master's `slow` shard has been red on **both** H2 and PostgreSQL since that merge - and stayed red through every run after it (#7033, #7018, #7034).

```
[ERROR] IntentEngineIT.glue_template_generates_the_trigger_and_resolver_handlers:933
  the lookup should query the register with a typed Criteria built from the match keys
  ==> expected: <true> but was: <false>
```

#7032 made a lookup's operands paths rather than columns, and with that every operand is now **hoisted into a local** before it is null-tested and bound, so a path is walked once and the same value reaches both places. Three of this test's assertions read the pre-hoist text:

- `.eq("Customer", entity.Customer)` is now `.eq("Customer", key0)`
- `Long at = millis(entity.OrderDate)` is now `Object on = entity.OrderDate;` followed by `Long at = millis(on)`
- `stamp(entity.Id, "found", resolved)` is now `stamp(entity, "found", resolved, java.util.Map.of())` - the entity itself (the copy guard reads the record's current values) plus the copied-scalars map, empty for a lookup declaring no `copy:`

The fixture declares a bare property, which is the case that was meant to generate byte-identically, so this is the assertion catching up with a deliberate change - the emitted lookup is the one #7032 intends. The added `Object key0 = entity.Customer;` assertion pins the hoist itself, so the bare-property path is covered here the same way the multi-hop one is in `resolve_prices_a_line_from_the_header_and_copies_the_found_scalar`.

**Verified:** full `-P quick-build` install green, then the test method run headless against it - `Tests run: 1, Failures: 0, Errors: 0`. `formatter:validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)