### PR TITLE
intent: a wait step's `when` resolves a status name to its seed id

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/StatusSymbolResolver.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/StatusSymbolResolver.java
@@ -18,6 +18,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.eclipse.dirigible.components.intent.generator.ProcessWaitSupport;
+
 /**
  * Resolves a status referenced by its <b>seeded name</b> to the seed id, everywhere the intent
  * names a status, on the raw YAML tree - before the typed Gson mapping, so every downstream
@@ -223,18 +225,33 @@ final class StatusSymbolResolver {
             if (trigger != null && trigger.get("when") != null) {
                 rewriteWhen(trigger, statusRelationName(triggerEntity), statusOf(triggerEntity), subject + " trigger when");
             }
-            // `setRelationField: <Relation>` + `value:` writes an id of THAT relation's target - the
-            // status in the canonical case, but the same shape serves any nomenclature FK.
             for (Object stepNode : asList(process.get("steps"))) {
-                Map<?, ?> args = asMap(asMap(stepNode) == null ? null : asMap(stepNode).get("args"));
+                Map<?, ?> step = asMap(stepNode);
+                Map<?, ?> args = asMap(step == null ? null : step.get("args"));
+                if (args == null) {
+                    continue;
+                }
+                String stepSubject = subject + " step [" + text(step, "name") + "]";
+                // A `wait` step's guard qualifies the event that RESUMES the parked instance, and it is
+                // read against the event entity's own record - not necessarily the trigger entity's
+                // (`via:` is exactly the case where the two differ), so the nomenclature is the event
+                // entity's. Left unresolved, the name reached the generated listener as a string
+                // compared against the integer status FK: never true, and because a wait that matches
+                // nothing is a deliberate no-op, the instance simply stayed parked with nothing logged
+                // (#6907).
+                if ("wait".equals(lower(text(step, "kind"))) && args.get("when") != null) {
+                    String eventEntity = waitEventEntityOf(args);
+                    rewriteWhen(args, statusRelationName(eventEntity), statusOf(eventEntity), stepSubject + " when");
+                }
+                // `setRelationField: <Relation>` + `value:` writes an id of THAT relation's target - the
+                // status in the canonical case, but the same shape serves any nomenclature FK.
                 String relationName = text(args, "setRelationField");
                 if (relationName == null || args.get("value") == null) {
                     continue;
                 }
                 Map<?, ?> relation = toOneRelation(triggerEntity, relationName);
                 Target target = relation == null ? new Target(null, null) : new Target(text(relation, "to"), text(relation, "model"));
-                putResolved(args, "value", target,
-                        subject + " step [" + text(asMap(stepNode), "name") + "] setRelationField [" + relationName + "] value");
+                putResolved(args, "value", target, stepSubject + " setRelationField [" + relationName + "] value");
             }
         }
     }
@@ -365,6 +382,22 @@ final class StatusSymbolResolver {
         }
         for (String event : List.of("onCreate", "onUpdate", "onDelete", "onTransition")) {
             String entity = text(trigger, event);
+            if (entity != null) {
+                return entity;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The entity whose lifecycle event resumes a {@code wait} step - the target of the one
+     * {@code onCreate}/{@code onUpdate}/{@code onTransition} arg it declares. Read through the
+     * generator's own list, so the vocabulary a wait accepts and the guard resolved against it cannot
+     * drift apart (the parser validates the same list).
+     */
+    private static String waitEventEntityOf(Map<?, ?> args) {
+        for (String event : ProcessWaitSupport.EVENT_KINDS) {
+            String entity = text(args, event);
             if (entity != null) {
                 return entity;
             }

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueTransitionAxisTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueTransitionAxisTest.java
@@ -80,6 +80,53 @@ class GlueTransitionAxisTest {
                 to: { topic: "codbex.fines" }
             """;
 
+    /**
+     * A flow that PARKS until the record reaches a status - the shape the status axis invites, and the
+     * one whose guard was never resolved.
+     */
+    private static final String WAITING = """
+              - name: Dunning
+                trigger: { onCreate: Fine }
+                steps:
+                  - { name: hold, kind: wait, args: { onTransition: Fine, when: "Status == IDENTIFIED", next: remind } }
+                  - { name: remind, kind: end }
+            """;
+
+    /** A wait resumed by ANOTHER entity's transition, walked back through {@code via:}. */
+    private static final String WAITING_VIA = """
+              - name: Collection
+                trigger: { onCreate: Fine }
+                steps:
+                  - { name: settle, kind: wait, args: { onTransition: Payment, via: fine, when: "Status == SETTLED", next: closed } }
+                  - { name: closed, kind: end }
+            """;
+
+    /** The payment whose own nomenclature the {@code via:} wait's guard is read against. */
+    private static final String PAYMENT = """
+              - name: PaymentStatus
+                kind: setting
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: Payment
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: amount, type: decimal }
+                relations:
+                  - { name: fine, kind: manyToOne, to: Fine }
+                  - { name: Status, kind: manyToOne, to: PaymentStatus, function: EntityStatus, init: 1 }
+            """;
+
+    /** The payment nomenclature's own seeds - deliberately numbered apart from the fine's. */
+    private static final String PAYMENT_SEEDS = """
+              - name: paymentStatuses
+                entity: PaymentStatus
+                rows:
+                  - { id: 1, name: NEW }
+                  - { id: 2, name: PENDING }
+                  - { id: 3, name: SETTLED }
+            """;
+
     /** The follow-up flow, started by the transition the first flow produces. */
     private static final String DUNNING = """
               - name: Dunning
@@ -164,5 +211,43 @@ class GlueTransitionAxisTest {
         // - which is exactly the one that needs a status guard - could not start at all.
         assertEquals("java.util.Objects.equals(entity.Status, 2)", dunning.get("guardExpression"),
                 "the trigger's status guard must compare against the seed id, not against the name as a string");
+    }
+
+    /**
+     * A {@code wait} step's guard was the last {@code when} in the DSL whose status NAME survived
+     * unresolved: the wait template emits it verbatim, so the generated listener compared the integer
+     * status FK against the string {@code "IDENTIFIED"}. Always false - and since a wait that matches
+     * nothing is a deliberate no-op, the parked instance simply never resumed, with nothing logged
+     * anywhere (#6907).
+     */
+    @Test
+    void aWaitStatusGuardResolvesToTheSeedId() {
+        IntentModel model = IntentParser.parse(YAML.replace("notifications:", WAITING + "notifications:"));
+
+        Map<String, Object> wait = only(GlueIntentGenerator.buildWaitsForTest(model));
+
+        assertEquals("Fine", wait.get("eventEntity"));
+        assertEquals("-transitioned", wait.get("topicSuffix"));
+        assertEquals("java.util.Objects.equals(entity.Status, 2)", wait.get("guardExpression"),
+                "the wait's status guard must compare against the seed id, not against the name as a string");
+    }
+
+    /**
+     * And it resolves against the EVENT entity's nomenclature, not the trigger entity's - the two
+     * differ exactly when the wait walks back through {@code via:}, and taking the id from the wrong
+     * lifecycle would be the #6645 failure again one level down.
+     */
+    @Test
+    void aViaWaitResolvesAgainstTheEventEntitysNomenclature() {
+        IntentModel model = IntentParser.parse(YAML.replace("seeds:", PAYMENT + "seeds:")
+                                                   .replace("processes:", PAYMENT_SEEDS + "processes:")
+                                                   .replace("notifications:", WAITING_VIA + "notifications:"));
+
+        Map<String, Object> wait = only(GlueIntentGenerator.buildWaitsForTest(model));
+
+        assertEquals("Payment", wait.get("eventEntity"));
+        assertEquals("Fine", wait.get("parentEntity"));
+        assertEquals("java.util.Objects.equals(entity.Status, 3)", wait.get("guardExpression"),
+                "the guard is over the payment's own status nomenclature, which numbers SETTLED apart from any fine status");
     }
 }


### PR DESCRIPTION
Fixes #6907

## The bug

`StatusSymbolResolver` rewrites a status referenced by its **seeded name** to the seed id at every site that names one — `transitions`, `abortOn`, a step's `setRelationField` `value`, a posting / `generates` / `resolves` guard, a report `filter`, an entity's `immutableWhen`, and (since #6906) a process **trigger**'s `when`. A `wait` step's `when` was the one left out.

The wait template emits that guard verbatim, so

```yaml
- { name: hold, kind: wait, args: { onTransition: Fine, when: "Status == IDENTIFIED", next: remind } }
```

generated `java.util.Objects.equals(entity.Status, "IDENTIFIED")` — the integer status FK compared against a string. Never true, so `Process.correlateMessageEvent` was never reached and the parked instance sat there forever. Because "no matching parked instance is a no-op, never an error" is the fail-soft glue convention, a guard that can never hold is indistinguishable from an event that was not for this wait: nothing is logged. The numeric form (`when: "Status == 1"`) worked, which is why it went unnoticed — while the `onTransition` axis (#6810) made the symbolic form the normal thing to write.

## The fix

The guard is resolved in the same `rewriteProcesses` steps loop that already handles `setRelationField` + `value`, against the status nomenclature of the step's **own event entity** (`args.onCreate` / `onUpdate` / `onTransition`) — not the trigger entity's. `via:` is exactly the case where the two differ, and taking the id from the wrong lifecycle would be the #6645 failure one level down. The event kinds are read from `ProcessWaitSupport.EVENT_KINDS`, the list the parser already validates a wait against, so the vocabulary a wait accepts and the nomenclature its guard resolves against cannot drift apart.

Unchanged behaviour elsewhere: a numeric guard, a guard over a non-status column, and an event entity with no `function: EntityStatus` relation are all left exactly as before.

## Tests

Two additions to `GlueTransitionAxisTest`, next to the trigger assertion from #6906:

- `aWaitStatusGuardResolvesToTheSeedId` — the direct wait's `guardExpression` is `…(entity.Status, 2)`.
- `aViaWaitResolvesAgainstTheEventEntitysNomenclature` — a wait resumed by a payment's transition, walked back through `via: fine`, resolves against the payment's own numbering (`SETTLED` = 3, deliberately numbered apart from every fine status).

Both fail on master with the name surviving as a string. `engine-intent`: 1000 tests green, `formatter:validate` clean, javadoc clean under `-P release`.