### PR TITLE
cms-seed: the seed content is inline bytes, not a large object

### DIFF
--- a/components/core/core-liquibase/src/main/resources/db/changelog/dirigible-system.json
+++ b/components/core/core-liquibase/src/main/resources/db/changelog/dirigible-system.json
@@ -9906,6 +9906,38 @@
           }
         ]
       }
+    },
+    {
+      "changeSet": {
+        "id": "convert-DIRIGIBLE_CMS_SEEDS_CMS_SEED_CONTENT-to-bytea",
+        "author": "dirigible",
+        "comment": "The seed content was a @Lob byte[], which PostgreSQL renders as an oid large object - and pgjdbc refuses the large-object API on the auto-commit connection the synchronization thread saves seeds on, so every seed save failed there. The column is inline bytea now; deployments that already created it as oid are converted here, the large objects are unlinked, and one whose large object is already gone converts to NULL (the next synchronization re-reads the file).",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "dbms": {
+              "type": "postgresql"
+            }
+          },
+          {
+            "sqlCheck": {
+              "expectedResult": "1",
+              "sql": "SELECT count(*) FROM information_schema.columns WHERE lower(table_name) = 'dirigible_cms_seeds' AND lower(column_name) = 'cms_seed_content' AND lower(data_type) = 'oid'"
+            }
+          }
+        ],
+        "changes": [
+          {
+            "sql": {
+              "dbms": "postgresql",
+              "splitStatements": true,
+              "sql": "CREATE TEMPORARY TABLE DIRIGIBLE_CMS_SEEDS_LOBS AS SELECT CMS_SEED_CONTENT AS LOB_OID FROM DIRIGIBLE_CMS_SEEDS WHERE CMS_SEED_CONTENT IS NOT NULL;\nUPDATE DIRIGIBLE_CMS_SEEDS SET CMS_SEED_CONTENT = NULL WHERE CMS_SEED_CONTENT IS NOT NULL AND NOT EXISTS (SELECT 1 FROM pg_largeobject_metadata m WHERE m.oid = CMS_SEED_CONTENT);\nALTER TABLE DIRIGIBLE_CMS_SEEDS ALTER COLUMN CMS_SEED_CONTENT TYPE bytea USING (CASE WHEN CMS_SEED_CONTENT IS NULL THEN NULL ELSE lo_get(CMS_SEED_CONTENT) END);\nSELECT lo_unlink(m.oid) FROM pg_largeobject_metadata m JOIN DIRIGIBLE_CMS_SEEDS_LOBS l ON l.LOB_OID = m.oid;\nDROP TABLE DIRIGIBLE_CMS_SEEDS_LOBS;"
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/components/engine/engine-document/CLAUDE.md
+++ b/components/engine/engine-document/CLAUDE.md
@@ -79,9 +79,17 @@ formats in the form money pattern `### ### ### ##0.00`).
   `IOException` `getObjectByPath` throws (logged at DEBUG with the throwable). Writes go through the
   raw engine-cms interfaces (`CmisSessionFactory.getSession()`), which bypass CMS role checks —
   correct for a server-side seeder, same as `data-processes`' `BaseExportTask`.
-- `CmsSeed` stores the raw content in a `CMS_SEED_CONTENT` BLOB (bytes, so binary seeds work) plus
-  the target `CMS_SEED_PATH`, so the seeding phase does
-  not re-read the repository.
+- `CmsSeed` stores the raw content in a `CMS_SEED_CONTENT` binary column (bytes, so binary seeds
+  work) plus the target `CMS_SEED_PATH`, so the seeding phase does not re-read the repository.
+  **The column is `@JdbcTypeCode(SqlTypes.LONG32VARBINARY)`, never `@Lob`.** A `@Lob byte[]` is an
+  `oid` large object on PostgreSQL, and pgjdbc refuses the large-object API on an auto-commit
+  connection — which is exactly the connection `parseImpl` reads and saves the seed on — so every
+  seed save on a PostgreSQL SystemDB failed with "Large Objects may not be used in auto-commit
+  mode", silently: the failure is in `parseImpl`, before the artefact has a lifecycle, so nothing
+  ever shows up as an artefact in error (#7059). The mapping renders `bytea` on PostgreSQL and
+  leaves H2 (`blob`) and MSSQL (`varbinary(max)`) exactly as they were;
+  `CmsSeedContentMappingTest` pins all three, and the changelog's
+  `convert-DIRIGIBLE_CMS_SEEDS_CMS_SEED_CONTENT-to-bytea` converts an already-created `oid` column.
 
 ## Images in a template (`PrintImageResolver`)
 

--- a/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/domain/CmsSeed.java
+++ b/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/domain/CmsSeed.java
@@ -10,14 +10,14 @@
 package org.eclipse.dirigible.components.engine.document.domain;
 
 import org.eclipse.dirigible.components.base.artefact.Artefact;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
-import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 
 /**
@@ -43,9 +43,19 @@ public class CmsSeed extends Artefact {
     @Column(name = "CMS_SEED_PATH", length = 1020)
     private String cmsPath;
 
-    /** The raw file content (kept so the seed phase does not re-read the repository). */
-    @Lob
-    @Basic
+    /**
+     * The raw file content (kept so the seed phase does not re-read the repository).
+     * <p>
+     * Mapped as inline binary, deliberately NOT as a {@code @Lob}. It renders {@code bytea} on
+     * PostgreSQL and leaves H2 ({@code blob}) and SQL Server ({@code varbinary(max)}) with the column
+     * they already have, so no deployed schema but PostgreSQL's has anything to migrate. On PostgreSQL
+     * Hibernate maps a {@code @Lob byte[]} to an {@code oid} large object, and pgjdbc's large-object
+     * API refuses to run in auto-commit mode - which is exactly how the synchronization thread reads
+     * and writes this row, so every seed save failed there with "Large Objects may not be used in
+     * auto-commit mode". Seed content is a single file's bytes; it belongs in the row, not in a
+     * side-table of large objects.
+     */
+    @JdbcTypeCode(SqlTypes.LONG32VARBINARY)
     @Column(name = "CMS_SEED_CONTENT")
     private byte[] content;
 

--- a/components/engine/engine-document/src/test/java/org/eclipse/dirigible/components/engine/document/domain/CmsSeedContentMappingTest.java
+++ b/components/engine/engine-document/src/test/java/org/eclipse/dirigible/components/engine/document/domain/CmsSeedContentMappingTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.document.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.PersistentClass;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The seed content column must be inline binary on every dialect - never a PostgreSQL {@code oid}
+ * large object. A {@code @Lob byte[]} renders as {@code oid} there, and pgjdbc's large-object API
+ * throws "Large Objects may not be used in auto-commit mode" for exactly the auto-commit connection
+ * the synchronization thread saves seeds on, so every seed save failed on a PostgreSQL SystemDB.
+ */
+class CmsSeedContentMappingTest {
+
+    @Test
+    void postgreSqlRendersInlineBytesNotALargeObject() {
+        assertThat(contentColumnType("org.hibernate.dialect.PostgreSQLDialect")).isEqualTo("bytea");
+    }
+
+    /**
+     * The other two dialects are unchanged by the mapping - they rendered (and keep rendering) an
+     * inline binary column, so no deployed schema has to be migrated off a large object but
+     * PostgreSQL's.
+     */
+    @Test
+    void theOtherDialectsKeepTheColumnTheyAlreadyHave() {
+        assertThat(contentColumnType("org.hibernate.dialect.H2Dialect")).isEqualTo("blob");
+        assertThat(contentColumnType("org.hibernate.dialect.SQLServerDialect")).isEqualTo("varbinary(max)");
+    }
+
+    /** The DDL type Hibernate would give the content column on the given dialect. */
+    private static String contentColumnType(String dialect) {
+        StandardServiceRegistry registry = new StandardServiceRegistryBuilder().applySetting("hibernate.dialect", dialect)
+                                                                               .build();
+        try {
+            Metadata metadata = new MetadataSources(registry).addAnnotatedClass(CmsSeed.class)
+                                                             .buildMetadata();
+            PersistentClass entity = metadata.getEntityBinding(CmsSeed.class.getName());
+            Column content = (Column) entity.getProperty("content")
+                                            .getSelectables()
+                                            .get(0);
+
+            return content.getSqlType(metadata)
+                          .toLowerCase(Locale.ROOT);
+        } finally {
+            StandardServiceRegistryBuilder.destroy(registry);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #7059

## The failure

On a PostgreSQL SystemDB every `cms-seed` save failed, on every synchronization pass:

```
ERROR CmsSeedSynchronizer - Failed to save CMS seed [CmsSeed{...standard.print...}]
org.springframework.orm.jpa.JpaSystemException: Unable to access lob stream
Caused by: org.postgresql.util.PSQLException: Large Objects may not be used in auto-commit mode.
```

`CmsSeed.content` was a `@Lob byte[]` - the only `@Lob` in `components/` main code. On PostgreSQL Hibernate maps that to an `oid` large object, and pgjdbc's large-object API refuses to run in auto-commit mode, which is exactly the connection `CmsSeedSynchronizer.parseImpl` does its `findByKey` + `save` on. So no `doc/` file could reach the CMS on PostgreSQL, and nothing said so: the failure is in `parseImpl`, before the artefact has a lifecycle, so Monitoring reported "Nothing needs attention" while 60 seeds failed per pass. H2 never showed it - its LOBs need no transaction.

## The fix

`@JdbcTypeCode(SqlTypes.LONG32VARBINARY)` instead of `@Lob`. Seed content is one file's bytes; it belongs in the row, not in a side-table of large objects - and inline bytes have no LOB-transaction coupling on any dialect.

The rendered DDL, asserted by the new `CmsSeedContentMappingTest`:

| dialect | before | after |
| --- | --- | --- |
| PostgreSQL | `oid` | `bytea` |
| H2 | `blob` | `blob` |
| SQL Server | `varbinary(max)` | `varbinary(max)` |

So PostgreSQL is the only deployed schema with anything to migrate, and the changelog's `convert-DIRIGIBLE_CMS_SEEDS_CMS_SEED_CONTENT-to-bytea` does it: capture the oids, null the rows whose large object is already gone (the next synchronization re-reads the file - seed content is derived, never authored), `ALTER ... TYPE bytea USING lo_get(...)`, then unlink the large objects it just inlined. Guarded by its `dbms` plus a `sqlCheck` for an `oid`-typed column, so H2, SQL Server and a fresh PostgreSQL mark it ran and touch nothing.

## Verification

- `CmsSeedContentMappingTest` - the rendered column type per dialect (this is the whole fix, so it is what the test pins).
- `SystemChangelogIdempotencyTest` - unchanged, and the log shows the new changeset marked ran on H2 via its precondition.
- A real PostgreSQL 16, all three states: an existing `oid` table converts with content intact, the orphan-oid row nulled and zero large objects left behind; a fresh database skips; a re-run is a no-op. (CI has no PostgreSQL **SystemDB** leg - see #7008 - so this was done by hand against a throwaway container.)

## Scope

Deliberately only the LOB coupling. #7008's other three defects - the SystemDB dialect defaulting to `H2Dialect` regardless of the driver, `DIRIGIBLE_CMS_SEEDS` (and three more tables) having no `createTable` changeset at all, and the swallowed `hbm2ddl` failure - are untouched and stay with that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)