### PR TITLE
sdk: a String handed to Base64/Hex/Digest is text, not a JSON byte array (#7042)

### DIFF
--- a/components/api/api-modules-java/README.md
+++ b/components/api/api-modules-java/README.md
@@ -82,11 +82,11 @@ log.info("file size: {}", Files.size("/users/admin/workspace/proj/foo.txt"));
 | `security/user`                      | `sdk.security.User`                                            |       |
 | `template/engines`                   | `sdk.template.TemplateEngines`                                 |       |
 | `utils/alphanumeric`                 | `sdk.utils.Alphanumeric`                                       | `SecureRandom`-backed. |
-| `utils/base64`                       | `sdk.utils.Base64`                                             |       |
+| `utils/base64`                       | `sdk.utils.Base64`                                             | A `String` argument is text, encoded as UTF-8 bytes (as in the TS module). |
 | `utils/converter`                    | `sdk.utils.Converter`                                          | Jackson-backed JSON helpers. |
-| `utils/digest`                       | `sdk.utils.Digest`                                             |       |
+| `utils/digest`                       | `sdk.utils.Digest`                                             | A `String` argument is text, encoded as UTF-8 bytes (as in the TS module). |
 | `utils/escape`                       | `sdk.utils.Escape`                                             |       |
-| `utils/hex`                          | `sdk.utils.Hex`                                                |       |
+| `utils/hex`                          | `sdk.utils.Hex`                                                | A `String` argument is text, encoded as UTF-8 bytes (as in the TS module). |
 | `utils/qrcode`                       | `sdk.utils.QrCode`                                             |       |
 | `utils/url`                          | `sdk.utils.Url`                                                | Named `Url` to avoid clashing with `java.net.URL`. |
 | `utils/utf8`                         | `sdk.utils.Utf8`                                               |       |

--- a/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/utils/Base64.java
+++ b/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/utils/Base64.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.dirigible.sdk.utils;
 
+import java.nio.charset.StandardCharsets;
 import org.eclipse.dirigible.components.api.utils.Base64Facade;
 
 /**
@@ -16,6 +17,9 @@ import org.eclipse.dirigible.components.api.utils.Base64Facade;
  * {@code decode} overloads handle the common String &harr; byte[] cases; the {@code Native} pair
  * returns / accepts byte arrays on both sides for callers that already work in bytes (avoiding the
  * intermediate {@link String} allocation).
+ * <p>
+ * A {@link String} argument is always text: {@link #encode(String)} encodes its UTF-8 bytes and
+ * {@link #decode(String)} reads base64 text, so {@code decode(encode(text))} round-trips.
  * <p>
  * Prefer this over {@link java.util.Base64} when you want behaviour identical to the TS / JS
  * surface — the underlying facade uses Apache Commons Codec, which produces unchunked output (no
@@ -25,8 +29,14 @@ public final class Base64 {
 
     private Base64() {}
 
+    /**
+     * Base64-encodes the UTF-8 bytes of the given text.
+     *
+     * @param input the text to encode
+     * @return the base64 representation
+     */
     public static String encode(String input) {
-        return Base64Facade.encode(input);
+        return Base64Facade.encode(input.getBytes(StandardCharsets.UTF_8));
     }
 
     public static String encode(byte[] input) {

--- a/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/utils/Digest.java
+++ b/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/utils/Digest.java
@@ -9,14 +9,19 @@
  */
 package org.eclipse.dirigible.sdk.utils;
 
+import java.nio.charset.StandardCharsets;
 import org.eclipse.dirigible.components.api.utils.DigestFacade;
 
 /**
- * One-shot cryptographic-digest helpers — MD5, SHA-1, SHA-256, SHA-384, SHA-512. Each algorithm
- * exposes four variants: {@code byte[]} or {@link String} input, raw {@code byte[]} or
- * hex-{@link String} output. Use the {@code Hex} variants when you want a printable identifier
- * (cache keys, ETags, fingerprints) and the raw byte variants when you'll feed the digest into
- * another cryptographic step.
+ * One-shot cryptographic-digest helpers — MD5, SHA-1, SHA-256, SHA-384, SHA-512. Every algorithm
+ * accepts either {@code byte[]} or {@link String} input; MD5 and SHA-1 additionally offer a
+ * {@code Hex} variant returning a printable {@link String} instead of the raw {@code byte[]}. Use
+ * the {@code Hex} variants when you want a printable identifier (cache keys, ETags, fingerprints)
+ * and the raw byte variants when you'll feed the digest into another cryptographic step; wrap any
+ * digest in {@link Hex#encode(byte[])} to print it.
+ * <p>
+ * A {@link String} argument is always text — it is digested as its UTF-8 bytes, so
+ * {@code sha256(text)} equals {@code sha256(text.getBytes(StandardCharsets.UTF_8))}.
  * <p>
  * MD5 and SHA-1 are kept for compatibility with file fingerprinting / ETag use cases but should not
  * be used for any new security-sensitive purpose — prefer {@link #sha256(String) sha256} or
@@ -27,56 +32,98 @@ public final class Digest {
 
     private Digest() {}
 
+    /**
+     * Calculates the MD5 digest of the text's UTF-8 bytes.
+     *
+     * @param input the text to digest
+     * @return the digest
+     */
     public static byte[] md5(String input) {
-        return DigestFacade.md5(input);
+        return DigestFacade.md5(input.getBytes(StandardCharsets.UTF_8));
     }
 
     public static byte[] md5(byte[] input) {
         return DigestFacade.md5(input);
     }
 
+    /**
+     * Calculates the MD5 hex-encoded digest of the text's UTF-8 bytes.
+     *
+     * @param input the text to digest
+     * @return the hex-encoded digest
+     */
     public static String md5Hex(String input) {
-        return DigestFacade.md5Hex(input);
+        return DigestFacade.md5Hex(input.getBytes(StandardCharsets.UTF_8));
     }
 
     public static String md5Hex(byte[] input) {
         return DigestFacade.md5Hex(input);
     }
 
+    /**
+     * Calculates the SHA-1 digest of the text's UTF-8 bytes.
+     *
+     * @param input the text to digest
+     * @return the digest
+     */
     public static byte[] sha1(String input) {
-        return DigestFacade.sha1(input);
+        return DigestFacade.sha1(input.getBytes(StandardCharsets.UTF_8));
     }
 
     public static byte[] sha1(byte[] input) {
         return DigestFacade.sha1(input);
     }
 
+    /**
+     * Calculates the SHA-1 hex-encoded digest of the text's UTF-8 bytes.
+     *
+     * @param input the text to digest
+     * @return the hex-encoded digest
+     */
     public static String sha1Hex(String input) {
-        return DigestFacade.sha1Hex(input);
+        return DigestFacade.sha1Hex(input.getBytes(StandardCharsets.UTF_8));
     }
 
     public static String sha1Hex(byte[] input) {
         return DigestFacade.sha1Hex(input);
     }
 
+    /**
+     * Calculates the SHA-256 digest of the text's UTF-8 bytes.
+     *
+     * @param input the text to digest
+     * @return the digest
+     */
     public static byte[] sha256(String input) {
-        return DigestFacade.sha256(input);
+        return DigestFacade.sha256(input.getBytes(StandardCharsets.UTF_8));
     }
 
     public static byte[] sha256(byte[] input) {
         return DigestFacade.sha256(input);
     }
 
+    /**
+     * Calculates the SHA-384 digest of the text's UTF-8 bytes.
+     *
+     * @param input the text to digest
+     * @return the digest
+     */
     public static byte[] sha384(String input) {
-        return DigestFacade.sha384(input);
+        return DigestFacade.sha384(input.getBytes(StandardCharsets.UTF_8));
     }
 
     public static byte[] sha384(byte[] input) {
         return DigestFacade.sha384(input);
     }
 
+    /**
+     * Calculates the SHA-512 digest of the text's UTF-8 bytes.
+     *
+     * @param input the text to digest
+     * @return the digest
+     */
     public static byte[] sha512(String input) {
-        return DigestFacade.sha512(input);
+        return DigestFacade.sha512(input.getBytes(StandardCharsets.UTF_8));
     }
 
     public static byte[] sha512(byte[] input) {

--- a/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/utils/Hex.java
+++ b/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/utils/Hex.java
@@ -9,12 +9,16 @@
  */
 package org.eclipse.dirigible.sdk.utils;
 
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.codec.DecoderException;
 import org.eclipse.dirigible.components.api.utils.HexFacade;
 
 /**
  * Hex (base-16) encoding helpers. Lower-case alphabet, no separators — useful for rendering
  * digests, fingerprints, and binary identifiers as printable strings.
+ * <p>
+ * A {@link String} argument is always text: {@link #encode(String)} encodes its UTF-8 bytes and
+ * {@link #decode(String)} reads hex text, so {@code decode(encode(text))} round-trips.
  * <p>
  * {@link #decode(String)} throws {@link DecoderException} for invalid input (odd length, non-hex
  * character); reach for it when input is user-supplied and you want to surface a client-friendly
@@ -24,8 +28,14 @@ public final class Hex {
 
     private Hex() {}
 
+    /**
+     * Hex-encodes the UTF-8 bytes of the given text.
+     *
+     * @param input the text to encode
+     * @return the hexadecimal representation
+     */
     public static String encode(String input) {
-        return HexFacade.encode(input);
+        return HexFacade.encode(input.getBytes(StandardCharsets.UTF_8));
     }
 
     public static String encode(byte[] input) {

--- a/components/api/api-modules-java/src/test/java/org/eclipse/dirigible/sdk/utils/Base64Test.java
+++ b/components/api/api-modules-java/src/test/java/org/eclipse/dirigible/sdk/utils/Base64Test.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.sdk.utils;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A {@link String} handed to the SDK is text, not the JSON byte array the shared facades accept for
+ * the GraalJS surface. These assertions pin that: {@code encode} takes the argument's UTF-8 bytes,
+ * which makes it agree with {@code decode} and with the {@code byte[]} overload.
+ */
+class Base64Test {
+
+    @Test
+    void encodesTextAsUtf8Bytes() {
+        assertEquals("dXNlcjpzZWNyZXQ=", Base64.encode("user:secret"));
+    }
+
+    @Test
+    void encodesEmptyText() {
+        assertEquals("", Base64.encode(""));
+    }
+
+    @Test
+    void encodesNonAsciiTextAsUtf8() {
+        // "ключ" is 8 bytes in UTF-8, so the result must not depend on the platform charset
+        assertEquals(Base64.encode("ключ".getBytes(StandardCharsets.UTF_8)), Base64.encode("ключ"));
+    }
+
+    @Test
+    void stringOverloadAgreesWithBytesOverload() {
+        String text = "Hello, World!";
+        assertEquals(Base64.encode(text.getBytes(StandardCharsets.UTF_8)), Base64.encode(text));
+    }
+
+    @Test
+    void decodeRoundTripsEncode() {
+        String text = "Hello, World! - ключ";
+        assertEquals(text, new String(Base64.decode(Base64.encode(text)), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void jsonByteArrayLiteralIsTreatedAsText() {
+        // The pre-fix behaviour parsed this as the bytes 104, 105 ("hi"); it is now plain text
+        assertArrayEquals("[104,105]".getBytes(StandardCharsets.UTF_8), Base64.decode(Base64.encode("[104,105]")));
+    }
+}

--- a/components/api/api-modules-java/src/test/java/org/eclipse/dirigible/sdk/utils/DigestTest.java
+++ b/components/api/api-modules-java/src/test/java/org/eclipse/dirigible/sdk/utils/DigestTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.sdk.utils;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Every {@code (String)} digest overload hashes the text's UTF-8 bytes. The expected values are the
+ * published digests of "hello", so a change of input interpretation cannot pass unnoticed.
+ */
+class DigestTest {
+
+    private static final String INPUT = "hello";
+
+    private static byte[] utf8() {
+        return INPUT.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void md5HexOfText() {
+        assertEquals("5d41402abc4b2a76b9719d911017c592", Digest.md5Hex(INPUT));
+    }
+
+    @Test
+    void md5OfText() {
+        assertArrayEquals(Digest.md5(utf8()), Digest.md5(INPUT));
+    }
+
+    @Test
+    void sha1HexOfText() {
+        assertEquals("aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d", Digest.sha1Hex(INPUT));
+    }
+
+    @Test
+    void sha1OfText() {
+        assertArrayEquals(Digest.sha1(utf8()), Digest.sha1(INPUT));
+    }
+
+    @Test
+    void sha256OfText() {
+        assertEquals("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", Hex.encode(Digest.sha256(INPUT)));
+    }
+
+    @Test
+    void sha384OfText() {
+        assertEquals("59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684f",
+                Hex.encode(Digest.sha384(INPUT)));
+    }
+
+    @Test
+    void sha512OfText() {
+        assertEquals("9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da"
+                + "0c4663475c2e5c3adef46f73bcdec043", Hex.encode(Digest.sha512(INPUT)));
+    }
+
+    @Test
+    void digestsNonAsciiTextAsUtf8() {
+        assertArrayEquals(Digest.sha256("ключ".getBytes(StandardCharsets.UTF_8)), Digest.sha256("ключ"));
+    }
+
+    @Test
+    void jsonByteArrayLiteralIsTreatedAsText() {
+        // The pre-fix behaviour digested the bytes 104, 105 ("hi"); it is now the literal text
+        assertArrayEquals(Digest.sha256("[104,105]".getBytes(StandardCharsets.UTF_8)), Digest.sha256("[104,105]"));
+    }
+}

--- a/components/api/api-modules-java/src/test/java/org/eclipse/dirigible/sdk/utils/HexTest.java
+++ b/components/api/api-modules-java/src/test/java/org/eclipse/dirigible/sdk/utils/HexTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.sdk.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.codec.DecoderException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The {@code encode(String)} counterpart of {@link Base64Test}: hex-encoding text encodes its UTF-8
+ * bytes, so it round-trips through {@link Hex#decode(String)}.
+ */
+class HexTest {
+
+    @Test
+    void encodesTextAsUtf8Bytes() {
+        assertEquals("48656c6c6f2c20576f726c6421", Hex.encode("Hello, World!"));
+    }
+
+    @Test
+    void encodesEmptyText() {
+        assertEquals("", Hex.encode(""));
+    }
+
+    @Test
+    void stringOverloadAgreesWithBytesOverload() {
+        String text = "ключ";
+        assertEquals(Hex.encode(text.getBytes(StandardCharsets.UTF_8)), Hex.encode(text));
+    }
+
+    @Test
+    void decodeRoundTripsEncode() throws DecoderException {
+        String text = "Hello, World! - ключ";
+        assertEquals(text, new String(Hex.decode(Hex.encode(text)), StandardCharsets.UTF_8));
+    }
+}

--- a/components/api/api-utils/src/test/java/org/eclipse/dirigible/components/api/utils/FacadeJsonBytesContractTest.java
+++ b/components/api/api-utils/src/test/java/org/eclipse/dirigible/components/api/utils/FacadeJsonBytesContractTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.api.utils;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The {@code (String)} overloads of these facades read their argument as a JSON array of byte
+ * values — the form a GraalJS byte array arrives in. The Java SDK wrappers in
+ * {@code org.eclipse.dirigible.sdk.utils} deliberately no longer route through them (issue #7042),
+ * so this pins the convention the JS/TS surface still depends on.
+ */
+class FacadeJsonBytesContractTest {
+
+    /** {@code [104,105]} is "hi". */
+    private static final String HI_AS_JSON_BYTES = "[104,105]";
+
+    @Test
+    void base64EncodeReadsJsonByteArray() {
+        assertEquals("aGk=", Base64Facade.encode(HI_AS_JSON_BYTES));
+    }
+
+    @Test
+    void hexEncodeReadsJsonByteArray() {
+        assertEquals("6869", HexFacade.encode(HI_AS_JSON_BYTES));
+    }
+
+    @Test
+    void digestReadsJsonByteArray() {
+        assertEquals("49f68a5c8493ec2c0bf489821c21fc3b", DigestFacade.md5Hex(HI_AS_JSON_BYTES));
+        assertArrayEquals(DigestFacade.sha256(new byte[] {104, 105}), DigestFacade.sha256(HI_AS_JSON_BYTES));
+    }
+}


### PR DESCRIPTION
Fixes #7042.

## The problem

The `(String)` overloads of `sdk.utils.Base64.encode`, `sdk.utils.Hex.encode` and every `sdk.utils.Digest` algorithm passed their argument to `BytesHelper.jsonToBytes`, i.e. `GsonHelper.fromJson(input, byte[].class)`. They therefore required a JSON array of byte values (`"[104,105]"`) and threw on ordinary text:

```java
Base64.encode("user:secret");   // com.google.gson.JsonSyntaxException: Expected BEGIN_ARRAY but was STRING
```

They also disagreed with their own siblings - `Base64.decode(String)` reads base64 *text*, `Hex.decode(String)` reads hex *text* - so the intuitive round trip failed on the first call, and the javadoc said the opposite of what happened.

## The fix

The JSON-array convention is real, but it belongs to the GraalJS surface, where a JS byte array arrives as a JSON array string. `api-modules-java` is precisely the module whose job is to hide it.

The TS SDK already does exactly that: `base64.ts` / `hex.ts` / `digest.ts` convert a JS string to UTF-8 bytes themselves (`baos.writeText(data)`) and call the `*Native(byte[])` facade methods - they never touch the `(String)` facade overloads. The Java mirror now does the same, so the two SDKs agree and `encode` / `decode` are symmetric within each class.

Only the SDK wrappers change. The facades keep the JSON-array contract the JS/TS modules depend on.

Also corrected: `Digest`'s javadoc claim that "each algorithm exposes four variants" was untrue - only MD5 and SHA-1 have a `Hex` variant, matching the TS module - and now says what the class actually offers, pointing at `Hex.encode(byte[])` for the rest.

## Compatibility

This changes behaviour for anyone passing the JSON-array form *through the SDK*. Per the issue, that form is only reachable by accident and these wrappers are recent (#6002), so this is the straight fix rather than a second method name. The JS/TS surface is untouched.

## Tests

- `Base64Test`, `HexTest`, `DigestTest` (19 tests): known vectors (`"user:secret"` -> `dXNlcjpzZWNyZXQ=`, the published `hello` digests for MD5/SHA-1/SHA-256/SHA-384/SHA-512), `String`-vs-`byte[]` overload agreement, non-ASCII UTF-8 (so a platform-charset regression fails), empty input, `decode(encode(x))` round trips, and an explicit assertion that `"[104,105]"` is now literal text - pinning the deliberate change.
- `FacadeJsonBytesContractTest` in `api-utils`: pins that `Base64Facade` / `HexFacade` / `DigestFacade` `(String)` still read a JSON byte array, so the contract the JS/TS modules rely on cannot be "fixed" away by accident.

## Verification

- Reverting the three main files makes 17 of the 19 new tests fail with the reported `JsonSyntaxException` - they do reproduce the bug.
- `api-modules-java` full suite 55/55 green; `api-utils` full suite 9/9 green, including `UtilsSuiteTest`, which drives the GraalJS `utils/base64`, `utils/hex` and `utils/digest` modules end to end.
- No caller in the repo used these SDK methods, so nothing depended on the old semantics.
- `formatter:validate` clean; `-P release` javadoc build clean.

## Out of scope, worth a follow-up

- `Digest` has no `sha256Hex` / `sha384Hex` / `sha512Hex` - the issue's `Digest.sha256Hex("hello")` snippet does not compile. Neither the facade nor the TS module has them; `Hex.encode(Digest.sha256(text))` is the route, which the javadoc now states.
- The same `jsonToBytes` trap is reachable through other SDK wrappers - `Files.writeBytes(String, String)`, `Streams.writeBytes` / `createByteArrayInputStream(String)`, `Zip.write(..., String)`, `Response.write(String)`, `Workspace.setContent(File, String)`. Each sits next to an explicit `writeText` / `byte[]` sibling, so the name at least warns you, but they fail the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)