### PR TITLE
jobs: the Quartz driver delegate follows the database the job store runs on (#7049)

### DIFF
--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/config/QuartzConfig.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/config/QuartzConfig.java
@@ -19,6 +19,7 @@ import org.eclipse.dirigible.components.jobs.telemetry.JobFailuresCountListener;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.impl.jdbcjobstore.JobStoreTX;
+import org.quartz.impl.matchers.GroupMatcher;
 import org.quartz.utils.DBConnectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,22 +60,46 @@ class QuartzConfig {
         scheduler.getListenerManager()
                  .addJobListener(jobFailuresCountListener);
 
+        verifyTriggersAreReadable(scheduler);
+
         return scheduler;
+    }
+
+    /**
+     * Reads the trigger keys once so that a job store which cannot talk to its own tables is reported
+     * at startup. Without it a mismatched driver delegate degrades into a healthy looking instance that
+     * fires nothing, its only trace an ERROR repeating on every scheduler poll.
+     *
+     * @param scheduler the scheduler
+     */
+    private void verifyTriggersAreReadable(Scheduler scheduler) {
+        try {
+            scheduler.getTriggerKeys(GroupMatcher.anyTriggerGroup());
+        } catch (SchedulerException ex) {
+            logger.error(
+                    "The scheduler cannot read its triggers from the system database - no scheduled job will fire."
+                            + " Check that the Quartz tables exist there and that the driver delegate matches that database -"
+                            + " set [{}] to its delegate, for example [{}] for PostgreSQL",
+                    QuartzDriverDelegateResolver.DELEGATE_OVERRIDE_KEY, QuartzDriverDelegateResolver.POSTGRESQL_DELEGATE, ex);
+        }
     }
 
     /**
      * Scheduler factory bean.
      *
      * @param jobFactory the job factory
+     * @param systemDataSourceName the name of the system data source
+     * @param systemDataSource the system data source the job store runs on
+     * @param transactionManager the transaction manager
      * @return the scheduler factory bean
      * @throws IOException Signals that an I/O exception has occurred.
      */
     @Bean
     SchedulerFactoryBean schedulerFactoryBean(AutoWiringSpringBeanJobFactory jobFactory, @SystemDataSourceName String systemDataSourceName,
-            PlatformTransactionManager transactionManager) throws IOException {
+            @Qualifier("SystemDB") DataSource systemDataSource, PlatformTransactionManager transactionManager) throws IOException {
         SchedulerFactoryBean factory = new SchedulerFactoryBean();
         factory.setJobFactory(jobFactory);
-        factory.setQuartzProperties(quartzProperties(systemDataSourceName));
+        factory.setQuartzProperties(quartzProperties(systemDataSourceName, systemDataSource));
         factory.setTransactionManager(transactionManager);
         factory.setWaitForJobsToCompleteOnShutdown(false);
 
@@ -89,7 +114,7 @@ class QuartzConfig {
      * @return the properties
      * @throws IOException Signals that an I/O exception has occurred.
      */
-    private Properties quartzProperties(String systemDataSourceName) throws IOException {
+    private Properties quartzProperties(String systemDataSourceName, DataSource systemDataSource) throws IOException {
         PropertiesFactoryBean propertiesFactoryBean = new PropertiesFactoryBean();
         propertiesFactoryBean.setLocation(new ClassPathResource("/quartz.properties"));
         propertiesFactoryBean.afterPropertiesSet();
@@ -98,8 +123,7 @@ class QuartzConfig {
         String jobStoreClass = properties.getProperty("org.quartz.jobStore.class");
         if (null != jobStoreClass && jobStoreClass.equals(JobStoreTX.class.getCanonicalName())) {
             properties.setProperty("org.quartz.jobStore.dataSource", systemDataSourceName);
-            properties.setProperty("org.quartz.jobStore.driverDelegateClass", org.eclipse.dirigible.commons.config.Configuration.get(
-                    "DIRIGIBLE_SCHEDULER_DATABASE_DELEGATE", "org.quartz.impl.jdbcjobstore.StdJDBCDelegate"));
+            properties.setProperty("org.quartz.jobStore.driverDelegateClass", QuartzDriverDelegateResolver.resolve(systemDataSource));
         }
         return properties;
     }

--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/config/QuartzDriverDelegateResolver.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/config/QuartzDriverDelegateResolver.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.jobs.config;
+
+import java.sql.SQLException;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.components.database.DatabaseSystem;
+import org.eclipse.dirigible.components.database.DatabaseSystemDeterminer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolves the Quartz JDBC job store driver delegate for the database the job store actually runs
+ * on.
+ *
+ * <p>
+ * The standard delegate reads the trigger and job data columns as JDBC blobs, which PostgreSQL
+ * answers with a {@code BYTEA} the driver refuses to convert - every trigger read then fails and no
+ * job ever fires. The delegate is therefore derived from the job store's own data source, with
+ * {@code DIRIGIBLE_SCHEDULER_DATABASE_DELEGATE} kept as an explicit override.
+ */
+final class QuartzDriverDelegateResolver {
+
+    /** The delegate every database not needing a specialized one uses. */
+    static final String STANDARD_DELEGATE = "org.quartz.impl.jdbcjobstore.StdJDBCDelegate";
+
+    /** The configuration key overriding the derived delegate. */
+    static final String DELEGATE_OVERRIDE_KEY = "DIRIGIBLE_SCHEDULER_DATABASE_DELEGATE";
+
+    /** The delegate PostgreSQL needs - named in the failure message as the fix to apply. */
+    static final String POSTGRESQL_DELEGATE = "org.quartz.impl.jdbcjobstore.PostgreSQLDelegate";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(QuartzDriverDelegateResolver.class);
+
+    private static final Map<DatabaseSystem, String> DELEGATES_BY_DATABASE = Map.of(//
+            DatabaseSystem.POSTGRESQL, POSTGRESQL_DELEGATE, //
+            DatabaseSystem.MSSQL, "org.quartz.impl.jdbcjobstore.MSSQLDelegate"//
+    );
+
+    private QuartzDriverDelegateResolver() {}
+
+    /**
+     * Resolves the delegate for the given job store data source - the configured override when set,
+     * otherwise the delegate of the data source's database.
+     *
+     * @param dataSource the job store data source
+     * @return the fully qualified delegate class name, never blank
+     */
+    static String resolve(DataSource dataSource) {
+        String configuredDelegate = Configuration.get(DELEGATE_OVERRIDE_KEY);
+        if (StringUtils.isNotBlank(configuredDelegate)) {
+            LOGGER.info("Using the configured Quartz driver delegate [{}] from [{}]", configuredDelegate, DELEGATE_OVERRIDE_KEY);
+            return configuredDelegate.trim();
+        }
+
+        DatabaseSystem databaseSystem = determineDatabaseSystem(dataSource);
+        String delegate = delegateFor(databaseSystem);
+        LOGGER.info("Using the Quartz driver delegate [{}] derived from database [{}]", delegate, databaseSystem);
+        return delegate;
+    }
+
+    /**
+     * The delegate the given database needs.
+     *
+     * @param databaseSystem the database the job store runs on
+     * @return the fully qualified delegate class name
+     */
+    static String delegateFor(DatabaseSystem databaseSystem) {
+        return DELEGATES_BY_DATABASE.getOrDefault(databaseSystem, STANDARD_DELEGATE);
+    }
+
+    private static DatabaseSystem determineDatabaseSystem(DataSource dataSource) {
+        try {
+            return DatabaseSystemDeterminer.determine(dataSource);
+        } catch (SQLException ex) {
+            LOGGER.warn(
+                    "Failed to determine the database of the scheduler data source. Falling back to [{}]."
+                            + " Set [{}] explicitly if the scheduler cannot read its triggers",
+                    STANDARD_DELEGATE, DELEGATE_OVERRIDE_KEY, ex);
+            return DatabaseSystem.UNKNOWN;
+        }
+    }
+}

--- a/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/config/QuartzDriverDelegateResolverTest.java
+++ b/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/config/QuartzDriverDelegateResolverTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.jobs.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import java.sql.SQLException;
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.components.database.DatabaseSystem;
+import org.eclipse.dirigible.components.database.DirigibleDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * The driver delegate follows the database the job store runs on (#7049) - the standard delegate
+ * fails every trigger read on PostgreSQL.
+ */
+@ExtendWith(MockitoExtension.class)
+class QuartzDriverDelegateResolverTest {
+
+    @Mock
+    private DirigibleDataSource dataSource;
+
+    @AfterEach
+    void clearOverride() {
+        Configuration.remove(QuartzDriverDelegateResolver.DELEGATE_OVERRIDE_KEY);
+    }
+
+    @Test
+    void testPostgreSqlGetsItsOwnDelegate() throws SQLException {
+        when(dataSource.getDatabaseSystem()).thenReturn(DatabaseSystem.POSTGRESQL);
+
+        assertEquals("org.quartz.impl.jdbcjobstore.PostgreSQLDelegate", QuartzDriverDelegateResolver.resolve(dataSource));
+    }
+
+    @Test
+    void testMssqlGetsItsOwnDelegate() throws SQLException {
+        when(dataSource.getDatabaseSystem()).thenReturn(DatabaseSystem.MSSQL);
+
+        assertEquals("org.quartz.impl.jdbcjobstore.MSSQLDelegate", QuartzDriverDelegateResolver.resolve(dataSource));
+    }
+
+    @Test
+    void testH2KeepsTheStandardDelegate() throws SQLException {
+        when(dataSource.getDatabaseSystem()).thenReturn(DatabaseSystem.H2);
+
+        assertEquals(QuartzDriverDelegateResolver.STANDARD_DELEGATE, QuartzDriverDelegateResolver.resolve(dataSource));
+    }
+
+    @Test
+    void testUnmappedDatabaseKeepsTheStandardDelegate() {
+        assertEquals(QuartzDriverDelegateResolver.STANDARD_DELEGATE, QuartzDriverDelegateResolver.delegateFor(DatabaseSystem.MARIADB));
+        assertEquals(QuartzDriverDelegateResolver.STANDARD_DELEGATE, QuartzDriverDelegateResolver.delegateFor(DatabaseSystem.UNKNOWN));
+    }
+
+    @Test
+    void testConfiguredDelegateOverridesTheDerivedOne() {
+        Configuration.set(QuartzDriverDelegateResolver.DELEGATE_OVERRIDE_KEY, "org.quartz.impl.jdbcjobstore.HSQLDBDelegate");
+
+        assertEquals("org.quartz.impl.jdbcjobstore.HSQLDBDelegate", QuartzDriverDelegateResolver.resolve(dataSource));
+    }
+
+    @Test
+    void testBlankConfiguredDelegateIsIgnored() throws SQLException {
+        Configuration.set(QuartzDriverDelegateResolver.DELEGATE_OVERRIDE_KEY, "  ");
+        when(dataSource.getDatabaseSystem()).thenReturn(DatabaseSystem.POSTGRESQL);
+
+        assertEquals("org.quartz.impl.jdbcjobstore.PostgreSQLDelegate", QuartzDriverDelegateResolver.resolve(dataSource));
+    }
+}

--- a/modules/commons/commons-resources/src/main/resources/quartz.properties
+++ b/modules/commons/commons-resources/src/main/resources/quartz.properties
@@ -11,6 +11,9 @@
 #
 
 org.quartz.jobStore.class=org.quartz.impl.jdbcjobstore.JobStoreTX
+
+# will be derived from the system database by QuartzConfig,
+# overridable with DIRIGIBLE_SCHEDULER_DATABASE_DELEGATE
 org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.StdJDBCDelegate
 
 # will be set by QuartzConfig


### PR DESCRIPTION
## The bug

`QuartzConfig.quartzProperties` set `org.quartz.jobStore.driverDelegateClass` to `StdJDBCDelegate` for every database, overridable only by the undocumented `DIRIGIBLE_SCHEDULER_DATABASE_DELEGATE`. That delegate reads the trigger and job data columns as JDBC blobs, which PostgreSQL answers with a `BYTEA` the driver refuses to convert, so with the SystemDB on PostgreSQL every scheduler poll failed with

```
org.quartz.JobPersistenceException: Couldn't retrieve trigger: Cannot convert the column of type BYTEA to requested type long.
```

and **no `.job` in any module ever fired** while the health endpoints kept answering 200. An operator who had set the five documented SystemDB variables had no way to know a sixth was needed.

## The fix

- **The delegate follows the database.** `QuartzDriverDelegateResolver` derives it from the job store's own data source through the platform's `DatabaseSystemDeterminer`: PostgreSQL gets `PostgreSQLDelegate`, MSSQL gets `MSSQLDelegate`, every other supported database keeps `StdJDBCDelegate` (H2, MariaDB, MySQL and the rest are fine with it), and the chosen delegate is logged at INFO. `DIRIGIBLE_SCHEDULER_DATABASE_DELEGATE` stays as an explicit override, so a deployment that already sets it is unaffected; a blank value falls through to the derived one.
- **The failure mode is no longer silent.** The `scheduler` bean reads its trigger keys once at startup and, when it cannot, logs an ERROR naming the fix - instead of degrading into a healthy looking instance that runs nothing whose only trace is an ERROR repeating on every poll.

Behaviour is unchanged on H2 (the default) and for any deployment that sets the override.

## Tests

`QuartzDriverDelegateResolverTest` - PostgreSQL and MSSQL get their own delegate, H2 and unmapped databases keep the standard one, the configured override wins, a blank override is ignored. Full `engine-jobs` suite green (36 tests); `formatter:validate` and the `release`-profile javadoc pass on the module.

Fixes #7049