### PR TITLE
ui: one date format across forms, list filters and the Inbox (#7072)

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/basePage.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/basePage.js
@@ -165,7 +165,7 @@ function basePage() {
         + 'th,td{border:1px solid #999;padding:2pt;text-align:left;overflow-wrap:anywhere;word-break:break-word}'
         + 'th{background:#eee}.text-right{text-align:right}'
         + '</style></head><body><h1>' + esc(title) + '</h1>'
-        + '<p class="meta">' + rows.length + ' rows - ' + esc(new Date().toLocaleString()) + '</p>'
+        + '<p class="meta">' + rows.length + ' rows - ' + esc(HarmoniaFormat.value(new Date(), true)) + '</p>'
         + '<table><thead><tr>' + th + '</tr></thead><tbody>' + body + '</tbody></table></body></html>';
       const w = window.open('', '_blank');
       if (!w) return;

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/inboxPage.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/inboxPage.js
@@ -150,9 +150,12 @@ document.addEventListener('alpine:init', () => {
 
     stopAuto() { if (this._timer) { clearInterval(this._timer); this._timer = null; } },
 
+    // Task timestamps print through the instance Timestamp pattern, like every other date the
+    // application shows. toLocaleString() rendered them in the BROWSER's locale, so the Inbox could
+    // date a task dd/mm/yyyy on an instance whose lists and forms were all ISO.
     fmtTime(t) {
       if (!t) return '';
-      try { return new Date(t).toLocaleString(); } catch (_) { return String(t); }
+      try { return HarmoniaFormat.value(t, true); } catch (_) { return String(t); }
     },
   }));
 }, { once: true });

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/format.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/format.js
@@ -20,9 +20,13 @@
  * and dependency-free (no Alpine, no window.App): the standalone BPM task-form iframe loads it by
  * absolute URL and reads the same keys, so a form opened outside the shell formats the same way.
  *
- * DISPLAY formatting (HarmoniaFormat.number / .value) honours the patterns. INPUT round-tripping
- * (HarmoniaFormat.toDateInput) does NOT — an <input type="date|datetime-local|time"> dictates its own
- * value shape (YYYY-MM-DD, ...THH:mm, HH:mm), so that helper stays fixed; it lives here only to dedupe.
+ * DISPLAY formatting (HarmoniaFormat.number / .value) honours the patterns, and so does what a date
+ * INPUT shows and accepts: HarmoniaFormat.pickerConfig() describes the Date pattern to the Harmonia
+ * date pickers, which would otherwise display and parse in the document's (or the browser's) locale —
+ * the one surface where guessing is not merely inconsistent but silently wrong, 06.09.2026 typed into
+ * an m/d/yyyy field being a valid 9 June. The MODEL behind those inputs stays ISO regardless, which is
+ * what HarmoniaFormat.toDateInput produces: an <input> model dictates its own value shape
+ * (YYYY-MM-DD, ...THH:mm, HH:mm), so that helper is pattern-free; it lives here only to dedupe.
  *
  * Number rule (per the design decision): the DECIMAL COUNT and whether-to-group come from the field's
  * own DecimalFormat pattern (money scale 2 vs quantity scale 0 stay distinct); the GROUPING and DECIMAL
@@ -124,6 +128,48 @@
     .replace(/mm/g, pad(c.mi))
     .replace(/ss/g, pad(c.s));
 
+  // An ISO-ish date / date-time string as a backend or a user may write it: "2026-09-06",
+  // "2026-09-06T17:02:31", "2026-09-06 17:02". Anything trailing (a zone, fractional seconds) is
+  // ignored - the components below are all the display patterns can render.
+  const ISO_LIKE = /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?/;
+
+  // Pattern letters that carry a date field, and the order codes the Harmonia picker's config takes.
+  const DATE_FIELDS = { y: 'year', M: 'month', d: 'day' };
+  const ORDER_CODES = { year: 'Y', month: 'M', day: 'D' };
+
+  // Translate a DateTimeFormatter-style pattern into the { order, delimiter, options } config a
+  // Harmonia date picker takes, so the picker DISPLAYS and PARSES exactly what the instance Date
+  // setting says. Without it a picker follows the document language (or, absent one, the browser's),
+  // which is how a form parsed 06.09.2026 as 9 June while the same instance printed dates elsewhere
+  // day-first. A pattern that is not a plain three-field date with one repeated separator yields null,
+  // and the picker keeps its own locale default rather than a half-applied shape.
+  const pickerConfigFrom = (pattern) => {
+    const p = String(pattern);
+    const runs = [];
+    let i = 0;
+    while (i < p.length) {
+      const field = DATE_FIELDS[p[i]];
+      if (!field) { i++; continue; }
+      let j = i;
+      while (p[j] === p[i]) j++;
+      runs.push({ field: field, len: j - i, start: i, end: j });
+      i = j;
+    }
+    if (runs.length !== 3) return null;
+    const fields = runs.map((r) => r.field);
+    if (new Set(fields).size !== 3) return null;
+    const delimiter = p.slice(runs[0].end, runs[1].start);
+    if (!delimiter || delimiter !== p.slice(runs[1].end, runs[2].start)) return null;
+    const options = {};
+    runs.forEach((r) => {
+      // A year is spelled out in full only as yyyy; a month/day is zero-padded only as MM/dd.
+      options[r.field] = r.field === 'year'
+        ? (r.len >= 4 ? 'numeric' : '2-digit')
+        : (r.len >= 2 ? '2-digit' : 'numeric');
+    });
+    return { order: fields.map((f) => ORDER_CODES[f]).join(''), delimiter: delimiter, options: options };
+  };
+
   const HarmoniaFormat = {
     KEYS,
     defaults() {
@@ -164,12 +210,19 @@
         if (v.length >= 5) return applyDatePattern(p.dateTime, { y: v[0], mo: v[1], da: v[2], h: v[3], mi: v[4], s: v[5] || 0 });
         return v.join(', ');
       }
-      if (isDate && typeof v === 'number') {
-        const d = new Date(v < 1e11 ? v * 1000 : v); // epoch seconds or millis
+      if (isDate && (typeof v === 'number' || v instanceof Date)) {
+        const d = v instanceof Date ? v : new Date(v < 1e11 ? v * 1000 : v); // epoch seconds or millis
         if (!isNaN(d.getTime())) {
           return applyDatePattern(p.dateTime, {
             y: d.getFullYear(), mo: d.getMonth() + 1, da: d.getDate(), h: d.getHours(), mi: d.getMinutes(), s: d.getSeconds(),
           });
+        }
+      }
+      if (isDate && typeof v === 'string') {
+        const m = ISO_LIKE.exec(v);
+        if (m) {
+          const c = { y: +m[1], mo: +m[2], da: +m[3], h: +(m[4] || 0), mi: +(m[5] || 0), s: +(m[6] || 0) };
+          return applyDatePattern(m[4] === undefined ? p.date : p.dateTime, c);
         }
       }
       return v;
@@ -193,6 +246,26 @@
       if (v === null || v === undefined) return '';
       const uuid = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
       return uuid.test(String(v)) ? '' : v;
+    },
+
+    /**
+     * The active Date pattern as an input hint ("dd.mm.yyyy" for dd.MM.yyyy): the same pattern, lower
+     * cased, which is how a date placeholder is conventionally spelled. Shown in the date inputs so the
+     * expected field order is visible before anything is typed.
+     */
+    dateHint() {
+      return patterns().date.toLowerCase();
+    },
+
+    /**
+     * The { order, delimiter, options } configuration a Harmonia date / date-time picker popup takes,
+     * derived from the instance Date (or Timestamp) pattern. `kind` is 'date' (default) or 'dateTime';
+     * only the date half of a Timestamp pattern is described, the time segments being the picker's own.
+     * A pattern the picker cannot be configured from yields an empty config (its locale default).
+     */
+    pickerConfig(kind) {
+      const p = patterns();
+      return pickerConfigFrom(kind === 'dateTime' ? p.dateTime : p.date) || {};
     },
 
     /**

--- a/components/resources/resources-admin/src/main/resources/META-INF/dirigible/admin/index.html
+++ b/components/resources/resources-admin/src/main/resources/META-INF/dirigible/admin/index.html
@@ -340,9 +340,9 @@
                   </template>
                   <template x-if="col.widget === 'DATE'">
                     <div x-h-date-picker.table>
-                      <input type="text" />
+                      <input type="text" :placeholder="HarmoniaFormat.dateHint()" />
                       <button x-h-date-picker-trigger aria-label="Choose date"></button>
-                      <div x-h-date-picker-popup x-model="s.promptValues[col.name]"></div>
+                      <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="s.promptValues[col.name]"></div>
                     </div>
                   </template>
                   <template x-if="!['DROPDOWN','NUMBER','CHECKBOX','DATE'].includes(col.widget)">

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
@@ -397,9 +397,9 @@
                   </template>
                   <template x-if="col.widget === 'DATE'">
                     <div x-h-date-picker.table>
-                      <input type="text" />
+                      <input type="text" :placeholder="HarmoniaFormat.dateHint()" />
                       <button x-h-date-picker-trigger aria-label="Choose date"></button>
-                      <div x-h-date-picker-popup x-model="s.promptValues[col.name]"></div>
+                      <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="s.promptValues[col.name]"></div>
                     </div>
                   </template>
                   <template x-if="!['DROPDOWN','NUMBER','CHECKBOX','DATE'].includes(col.widget)">

--- a/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/index.html
+++ b/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/index.html
@@ -340,9 +340,9 @@
                   </template>
                   <template x-if="col.widget === 'DATE'">
                     <div x-h-date-picker.table>
-                      <input type="text" />
+                      <input type="text" :placeholder="HarmoniaFormat.dateHint()" />
                       <button x-h-date-picker-trigger aria-label="Choose date"></button>
-                      <div x-h-date-picker-popup x-model="s.promptValues[col.name]"></div>
+                      <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="s.promptValues[col.name]"></div>
                     </div>
                   </template>
                   <template x-if="!['DROPDOWN','NUMBER','CHECKBOX','DATE'].includes(col.widget)">

--- a/components/resources/resources-personal/src/main/resources/META-INF/dirigible/personal/index.html
+++ b/components/resources/resources-personal/src/main/resources/META-INF/dirigible/personal/index.html
@@ -371,9 +371,9 @@
                   </template>
                   <template x-if="col.widget === 'DATE'">
                     <div x-h-date-picker.table>
-                      <input type="text" />
+                      <input type="text" :placeholder="HarmoniaFormat.dateHint()" />
                       <button x-h-date-picker-trigger aria-label="Choose date"></button>
-                      <div x-h-date-picker-popup x-model="s.promptValues[col.name]"></div>
+                      <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="s.promptValues[col.name]"></div>
                     </div>
                   </template>
                   <template x-if="!['DROPDOWN','NUMBER','CHECKBOX','DATE'].includes(col.widget)">

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
@@ -83,15 +83,15 @@
         <span x-h-checkbox><input type="checkbox" x-model="form.${property.name}" /></span>
 #elseif($property.widgetType == "DATE")
         <div x-h-date-picker>
-          <input type="text" />
+          <input type="text" :placeholder="HarmoniaFormat.dateHint()" />
           <button x-h-date-picker-trigger aria-label="Choose date"></button>
-          <div x-h-date-picker-popup x-model="form.${property.name}"></div>
+          <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "DATETIME-LOCAL")
         <div x-h-datetime-picker>
           <input type="text" />
           <button x-h-datetime-picker-trigger aria-label="Choose date and time"></button>
-          <div x-h-datetime-picker-popup x-model="form.${property.name}"></div>
+          <div x-h-datetime-picker-popup="HarmoniaFormat.pickerConfig('dateTime')" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "TIME")
         <div x-h-time-picker>
@@ -389,7 +389,7 @@
                 <span x-h-checkbox><input type="checkbox" x-model="draft[col.name]" /></span>
               </template>
               <template x-if="!col.readonly && !col.lookup && col.date && !(itemMode === 'fill' && col.name === fillDateName())">
-                <div x-h-date-picker><input type="text" /><button x-h-date-picker-trigger aria-label="Choose date"></button><div x-h-date-picker-popup x-model="draft[col.name]"></div></div>
+                <div x-h-date-picker><input type="text" :placeholder="HarmoniaFormat.dateHint()" /><button x-h-date-picker-trigger aria-label="Choose date"></button><div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="draft[col.name]"></div></div>
               </template>
               <!-- Fill Month: the fill-target date column picks the MONTH - every working day gets a line. -->
               <template x-if="!col.readonly && !col.lookup && col.date && itemMode === 'fill' && col.name === fillDateName()">

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template
@@ -87,15 +87,15 @@
         <!-- Harmonia date picker: model is YYYY-MM-DD (same as the native date input it replaces),
              so form.${property.name} round-trips unchanged through toDateInput/toPayload. -->
         <div x-h-date-picker>
-          <input type="text" />
+          <input type="text" :placeholder="HarmoniaFormat.dateHint()" />
           <button x-h-date-picker-trigger aria-label="Choose date"></button>
-          <div x-h-date-picker-popup x-model="form.${property.name}"></div>
+          <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "DATETIME-LOCAL")
         <div x-h-datetime-picker>
           <input type="text" />
           <button x-h-datetime-picker-trigger aria-label="Choose date and time"></button>
-          <div x-h-datetime-picker-popup x-model="form.${property.name}"></div>
+          <div x-h-datetime-picker-popup="HarmoniaFormat.pickerConfig('dateTime')" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "TIME")
         <div x-h-time-picker>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
@@ -83,15 +83,15 @@
         <span x-h-checkbox><input type="checkbox" x-model="form.${property.name}" /></span>
 #elseif($property.widgetType == "DATE")
         <div x-h-date-picker>
-          <input type="text" />
+          <input type="text" :placeholder="HarmoniaFormat.dateHint()" />
           <button x-h-date-picker-trigger aria-label="Choose date"></button>
-          <div x-h-date-picker-popup x-model="form.${property.name}"></div>
+          <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "DATETIME-LOCAL")
         <div x-h-datetime-picker>
           <input type="text" />
           <button x-h-datetime-picker-trigger aria-label="Choose date and time"></button>
-          <div x-h-datetime-picker-popup x-model="form.${property.name}"></div>
+          <div x-h-datetime-picker-popup="HarmoniaFormat.pickerConfig('dateTime')" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "TIME")
         <div x-h-time-picker>
@@ -251,7 +251,7 @@
                 <span x-h-checkbox><input type="checkbox" x-model="draft[col.name]" /></span>
               </template>
               <template x-if="!col.readonly && !col.lookup && col.date">
-                <div x-h-date-picker><input type="text" /><button x-h-date-picker-trigger aria-label="Choose date"></button><div x-h-date-picker-popup x-model="draft[col.name]"></div></div>
+                <div x-h-date-picker><input type="text" :placeholder="HarmoniaFormat.dateHint()" /><button x-h-date-picker-trigger aria-label="Choose date"></button><div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="draft[col.name]"></div></div>
               </template>
               <template x-if="!col.readonly && !col.lookup && !col.date && !col.number && col.widget !== 'CHECKBOX'">
                 <input x-h-input type="text" x-model="draft[col.name]" :pattern="col.pattern" />

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-form-view.html.template
@@ -87,15 +87,15 @@
         <!-- Harmonia date picker: model is YYYY-MM-DD (same as the native date input it replaces),
              so form.${property.name} round-trips unchanged through toDateInput/toPayload. -->
         <div x-h-date-picker>
-          <input type="text" />
+          <input type="text" :placeholder="HarmoniaFormat.dateHint()" />
           <button x-h-date-picker-trigger aria-label="Choose date"></button>
-          <div x-h-date-picker-popup x-model="form.${property.name}"></div>
+          <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "DATETIME-LOCAL")
         <div x-h-datetime-picker>
           <input type="text" />
           <button x-h-datetime-picker-trigger aria-label="Choose date and time"></button>
-          <div x-h-datetime-picker-popup x-model="form.${property.name}"></div>
+          <div x-h-datetime-picker-popup="HarmoniaFormat.pickerConfig('dateTime')" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "TIME")
         <div x-h-time-picker>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -169,15 +169,15 @@
 #elseif($property.widgetType == "DATE")
         <!-- Harmonia date picker: model is YYYY-MM-DD (same as the native date input it replaces). -->
         <div x-h-date-picker>
-          <input type="text" id="f_${property.name}" :aria-invalid="!!errors.${property.name}"#if($readonly) disabled#end />
+          <input type="text" :placeholder="HarmoniaFormat.dateHint()" id="f_${property.name}" :aria-invalid="!!errors.${property.name}"#if($readonly) disabled#end />
           <button x-h-date-picker-trigger aria-label="Choose date"></button>
-          <div x-h-date-picker-popup x-model="form.${property.name}"></div>
+          <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "DATETIME-LOCAL")
         <div x-h-datetime-picker>
           <input type="text" id="f_${property.name}" :aria-invalid="!!errors.${property.name}"#if($readonly) disabled#end />
           <button x-h-datetime-picker-trigger aria-label="Choose date and time"></button>
-          <div x-h-datetime-picker-popup x-model="form.${property.name}"></div>
+          <div x-h-datetime-picker-popup="HarmoniaFormat.pickerConfig('dateTime')" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "TIME")
         <div x-h-time-picker>
@@ -726,9 +726,9 @@
               </template>
               <template x-if="!col.readonly && col.widget === 'DATE' && !(draftMode === 'fill' && col.name === fillDateName())">
                 <div x-h-date-picker.table>
-                  <input type="text" :disabled="col.readonly" :aria-invalid="draftFieldError === col.name" />
+                  <input type="text" :placeholder="HarmoniaFormat.dateHint()" :disabled="col.readonly" :aria-invalid="draftFieldError === col.name" />
                   <button x-h-date-picker-trigger aria-label="Choose date"></button>
-                  <div x-h-date-picker-popup x-model="draft[col.name]"></div>
+                  <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="draft[col.name]"></div>
                 </div>
               </template>
               <!-- Fill Month: the fill-target date column picks the MONTH - every working day gets a line. -->
@@ -743,7 +743,7 @@
                 <div x-h-datetime-picker.table>
                   <input type="text" :disabled="col.readonly" :aria-invalid="draftFieldError === col.name" />
                   <button x-h-datetime-picker-trigger aria-label="Choose date and time"></button>
-                  <div x-h-datetime-picker-popup x-model="draft[col.name]"></div>
+                  <div x-h-datetime-picker-popup="HarmoniaFormat.pickerConfig('dateTime')" x-model="draft[col.name]"></div>
                 </div>
               </template>
               <template x-if="!col.readonly && !['DROPDOWN','MULTISELECT','NUMBER','CHECKBOX','DATE','DATETIME-LOCAL'].includes(col.widget)">

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
@@ -228,15 +228,15 @@
         <!-- Harmonia date picker: model is YYYY-MM-DD (same as the native date input it replaces), so
              form.${property.name} round-trips unchanged. Readonly (preview) -> the input is disabled. -->
         <div x-h-date-picker>
-          <input type="text" id="f_${property.name}" :aria-invalid="!!errors.${property.name}"#if($readonly) disabled#end />
+          <input type="text" :placeholder="HarmoniaFormat.dateHint()" id="f_${property.name}" :aria-invalid="!!errors.${property.name}"#if($readonly) disabled#end />
           <button x-h-date-picker-trigger aria-label="Choose date"></button>
-          <div x-h-date-picker-popup x-model="form.${property.name}"></div>
+          <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "DATETIME-LOCAL")
         <div x-h-datetime-picker>
           <input type="text" id="f_${property.name}" :aria-invalid="!!errors.${property.name}"#if($readonly) disabled#end />
           <button x-h-datetime-picker-trigger aria-label="Choose date and time"></button>
-          <div x-h-datetime-picker-popup x-model="form.${property.name}"></div>
+          <div x-h-datetime-picker-popup="HarmoniaFormat.pickerConfig('dateTime')" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "TIME")
         <div x-h-time-picker>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
@@ -207,8 +207,21 @@
                         <option :value="opt.value" x-text="opt.text"></option>
                       </template>
                     </select>
-                    <input x-show="col.type !== 'fk' && col.type !== 'none'" x-model="columnFilters[col.name]"
-                           :type="col.type === 'date' ? 'date' : 'text'"
+                    <!-- A date column filters through the same Harmonia picker the forms use, configured from
+                         the instance Date pattern, so the shape it shows and accepts is the one the cells below
+                         it print. A native <input type="date"> renders in the BROWSER's locale instead, which is
+                         how one screen could offer dd.mm.yyyy while the form beside it read the same digits as
+                         m/d/yyyy. The model stays the ISO the search expects; the picker's change event bubbles
+                         to the cell, covering both a typed value and a picked one. -->
+                    <template x-if="col.type === 'date'">
+                      <div x-h-date-picker.table @change="applyServerFilter()">
+                        <input type="text" :placeholder="HarmoniaFormat.dateHint()" />
+                        <button x-h-date-picker-trigger :aria-label="T('$projectName:${tprefix}.defaults.filter', 'Filter…')"></button>
+                        <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="columnFilters[col.name]"></div>
+                      </div>
+                    </template>
+                    <input x-show="col.type !== 'fk' && col.type !== 'none' && col.type !== 'date'" x-model="columnFilters[col.name]"
+                           type="text"
                            @input.debounce.400ms="applyServerFilter()"
                            :placeholder="T('$projectName:${tprefix}.defaults.filter', 'Filter…')"
                            class="w-full text-sm rounded-md border border-border bg-transparent px-2 py-1" />

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report-file/index.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report-file/index.html.template
@@ -52,9 +52,9 @@
             <label class="text-xs text-muted-foreground" x-text="paramLabel(p.name)"></label>
             <template x-if="p.kind === 'date'">
               <div x-h-date-picker>
-                <input type="text" @keydown.enter="applyFilters()" />
+                <input type="text" :placeholder="HarmoniaFormat.dateHint()" @keydown.enter="applyFilters()" />
                 <button x-h-date-picker-trigger aria-label="Pick date"></button>
-                <div x-h-date-picker-popup x-model="params[p.name]"></div>
+                <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="params[p.name]"></div>
               </div>
             </template>
             <template x-if="p.kind === 'number'">
@@ -80,15 +80,15 @@
                 <template x-if="col.kind === 'date'">
                   <div class="hbox gap-1 items-center">
                     <div x-h-date-picker>
-                      <input type="text" @keydown.enter="applyFilters()" />
+                      <input type="text" :placeholder="HarmoniaFormat.dateHint()" @keydown.enter="applyFilters()" />
                       <button x-h-date-picker-trigger aria-label="From date"></button>
-                      <div x-h-date-picker-popup x-model="filters[col.key].from"></div>
+                      <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="filters[col.key].from"></div>
                     </div>
                     <span x-h-text.muted>&ndash;</span>
                     <div x-h-date-picker>
-                      <input type="text" @keydown.enter="applyFilters()" />
+                      <input type="text" :placeholder="HarmoniaFormat.dateHint()" @keydown.enter="applyFilters()" />
                       <button x-h-date-picker-trigger aria-label="To date"></button>
-                      <div x-h-date-picker-popup x-model="filters[col.key].to"></div>
+                      <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="filters[col.key].to"></div>
                     </div>
                   </div>
                 </template>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report-file/report.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report-file/report.js.template
@@ -310,7 +310,7 @@ document.addEventListener('alpine:init', () => {
           + 'th,td{border:1px solid #999;padding:2pt;text-align:left;overflow-wrap:anywhere;word-break:break-word}'
           + 'th{background:#eee}.text-right{text-align:right}'
           + '</style></head><body><h1>' + esc(this.displayName) + '</h1>'
-          + '<p class="meta">' + rows.length + ' rows' + (this.activeFilterCount ? ' (filtered)' : '') + ' - ' + esc(new Date().toLocaleString()) + '</p>'
+          + '<p class="meta">' + rows.length + ' rows' + (this.activeFilterCount ? ' (filtered)' : '') + ' - ' + esc(HarmoniaFormat.value(new Date(), true)) + '</p>'
           + '<table><thead><tr>' + th + '</tr></thead><tbody>' + body + '</tbody></table></body></html>';
         const w = window.open('', '_blank');
         if (!w) return;

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report/table-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report/table-page.js.template
@@ -86,7 +86,7 @@ document.addEventListener('alpine:init', () => {
           + 'th,td{border:1px solid #999;padding:2pt;text-align:left;overflow-wrap:anywhere;word-break:break-word}'
           + 'th{background:#eee}.text-right{text-align:right}'
           + '</style></head><body><h1>${name}</h1>'
-          + '<p class="meta">' + rows.length + ' rows - ' + esc(new Date().toLocaleString()) + '</p>'
+          + '<p class="meta">' + rows.length + ' rows - ' + esc(HarmoniaFormat.value(new Date(), true)) + '</p>'
           + '<table><thead><tr>' + th + '</tr></thead><tbody>' + body + '</tbody></table></body></html>';
         const w = window.open('', '_blank');
         if (!w) return;

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
@@ -363,9 +363,9 @@
                   </template>
                   <template x-if="col.widget === 'DATE'">
                     <div x-h-date-picker.table>
-                      <input type="text" />
+                      <input type="text" :placeholder="HarmoniaFormat.dateHint()" />
                       <button x-h-date-picker-trigger aria-label="Choose date"></button>
-                      <div x-h-date-picker-popup x-model="s.promptValues[col.name]"></div>
+                      <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="s.promptValues[col.name]"></div>
                     </div>
                   </template>
                   <template x-if="!['DROPDOWN','NUMBER','CHECKBOX','DATE'].includes(col.widget)">

--- a/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/index.html.template
+++ b/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/index.html.template
@@ -88,9 +88,9 @@
         <div x-h-field>
           <label x-h-label for="$el.id"#tlabel($el)>$!el.label</label>
           <div x-h-date-picker>
-            <input type="text" id="$el.id"#if($el.readonly) disabled#end />
+            <input type="text" :placeholder="HarmoniaFormat.dateHint()" id="$el.id"#if($el.readonly) disabled#end />
             <button x-h-date-picker-trigger aria-label="Choose date"></button>
-            <div x-h-date-picker-popup x-model="model.$el.model"></div>
+            <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="model.$el.model"></div>
           </div>
         </div>
 #elseif($el.controlId == "input-datetime-local")
@@ -99,7 +99,7 @@
           <div x-h-datetime-picker>
             <input type="text" id="$el.id"#if($el.readonly) disabled#end />
             <button x-h-datetime-picker-trigger aria-label="Choose date and time"></button>
-            <div x-h-datetime-picker-popup x-model="model.$el.model"></div>
+            <div x-h-datetime-picker-popup="HarmoniaFormat.pickerConfig('dateTime')" x-model="model.$el.model"></div>
           </div>
         </div>
 #elseif($el.controlId == "input-time")

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/HarmoniaDateFormatIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/HarmoniaDateFormatIT.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The shared Harmonia runtime formats every date it PRINTS against the instance Date / Timestamp
+ * patterns; this covers the other half - what a date INPUT shows and accepts.
+ *
+ * <p>
+ * A Harmonia date picker left unconfigured displays and parses in the document's language, or
+ * absent one the browser's, which is a silent corruption rather than a cosmetic mismatch:
+ * {@code 06.09.2026} typed into an m/d/yyyy field is a perfectly valid 9 June, saved without a
+ * warning. So the picker is handed {@code HarmoniaFormat.pickerConfig()} - the instance pattern
+ * translated into the order/delimiter/width triple the widget takes - everywhere a date is entered.
+ *
+ * <p>
+ * The derivation itself is exercised by evaluating the shipped {@code format.js} in a polyglot
+ * context (it is deliberately dependency-free, so it needs only a {@code window} to attach to), and
+ * every generated surface that carries a date input is checked to pass the configuration on - a new
+ * picker added without it reopens the bug on that one screen only.
+ */
+class HarmoniaDateFormatIT {
+
+    private static final String FORMAT_JS = "/META-INF/dirigible/application-core/shell/js/services/format.js";
+
+    /** The generated / shipped surfaces where a date is entered. */
+    private static final List<String> PICKER_SURFACES =
+            List.of("/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template",
+                    "/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template",
+                    "/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template",
+                    "/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report-file/index.html.template",
+                    "/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template",
+                    "/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template",
+                    "/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template",
+                    "/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-form-view.html.template",
+                    "/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template",
+                    "/META-INF/dirigible/template-form-builder-harmonia/ui/index.html.template");
+
+    @Test
+    void theDefaultIsoPatternConfiguresThePickerYearFirst() {
+        try (Context context = load(null)) {
+            Value config = eval(context, "HarmoniaFormat.pickerConfig()");
+
+            assertEquals("YMD", config.getMember("order")
+                                      .asString());
+            assertEquals("-", config.getMember("delimiter")
+                                    .asString());
+            assertEquals("numeric", config.getMember("options")
+                                          .getMember("year")
+                                          .asString());
+            assertEquals("2-digit", config.getMember("options")
+                                          .getMember("month")
+                                          .asString());
+        }
+    }
+
+    @Test
+    void aDayFirstPatternConfiguresThePickerDayFirst() {
+        try (Context context = load("dd.MM.yyyy")) {
+            Value config = eval(context, "HarmoniaFormat.pickerConfig()");
+
+            assertEquals("DMY", config.getMember("order")
+                                      .asString());
+            assertEquals(".", config.getMember("delimiter")
+                                    .asString());
+            assertEquals("2-digit", config.getMember("options")
+                                          .getMember("day")
+                                          .asString());
+            assertEquals("dd.mm.yyyy", eval(context, "HarmoniaFormat.dateHint()").asString());
+        }
+    }
+
+    @Test
+    void anUnpaddedMonthFirstPatternKeepsItsWidths() {
+        try (Context context = load("M/d/yy")) {
+            Value config = eval(context, "HarmoniaFormat.pickerConfig()");
+
+            assertEquals("MDY", config.getMember("order")
+                                      .asString());
+            assertEquals("/", config.getMember("delimiter")
+                                    .asString());
+            assertEquals("numeric", config.getMember("options")
+                                          .getMember("month")
+                                          .asString());
+            assertEquals("2-digit", config.getMember("options")
+                                          .getMember("year")
+                                          .asString());
+        }
+    }
+
+    /**
+     * A pattern the widget cannot be configured from must leave it alone rather than half-applied: a
+     * missing field, a repeated one, or two different separators all yield an empty configuration.
+     */
+    @Test
+    void aPatternThatIsNotAPlainDateLeavesThePickerAlone() {
+        for (String pattern : List.of("yyyy-MM", "dd/MM-yyyy", "dd.MM.dd", "MMMM d, yyyy")) {
+            try (Context context = load(pattern)) {
+                assertEquals(0, eval(context, "Object.keys(HarmoniaFormat.pickerConfig()).length").asInt(),
+                        "expected no picker configuration from [" + pattern + "]");
+            }
+        }
+    }
+
+    /**
+     * The Inbox prints a task's timestamp - a {@code java.util.Date} on the wire, a {@code Date} object
+     * for its own "updated" stamp - and used to hand both to {@code toLocaleString()}.
+     */
+    @Test
+    void aTimestampPrintsThroughTheInstancePatternWhateverShapeItArrivesIn() {
+        try (Context context = load("dd.MM.yyyy", "dd.MM.yyyy HH:mm")) {
+            assertEquals("06.09.2026 17:02", eval(context, "HarmoniaFormat.value(new Date(2026, 8, 6, 17, 2, 31), true)").asString());
+            assertEquals("06.09.2026 17:02", eval(context, "HarmoniaFormat.value('2026-09-06T17:02:31', true)").asString());
+            assertEquals("06.09.2026", eval(context, "HarmoniaFormat.value('2026-09-06', true)").asString());
+            assertEquals("06.09.2026 17:02", eval(context, "HarmoniaFormat.value(new Date(2026, 8, 6, 17, 2).getTime(), true)").asString());
+        }
+    }
+
+    @Test
+    void everyDatePickerIsConfiguredFromTheInstancePattern() throws Exception {
+        for (String surface : PICKER_SURFACES) {
+            String content = read(surface);
+
+            assertTrue(
+                    content.contains("x-h-date-picker-popup=\"HarmoniaFormat.pickerConfig()\"")
+                            || content.contains("x-h-datetime-picker-popup=\"HarmoniaFormat.pickerConfig('dateTime')\""),
+                    surface + " declares no configured picker at all - has the markup moved?");
+            assertTrue(!content.contains("x-h-date-picker-popup ") && !content.contains("x-h-datetime-picker-popup "),
+                    surface + " carries a picker with no configuration, which parses in the browser's locale");
+        }
+    }
+
+    /** A date column filters through the same picker, not a native input in the browser's locale. */
+    @Test
+    void theListColumnFilterIsThePickerToo() throws Exception {
+        String content = read("/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template");
+
+        assertTrue(content.contains("x-h-date-picker-popup=\"HarmoniaFormat.pickerConfig()\" x-model=\"columnFilters[col.name]\""),
+                "the date column filter must bind the picker to the column filter");
+        assertTrue(!content.contains("'date' : 'text'"), "the native date input must be gone: " + content);
+    }
+
+    private static Value eval(Context context, String expression) {
+        return context.eval("js", expression);
+    }
+
+    private static Context load(String datePattern) {
+        return load(datePattern, null);
+    }
+
+    /**
+     * Evaluate the shipped format.js over the two stubs it touches - a {@code window} to publish itself
+     * on and a {@code localStorage} holding the instance patterns (absent ones fall back to the file's
+     * own defaults, exactly as in a browser with nothing stored).
+     */
+    private static Context load(String datePattern, String dateTimePattern) {
+        Context context = Context.newBuilder("js")
+                                 .allowAllAccess(true)
+                                 // Nothing here is performance sensitive, and the interpreter-only notice
+                                 // is written straight to the native stream, which the forked test JVM reports
+                                 // as a corrupted channel.
+                                 .option("engine.WarnInterpreterOnly", "false")
+                                 .build();
+        StringBuilder stored = new StringBuilder("var __stored = {};");
+        if (datePattern != null) {
+            stored.append("__stored['codbex.harmonia.format.date'] = '")
+                  .append(datePattern)
+                  .append("';");
+        }
+        if (dateTimePattern != null) {
+            stored.append("__stored['codbex.harmonia.format.datetime'] = '")
+                  .append(dateTimePattern)
+                  .append("';");
+        }
+        context.eval("js",
+                "var window = this; " + stored + " var localStorage = { getItem: function (k) { return __stored[k] || null; } };");
+        try {
+            context.eval("js", read(FORMAT_JS));
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to evaluate " + FORMAT_JS, ex);
+        }
+        return context;
+    }
+
+    private static String read(String resource) throws Exception {
+        try (InputStream in = HarmoniaDateFormatIT.class.getResourceAsStream(resource)) {
+            if (in == null) {
+                throw new IllegalStateException("Missing classpath resource: " + resource);
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}


### PR DESCRIPTION
A Harmonia date picker left unconfigured displays and parses in the document's language, or absent one the browser's, while the list filter beside it was a native `<input type="date">` following the OS locale and the Inbox printed through `toLocaleString()`. Three surfaces of one application, three sources of truth - and the form's was a silent corruption rather than a cosmetic mismatch: `06.09.2026` typed into an m/d/yyyy field is a perfectly valid 9 June, saved with no warning, wrong VAT period and all.

## The one source of truth already exists

The instance owns one **Date** and one **Timestamp** pattern - the shared runtime's *Region & Language* setting, which every value the application PRINTS already goes through (`HarmoniaFormat.value`). Those patterns now govern what a date **INPUT** shows and accepts too:

- **`HarmoniaFormat.pickerConfig()`** translates the pattern into the `{ order, delimiter, options }` triple the Harmonia widget takes (`dd.MM.yyyy` -> `DMY` / `.` / 2-digit day+month), and every generated surface that enters a date hands it to its picker: the manage form, the document header and its line grid, the report parameters and column filters, the shells' prompt dialogs, and the form builder's task form. The date-time pickers get the date half of the Timestamp pattern.
- **A date column filters through that same picker**, not a native `<input type="date">` - which is exactly how one screen could offer `dd.mm.yyyy` while the form beside it read the same digits as `m/d/yyyy`. The model stays the ISO the search expects; the picker's `change` bubbles to the cell, covering a typed value and a picked one alike.
- **`HarmoniaFormat.dateHint()`** puts the expected shape in the input's placeholder, so the field order is visible before anything is typed.
- **The Inbox** prints its task timestamps through the Timestamp pattern, as do the "generated at" stamps of the printed tables.

A pattern that is not a plain three-field date - a missing field, a repeated one, two different separators - configures **nothing** rather than half of it, and the picker keeps its own default. The MODEL behind every input stays ISO throughout, so nothing the server sees changes, and an instance that never touched the Date setting still renders the ISO it always did - now everywhere.

## Verified

`HarmoniaDateFormatIT` evaluates the shipped `format.js` in a polyglot context and asserts the derivation (ISO, day-first, an unpadded month-first pattern, and the four shapes that must configure nothing), that a timestamp prints through the pattern whatever shape it arrives in, and that **every** picker surface passes the configuration on - a new picker added without it reopens the bug on that one screen only. `ModelGenerationIT` (every template, twice) stays green.

The widget contract itself was checked against the real `harmonia.min.js` in a browser whose `navigator.language` is `en-GB` and whose document declares `en-US`: under `dd.MM.yyyy` typing `03.02.2027` yields the model `2027-02-03`, and under `MM/dd/yyyy` the same digits yield `2027-03-02` - the instance pattern decides, not the browser.

Fixes #7072