### PR TITLE
tests: waitForTenantProvisioning triggers the provisioning job instead of racing the boot firing

### DIFF
--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/base/IntegrationTest.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/base/IntegrationTest.java
@@ -73,11 +73,31 @@ public abstract class IntegrationTest {
         tenants.forEach(tenantCreator::createTenant);
     }
 
+    /**
+     * Provisions the given tenants and waits until every one of them is {@code PROVISIONED}.
+     *
+     * <p>
+     * Creating a tenant only stores it in status {@code INITIAL}; provisioning happens in the Quartz
+     * {@code TenantsProvisioningJob}, whose schedule is 15 minutes wide by default. The job is
+     * therefore triggered explicitly here rather than waited for - otherwise a tenant created after the
+     * job's single boot firing could never be provisioned within the timeout below, and the failure
+     * would surface as a bare {@code ConditionTimeoutException} that reads like a product bug.
+     */
     protected void waitForTenantsProvisioning(List<DirigibleTestTenant> tenants) {
-        tenants.forEach(this::waitForTenantProvisioning);
+        tenantCreator.triggerTenantsProvisioning();
+        tenants.forEach(this::awaitTenantProvisioned);
     }
 
+    /**
+     * Provisions the given tenant and waits until it is {@code PROVISIONED}.
+     *
+     * @see #waitForTenantsProvisioning(List)
+     */
     protected void waitForTenantProvisioning(DirigibleTestTenant tenant) {
+        waitForTenantsProvisioning(List.of(tenant));
+    }
+
+    private void awaitTenantProvisioned(DirigibleTestTenant tenant) {
         Awaitility.await()
                   .pollInterval(3, TimeUnit.SECONDS)
                   .atMost(35, TimeUnit.SECONDS)

--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/base/TenantCreator.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/base/TenantCreator.java
@@ -9,26 +9,37 @@
  */
 package org.eclipse.dirigible.tests.base;
 
+import org.awaitility.Awaitility;
 import org.eclipse.dirigible.components.tenants.domain.Tenant;
 import org.eclipse.dirigible.components.tenants.domain.TenantStatus;
 import org.eclipse.dirigible.components.tenants.service.TenantService;
 import org.eclipse.dirigible.components.tenants.service.UserService;
 import org.eclipse.dirigible.tests.framework.tenant.DirigibleTestTenant;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
 
 @Component
 public class TenantCreator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TenantCreator.class);
 
+    /** The Quartz key the platform registers its tenant provisioning system job under. */
+    private static final JobKey PROVISIONING_JOB = JobKey.jobKey("TenantsProvisioningJob", "system");
+
     private final TenantService tenantService;
     private final UserService userService;
+    private final Scheduler scheduler;
 
-    TenantCreator(TenantService tenantService, UserService userService) {
+    TenantCreator(TenantService tenantService, UserService userService, Scheduler scheduler) {
         this.tenantService = tenantService;
         this.userService = userService;
+        this.scheduler = scheduler;
     }
 
     public void createTenant(DirigibleTestTenant tenant) {
@@ -53,6 +64,36 @@ public class TenantCreator {
         tenantEntity.updateKey();
 
         return tenantService.save(tenantEntity);
+    }
+
+    /**
+     * Fires the platform's tenant provisioning job now, instead of waiting for its schedule.
+     *
+     * <p>
+     * {@link #createTenant} only stores the tenant in status {@code INITIAL}; the transition to
+     * {@code PROVISIONED} happens exclusively when the Quartz {@code TenantsProvisioningJob} runs, and
+     * its schedule is {@code DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS} wide (15 minutes by
+     * default). The only prompt firing is the one at scheduler startup, so a test that merely waited
+     * would be racing that boot firing: a tenant created after it could not be provisioned within any
+     * sane test timeout.
+     *
+     * <p>
+     * The job is registered on {@code ApplicationReadyEvent}; the short wait for its key covers a call
+     * made before that listener has run. The provisioner picks up every {@code INITIAL} tenant in one
+     * pass and is synchronized, so a trigger that lands while the boot firing is still running simply
+     * queues behind it and provisions whatever that run did not see.
+     */
+    public void triggerTenantsProvisioning() {
+        try {
+            Awaitility.await()
+                      .pollInterval(500, TimeUnit.MILLISECONDS)
+                      .atMost(30, TimeUnit.SECONDS)
+                      .until(() -> scheduler.checkExists(PROVISIONING_JOB));
+            scheduler.triggerJob(PROVISIONING_JOB);
+            LOGGER.info("Triggered tenants provisioning job [{}]", PROVISIONING_JOB);
+        } catch (SchedulerException ex) {
+            throw new IllegalStateException("Failed to trigger tenants provisioning job [" + PROVISIONING_JOB + "]", ex);
+        }
     }
 
     public boolean isTenantProvisioned(DirigibleTestTenant tenant) {

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/GlobalDestinationIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/GlobalDestinationIT.java
@@ -22,9 +22,6 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.quartz.JobKey;
-import org.quartz.Scheduler;
-import org.quartz.SchedulerException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 
@@ -66,12 +63,9 @@ class GlobalDestinationIT extends IntegrationTest {
     @Autowired
     private TenantContext tenantContext;
 
-    @Autowired
-    private Scheduler scheduler;
-
     @Test
     @Order(1)
-    void aGlobalDestinationIsReachedByItsBareNameFromOutsideTheTenant() throws SchedulerException {
+    void aGlobalDestinationIsReachedByItsBareNameFromOutsideTheTenant() {
         provisionTenant();
 
         publish(DestinationNameManager.GLOBAL_MARKER + GLOBAL_QUEUE);
@@ -82,7 +76,7 @@ class GlobalDestinationIT extends IntegrationTest {
 
     @Test
     @Order(2)
-    void aDestinationWithoutTheMarkerStaysScopedToItsTenant() throws SchedulerException {
+    void aDestinationWithoutTheMarkerStaysScopedToItsTenant() {
         provisionTenant();
 
         publish(TENANT_SCOPED_QUEUE);
@@ -103,21 +97,13 @@ class GlobalDestinationIT extends IntegrationTest {
         });
     }
 
-    /**
-     * Provision the shared tenant, once per class.
-     *
-     * <p>
-     * The provisioning job is triggered explicitly rather than waited for: its schedule is
-     * {@code DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS} wide, so a test that merely waited would
-     * be racing the single firing at startup.
-     */
-    private void provisionTenant() throws SchedulerException {
+    /** Provision the shared tenant, once per class. */
+    private void provisionTenant() {
         if (tenant != null) {
             return;
         }
         DirigibleTestTenant created = new DirigibleTestTenant("global-destination-it");
         createTenants(created);
-        scheduler.triggerJob(JobKey.jobKey("TenantsProvisioningJob", "system"));
         waitForTenantProvisioning(created);
         tenant = created;
     }

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaJobTenantIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaJobTenantIT.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.quartz.JobKey;
 import org.quartz.Scheduler;
-import org.quartz.SchedulerException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 
@@ -98,7 +97,7 @@ class JavaJobTenantIT extends IntegrationTest {
 
     @Test
     @Order(1)
-    void aTenantProvisionedAfterTheClassWasLoadedGetsTheJobToo() throws SchedulerException {
+    void aTenantProvisionedAfterTheClassWasLoadedGetsTheJobToo() {
         // The class is loaded while only the default tenant exists...
         publishJob("OnProvisionJob", "on-provision");
 
@@ -111,7 +110,7 @@ class JavaJobTenantIT extends IntegrationTest {
 
     @Test
     @Order(2)
-    void aJobLoadedWhileATenantExistsIsRegisteredForIt() throws SchedulerException {
+    void aJobLoadedWhileATenantExistsIsRegisteredForIt() {
         // Reverse order: the tenant is already there when the class is loaded, so this is the
         // load-time fan-out's job.
         provisionTenant();
@@ -121,22 +120,13 @@ class JavaJobTenantIT extends IntegrationTest {
         assertJobRunsInTheTenant("OnLoadJob", "on-load");
     }
 
-    /**
-     * Provision the shared tenant, once per class.
-     *
-     * <p>
-     * The provisioning job is triggered explicitly rather than waited for: its schedule is
-     * {@code DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS} wide (15 minutes by default) and the
-     * only prompt firing is the one at startup, so a test that merely waited would be racing that boot
-     * firing — which is exactly how a second tenant in the same class silently timed out.
-     */
-    private void provisionTenant() throws SchedulerException {
+    /** Provision the shared tenant, once per class. */
+    private void provisionTenant() {
         if (tenant != null) {
             return;
         }
         DirigibleTestTenant created = new DirigibleTestTenant(PROJECT);
         createTenants(created);
-        scheduler.triggerJob(JobKey.jobKey("TenantsProvisioningJob", "system"));
         waitForTenantProvisioning(created);
         tenant = created;
     }

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaListenerTenantIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaListenerTenantIT.java
@@ -26,9 +26,6 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.quartz.JobKey;
-import org.quartz.Scheduler;
-import org.quartz.SchedulerException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 
@@ -79,12 +76,9 @@ class JavaListenerTenantIT extends IntegrationTest {
     @Autowired
     private TenantContext tenantContext;
 
-    @Autowired
-    private Scheduler scheduler;
-
     @Test
     @Order(1)
-    void aTenantProvisionedAfterTheClassWasLoadedGetsSubscribedToo() throws SchedulerException {
+    void aTenantProvisionedAfterTheClassWasLoadedGetsSubscribedToo() {
         // The class is loaded while only the default tenant exists...
         publishEcho("OnProvision", "on-provision");
 
@@ -98,7 +92,7 @@ class JavaListenerTenantIT extends IntegrationTest {
 
     @Test
     @Order(2)
-    void aMessagePublishedInANonDefaultTenantReachesItsClientJavaListener() throws SchedulerException {
+    void aMessagePublishedInANonDefaultTenantReachesItsClientJavaListener() {
         // Reverse order: the tenant is already there when the class is loaded, so this is the
         // load-time fan-out's job.
         provisionTenant();
@@ -108,22 +102,13 @@ class JavaListenerTenantIT extends IntegrationTest {
         assertRoundTrip("on-load");
     }
 
-    /**
-     * Provision the shared tenant, once per class.
-     *
-     * <p>
-     * The provisioning job is triggered explicitly rather than waited for: its schedule is
-     * {@code DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS} wide (15 minutes by default) and the
-     * only prompt firing is the one at startup, so a test that merely waited would be racing that boot
-     * firing — which is exactly how a second tenant in the same class silently timed out.
-     */
-    private void provisionTenant() throws SchedulerException {
+    /** Provision the shared tenant, once per class. */
+    private void provisionTenant() {
         if (tenant != null) {
             return;
         }
         DirigibleTestTenant created = new DirigibleTestTenant("java-listener-tenant-it");
         createTenants(created);
-        scheduler.triggerJob(JobKey.jobKey("TenantsProvisioningJob", "system"));
         waitForTenantProvisioning(created);
         tenant = created;
     }

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantProvisioningApiIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantProvisioningApiIT.java
@@ -31,9 +31,6 @@ import org.eclipse.dirigible.tests.framework.tenant.DirigibleTestTenant;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.quartz.JobKey;
-import org.quartz.Scheduler;
-import org.quartz.SchedulerException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 
@@ -82,9 +79,6 @@ class TenantProvisioningApiIT extends IntegrationTest {
 
     @Autowired
     private DataSourceService dataSourceService;
-
-    @Autowired
-    private Scheduler scheduler;
 
     @BeforeAll
     static void enableTheApi() {
@@ -231,14 +225,13 @@ class TenantProvisioningApiIT extends IntegrationTest {
      * being untouched is a decision rather than a race the test won.
      */
     @Test
-    void theBuiltInProvisionerLeavesAnExternallyOwnedTenantAlone() throws SchedulerException {
+    void theBuiltInProvisionerLeavesAnExternallyOwnedTenantAlone() {
         String externallyOwned = "provisioning-api-it-untouched";
         restAssuredExecutor.execute(() -> register(externallyOwned, "Untouched").then()
                                                                                 .statusCode(201));
 
         DirigibleTestTenant ownedByThePlatform = new DirigibleTestTenant("provisioning-api-it-builtin");
         createTenants(ownedByThePlatform);
-        scheduler.triggerJob(JobKey.jobKey("TenantsProvisioningJob", "system"));
         waitForTenantProvisioning(ownedByThePlatform);
 
         Tenant tenant = tenantService.findById(externallyOwned)

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantSelectionIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TenantSelectionIT.java
@@ -37,9 +37,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.quartz.JobKey;
-import org.quartz.Scheduler;
-import org.quartz.SchedulerException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -110,9 +107,6 @@ class TenantSelectionIT extends IntegrationTest {
     @Autowired
     private TenantConfigurationService tenantConfigurationService;
 
-    @Autowired
-    private Scheduler scheduler;
-
     @BeforeAll
     static void useTokenGroupsResolution() {
         DirigibleConfig.MULTI_TENANT_MODE_ENABLED.setBooleanValue(true);
@@ -124,17 +118,15 @@ class TenantSelectionIT extends IntegrationTest {
     /**
      * Provisions the tenants and seeds the markers, once for the class.
      *
-     * @throws SchedulerException if the provisioning job cannot be triggered
      * @throws SQLException if a marker cannot be written
      */
     @BeforeEach
-    void provisionTenantsAndSeedMarkers() throws SchedulerException, SQLException {
+    void provisionTenantsAndSeedMarkers() throws SQLException {
         if (provisionedTenant != null) {
             return;
         }
         DirigibleTestTenant created = new DirigibleTestTenant("tenant-selection-it");
         createTenants(created);
-        scheduler.triggerJob(JobKey.jobKey("TenantsProvisioningJob", "system"));
         waitForTenantProvisioning(created);
         provisionedTenant = created;
 

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TokenGroupsTenantResolutionIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/TokenGroupsTenantResolutionIT.java
@@ -28,9 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.quartz.JobKey;
-import org.quartz.Scheduler;
-import org.quartz.SchedulerException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
@@ -90,9 +87,6 @@ class TokenGroupsTenantResolutionIT extends IntegrationTest {
     @Autowired
     private TenantConfigurationService tenantConfigurationService;
 
-    @Autowired
-    private Scheduler scheduler;
-
     @BeforeAll
     static void useTokenGroupsResolution() {
         DirigibleConfig.MULTI_TENANT_MODE_ENABLED.setBooleanValue(true);
@@ -103,22 +97,15 @@ class TokenGroupsTenantResolutionIT extends IntegrationTest {
     /**
      * Provisions the tenant and seeds the markers, once for the class.
      *
-     * <p>
-     * The provisioning job is triggered explicitly rather than waited for: its schedule is
-     * {@code DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS} wide (15 minutes by default) and the
-     * only prompt firing is the one at startup.
-     *
-     * @throws SchedulerException if the provisioning job cannot be triggered
      * @throws SQLException if a marker cannot be written
      */
     @BeforeEach
-    void provisionTenantsAndSeedMarkers() throws SchedulerException, SQLException {
+    void provisionTenantsAndSeedMarkers() throws SQLException {
         if (provisionedTenant != null) {
             return;
         }
         DirigibleTestTenant created = new DirigibleTestTenant("token-groups-resolution-it");
         createTenants(created);
-        scheduler.triggerJob(JobKey.jobKey("TenantsProvisioningJob", "system"));
         waitForTenantProvisioning(created);
         provisionedTenant = created;
 


### PR DESCRIPTION
Fixes #6785

### Problem

`IntegrationTest.waitForTenantProvisioning` polls for `PROVISIONED` for 35 seconds, but nothing in that path triggers provisioning. `TenantCreator.createTenant` only saves the tenant in status `INITIAL`; the transition happens exclusively in the Quartz `TenantsProvisioningJob`, whose schedule is `DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS` wide (15 minutes by default). The helper was racing the job's single boot firing, and a tenant created after it failed as a bare `ConditionTimeoutException` that reads like a product bug.

Six ITs had each grown the same inline workaround, `scheduler.triggerJob(JobKey.jobKey("TenantsProvisioningJob", "system"))`, right before calling the helper.

### Change

- `TenantCreator.triggerTenantsProvisioning()` waits (briefly) for the job key to be registered on `ApplicationReadyEvent`, then triggers it. The provisioner is synchronized and picks up every `INITIAL` tenant per pass, so a trigger that lands during the boot firing queues behind it and provisions whatever that run did not see.
- `IntegrationTest.waitForTenantsProvisioning` triggers once, then awaits each tenant; `waitForTenantProvisioning` delegates to it. The 3s/35s polling is unchanged.
- `GlobalDestinationIT`, `JavaJobTenantIT`, `JavaListenerTenantIT`, `TenantProvisioningApiIT`, `TenantSelectionIT`, `TokenGroupsTenantResolutionIT` drop the inline trigger and the `Scheduler` plumbing they only kept for it (`JavaJobTenantIT` keeps its `Scheduler` for its own job).

### Verification

`mvn -pl tests/tests-framework,tests/tests-integrations verify -DskipITs=false -Dit.test=NumberingSdkIT,TenantProvisioningApiIT,GlobalDestinationIT,TenantSelectionIT,JavaJobTenantIT` - 32 tests, 0 failures. `NumberingSdkIT` is a caller that never had the workaround, so it now provisions through the helper alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
