### PR TITLE
Swappable modules classloader: the swap is no longer inert behind loader.path (#6789)

### DIFF
--- a/build/application/Dockerfile
+++ b/build/application/Dockerfile
@@ -33,15 +33,19 @@ COPY target/dirigible-application-*-executable.jar dirigible.jar
 # missing /modules is a no-op. Set LOADER_PATH to use other locations (comma-separated).
 #
 # /root/.dirigible/resolved-modules is where the platform links the maven dependencies declared in
-# project.json files (see DIRIGIBLE_DEPENDENCIES_DIR) - resolved at boot or on demand, they join
-# the classpath on the NEXT restart. Mount /root/.dirigible on a volume to keep them across runs.
+# project.json files (see DIRIGIBLE_DEPENDENCIES_DIR). It is deliberately NOT on loader.path: those
+# jars are served by the swappable modules classloader, which the boot-time resolution installs. On
+# loader.path they would also be defined by the application classloader, and the modules classloader
+# is parent-first - every later upgrade and removal would resolve to that first, stale copy and the
+# swap would silently change nothing. Mount /root/.dirigible on a volume to keep the local maven
+# repository (and so an offline boot, see DIRIGIBLE_DEPENDENCIES_FROZEN) across runs.
 RUN mkdir -p /modules /root/.dirigible/resolved-modules
 
 # A -jar launch: the executable jar's ZIP layout makes PropertiesLauncher the Main-Class (so
 # -Dloader.path keeps working), and -jar is what makes the JVM honor the Launcher-Agent-Class
 # manifest entry - the launcher agent that lets scope-platform dependency jars (JDBC drivers,
 # JNI-bearing libraries) be appended to the system classloader without a restart.
-ENTRYPOINT ["java", "--add-opens", "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED", "--add-opens", "java.base/java.nio=ALL-UNNAMED", "-Dloader.path=/modules,/root/.dirigible/resolved-modules", "-jar", "/dirigible.jar"]
+ENTRYPOINT ["java", "--add-opens", "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED", "--add-opens", "java.base/java.nio=ALL-UNNAMED", "-Dloader.path=/modules", "-jar", "/dirigible.jar"]
 
 # 8080 for the spring boot application,
 # 8081 for graalium debug port

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesService.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesService.java
@@ -54,6 +54,15 @@ class DependenciesService {
     /** The failures key carrying a frozen boot without a lockfile. */
     private static final String LOCKFILE_FAILURE_KEY = "project-lock.json";
 
+    /** The failures key carrying a registry-payload reconciliation failure. */
+    private static final String PAYLOAD_FAILURE_KEY = "registry-payload";
+
+    /** The first retry delay after a failed pass, in milliseconds. */
+    private static final long RETRY_BASE_MILLIS = 60_000L;
+
+    /** The retry delay ceiling after repeated failures, in milliseconds. */
+    private static final long RETRY_MAX_MILLIS = 900_000L;
+
     /** The collector. */
     private final ProjectDependenciesCollector collector;
 
@@ -80,6 +89,14 @@ class DependenciesService {
 
     /** The fingerprint of the declarations the last resolution processed, null before it. */
     private volatile String lastDeclaredFingerprint;
+
+    /**
+     * When the last pass reported failures, the moment the watcher may retry it; 0 when it was clean.
+     */
+    private volatile long retryAtMillis;
+
+    /** The current retry delay, doubled on every consecutive failing pass. */
+    private volatile long retryDelayMillis = RETRY_BASE_MILLIS;
 
     /**
      * Instantiates a new dependencies service.
@@ -133,6 +150,38 @@ class DependenciesService {
     }
 
     /**
+     * Whether the watcher should re-run the pipeline although the declarations did not change - the
+     * previous pass reported failures and its backoff has elapsed. A resolution that fails on a
+     * repository outage must not disarm the watcher until someone edits a project.json: the
+     * declarations are unchanged when the network recovers, so nothing but a retry ever activates them.
+     *
+     * @return true when a retry is due
+     */
+    boolean isRetryDue() {
+        long due = retryAtMillis;
+        return due != 0 && System.currentTimeMillis() >= due;
+    }
+
+    /**
+     * Records the outcome of one pass for the watcher's retry decision - a clean pass clears the
+     * backoff, a failing one schedules the next retry and doubles the delay up to the ceiling.
+     *
+     * @param clean whether the pass reported no failures
+     */
+    private void recordPassOutcome(boolean clean) {
+        if (clean) {
+            retryAtMillis = 0;
+            retryDelayMillis = RETRY_BASE_MILLIS;
+            return;
+        }
+        long delay = retryDelayMillis;
+        retryAtMillis = System.currentTimeMillis() + delay;
+        retryDelayMillis = Math.min(delay * 2, RETRY_MAX_MILLIS);
+        LOGGER.info("The dependency pass reported failures - retrying in [{}] second(s) even if the declarations do not change",
+                delay / 1000);
+    }
+
+    /**
      * Runs the resolution of both dependency tiers and reconciles the results into the running system.
      * In frozen mode the activated set comes from the lockfile alone; otherwise the union is resolved,
      * verified against the lockfile and activated - the platform tier (appended to the system
@@ -144,11 +193,16 @@ class DependenciesService {
      */
     synchronized DependenciesState resolveAndActivate() {
         DeclaredDependencies declared = collector.collect();
-        lastDeclaredFingerprint = declared.fingerprint();
         Path localRepository = MavenResolverConfig.fromConfiguration()
                                                   .localRepository();
         DependenciesState state = isFrozen() ? activateFrozen(declared, localRepository) : resolveDynamic(declared, localRepository);
         lastState.set(state);
+        // the fingerprint disarms the watcher for these declarations, so a failing pass arms the
+        // backoff instead: unchanged declarations that failed on a repository 503 or a network blip
+        // are retried until they resolve, rather than waiting for someone to edit a project.json
+        lastDeclaredFingerprint = declared.fingerprint();
+        recordPassOutcome(state.failures()
+                               .isEmpty());
         LOGGER.info(
                 "Maven dependency {} completed: [{}] declared, [{}] jar(s) activated, [{}] platform-scoped, [{}] mediated,"
                         + " [{}] failure(s), classloader generation [{}]",
@@ -212,7 +266,7 @@ class DependenciesService {
         if (moduleGate.isEmpty()) {
             outcome = dependencySynchronizer.swap(localRepository, paths(verifiedModule), paths(verifiedPlatform), moduleResult.mediated());
         } else {
-            outcome = SwapOutcome.kept(null);
+            outcome = SwapOutcome.kept((String) null);
             LOGGER.error("Not swapping the dependency layer: [{}] declaration/resolution failure(s) - the installed generation keeps "
                     + "serving. Failures: {}", moduleGate.size(), moduleGate);
         }
@@ -221,9 +275,7 @@ class DependenciesService {
         failures.putAll(platformResult.failures());
         failures.putAll(moduleResult.failures());
         failures.putAll(integrityFailures);
-        if (outcome.error() != null) {
-            failures.put(SWAP_FAILURE_KEY, outcome.error());
-        }
+        reportSwapFailures(outcome, failures);
 
         // both tiers seed the next launch's classpath through the resolved-modules directory;
         // stale links are removed only after a fully clean pass
@@ -245,6 +297,7 @@ class DependenciesService {
         reportResolution(platformResult, List.of(), integrityFailures, outcome.swapped(), ArtifactStatus.SCOPE_PLATFORM, report);
         platformStates.forEach(state -> report.add(
                 new ArtifactStatus(state.coordinate(), ArtifactStatus.SCOPE_PLATFORM, state.status(), state.message())));
+        reportSwapOutcome(outcome, report);
 
         return state(false, declared, paths(allArtifacts), mediated, failures, platformStates, report, localRepository);
     }
@@ -282,16 +335,14 @@ class DependenciesService {
             outcome =
                     dependencySynchronizer.swap(localRepository, plan.artifacts(ArtifactStatus.SCOPE_MODULE), platformArtifacts, Map.of());
         } else {
-            outcome = SwapOutcome.kept(null);
+            outcome = SwapOutcome.kept((String) null);
             LOGGER.error("Not swapping the dependency layer: [{}] declaration failure(s) - the installed generation keeps serving."
                     + " Failures: {}", moduleGate.size(), moduleGate);
         }
 
         Map<String, String> failures = new LinkedHashMap<>(declared.errors());
         failures.putAll(plan.failures());
-        if (outcome.error() != null) {
-            failures.put(SWAP_FAILURE_KEY, outcome.error());
-        }
+        reportSwapFailures(outcome, failures);
 
         List<Path> allArtifacts = new ArrayList<>(plan.activations()
                                                       .stream()
@@ -327,6 +378,7 @@ class DependenciesService {
         }
         platformStates.forEach(state -> report.add(
                 new ArtifactStatus(state.coordinate(), ArtifactStatus.SCOPE_PLATFORM, state.status(), state.message())));
+        reportSwapOutcome(outcome, report);
 
         return state(true, declared, allArtifacts, Map.of(), failures, platformStates, report, localRepository);
     }
@@ -449,6 +501,65 @@ class DependenciesService {
             artifacts.add(new Lockfile.LockedArtifact(artifact.coordinate(), hashes.get(artifact.coordinate()), requestedBy, artifact.via(),
                     scope));
         }
+    }
+
+    /**
+     * Adds the swap's own failures: the abort reason, the per-declaration rejections (the rest of the
+     * resolution still activated) and a registry-payload reconciliation failure.
+     *
+     * @param outcome the swap outcome
+     * @param failures the failures to add to
+     */
+    private static void reportSwapFailures(SwapOutcome outcome, Map<String, String> failures) {
+        if (outcome.error() != null) {
+            failures.put(SWAP_FAILURE_KEY, outcome.error());
+        }
+        failures.putAll(outcome.rejected());
+        if (outcome.payloadError() != null) {
+            failures.put(PAYLOAD_FAILURE_KEY, outcome.payloadError());
+        }
+    }
+
+    /**
+     * Corrects the per-artifact report with what the swap actually did: a rejected declaration carries
+     * its rejection reason, and an artifact the launch classpath already provides is reported as
+     * shadowed rather than active - a swap that reports a new artifact as serving while parent-first
+     * delegation keeps serving another version is the one outcome an operator cannot debug.
+     *
+     * @param outcome the swap outcome
+     * @param report the per-artifact report to correct
+     */
+    private static void reportSwapOutcome(SwapOutcome outcome, List<ArtifactStatus> report) {
+        if (outcome.rejected()
+                   .isEmpty()
+                && outcome.shadowed()
+                          .isEmpty()) {
+            return;
+        }
+        Set<String> reported = new LinkedHashSet<>();
+        report.replaceAll(status -> {
+            String rejection = outcome.rejected()
+                                      .get(status.coordinate());
+            if (rejection != null) {
+                reported.add(status.coordinate());
+                return new ArtifactStatus(status.coordinate(), status.scope(), ArtifactStatus.STATUS_FAILED, rejection);
+            }
+            if (outcome.shadowed()
+                       .contains(status.coordinate())
+                    && ArtifactStatus.STATUS_ACTIVE.equals(status.status())) {
+                return new ArtifactStatus(status.coordinate(), status.scope(), ArtifactStatus.STATUS_SHADOWED,
+                        "The launch classpath (loader.path / LOADER_PATH) already carries this artifact - parent-first delegation serves"
+                                + " that copy, so the declared one is inert. Remove it from the launch classpath to let the declaration"
+                                + " take effect.");
+            }
+            return status;
+        });
+        outcome.rejected()
+               .forEach((coordinate, reason) -> {
+                   if (!reported.contains(coordinate)) {
+                       report.add(new ArtifactStatus(coordinate, ArtifactStatus.SCOPE_MODULE, ArtifactStatus.STATUS_FAILED, reason));
+                   }
+               });
     }
 
     /**

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesWatcher.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependenciesWatcher.java
@@ -9,28 +9,60 @@
  */
 package org.eclipse.dirigible.components.dependencies;
 
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Watches the registry's project.json maven declarations and runs the swap pipeline when they
  * change - so a published dependency change takes effect without a restart and without a manual
- * resolve call. The check is a cheap fingerprint comparison over the collected declarations; the
- * pipeline runs only on an actual change, so a persistently failing declaration is retried only
- * when it changes again.
+ * resolve call. The check is a cheap stamp comparison over the declaring resources, escalating to a
+ * fingerprint over the parsed declarations only when the stamp moved; the pipeline runs only on an
+ * actual change, and a pass that failed is retried on the service's own backoff.
+ *
+ * <p>
+ * The tick runs on a dedicated single-thread executor rather than Spring's shared
+ * {@code TaskScheduler}: one tick performs a maven resolution (network, subject to connect and read
+ * timeouts) and a full javac rebuild of the client codebase, and the shared scheduler's pool holds
+ * exactly one thread - which the security access-constraint refresh and the transpiler watchdog
+ * also run on. Blocking it for the duration of a resolve-and-rebuild would stop enforcing newly
+ * published {@code *.access} constraints.
  */
 @Component
 class DependenciesWatcher {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DependenciesWatcher.class);
 
+    /** The delay before the first tick - the boot-time resolution arms the watcher. */
+    private static final long INITIAL_DELAY_MILLIS = 10_000;
+
+    /** The delay between ticks. */
+    private static final long INTERVAL_MILLIS = 5_000;
+
+    /**
+     * Every so many ticks the declarations are collected even when the cheap stamp did not move - the
+     * stamp cannot distinguish two writes of equal size within one filesystem timestamp granularity, so
+     * a missed edit self-heals within a minute instead of waiting for the next change.
+     */
+    private static final int FULL_COLLECT_EVERY = 12;
+
     /** The dependencies service. */
     private final DependenciesService dependenciesService;
 
     /** The collector. */
     private final ProjectDependenciesCollector collector;
+
+    /** The watcher's own executor - never Spring's shared scheduler, see the class javadoc. */
+    private ScheduledExecutorService executor;
+
+    /** The tick counter behind {@link #FULL_COLLECT_EVERY}. */
+    private int ticks;
 
     /**
      * Instantiates a new dependencies watcher.
@@ -44,10 +76,43 @@ class DependenciesWatcher {
     }
 
     /**
+     * Starts the watch loop on the dedicated executor.
+     */
+    @PostConstruct
+    void start() {
+        executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "dirigible-dependencies-watcher");
+            thread.setDaemon(true);
+            return thread;
+        });
+        executor.scheduleWithFixedDelay(this::tick, INITIAL_DELAY_MILLIS, INTERVAL_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Stops the watch loop.
+     */
+    @PreDestroy
+    void stop() {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * One watch tick, guarded so a failure never kills the scheduled loop.
+     */
+    private void tick() {
+        try {
+            watch();
+        } catch (RuntimeException | Error e) {
+            LOGGER.error("The dependency watch tick failed", e);
+        }
+    }
+
+    /**
      * One watch tick. Armed only after the boot-time resolution recorded the first fingerprint, so the
      * watcher never races the startup sequence.
      */
-    @Scheduled(initialDelay = 10_000, fixedDelay = 5_000)
     void watch() {
         if (!dependenciesService.isDynamicEnabled() && !dependenciesService.isFrozen()) {
             return;
@@ -56,12 +121,20 @@ class DependenciesWatcher {
         if (last == null) {
             return;
         }
-        String current = collector.collect()
-                                  .fingerprint();
-        if (current.equals(last)) {
+        boolean retryDue = dependenciesService.isRetryDue();
+        boolean stampMoved = collector.declarationsMayHaveChanged();
+        boolean forceCollect = ++ticks % FULL_COLLECT_EVERY == 0;
+        if (!retryDue && !stampMoved && !forceCollect) {
+            // nothing under the registry's project.json files moved - no read, no parse, no log
             return;
         }
-        LOGGER.info("The registry's maven dependency declarations changed - running the swap pipeline");
+        if (!retryDue && collector.collect()
+                                  .fingerprint()
+                                  .equals(last)) {
+            return;
+        }
+        LOGGER.info(retryDue ? "Retrying the dependency swap pipeline after a failed pass"
+                : "The registry's maven dependency declarations changed - running the swap pipeline");
         try {
             dependenciesService.resolveAndActivate();
         } catch (RuntimeException e) {

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependencySynchronizer.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/DependencySynchronizer.java
@@ -95,8 +95,14 @@ class DependencySynchronizer {
      * @param error the abort reason, null when the swap succeeded or nothing changed
      * @param added the arrived coordinates
      * @param removed the left coordinates
+     * @param rejected the coordinates the module tier refused, with the reason - the rest of the
+     *        resolution still activated
+     * @param shadowed the arrived coordinates the launch classpath already provides, so parent-first
+     *        delegation keeps serving the launch-classpath version and the arrival is inert
+     * @param payloadError the registry-payload reconciliation failure, null when it succeeded
      */
-    record SwapOutcome(boolean swapped, String error, Set<String> added, Set<String> removed) {
+    record SwapOutcome(boolean swapped, String error, Set<String> added, Set<String> removed, Map<String, String> rejected,
+            Set<String> shadowed, String payloadError) {
 
         /**
          * Kept the current generation.
@@ -105,7 +111,17 @@ class DependencySynchronizer {
          * @return the outcome
          */
         static SwapOutcome kept(String error) {
-            return new SwapOutcome(false, error, Set.of(), Set.of());
+            return new SwapOutcome(false, error, Set.of(), Set.of(), Map.of(), Set.of(), null);
+        }
+
+        /**
+         * Kept the current generation, with per-declaration rejections to report.
+         *
+         * @param rejected the rejected coordinates and their reasons
+         * @return the outcome
+         */
+        static SwapOutcome kept(Map<String, String> rejected) {
+            return new SwapOutcome(false, null, Set.of(), Set.of(), rejected, Set.of(), null);
         }
     }
 
@@ -137,25 +153,21 @@ class DependencySynchronizer {
 
         ModulesClassLoader current = loaderHolder.current();
         Set<Path> currentJars = new LinkedHashSet<>(current.jars());
-        if (loaderHolder.generation() > 0 && currentJars.equals(new LinkedHashSet<>(target))) {
-            return SwapOutcome.kept(null);
-        }
-
         Set<Path> platformTier = new LinkedHashSet<>(platformJars);
-        List<Path> added = target.stream()
-                                 .filter(jar -> !currentJars.contains(jar))
-                                 .toList();
-        List<Path> removed = currentJars.stream()
-                                        .filter(jar -> !target.contains(jar))
-                                        .toList();
-        List<Path> addedModuleTier = added.stream()
-                                          .filter(jar -> !platformTier.contains(jar))
-                                          .toList();
+        Set<Path> launchTier = new LinkedHashSet<>(launchClasspathJars);
 
         // validate everything BEFORE the first side effect - an aborted swap leaves generation N
-        // installed and serving, with no partial state anywhere
+        // installed and serving, with no partial state anywhere. Only arriving module-tier jars are
+        // validated: a launch-classpath jar is already loaded by the application classloader, so
+        // vetoing it here would abort every swap for the lifetime of the process over a drop-in
+        // nobody declared.
         Map<Path, Inspection> inspections = new LinkedHashMap<>();
-        for (Path jar : addedModuleTier) {
+        Map<String, String> rejected = new LinkedHashMap<>();
+        Set<Path> rejectedJars = new LinkedHashSet<>();
+        for (Path jar : target) {
+            if (currentJars.contains(jar) || platformTier.contains(jar) || launchTier.contains(jar)) {
+                continue;
+            }
             Inspection inspection;
             try {
                 inspection = ModuleJarInspector.inspect(jar);
@@ -166,23 +178,57 @@ class DependencySynchronizer {
             }
             if (!inspection.nativeLibraries()
                            .isEmpty()) {
-                String error = "Jar [" + jar.getFileName() + "] contains native libraries " + inspection.nativeLibraries()
+                // per-declaration, not per-swap: one library shipping a native resource must not keep
+                // every other project's dependencies from ever activating
+                String reason = "Contains native libraries " + inspection.nativeLibraries()
                         + " which the swappable module tier cannot host (a native library binds to exactly one classloader)."
                         + " Declare it with scope \"platform\" instead, or bake it into the image.";
-                LOGGER.error("Dependency swap aborted: {}", error);
-                return SwapOutcome.kept(error);
+                LOGGER.error("Rejecting the module-tier dependency [{}]: {}", jar.getFileName(), reason);
+                rejected.put(coordinate(localRepository, jar), reason);
+                rejectedJars.add(jar);
+                continue;
             }
             inspections.put(jar, inspection);
         }
+        if (!rejectedJars.isEmpty()) {
+            target.removeAll(rejectedJars);
+            inspections.keySet()
+                       .removeAll(rejectedJars);
+        }
 
-        warnOnPlatformShadowing(inspections);
+        if (loaderHolder.generation() > 0 && currentJars.equals(new LinkedHashSet<>(target))) {
+            return SwapOutcome.kept(rejected);
+        }
+
+        List<Path> added = target.stream()
+                                 .filter(jar -> !currentJars.contains(jar))
+                                 .toList();
+        List<Path> removed = currentJars.stream()
+                                        .filter(jar -> !target.contains(jar))
+                                        .toList();
+        List<Path> addedModuleTier = added.stream()
+                                          .filter(jar -> !platformTier.contains(jar) && !launchTier.contains(jar))
+                                          .toList();
         List<Path> removedModuleTier = removed.stream()
-                                              .filter(jar -> !platformTier.contains(jar))
+                                              .filter(jar -> !platformTier.contains(jar) && !launchTier.contains(jar))
                                               .toList();
-        reconcileRegistryPayload(addedModuleTier, removedModuleTier, inspections);
 
+        Set<Path> shadowedJars = shadowedByLaunchClasspath(inspections);
+
+        // the classloader generation is the authoritative half of the swap and is installed first;
+        // the registry payload follows, guarded - a repository write failure must not leave the
+        // pipeline reporting a 500 with a half-removed payload and no new generation
         loaderHolder.swap(target);
         int generation = loaderHolder.generation();
+        String payloadError = null;
+        try {
+            reconcileRegistryPayload(addedModuleTier, removedModuleTier, inspections);
+        } catch (RuntimeException e) {
+            payloadError = "The dependency layer swapped to generation [" + generation
+                    + "], but reconciling the registry payload failed - some module content may be missing or stale. Cause: "
+                    + e.getMessage();
+            LOGGER.error("Registry payload reconciliation failed after the swap to generation [{}]", generation, e);
+        }
 
         Set<String> addedCoordinates = coordinates(localRepository, added);
         Set<String> removedCoordinates = coordinates(localRepository, removed);
@@ -191,70 +237,78 @@ class DependencySynchronizer {
                     removedCoordinates);
             eventPublisher.publishEvent(new DependenciesChangedEvent(this, addedCoordinates, removedCoordinates, mediated, generation));
         }
-        return new SwapOutcome(true, null, addedCoordinates, removedCoordinates);
+        return new SwapOutcome(true, null, addedCoordinates, removedCoordinates, rejected,
+                coordinates(localRepository, List.copyOf(shadowedJars)), payloadError);
     }
 
     /**
-     * Removes the registry payload of leaving JARs and lays the payload of arriving ones. A project
-     * carried by a JAR that stays is never removed, and an upgraded module's project is removed and
-     * immediately re-laid from the new JAR.
+     * Removes the registry payload of leaving JARs and lays the payload of arriving ones. Only the
+     * entries a leaving JAR actually carried are removed, and only those no remaining JAR still carries
+     * - an upgrade is a remove followed by a re-expand, so removing the whole project collection would
+     * destroy whatever else was published under it.
      *
      * @param added the arriving jars
      * @param removed the leaving jars
      * @param inspections the arriving jars' inspections
      */
     private void reconcileRegistryPayload(List<Path> added, List<Path> removed, Map<Path, Inspection> inspections) {
-        Set<String> removedProjects = new LinkedHashSet<>();
+        Set<String> removedEntries = new LinkedHashSet<>();
         for (Path jar : removed) {
             try {
-                removedProjects.addAll(ModuleJarInspector.inspect(jar)
-                                                         .projects());
+                removedEntries.addAll(ModuleJarInspector.inspect(jar)
+                                                        .registryEntries());
             } catch (IOException e) {
                 // the immutable local-repo file was deleted externally - its payload cannot be
                 // attributed any more; the per-artefact synchronizers will reap orphans over time
                 LOGGER.warn("Cannot inspect the removed jar [{}] for its registry payload", jar, e);
             }
         }
-        if (!removedProjects.isEmpty()) {
-            // a project is only removed when NO remaining jar still carries it
+        if (!removedEntries.isEmpty()) {
+            // an entry is only removed when NO remaining jar still carries it
             ModulesClassLoader current = loaderHolder.current();
             for (Path staying : current.jars()) {
                 if (removed.contains(staying) || !Files.isRegularFile(staying)) {
                     continue;
                 }
                 try {
-                    removedProjects.removeAll(ModuleJarInspector.inspect(staying)
-                                                                .projects());
+                    removedEntries.removeAll(ModuleJarInspector.inspect(staying)
+                                                               .registryEntries());
                 } catch (IOException e) {
                     LOGGER.warn("Cannot inspect the staying jar [{}] while removing registry payload", staying, e);
                 }
             }
-            removedProjects.forEach(classpathExpander::remove);
+            classpathExpander.remove(removedEntries);
         }
         for (Path jar : added) {
-            if (!inspections.get(jar)
-                            .projects()
-                            .isEmpty()) {
+            Inspection inspection = inspections.get(jar);
+            if (inspection != null && !inspection.projects()
+                                                 .isEmpty()) {
                 classpathExpander.expand(jar);
             }
         }
     }
 
     /**
-     * WARN when an arriving artifact is also present on the platform classpath - parent-first
-     * delegation resolves such classes to the platform's version, so the declared version is inert.
+     * The arriving artifacts the launch classpath already provides - parent-first delegation resolves
+     * such classes to the launch-classpath version, so the declared one never serves. Reported as
+     * {@code shadowed} rather than active: a swap that silently changed nothing is the one outcome an
+     * operator cannot debug.
      *
      * @param inspections the arriving jars' inspections
+     * @return the shadowed jars
      */
-    private void warnOnPlatformShadowing(Map<Path, Inspection> inspections) {
+    private Set<Path> shadowedByLaunchClasspath(Map<Path, Inspection> inspections) {
+        Set<Path> shadowed = new LinkedHashSet<>();
         ClassLoader platform = getClass().getClassLoader();
         inspections.forEach((jar, inspection) -> {
             String probe = inspection.representativeClassResource();
             if (probe != null && platform.getResource(probe) != null) {
-                LOGGER.warn("The resolved artifact [{}] is also present on the platform classpath - parent-first delegation serves "
-                        + "the platform's version, not the declared one", jar.getFileName());
+                shadowed.add(jar);
+                LOGGER.warn("The resolved artifact [{}] is also present on the launch classpath - parent-first delegation serves "
+                        + "that version, not the declared one; the arrival is inert", jar.getFileName());
             }
         });
+        return shadowed;
     }
 
     /**

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ModuleJarInspector.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ModuleJarInspector.java
@@ -30,17 +30,32 @@ final class ModuleJarInspector {
     /**
      * The inspection result.
      *
-     * @param projects the projects carried under META-INF/dirigible
-     * @param nativeLibraries the native library entries (.so / .dylib / .dll), empty for a loadable
-     *        module jar
+     * @param projects the projects carried under META-INF/dirigible - empty when the jar carries the
+     *        {@code .skip} marker, because then nothing of it is laid into the registry
+     * @param registryEntries the registry-relative paths the jar lays down, in
+     *        {@code /<project>/<path>} form - the exact set {@link #projects()} is derived from, and
+     *        the granularity at which the payload is removed again
+     * @param nativeLibraries the native library entries (.so / .so.N / .dylib / .jnilib / .dll), empty
+     *        for a loadable module jar
      * @param representativeClassResource a class entry usable to probe whether the parent classpath
      *        already carries this artifact, null when the jar has no classes
      */
-    record Inspection(Set<String> projects, List<String> nativeLibraries, String representativeClassResource) {
+    record Inspection(Set<String> projects, Set<String> registryEntries, List<String> nativeLibraries, String representativeClassResource) {
     }
 
     /** The registry payload root inside a jar. */
     private static final String DIRIGIBLE_ROOT = "META-INF/dirigible/";
+
+    /** The marker that opts a jar out of the registry expansion entirely. */
+    private static final String SKIP_MARKER = DIRIGIBLE_ROOT + ".skip";
+
+    /**
+     * A native library entry: the platform suffixes plus the versioned ELF form ({@code libfoo.so.1}).
+     * A jar carrying one cannot live on the swappable module tier - the JVM binds a native library to
+     * exactly one classloader.
+     */
+    private static final java.util.regex.Pattern NATIVE_LIBRARY = java.util.regex.Pattern.compile(
+            ".*(\\.so|\\.so(\\.\\d+)+|\\.dylib|\\.jnilib|\\.dll)$", java.util.regex.Pattern.CASE_INSENSITIVE);
 
     /**
      * A registry project name must be a plain path segment - no dots-only names, no separators - so it
@@ -64,9 +79,14 @@ final class ModuleJarInspector {
      */
     static Inspection inspect(Path jarPath) throws IOException {
         Set<String> projects = new LinkedHashSet<>();
+        Set<String> registryEntries = new LinkedHashSet<>();
         List<String> nativeLibraries = new ArrayList<>();
         String representativeClassResource = null;
         try (JarFile jar = new JarFile(jarPath.toFile())) {
+            // the .skip marker opts the jar out of the registry expansion (ClasspathExpander honors it
+            // too) - such a jar carries NO projects, so its removal must not delete a registry
+            // collection it never created
+            boolean skipped = jar.getJarEntry(SKIP_MARKER) != null;
             Enumeration<JarEntry> entries = jar.entries();
             while (entries.hasMoreElements()) {
                 JarEntry entry = entries.nextElement();
@@ -75,6 +95,9 @@ final class ModuleJarInspector {
                 }
                 String name = entry.getName();
                 if (name.startsWith(DIRIGIBLE_ROOT)) {
+                    if (skipped) {
+                        continue;
+                    }
                     String rest = name.substring(DIRIGIBLE_ROOT.length());
                     int slash = rest.indexOf('/');
                     if (slash > 0) {
@@ -91,8 +114,10 @@ final class ModuleJarInspector {
                                     + project + "] under META-INF/dirigible/ - refusing the jar");
                         }
                         projects.add(project);
+                        registryEntries.add("/" + rest);
                     }
-                } else if (name.endsWith(".so") || name.endsWith(".dylib") || name.endsWith(".dll")) {
+                } else if (NATIVE_LIBRARY.matcher(name)
+                                         .matches()) {
                     nativeLibraries.add(name);
                 } else if (representativeClassResource == null && name.endsWith(".class") && !name.startsWith("META-INF/")
                         && !"module-info.class".equals(name)) {
@@ -100,7 +125,7 @@ final class ModuleJarInspector {
                 }
             }
         }
-        return new Inspection(projects, nativeLibraries, representativeClassResource);
+        return new Inspection(projects, registryEntries, nativeLibraries, representativeClassResource);
     }
 
 }

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ProjectDependenciesCollector.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ProjectDependenciesCollector.java
@@ -13,6 +13,7 @@ import org.eclipse.dirigible.components.project.ProjectMetadata;
 import org.eclipse.dirigible.components.project.ProjectMetadataDependency;
 import org.eclipse.dirigible.components.project.ProjectMetadataUtils;
 import org.eclipse.dirigible.repository.api.ICollection;
+import org.eclipse.dirigible.repository.api.IEntityInformation;
 import org.eclipse.dirigible.repository.api.IRepository;
 import org.eclipse.dirigible.repository.api.IRepositoryStructure;
 import org.eclipse.dirigible.repository.api.IResource;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -44,6 +46,12 @@ class ProjectDependenciesCollector {
 
     /** The diagnostics the previous collection reported, joined - see {@link #report(List)}. */
     private final AtomicReference<String> reported = new AtomicReference<>("");
+
+    /**
+     * The stamp of the declaring resources at the previous check - see
+     * {@link #declarationsMayHaveChanged()}.
+     */
+    private final AtomicReference<String> stamped = new AtomicReference<>("");
 
     /**
      * Instantiates a new collector.
@@ -72,6 +80,58 @@ class ProjectDependenciesCollector {
         }
         report(notices);
         return new DeclaredDependencies(dependencies, errors, declaredBy);
+    }
+
+    /**
+     * A cheap change probe for the watcher: whether anything about the registry's {@code project.json}
+     * files moved since the last call. Reading and JSON-parsing every project descriptor a few times a
+     * minute is real work on a database-backed repository with hundreds of projects, and the watch tick
+     * needs none of it while nothing changes - it only needs to know whether to look.
+     *
+     * <p>
+     * Conservative by construction: when the repository cannot report the metadata, the answer is
+     * "maybe", and the caller collects. The stamp cannot distinguish two writes of equal size within
+     * one filesystem timestamp granularity, so the watcher additionally forces a full collection
+     * periodically.
+     *
+     * @return true when the declarations may have changed
+     */
+    boolean declarationsMayHaveChanged() {
+        String stamp = declarationStamp();
+        return stamp == null || !stamp.equals(stamped.getAndSet(stamp));
+    }
+
+    /**
+     * The stamp of every registry project's {@code project.json} - path, size and modification time.
+     *
+     * @return the stamp, null when the repository cannot report it
+     */
+    private String declarationStamp() {
+        try {
+            StringBuilder stamp = new StringBuilder();
+            ICollection registry = repository.getCollection(IRepositoryStructure.PATH_REGISTRY_PUBLIC);
+            if (!registry.exists()) {
+                return "";
+            }
+            for (ICollection project : registry.getCollections()) {
+                IResource descriptor = project.getResource(ProjectMetadata.PROJECT_METADATA_FILE_NAME);
+                if (!descriptor.exists()) {
+                    continue;
+                }
+                IEntityInformation information = descriptor.getInformation();
+                Date modifiedAt = information.getModifiedAt();
+                stamp.append(project.getName())
+                     .append('|')
+                     .append(information.getSize())
+                     .append('|')
+                     .append(modifiedAt == null ? "?" : modifiedAt.getTime())
+                     .append(';');
+            }
+            return stamp.toString();
+        } catch (RuntimeException e) {
+            LOGGER.debug("Cannot stamp the registry's dependency declarations - collecting them instead", e);
+            return null;
+        }
     }
 
     /**

--- a/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ResolvedModulesLinker.java
+++ b/components/core/core-dependencies/src/main/java/org/eclipse/dirigible/components/dependencies/ResolvedModulesLinker.java
@@ -26,10 +26,17 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 /**
- * Maintains the resolved-modules directory - the stable directory the launch classpath includes
- * (see the loader.path entry in the application's Dockerfile). At runtime the resolved jars are
- * served by the swappable modules classloader; this directory is the seed that keeps them on the
- * classpath from the first moment of the next launch.
+ * Maintains the resolved-modules directory - the stable, operator-visible inventory of what the
+ * declarations currently resolve to, one link per activated artifact.
+ *
+ * <p>
+ * It is deliberately <b>not</b> a launch-classpath entry. The resolved jars are served by the
+ * swappable modules classloader, which the boot-time resolution installs; putting this directory on
+ * {@code loader.path} would also define those classes on the application classloader, and since the
+ * modules classloader is parent-first, every later upgrade and removal would resolve to that first,
+ * stale copy - the swap would report a new generation while nothing about the served classes
+ * changed. An instance that must come up without a remote repository uses frozen mode over the
+ * local maven repository instead.
  */
 @Component
 class ResolvedModulesLinker {

--- a/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/DependencySwapTest.java
+++ b/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/DependencySwapTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.dependencies;
+
+import org.eclipse.dirigible.components.dependencies.DependencySynchronizer.SwapOutcome;
+import org.eclipse.dirigible.components.initializers.classpath.ClasspathExpander;
+import org.eclipse.dirigible.engine.java.runtime.ModulesClassLoaderHolder;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.repository.local.LocalRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * What the swap does to the running system beyond installing a generation: which declarations it
+ * refuses, and how much of the registry a leaving or upgraded module takes with it.
+ */
+class DependencySwapTest {
+
+    @TempDir
+    Path tempDir;
+
+    private IRepository repository;
+    private ModulesClassLoaderHolder loaderHolder;
+    private DependencySynchronizer synchronizer;
+    private Path localRepository;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        repository = new LocalRepository(tempDir.resolve("repository")
+                                                .toString(),
+                true);
+        loaderHolder = new ModulesClassLoaderHolder();
+        synchronizer = new DependencySynchronizer(loaderHolder, new ClasspathExpander(repository), event -> {
+        });
+        localRepository = Files.createDirectories(tempDir.resolve("m2"));
+    }
+
+    @Test
+    void aNativeLibraryRejectsOnlyItsOwnDeclaration() throws IOException {
+        Path plain = artifact("com.example", "plain", "1.0.0", Map.of("com/example/Plain.class", "bytes"));
+        Path nativeBearing = artifact("com.example", "sqlite", "1.0.0", Map.of("org/sqlite/native/libsqlite.so", "bytes"));
+
+        SwapOutcome outcome = synchronizer.swap(localRepository, List.of(plain, nativeBearing), List.of(), Map.of());
+
+        // the offending coordinate is refused; every other project's dependency still activates -
+        // one library shipping a native resource must not block the whole instance
+        assertThat(outcome.swapped()).isTrue();
+        assertThat(outcome.error()).isNull();
+        assertThat(outcome.rejected()).containsOnlyKeys("com.example:sqlite:1.0.0");
+        assertThat(outcome.rejected()
+                          .get("com.example:sqlite:1.0.0")).contains("platform");
+        assertThat(loaderHolder.current()
+                               .jars()).containsExactly(plain);
+    }
+
+    @Test
+    void anUpgradeKeepsWhatTheModuleDidNotPublish() throws IOException {
+        Path version1 = artifact("com.example", "mod", "1.0.0", Map.of("META-INF/dirigible/mod/greeting.txt", "v1"));
+        Path version2 = artifact("com.example", "mod", "1.1.0", Map.of("META-INF/dirigible/mod/greeting.txt", "v2"));
+
+        synchronizer.swap(localRepository, List.of(version1), List.of(), Map.of());
+        // a customization published into the module's project folder, by a developer or another tool
+        repository.createResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/mod/mine.txt", "mine".getBytes(StandardCharsets.UTF_8));
+
+        synchronizer.swap(localRepository, List.of(version2), List.of(), Map.of());
+
+        assertThat(content("/mod/greeting.txt")).isEqualTo("v2");
+        assertThat(content("/mod/mine.txt")).isEqualTo("mine");
+    }
+
+    @Test
+    void aRemovedModuleTakesOnlyItsOwnPayload() throws IOException {
+        Path mod = artifact("com.example", "mod", "1.0.0", Map.of("META-INF/dirigible/mod/greeting.txt", "v1"));
+        synchronizer.swap(localRepository, List.of(mod), List.of(), Map.of());
+        repository.createResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/mod/mine.txt", "mine".getBytes(StandardCharsets.UTF_8));
+
+        synchronizer.swap(localRepository, List.of(), List.of(), Map.of());
+
+        assertThat(repository.hasResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/mod/greeting.txt")).isFalse();
+        assertThat(content("/mod/mine.txt")).isEqualTo("mine");
+    }
+
+    @Test
+    void aSkippedJarNeverRemovesAProjectOfTheSameName() throws IOException {
+        Path skipped = artifact("com.example", "skipped", "1.0.0",
+                Map.of("META-INF/dirigible/.skip", "", "META-INF/dirigible/mine/hidden.txt", "never laid down"));
+        synchronizer.swap(localRepository, List.of(skipped), List.of(), Map.of());
+        // a developer's own project that happens to carry the same name as the jar's skipped payload
+        repository.createResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/mine/file.txt", "mine".getBytes(StandardCharsets.UTF_8));
+
+        synchronizer.swap(localRepository, List.of(), List.of(), Map.of());
+
+        assertThat(content("/mine/file.txt")).isEqualTo("mine");
+    }
+
+    private String content(String registryRelativePath) {
+        return new String(repository.getResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + registryRelativePath)
+                                    .getContent(),
+                StandardCharsets.UTF_8);
+    }
+
+    private Path artifact(String groupId, String artifactId, String version, Map<String, String> entries) throws IOException {
+        Path directory = Files.createDirectories(localRepository.resolve(groupId.replace('.', '/'))
+                                                                .resolve(artifactId)
+                                                                .resolve(version));
+        Path jar = directory.resolve(artifactId + "-" + version + ".jar");
+        try (OutputStream file = Files.newOutputStream(jar); JarOutputStream out = new JarOutputStream(file)) {
+            for (Map.Entry<String, String> entry : entries.entrySet()) {
+                out.putNextEntry(new JarEntry(entry.getKey()));
+                out.write(entry.getValue()
+                               .getBytes(StandardCharsets.UTF_8));
+                out.closeEntry();
+            }
+        }
+        return jar;
+    }
+
+}

--- a/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/ModuleJarInspectorTest.java
+++ b/components/core/core-dependencies/src/test/java/org/eclipse/dirigible/components/dependencies/ModuleJarInspectorTest.java
@@ -64,6 +64,45 @@ class ModuleJarInspectorTest {
                 "a backslash-bearing name is a path on Windows and must never pass inspection");
     }
 
+    @Test
+    void theRegistryEntriesAreReportedPerFile() throws IOException {
+        Path jar = jarWithEntries("META-INF/dirigible/my-project/file.txt", "META-INF/dirigible/my-project/sub/other.txt");
+
+        ModuleJarInspector.Inspection inspection = ModuleJarInspector.inspect(jar);
+
+        // the removal granularity: only what the jar laid down leaves again, never the whole project
+        assertEquals(Set.of("/my-project/file.txt", "/my-project/sub/other.txt"), inspection.registryEntries(),
+                "every payload entry should be reported");
+    }
+
+    @Test
+    void aSkippedJarCarriesNoProjects() throws IOException {
+        Path jar = jarWithEntries("META-INF/dirigible/.skip", "META-INF/dirigible/my-project/file.txt");
+
+        ModuleJarInspector.Inspection inspection = ModuleJarInspector.inspect(jar);
+
+        // the expansion honors .skip, so nothing of this jar is ever in the registry - reporting the
+        // project would make its removal delete a collection the jar never created (possibly a
+        // developer's own project of that name)
+        assertTrue(inspection.projects()
+                             .isEmpty(),
+                "a .skip jar lays nothing down, so it carries no projects");
+        assertTrue(inspection.registryEntries()
+                             .isEmpty(),
+                "a .skip jar lays nothing down, so it has no registry entries");
+    }
+
+    @Test
+    void versionedAndAppleNativeLibrariesAreDetected() throws IOException {
+        Path jar = jarWithEntries("lib/libfoo.so.1", "lib/libbar.jnilib", "lib/baz.DLL");
+
+        ModuleJarInspector.Inspection inspection = ModuleJarInspector.inspect(jar);
+
+        assertEquals(3, inspection.nativeLibraries()
+                                  .size(),
+                "the versioned, the Apple and the upper-case Windows form are all native libraries: " + inspection.nativeLibraries());
+    }
+
     private Path jarWithEntries(String... entryNames) throws IOException {
         Path jar = tempDir.resolve("module.jar");
         try (OutputStream file = Files.newOutputStream(jar); JarOutputStream out = new JarOutputStream(file)) {

--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/classpath/ClasspathExpander.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/classpath/ClasspathExpander.java
@@ -11,6 +11,7 @@ package org.eclipse.dirigible.components.initializers.classpath;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.eclipse.dirigible.repository.api.ICollection;
 import org.eclipse.dirigible.repository.api.IRepository;
 import org.eclipse.dirigible.repository.api.IRepositoryStructure;
 import org.slf4j.Logger;
@@ -25,8 +26,12 @@ import java.net.JarURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -133,18 +138,72 @@ public class ClasspathExpander {
     }
 
     /**
-     * Removes a project's content from the registry - the inverse of {@link #expand(Path)}, used when
-     * the module jar carrying the project leaves the running system. The per-artefact synchronizers
-     * clean up the runtime state of the removed files on their next pass.
+     * Removes the given registry paths - the inverse of {@link #expand(Path)}, used when the module jar
+     * carrying them leaves the running system. Only the resources the leaving jar actually carried are
+     * deleted (an upgrade is a remove followed by a re-expand, so deleting the whole project collection
+     * would destroy anything else published under it), and a collection left empty by the removal is
+     * pruned up to - but never including - the registry root. The per-artefact synchronizers clean up
+     * the runtime state of the removed files on their next pass.
      *
-     * @param project the project name directly under the registry root
+     * @param registryPaths the registry-relative paths, in {@code /<project>/<path>} form
      */
-    public void remove(String project) {
-        String path = IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepository.SEPARATOR + project;
-        if (repository.hasCollection(path)) {
-            repository.removeCollection(path);
-            LOGGER.info("Removed the registry content of project [{}]", project);
+    public void remove(Collection<String> registryPaths) {
+        Set<String> emptyCandidates = new LinkedHashSet<>();
+        int removed = 0;
+        for (String registryPath : registryPaths) {
+            String path = IRepositoryStructure.PATH_REGISTRY_PUBLIC + normalized(registryPath);
+            if (repository.hasResource(path)) {
+                repository.removeResource(path);
+                removed++;
+            }
+            int slash = path.lastIndexOf(IRepository.SEPARATOR.charAt(0));
+            if (slash > 0) {
+                emptyCandidates.add(path.substring(0, slash));
+            }
         }
+        pruneEmptyCollections(emptyCandidates);
+        if (removed > 0) {
+            LOGGER.info("Removed [{}] registry resource(s) laid down by a leaving module jar", removed);
+        }
+    }
+
+    /**
+     * Removes the collections left empty by a payload removal, walking upwards while the parent is
+     * itself empty. The registry root is never removed.
+     *
+     * @param candidates the collections to check
+     */
+    private void pruneEmptyCollections(Set<String> candidates) {
+        for (String candidate : candidates) {
+            String path = candidate;
+            while (path.length() > IRepositoryStructure.PATH_REGISTRY_PUBLIC.length() && repository.hasCollection(path)) {
+                ICollection collection = repository.getCollection(path);
+                if (!collection.getChildren()
+                               .isEmpty()) {
+                    break;
+                }
+                repository.removeCollection(path);
+                int slash = path.lastIndexOf(IRepository.SEPARATOR.charAt(0));
+                if (slash <= 0) {
+                    break;
+                }
+                path = path.substring(0, slash);
+            }
+        }
+    }
+
+    /**
+     * The registry-relative path with exactly one leading separator.
+     *
+     * @param registryPath the path
+     * @return the normalized path
+     */
+    private static String normalized(String registryPath) {
+        String path = registryPath;
+        while (path.startsWith(IRepository.SEPARATOR)) {
+            path = path.substring(1);
+        }
+        return IRepository.SEPARATOR + path;
     }
 
     /**
@@ -176,9 +235,17 @@ public class ClasspathExpander {
                     while (relative.startsWith("/")) {
                         relative = relative.substring(1);
                     }
-                    Path target = relative.isEmpty() || relative.indexOf('\\') >= 0 ? null
-                            : registryRoot.resolve(relative)
-                                          .normalize();
+                    // Path parsing is platform-dependent: on Windows an entry name carrying ':', '?',
+                    // '*' or '"' throws InvalidPathException, which would otherwise abort the whole
+                    // sweep (or the whole swap) over one skippable entry
+                    Path target;
+                    try {
+                        target = relative.isEmpty() || relative.indexOf('\\') >= 0 ? null
+                                : registryRoot.resolve(relative)
+                                              .normalize();
+                    } catch (InvalidPathException e) {
+                        target = null;
+                    }
                     if (target == null || !target.startsWith(registryRoot) || target.equals(registryRoot)) {
                         LOGGER.warn("Skipping the jar entry [{}] - its path would escape the registry root", entry.getName()
                                                                                                                   .replace('\r', '_')

--- a/components/core/core-initializers/src/test/java/org/eclipse/dirigible/components/initializers/classpath/ClasspathExpanderTest.java
+++ b/components/core/core-initializers/src/test/java/org/eclipse/dirigible/components/initializers/classpath/ClasspathExpanderTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -47,7 +48,7 @@ class ClasspathExpanderTest {
     }
 
     @Test
-    void expands_a_single_jar_into_the_registry_and_removes_its_project() throws IOException {
+    void expands_a_single_jar_into_the_registry_and_removes_its_entries() throws IOException {
         Path jar = jarWithEntries("module.jar",
                 Map.of("META-INF/dirigible/my-module/hello.txt", "payload", "META-INF/dirigible/my-module/sub/nested.txt", "nested"));
 
@@ -56,11 +57,29 @@ class ClasspathExpanderTest {
         assertThat(resourceContent("/my-module/hello.txt")).isEqualTo("payload");
         assertThat(resourceContent("/my-module/sub/nested.txt")).isEqualTo("nested");
 
-        expander.remove("my-module");
+        List<String> entries = List.of("/my-module/hello.txt", "/my-module/sub/nested.txt");
+        expander.remove(entries);
 
+        // the entries are gone and the collections they left empty are pruned
         assertThat(repository.hasCollection(IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/my-module")).isFalse();
-        // removing an absent project is a no-op, not an error
-        expander.remove("my-module");
+        // removing absent entries is a no-op, not an error
+        expander.remove(entries);
+    }
+
+    @Test
+    void removing_a_jars_entries_keeps_the_rest_of_the_project() throws IOException {
+        Path jar = jarWithEntries("module.jar", Map.of("META-INF/dirigible/my-module/hello.txt", "payload"));
+        expander.expand(jar);
+        // something else published into the same project folder - a customization, an extension, or
+        // simply a developer's own file. An upgrade removes and re-expands the module, so a
+        // project-wide removal would destroy it.
+        repository.createResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/my-module/mine.txt",
+                "mine".getBytes(StandardCharsets.UTF_8));
+
+        expander.remove(List.of("/my-module/hello.txt"));
+
+        assertThat(repository.hasResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/my-module/hello.txt")).isFalse();
+        assertThat(resourceContent("/my-module/mine.txt")).isEqualTo("mine");
     }
 
     @Test

--- a/components/engine/engine-java/CLAUDE.md
+++ b/components/engine/engine-java/CLAUDE.md
@@ -67,6 +67,12 @@ classes at the jar ROOT are injected by the build itself, with the nested jars k
   honors it natively, so there is no `DIRIGIBLE_*` property for this.
 - `ClassPathIndex` appends the same `loader.path` / `LOADER_PATH` jars to the **compile** classpath, so
   registry sources can still be compiled against a drop-in module's classes.
+- **Never put the resolved-modules directory (`DIRIGIBLE_DEPENDENCIES_DIR`) on `loader.path`.** Those
+  jars are served by the swappable `ModulesClassLoader`, which is parent-first: with the same jars also
+  on the application classloader, an upgrade or a removal resolves to the launch-classpath copy and the
+  swap silently changes nothing. The pipeline detects the case and reports such an artifact as
+  `shadowed` rather than `active`, but the only fix is to keep the directory off the launch classpath
+  (the shipped `Dockerfile` does).
 
 ## The bean container (`ComponentContainer`, `engine-java`)
 

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/CompiledModuleClassProvider.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/CompiledModuleClassProvider.java
@@ -98,14 +98,38 @@ public class CompiledModuleClassProvider {
      * @param classLoader the classloader to scan and load through
      */
     public synchronized void rediscover(ClassLoader classLoader) {
+        rediscover(classLoader, /* dispatch */ true);
+    }
+
+    /**
+     * Re-runs compiled-module discovery through the given classloader and installs the result as the
+     * compiled sub-generation, either dispatching it right away or only recording it.
+     *
+     * <p>
+     * The dependency swap pipeline records without dispatching: the client-source rebuild that follows
+     * it in the same reaction dispatches the union itself, over a {@code ClientClassLoader} parented on
+     * the freshly installed modules generation. Dispatching here too would run the whole generation
+     * dispatch twice per swap - and the first pass would run against the retired dependency jars.
+     *
+     * @param classLoader the classloader to scan and load through
+     * @param dispatch whether the discovered set is dispatched to the consumers right away
+     * @return whether anything was installed or recorded
+     */
+    public synchronized boolean rediscover(ClassLoader classLoader, boolean dispatch) {
         List<LoadedClass> classes = discover(classLoader);
         if (classes.isEmpty() && !installedBefore) {
-            return;
+            return false;
         }
         installedBefore = !classes.isEmpty();
-        javaLoader.installCompiledModules(classes);
+        if (dispatch) {
+            javaLoader.installCompiledModules(classes);
+        } else {
+            javaLoader.recordCompiledModules(classes);
+        }
         LOGGER.info("Registered [{}] class(es) from AOT compiled module(s) on the classpath", classes.size());
+        return true;
     }
+
 
     /**
      * Scan the classpath of the given classloader for {@code .compiled} markers and load every listed

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/JavaLoader.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/JavaLoader.java
@@ -259,12 +259,7 @@ public class JavaLoader {
      *         since the previous compiled install; never registry-source classes)
      */
     public synchronized Set<String> installCompiledModules(List<LoadedClass> classes) {
-        compiledGeneration.clear();
-        for (LoadedClass info : classes) {
-            if (info != null) {
-                compiledGeneration.put(info.fqn(), info);
-            }
-        }
+        recordCompiledModules(classes);
         // No runtime-compiled client code yet → give the holder an empty ClientClassLoader whose parent
         // chain (modules loader → platform classloader) already resolves the compiled-module classes.
         ClientClassLoader loader = loaderHolder.current();
@@ -272,6 +267,25 @@ public class JavaLoader {
             loader = new ClientClassLoader(modulesLoaderHolder.current(), Map.of());
         }
         return applyGeneration(mergedGeneration(), loader);
+    }
+
+    /**
+     * Records the compiled sub-generation <b>without</b> dispatching it - the half of
+     * {@link #installCompiledModules(List)} that a caller uses when a {@link #rebuild(List)} is about
+     * to follow: the rebuild's own {@code applyGeneration} then dispatches the union once, over a
+     * {@code ClientClassLoader} parented on the new modules generation. Dispatching here as well would
+     * re-instantiate every client bean and re-register every job, listener, controller mapping and
+     * websocket twice per swap, the first time against the retired dependency jars.
+     *
+     * @param classes the compiled modules' top-level classes
+     */
+    public synchronized void recordCompiledModules(List<LoadedClass> classes) {
+        compiledGeneration.clear();
+        for (LoadedClass info : classes) {
+            if (info != null) {
+                compiledGeneration.put(info.fqn(), info);
+            }
+        }
     }
 
     /**

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/synchronizer/JavaDependenciesChangedListener.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/synchronizer/JavaDependenciesChangedListener.java
@@ -25,6 +25,10 @@ import org.springframework.stereotype.Component;
  * client sources so the new {@code ClientClassLoader} generation parents on the new modules
  * classloader. Runs synchronously on the swapping thread - the swap pipeline's success includes
  * this reaction.
+ *
+ * <p>
+ * The AOT rediscovery only <b>records</b> its result: the client rebuild that follows dispatches
+ * the union to the consumers exactly once, over a correctly parented loader.
  */
 @Component
 class JavaDependenciesChangedListener {
@@ -69,8 +73,16 @@ class JavaDependenciesChangedListener {
         LOGGER.info("Dependency layer swapped to generation [{}] (added {}, removed {}) - rediscovering AOT modules and rebuilding "
                 + "the client sources", event.getGeneration(), event.getAdded(), event.getRemoved());
         classPathIndex.invalidate();
-        compiledModuleClassProvider.rediscover(modulesLoaderHolder.current());
-        javaSynchronizer.rebuildOnDependenciesChanged();
+        // record only: the rebuild below dispatches the union of the AOT and registry-compiled sets
+        // once, over a ClientClassLoader parented on the new modules generation. Dispatching here as
+        // well would re-instantiate every client bean and re-register every job, JMS listener,
+        // controller mapping and websocket twice per swap - the first time against the retired jars.
+        boolean recorded = compiledModuleClassProvider.rediscover(modulesLoaderHolder.current(), /* dispatch */ false);
+        if (!javaSynchronizer.rebuildOnDependenciesChanged() && recorded) {
+            // the rebuild deferred itself to the next synchronization cycle - dispatch the recorded
+            // compiled set now, so an arriving AOT module never waits for it
+            compiledModuleClassProvider.rediscover(modulesLoaderHolder.current());
+        }
     }
 
 }

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/synchronizer/JavaSynchronizer.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/synchronizer/JavaSynchronizer.java
@@ -222,12 +222,15 @@ public class JavaSynchronizer extends BaseSynchronizer<JavaFile, Long> {
      * dependency-layer swap, so client sources compile against the new JAR set and the new
      * {@code ClientClassLoader} generation parents on the new modules classloader. {@code JavaLoader}'s
      * own synchronization serializes this with a concurrently running pass.
+     *
+     * @return whether a generation was installed - false when the rebuild deferred itself to the next
+     *         cycle, in which case the caller still owes the dispatch of whatever it recorded
      */
-    void rebuildOnDependenciesChanged() {
-        rebuildAll();
+    boolean rebuildOnDependenciesChanged() {
+        return rebuildAll();
     }
 
-    private void rebuildAll() {
+    private boolean rebuildAll() {
         List<JavaFile> all = javaFileService.getAll();
         List<JavaLoader.ClientSource> sources = new ArrayList<>(all.size());
         for (JavaFile file : all) {
@@ -242,7 +245,7 @@ public class JavaSynchronizer extends BaseSynchronizer<JavaFile, Long> {
                 LOGGER.info("Java source [{}] is registered but currently missing - deferring the rebuild to the next cycle",
                         file.getLocation());
                 dirty.set(true);
-                return;
+                return false;
             }
             byte[] bytes;
             try {
@@ -292,6 +295,7 @@ public class JavaSynchronizer extends BaseSynchronizer<JavaFile, Long> {
                 clearCompilationProblems(file.getLocation());
             }
         }
+        return true;
     }
 
     /**

--- a/components/ide/ide-java-lsp/src/main/java/org/eclipse/dirigible/components/ide/lsp/java/process/JdtLsManager.java
+++ b/components/ide/ide-java-lsp/src/main/java/org/eclipse/dirigible/components/ide/lsp/java/process/JdtLsManager.java
@@ -10,6 +10,7 @@
 package org.eclipse.dirigible.components.ide.lsp.java.process;
 
 import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.components.base.dependencies.DependenciesChangedEvent;
 import org.eclipse.dirigible.engine.java.runtime.ClassPathIndex;
 import org.eclipse.dirigible.engine.java.runtime.JavaCompiledEvent;
 import org.eclipse.dirigible.engine.java.runtime.JavaCompiledOutputDirectory;
@@ -20,6 +21,7 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -91,7 +93,8 @@ public class JdtLsManager implements DisposableBean, ApplicationRunner, Applicat
     private volatile boolean available = false;
 
     /**
-     * Memoised default {@code .classpath} XML, shared by every project. See
+     * Memoised default {@code .classpath} XML, shared by every project. Dropped whenever the dependency
+     * layer swaps, because {@link ClassPathIndex} is invalidated then. See
      * {@link #defaultClasspathXml()}.
      */
     private volatile String defaultClasspathXml;
@@ -184,6 +187,27 @@ public class JdtLsManager implements DisposableBean, ApplicationRunner, Applicat
         instances.values()
                  .forEach(JdtLsInstance::destroy);
         instances.clear();
+    }
+
+    /**
+     * Re-renders the shared {@code .classpath} after a dependency-layer swap and rewrites it for every
+     * live workspace. The index behind it was just invalidated, so the memoised XML is stale: without
+     * this a restartlessly added dependency compiles and serves correctly while the editor still
+     * reports its import as unresolved.
+     *
+     * @param event the swap event
+     */
+    @EventListener
+    public void onDependenciesChanged(DependenciesChangedEvent event) {
+        defaultClasspathXml = null;
+        logger.info("[java-lsp] Dependency layer swapped to generation {} - refreshing the Java editor classpath", event.getGeneration());
+        for (String key : instances.keySet()) {
+            int separator = key.indexOf('/');
+            if (separator <= 0) {
+                continue;
+            }
+            ensureEclipseProjectFilesForWorkspace(workspaceRoot(key.substring(0, separator), key.substring(separator + 1)));
+        }
     }
 
     /**
@@ -344,8 +368,9 @@ public class JdtLsManager implements DisposableBean, ApplicationRunner, Applicat
      * single entry resolves cross-project and published types.</li>
      * </ul>
      * Plus the project's own sources via {@code src path=""}. Memoised because
-     * {@link ClassPathIndex#classPathEntries()} is itself cached for the application lifetime and
-     * {@code compiledOutputDir} is a fixed path, so the rendered XML never changes within a run.
+     * {@link ClassPathIndex#classPathEntries()} is cached and {@code compiledOutputDir} is a fixed
+     * path, so the rendered XML changes only when the dependency layer swaps - which drops the memo
+     * (see {@link #onDependenciesChanged(DependenciesChangedEvent)}).
      */
     private String defaultClasspathXml() {
         String cached = defaultClasspathXml;

--- a/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
+++ b/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
@@ -199,7 +199,9 @@ public enum DirigibleConfig {
     DEPENDENCIES_DYNAMIC_ENABLED("DIRIGIBLE_DEPENDENCIES_DYNAMIC", Boolean.TRUE.toString()),
 
     /**
-     * Directory the resolved dependency JARs are linked into; blank means [user
+     * Directory the resolved dependency JARs are linked into - the inventory of what the declarations
+     * resolve to, not a launch-classpath entry (the swappable modules classloader serves them; on
+     * loader.path the application classloader would shadow every later upgrade). Blank means [user
      * home]/.dirigible/resolved-modules.
      */
     DEPENDENCIES_DIR("DIRIGIBLE_DEPENDENCIES_DIR", null),

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/DynamicDependenciesIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/DynamicDependenciesIT.java
@@ -18,6 +18,7 @@ import org.eclipse.dirigible.repository.api.IRepositoryStructure;
 import org.eclipse.dirigible.tests.base.IntegrationTest;
 import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.eclipse.dirigible.tests.framework.util.MavenFixtures;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -31,6 +32,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.function.Consumer;
@@ -41,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 
 /**
  * The restartless dependency lifecycle, end to end over one running platform: an AOT module jar
@@ -67,6 +71,16 @@ class DynamicDependenciesIT extends IntegrationTest {
 
     private static final long AWAIT_SECONDS = 60;
 
+    /** The coordinate of the native-library fixture the module tier refuses. */
+    private static final String NATIVE_COORDINATE = "com.example:native-lib:1.0.0";
+
+    /** The runtime configuration this test overrides, restored afterwards. */
+    private static final List<String> OVERRIDDEN_CONFIGURATION =
+            List.of("DIRIGIBLE_MAVEN_REPOSITORIES", "DIRIGIBLE_MAVEN_LOCAL_REPO", "DIRIGIBLE_DEPENDENCIES_DIR");
+
+    /** The overridden configuration's previous values, null when it was unset. */
+    private static final Map<String, String> PREVIOUS_CONFIGURATION = new LinkedHashMap<>();
+
     @TempDir
     static Path tempDir;
 
@@ -84,6 +98,7 @@ class DynamicDependenciesIT extends IntegrationTest {
 
     @BeforeAll
     static void prepareFixtures() throws IOException {
+        OVERRIDDEN_CONFIGURATION.forEach(key -> PREVIOUS_CONFIGURATION.put(key, Configuration.get(key)));
         fixtureRepo = Files.createDirectories(tempDir.resolve("fixture-repo"));
         localRepository = tempDir.resolve("local-repo");
         // the fixture repository REPLACES Maven Central, so no request can leave the machine
@@ -171,16 +186,18 @@ class DynamicDependenciesIT extends IntegrationTest {
 
     @Test
     @Order(4)
-    void a_native_library_jar_is_rejected_and_the_installed_generation_keeps_serving() {
+    void a_native_library_jar_is_rejected_without_disturbing_the_other_declarations() {
         writeProjectJson("""
                 { "type": "maven", "id": "com.example:hello-module:1.1.0" },
                 { "type": "maven", "id": "com.example:textlib:1.0.0" },
                 { "type": "maven", "id": "com.example:native-lib:1.0.0" }""");
-        resolveExpecting(response -> response.body("failures", hasKey("modules-swap"))
-                                             .body("failures.'modules-swap'", containsString("lib/dummy.so"))
-                                             .body("failures.'modules-swap'", containsString("platform")));
+        // the rejection is per declaration, not per swap: one library shipping a native resource must
+        // not keep every other project's dependencies from activating
+        resolveExpecting(response -> response.body("failures", hasKey(NATIVE_COORDINATE))
+                                             .body("failures.'" + NATIVE_COORDINATE + "'", containsString("lib/dummy.so"))
+                                             .body("failures.'" + NATIVE_COORDINATE + "'", containsString("platform"))
+                                             .body("failures", not(hasKey("modules-swap"))));
 
-        // no partial swap - the previous generation answers as before
         awaitEndpoint(MODULE_ENDPOINT, "hello from 1.1.0 via dirigible-modules");
         awaitEndpoint(CLIENT_ENDPOINT, "DIRIGIBLE!");
     }
@@ -209,6 +226,37 @@ class DynamicDependenciesIT extends IntegrationTest {
         assertThat(repository.hasResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/hello-module/greeting.txt")).isFalse();
         // the surviving dependency keeps serving
         awaitEndpoint(CLIENT_ENDPOINT, "DIRIGIBLE!");
+    }
+
+    /**
+     * The whole shard shares one JVM and one Spring context, and this test's fixtures live under a
+     * {@code @TempDir} that is deleted when the class finishes: a leftover registry project declaring a
+     * dependency that no longer exists would make every later client-Java rebuild in the same fork
+     * compile against a deleted classpath entry, and a leftover {@code DIRIGIBLE_MAVEN_REPOSITORIES}
+     * would point every later resolution at a deleted fixture repository.
+     */
+    @Test
+    @Order(7)
+    void the_fixtures_leave_no_trace_in_the_shared_jvm() {
+        // the declarations go first, so the pipeline deactivates the fixture jars while they still
+        // exist; then the project - source, descriptor and all
+        writeProjectJson("");
+        resolveExpecting(response -> response.body("failures", anEmptyMap()));
+        repository.removeCollection(IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT);
+        synchronizationProcessor.forceProcessSynchronizers();
+
+        awaitEndpointStatus(CLIENT_ENDPOINT, 404);
+    }
+
+    @AfterAll
+    static void restoreConfiguration() {
+        PREVIOUS_CONFIGURATION.forEach((key, value) -> {
+            if (value == null) {
+                Configuration.remove(key);
+            } else {
+                Configuration.set(key, value);
+            }
+        });
     }
 
     private void writeProjectJson(String dependencyEntries) {


### PR DESCRIPTION
Fixes the review findings of #6789 on the swappable modules classloader (#6787), which merged in the meantime. Verified with `DynamicDependenciesIT` (7/7), `DependencyResolutionIT`, `DependencyLockfileIT`, `PlatformScopeDependencyIT` (10/10) and the `core-dependencies` / `core-initializers` / `engine-java` / `ide-java-lsp` unit suites, plus new unit coverage.

### Blockers

**1. Restartless upgrade and removal were inert in the shipped image after the first restart.** `loader.path` no longer carries `/root/.dirigible/resolved-modules`; the boot-time resolution installs those jars through the swappable modules classloader, which is where an upgrade can actually replace them. On the application classloader they shadowed every later generation (parent-first), so the pipeline reported a swap that changed nothing. The Dockerfile, `ResolvedModulesLinker`, `DIRIGIBLE_DEPENDENCIES_DIR` and `engine-java/CLAUDE.md` say why. Where an operator still puts them on `LOADER_PATH`, the arriving artifact is now reported `shadowed` instead of `active`, with the fix in the message.

**2. The watcher starved the shared scheduler.** `DependenciesWatcher` owns a daemon single-thread `ScheduledExecutorService`; a maven resolution plus a full javac rebuild no longer blocks `AccessVerifier`'s two refreshes and `TscWatcherService` on Spring's one-thread pool.

### Before-merge findings

**3.** The native-library veto rejects only the offending coordinate (`failures` keyed by coordinate, the rest of the resolution activates), skips launch-classpath jars entirely, and recognizes `libfoo.so.1` and `.jnilib`.

**4.** A leaving or upgraded module removes only the registry entries its jar carried (`Inspection#registryEntries`), pruning collections it emptied - a customization published under `/registry/public/<project>` survives every version bump. `ModuleJarInspector` now honors `META-INF/dirigible/.skip`, so a skipped jar reports no projects and its removal cannot delete a developer's project of the same name.

**5.** The classloader generation is installed first, then the registry payload, guarded: a `RepositoryWriteException` / `UncheckedIOException` becomes a `registry-payload` entry in `failures` instead of a 500 over half-removed payload with no new generation.

**6.** The fingerprint no longer disarms the watcher after a failed pass: failures arm an exponential backoff (60s doubling to 15min, reset on a clean pass), so a repository 503 or a network blip self-heals without editing `project.json`.

**7.** One swap, one dispatch: `CompiledModuleClassProvider.rediscover(loader, dispatch=false)` records the AOT set and the client rebuild applies the union once over a correctly parented `ClientClassLoader`. Beans, jobs, JMS listeners, controller mappings and websockets are no longer torn down and rebuilt twice per swap, the first time against the retired jars. If the rebuild defers itself, the recorded set is dispatched directly.

**8.** `JdtLsManager` observes `DependenciesChangedEvent`, drops the memoised `.classpath` XML and rewrites it for every live workspace - a restartlessly added dependency no longer shows as an unresolved import while the runtime serves it.

### Smaller

**9.** The tick skips the registry read and parse while a cheap stamp over the `project.json` resources has not moved, with a forced full collection every 12th tick so an edit the stamp cannot see self-heals within a minute. (The ERROR-every-5-seconds half was already fixed by the collector's diagnostic de-duplication.)

**10.** `InvalidPathException` skips the offending jar entry instead of aborting the whole startup sweep (and the whole swap) on Windows.

**11.** `DynamicDependenciesIT` restores the three configuration keys it overrides and removes its registry project, descriptor and client source. (Failsafe has since gained `reuseForks=false`, so the blast radius was already one class - the cleanup keeps it that way.)

### New coverage

- `DependencySwapTest`: per-declaration native rejection, an upgrade and a removal keeping non-jar registry content, and a `.skip` jar never removing a project of the same name.
- `ModuleJarInspectorTest`: registry entries, `.skip`, versioned/Apple/upper-case native forms.
- `ClasspathExpanderTest`: entry-scoped removal with collection pruning, and content the jar did not publish surviving it.
- `DynamicDependenciesIT`: the native-lib step now asserts a per-coordinate failure and no `modules-swap` abort; a final step asserts the fixtures leave no trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)