### PR TITLE
ui: a refused action says so, and the page catches up (#7073)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/transition/TransitionsIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/transition/TransitionsIntentGenerator.java
@@ -10,13 +10,16 @@
 package org.eclipse.dirigible.components.intent.generator.transition;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.dirigible.components.base.helpers.JsonHelper;
 import org.eclipse.dirigible.components.intent.generator.IntentGenerationContext;
 import org.eclipse.dirigible.components.intent.generator.IntentNaming;
 import org.eclipse.dirigible.components.intent.generator.IntentTargetGenerator;
+import org.eclipse.dirigible.components.intent.model.EntityIntent;
 import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.model.RelationIntent;
 import org.eclipse.dirigible.components.intent.model.TransitionIntent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +36,12 @@ import org.springframework.stereotype.Component;
  * record's id to it and toasts the result. A transition declaring a {@code notify:} block
  * additionally carries {@code notifies}, which tells that store the response is {@code { record,
  * notify }} and its delivery outcome is worth a warning.
+ *
+ * <p>
+ * The descriptor also mirrors the {@code from:} guard ({@code statusProperty} + {@code from}) so
+ * the button can be hidden on a record the transition cannot apply to (dirigible #7073) - Void
+ * offered on a paid invoice and answered with a 409 is the failure that asked for it. The server's
+ * check stays authoritative; this only keeps an impossible button off the screen.
  *
  * <p>
  * The endpoint is the REST {@code @Controller} generated (server half) from the {@code .glue}
@@ -73,7 +82,7 @@ public class TransitionsIntentGenerator implements IntentTargetGenerator {
             String modulePath = project + "/" + fileBase + ".js";
             context.writeModelFile(fileBase + ".extension", buildExtensionJson(project, modulePath, t));
             context.writeModelFile(fileBase + ".js", buildDescriptorModule(project, IntentNaming.javaModule(context), t,
-                    IntentNaming.customActionTranslationKey(project, context, name)));
+                    IntentNaming.customActionTranslationKey(project, context, name), statusProperty(model, t.getForEntity())));
         }
     }
 
@@ -85,7 +94,29 @@ public class TransitionsIntentGenerator implements IntentTargetGenerator {
         return JsonHelper.toJson(extension);
     }
 
-    private static String buildDescriptorModule(String project, String javaModule, TransitionIntent t, String translationKey) {
+    /**
+     * The PascalCase name of the entity's {@code function: EntityStatus} relation - the property the
+     * record carries its current status in, and the one the {@code from:} check reads on the client.
+     * Empty when the entity declares none (the parser already reported that; the button then simply
+     * stays unguarded and the server's 409 remains the only gate).
+     */
+    private static String statusProperty(IntentModel model, String entityName) {
+        for (EntityIntent entity : model.getEntities()) {
+            if (!entity.getName()
+                       .equals(entityName)) {
+                continue;
+            }
+            for (RelationIntent relation : entity.getRelations()) {
+                if (relation.isEntityStatus()) {
+                    return IntentNaming.pascalCase(relation.getName());
+                }
+            }
+        }
+        return "";
+    }
+
+    private static String buildDescriptorModule(String project, String javaModule, TransitionIntent t, String translationKey,
+            String statusProperty) {
         Map<String, Object> view = new LinkedHashMap<>();
         view.put("id", project + "-" + t.getForEntity() + "-" + t.getName());
         String label = IntentNaming.customActionLabel(t.getName(), t.getLabel());
@@ -97,6 +128,19 @@ public class TransitionsIntentGenerator implements IntentTargetGenerator {
                 + "Transition/run");
         view.put("view", t.getForEntity());
         view.put("type", "entity");
+        // A status flip is not a create: the shell words its toast from `kind` rather than reporting
+        // "Created <ref>" for a record that already existed (dirigible #7073).
+        view.put("kind", "transition");
+        // The `from:` guard, mirrored onto the client (dirigible #7073). The server's 409 stays
+        // authoritative - this is what lets the button be HIDDEN on a record the transition can
+        // never apply to, instead of offering Void on a paid invoice and answering the click with a
+        // refusal. A `when:` guard is deliberately NOT mirrored: it is a Calc expression over the
+        // stored record, and a client re-implementation of it would drift from the server's.
+        List<Integer> from = t.getFrom();
+        if (statusProperty != null && !statusProperty.isBlank() && from != null && !from.isEmpty()) {
+            view.put("statusProperty", statusProperty);
+            view.put("from", from);
+        }
         if (t.getNotify() != null) {
             // A transition that mails answers { record, notify } instead of the bare record (dirigible
             // #7023), so the shell reports a failed delivery as a warning instead of a green toast.

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/TransitionActionDescriptorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/TransitionActionDescriptorTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.dirigible.components.intent.generator.transition.TransitionsIntentGenerator;
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.parser.IntentParser;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IResource;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * A transition's client descriptor must carry the {@code from:} guard the server enforces
+ * (dirigible #7073). Without it the generated UI offered Void on a paid invoice, POSTed it, and
+ * dropped the resulting 409 on the floor - the user was left believing the invoice had been voided.
+ */
+class TransitionActionDescriptorTest {
+
+    private static final String YAML = """
+            name: billing
+            entities:
+              - name: InvoiceStatus
+                function: Setting
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: Invoice
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: total, type: decimal }
+                relations:
+                  - { name: Status, kind: manyToOne, to: InvoiceStatus, function: EntityStatus, init: 1 }
+            transitions:
+              - name: voidInvoice
+                forEntity: Invoice
+                from: [3, 4]
+                setStatus: 6
+            seeds:
+              - name: invoice-statuses
+                entity: InvoiceStatus
+                rows:
+                  - { id: 1, name: DRAFT,     stage: draft }
+                  - { id: 3, name: ISSUED,    stage: live }
+                  - { id: 4, name: PARTIAL,   stage: live }
+                  - { id: 6, name: VOID,      stage: void }
+            """;
+
+    @Test
+    void theDescriptorMirrorsTheFromGuardTheServerEnforces() {
+        String descriptor = compact(descriptor(YAML));
+
+        assertTrue(descriptor.contains("\"statusProperty\":\"Status\""),
+                "the client needs the property the record carries its status in: " + descriptor);
+        assertTrue(descriptor.contains("\"from\":[3,4]"), "the allowed source statuses must reach the button: " + descriptor);
+        // A status flip is not a create - the shell words its toast from this.
+        assertTrue(descriptor.contains("\"kind\":\"transition\""), descriptor);
+    }
+
+    @Test
+    void theGuardNamesTheEntitysOwnStatusRelation() {
+        // The property is READ off the record in the browser, so it must be the relation this entity
+        // actually declares - not the conventional "Status" every model happens to use.
+        String descriptor = compact(descriptor(YAML.replace("name: Status,", "name: State,")));
+
+        assertTrue(descriptor.contains("\"statusProperty\":\"State\""), descriptor);
+    }
+
+    @Test
+    void aWhenGuardIsNotMirroredOntoTheButton() {
+        // `when:` is a Calc expression evaluated server-side over the stored record. A client
+        // re-implementation of it would drift from the server's and start hiding buttons that work,
+        // so only `from:` - a plain status comparison - crosses over. The 409 covers the rest.
+        // The text block is already dedented at compile time, so the added key is indented to match
+        // its siblings there (4 spaces), not as it reads in the source above.
+        String descriptor = compact(descriptor(YAML.replace("setStatus: 6", "setStatus: 6\n    when: \"total == 0\"")));
+
+        assertTrue(descriptor.contains("\"from\":[3,4]"), descriptor);
+        assertFalse(descriptor.contains("when"), "a when: guard has no client half: " + descriptor);
+    }
+
+    /** The descriptor's JSON with its pretty-printing whitespace removed, for readable assertions. */
+    private static String compact(String descriptor) {
+        return descriptor.replaceAll("\\s+", "");
+    }
+
+    /** The written {@code voidInvoice-transition-action.js} descriptor module. */
+    private static String descriptor(String yaml) {
+        IntentModel model = IntentParser.parse(yaml);
+        IRepository repository = mock(IRepository.class);
+        IResource missing = mock(IResource.class);
+        when(repository.getResource(anyString())).thenReturn(missing);
+        when(missing.exists()).thenReturn(false);
+        IntentGenerationContext context = new IntentGenerationContext(model, "/proj", "proj", "workspace", "billing", repository);
+
+        new TransitionsIntentGenerator().generate(context);
+
+        ArgumentCaptor<String> paths = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<byte[]> contents = ArgumentCaptor.forClass(byte[].class);
+        verify(repository, atLeastOnce()).createResource(paths.capture(), contents.capture());
+        for (int i = 0; i < paths.getAllValues()
+                                 .size(); i++) {
+            if (paths.getAllValues()
+                     .get(i)
+                     .endsWith("/voidInvoice-transition-action.js")) {
+                return new String(contents.getAllValues()
+                                          .get(i),
+                        StandardCharsets.UTF_8);
+            }
+        }
+        return fail("the transition descriptor module was not written: " + paths.getAllValues());
+    }
+}

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/detailPanel.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/detailPanel.js
@@ -67,6 +67,14 @@ function detailPanel(def, masterId) {
       }
       await this.load();
       this.loadLookups();
+      // A custom action can create or change rows this panel lists (a Record Reminder writes a
+      // PaymentReminder against the open invoice), and it does so behind the panel's back - through
+      // its own endpoint, not this panel's editing path. Re-read on every action so the panel stops
+      // saying "No records" about a record that exists (issue #7073).
+      this.onActionDone(async () => {
+        await this.load();
+        this.loadLookups();
+      });
     },
 
     // Fetch the referenced rows for each relationship column once, keyed by FK -> the whole row (so both

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/basePage.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/basePage.js
@@ -27,6 +27,41 @@ function basePage() {
     refreshIcons() {},
 
     /**
+     * Re-read this component's data whenever a custom action finishes.
+     *
+     * The customActions store raises `harmonia:action-done` after every action it runs (a transition,
+     * a create-from, a page action that closed) - and until #7073 nothing listened to it, so a
+     * Record Reminder that had already created its row left the panel showing "No records" until the
+     * user reloaded the page by hand. An action changes server-side state the open page is a view of;
+     * the page has to go and look again.
+     *
+     * `handler` is the component's own reload. Registered once, per component instance, and removed
+     * in destroy() below - a page navigated away from must not keep reloading in the background.
+     */
+    onActionDone(handler) {
+      this._actionDoneHandlers = this._actionDoneHandlers || [];
+      const listener = () => {
+        try {
+          const done = handler.call(this);
+          if (done && typeof done.catch === 'function') done.catch((e) => console.error('[action-done] reload failed', e));
+        } catch (e) {
+          console.error('[action-done] reload failed', e);
+        }
+      };
+      this._actionDoneHandlers.push(listener);
+      window.addEventListener('harmonia:action-done', listener);
+    },
+
+    /**
+     * Alpine calls this when the component's element goes away. A component that overrides destroy()
+     * must call basePage's (or drop its own action-done listeners itself).
+     */
+    destroy() {
+      (this._actionDoneHandlers || []).forEach((listener) => window.removeEventListener('harmonia:action-done', listener));
+      this._actionDoneHandlers = [];
+    },
+
+    /**
      * Open a calendar that is SCOPED BY the record in front of us (intent `calendar.scope`): the
      * calendar entity's own page, filtered to this record through the query parameter its scope
      * foreign key reads - the same URL the calendar page itself builds when it navigates to create.

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/api.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/api.js
@@ -67,6 +67,7 @@ App.services.api = {
       case 401: return 'Unauthorized';
       case 403: return 'InsufficientPermission';
       case 404: return 'NotFound';
+      case 409: return 'Conflict';
       case 422: return 'ValidationError';
       case 502: return 'UpstreamError';
       default:  return 'InternalServerError';
@@ -142,7 +143,10 @@ App.services.api = {
       ? new ApiError({
           httpStatus: r.status,
           errorType: parsed.errorType || parsed.code || this.typeFromStatus(r.status),
-          errorMessage: parsed.errorMessage || parsed.message || r.statusText,
+          // `error` is what the generated transition/check controllers answer a refusal with
+          // (dirigible #7073); without it their authored "allowed only from status [3, 4]" text was
+          // dropped on the floor and the caller was left with the bare status line.
+          errorMessage: parsed.errorMessage || parsed.message || parsed.error || r.statusText,
           errorCauses: parsed.errorCauses,
         })
       : new ApiError({

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/apiError.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/apiError.js
@@ -33,6 +33,7 @@
       InsufficientPermission: 'You do not have permission to perform this action.',
       TokenExpired:           'Your session has expired. Please sign in again.',
       NotFound:               'The requested item could not be found.',
+      Conflict:               'This is not allowed in the record\u2019s current state.',
       UpstreamError:          'A dependent service is unavailable. Please try again shortly.',
       InternalServerError:    'Something went wrong on our end. Please try again.',
       NetworkError:           'Unable to reach the server. Check your connection and try again.',
@@ -59,6 +60,30 @@
     messageFor(err, fallback) {
       const type = err && err.errorType;
       return (type && this.messages[type]) || fallback || this.default;
+    },
+
+    /**
+     * The message for a REFUSAL - a business rule the server applied to something the user asked for
+     * (a transition outside its `from:` statuses, a `checks:` gate) rather than a fault.
+     *
+     * Those messages are authored, in the intent, to be read by the person who pressed the button
+     * ("VoidSalesInvoice is allowed only from status [3, 4] - current status is [6]"), so here the
+     * server's text IS the user-facing text and the generic catalog line would destroy the only
+     * information the response carried (dirigible #7073). Restricted to the two statuses that mean
+     * "your request was refused" - 400 and 409; every other failure keeps going through messageFor,
+     * where a developer-facing errorMessage never reaches the screen.
+     */
+    refusalMessageFor(err, fallback) {
+      const status = err && err.httpStatus;
+      const message = typeof (err && err.errorMessage) === 'string' ? err.errorMessage.trim() : '';
+      // A refusal is one authored sentence. A markup blob or an essay is a proxy/container error page
+      // that happens to carry the same status - show the catalog line for those rather than pasting
+      // an HTML document into a toast.
+      const readable = message && message.length <= 300 && message.indexOf('<') === -1;
+      if ((status === 400 || status === 409) && readable) {
+        return message;
+      }
+      return this.messageFor(err, fallback);
     },
 
     /** Per-field message for a single 422 errorCauses[] entry. */

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/customActions.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/customActions.js
@@ -35,6 +35,11 @@
  * The action page opens in the dialog wired in index.html; on its `harmonia.form.close` message (or an
  * explicit close) the store closes it and raises a `harmonia:action-done` window event, so a view that
  * a mutating action changed (duplicate / create-from / aggregate) can refresh without a manual reload.
+ *
+ * Every outcome is ANNOUNCED - a transient toast plus an entry in the notification centre (issue
+ * #7073). A refusal shows the reason the server sent (a transition outside its `from:` statuses says
+ * so in its 409), a success says what happened, and a page action that finished reports through the
+ * same path. Nothing an action does ends in silence.
  */
 document.addEventListener('alpine:init', () => {
   Alpine.store('customActions', {
@@ -70,9 +75,14 @@ document.addEventListener('alpine:init', () => {
 
     init() {
       this.load();
-      // An action page (opened in the app-wide dialog) asks its host to close when it is done.
+      // An action page (opened in the app-wide dialog) asks its host to close when it is done. That
+      // message means the page FINISHED its work (the user dismissing the dialog closes it directly
+      // instead), so it is also the outcome the toast reports - a page may say so itself with
+      // `status` ('ok' | 'error') and `message`, and one that says nothing still gets the default
+      // "<label> completed" rather than the silence Save as Template used to end in (issue #7073).
       window.addEventListener('message', (e) => {
-        if (e && e.data && e.data.type === 'harmonia.form.close' && this.dialogOpen) this.closeDialog();
+        if (!e || !e.data || e.data.type !== 'harmonia.form.close' || !this.dialogOpen) return;
+        this.closeDialog({ status: e.data.status, message: e.data.message });
       });
       // Re-read the contributions on navigation so a newly published action shows without a full reload.
       document.addEventListener('pinecone:end', () => { if (this.loaded) this.load(); });
@@ -133,11 +143,32 @@ document.addEventListener('alpine:init', () => {
     // is 'page' (a toolbar action on the whole view; matches page or an unset type) or 'entity' (a
     // per-record action). Contributors set `view`/`type` on the descriptor (a `perspective` field, if
     // present, stays informational). The list arrives already order-sorted from the endpoint.
-    getActions(view, type) {
+    //
+    // `record` (optional, entity actions only) is the record the buttons would act on: an action the
+    // record's current status can never accept is left out entirely rather than offered and refused
+    // (issue #7073). Callers that have the row - every generated view does - should pass it.
+    getActions(view, type, record) {
       return (this.actions || []).filter((a) =>
         a && a.view === view &&
         (type === 'entity' ? a.type === 'entity'
-                           : (a.type === 'page' || a.type === undefined || a.type === null)));
+                           : (a.type === 'page' || a.type === undefined || a.type === null)) &&
+        this.appliesTo(a, record));
+    },
+
+    // Whether an action can apply to a record AT ALL. A transition descriptor mirrors its `from:`
+    // guard (`statusProperty` + `from`, emitted by TransitionsIntentGenerator), so Void stops being
+    // offered on a paid invoice - the case that produced a 409 the user never saw.
+    //
+    // It fails OPEN in every uncertain case: no guard on the descriptor, no record in hand, or a
+    // record that does not carry the status property (a list row projecting other columns). Hiding a
+    // button that WOULD have worked is worse than showing one the server refuses - and the server's
+    // check, including the `when:` guard that is deliberately not mirrored here, stays authoritative.
+    appliesTo(action, record) {
+      if (!action || !Array.isArray(action.from) || !action.from.length || !action.statusProperty) return true;
+      if (!record || typeof record !== 'object') return true;
+      const current = record[action.statusProperty];
+      if (current === undefined || current === null || current === '') return true;
+      return action.from.some((from) => String(from) === String(current));
     },
 
     // Trigger a contributed action. Two flavours, decided by the descriptor:
@@ -383,22 +414,37 @@ document.addEventListener('alpine:init', () => {
         } else if (notified && notified.status === 'skipped') {
           this.notify(label, (ref ? ref + ': ' : '') + 'no e-mail address on the record - nothing was sent', 'warning');
         } else {
-          this.notify(label, ref ? 'Created ' + ref : 'Completed', 'positive');
+          // A transition moved a record that already existed; a generate/create-from made a new one.
+          // Reporting a status flip as "Created INV-1" is how the Void toast read before #7073.
+          const done = action.kind === 'transition'
+            ? (ref ? 'Done - ' + ref : 'Done')
+            : (ref ? 'Created ' + ref : 'Completed');
+          this.notify(label, done, 'positive');
         }
         window.dispatchEvent(new CustomEvent('harmonia:action-done'));
       } catch (e) {
-        const msg = (App.services.apiErrors && App.services.apiErrors.messageFor)
-          ? App.services.apiErrors.messageFor(e, 'Action failed')
+        // A refusal (400/409) carries the authored reason the intent wrote for this exact moment -
+        // "allowed only from status [3, 4] - current status is [6]". That is the message the user
+        // needs; the generic catalog line is for faults (issue #7073).
+        const msg = (App.services.apiErrors && App.services.apiErrors.refusalMessageFor)
+          ? App.services.apiErrors.refusalMessageFor(e, 'Action failed')
           : 'Action failed';
         this.notify(label, msg, 'negative');
       }
     },
 
-    // Surface a notification through the shared notifications store (the shell's notification centre),
-    // degrading to the console when it is unavailable so an action never fails silently.
+    // Surface the outcome of an action the user just triggered: a transient toast over the page PLUS
+    // an entry in the shell's notification centre (announce does both). Recording it in the bell
+    // alone - what this did before #7073 - is indistinguishable from nothing happening, which is
+    // exactly how a refused Void came to read as a successful one.
+    // Degrades to the console when the store is unavailable, so an action never fails silently.
     notify(title, description, variant) {
       try {
         const store = window.Alpine && Alpine.store('notifications');
+        if (store && typeof store.announce === 'function') {
+          store.announce({ title: title, description: description, variant: variant });
+          return;
+        }
         if (store && typeof store.add === 'function') {
           store.add({ title: title, description: description, variant: variant });
           return;
@@ -407,9 +453,18 @@ document.addEventListener('alpine:init', () => {
       console.log('customActions: ' + title + (description ? ' - ' + description : ''));
     },
 
-    closeDialog() {
+    // Close the action dialog. `outcome` is present only when the PAGE reported it is done (see the
+    // message listener in init); the dialog's own X calls this with nothing, and a dismissal is not
+    // an outcome worth announcing.
+    closeDialog(outcome) {
+      const label = this.dialogTitle || 'Action';
       this.dialogOpen = false;
       this.dialogUrl = '';
+      if (outcome) {
+        const failed = outcome.status === 'error';
+        this.notify(label, outcome.message || (failed ? 'Action failed' : 'Completed'),
+          failed ? 'negative' : 'positive');
+      }
       // Let the originating view refresh after a (possibly) mutating action.
       window.dispatchEvent(new CustomEvent('harmonia:action-done'));
     },

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/notifications.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/notifications.js
@@ -14,8 +14,13 @@
  *
  * notifications store — the shell's in-app notification list behind the top-right bell. App code /
  * glue pushes entries via Alpine.store('notifications').add({ title, description, variant }); the
- * bell shows the unread count and the dropdown lists them. (Transient toasts are a separate concern,
- * via Harmonia's $notifications overlay declared in index.html.)
+ * bell shows the unread count and the dropdown lists them.
+ *
+ * announce({ title, description, variant }) is what code that just DID something calls: it records
+ * the entry in the bell AND raises the transient toast over Harmonia's notification overlay (the
+ * `toast` template every shell declares in index.html). Before it existed (dirigible #7073) the only
+ * feedback path was the bell, so a refused transition and a successful one looked exactly the same
+ * on screen - nothing - and the user assumed the click had worked.
  *
  * A first source is wired in: the user's actionable BPM tasks (from the processTasks store) are
  * surfaced as notifications via syncTasks() — a new task shows up here, a completed one drops off.
@@ -37,6 +42,33 @@ document.addEventListener('alpine:init', () => {
         variant: n.variant || 'information',
         unread: true,
       });
+    },
+
+    /**
+     * Record the entry in the bell AND show it as a transient toast. Use this for the OUTCOME of
+     * something the user just did; plain add() stays for background arrivals (a new task) that must
+     * not interrupt.
+     *
+     * The toast overlay is Harmonia's (`_h_notifications`, driven by the `toast` template in the
+     * shell's index.html). Missing overlay / missing template is not a reason to lose the message:
+     * the bell entry is written first, so the worst case is the pre-#7073 behaviour rather than a
+     * broken page.
+     */
+    announce(n) {
+      n = n || {};
+      this.add(n);
+      const variant = n.variant || 'information';
+      const text = [n.title, n.description].filter(Boolean).join(' - ');
+      try {
+        const toasts = window.Alpine && Alpine.store('_h_notifications');
+        if (!toasts || typeof toasts.push !== 'function') return;
+        // A refusal has to be READ; a success only has to be seen. Same reason the variant is
+        // carried through: the overlay template picks the icon from it.
+        const timeout = (variant === 'negative' || variant === 'warning') ? 12000 : 5000;
+        toasts.push(undefined, 'toast', 'top-right', timeout, { message: text, variant });
+      } catch (e) {
+        console.warn('notifications: could not raise the toast for "' + text + '"', e);
+      }
     },
 
     markAllRead() { this.items.forEach(n => { n.unread = false; }); },

--- a/components/resources/resources-admin/src/main/resources/META-INF/dirigible/admin/index.html
+++ b/components/resources/resources-admin/src/main/resources/META-INF/dirigible/admin/index.html
@@ -371,7 +371,8 @@
             <span x-h-avatar class="rounded-full" :data-variant="variant">
               <template x-if="variant === 'positive'"><svg x-h-icon data-icon="circle-success" role="img" aria-label="success"></svg></template>
               <template x-if="variant === 'negative'"><svg x-h-icon data-icon="circle-error" role="img" aria-label="error"></svg></template>
-              <template x-if="variant !== 'positive' && variant !== 'negative'"><svg x-h-icon data-icon="circle-info" role="img" aria-label="info"></svg></template>
+              <template x-if="variant === 'warning'"><svg x-h-icon data-icon="circle-warning" role="img" aria-label="warning"></svg></template>
+              <template x-if="variant !== 'positive' && variant !== 'negative' && variant !== 'warning'"><svg x-h-icon data-icon="circle-info" role="img" aria-label="info"></svg></template>
             </span>
           </div>
           <span x-h-notification-title class="flex-1" x-text="message"></span>

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
@@ -452,7 +452,8 @@
             <span x-h-avatar class="rounded-full" :data-variant="variant">
               <template x-if="variant === 'positive'"><svg x-h-icon data-icon="circle-success" role="img" aria-label="success"></svg></template>
               <template x-if="variant === 'negative'"><svg x-h-icon data-icon="circle-error" role="img" aria-label="error"></svg></template>
-              <template x-if="variant !== 'positive' && variant !== 'negative'"><svg x-h-icon data-icon="circle-info" role="img" aria-label="info"></svg></template>
+              <template x-if="variant === 'warning'"><svg x-h-icon data-icon="circle-warning" role="img" aria-label="warning"></svg></template>
+              <template x-if="variant !== 'positive' && variant !== 'negative' && variant !== 'warning'"><svg x-h-icon data-icon="circle-info" role="img" aria-label="info"></svg></template>
             </span>
           </div>
           <span x-h-notification-title class="flex-1" x-text="message"></span>

--- a/components/resources/resources-builder/src/main/resources/META-INF/dirigible/builder/index.html
+++ b/components/resources/resources-builder/src/main/resources/META-INF/dirigible/builder/index.html
@@ -400,7 +400,8 @@
             <span x-h-avatar class="rounded-full" :data-variant="variant">
               <template x-if="variant === 'positive'"><svg x-h-icon data-icon="circle-success" role="img" aria-label="success"></svg></template>
               <template x-if="variant === 'negative'"><svg x-h-icon data-icon="circle-error" role="img" aria-label="error"></svg></template>
-              <template x-if="variant !== 'positive' && variant !== 'negative'"><svg x-h-icon data-icon="circle-info" role="img" aria-label="info"></svg></template>
+              <template x-if="variant === 'warning'"><svg x-h-icon data-icon="circle-warning" role="img" aria-label="warning"></svg></template>
+              <template x-if="variant !== 'positive' && variant !== 'negative' && variant !== 'warning'"><svg x-h-icon data-icon="circle-info" role="img" aria-label="info"></svg></template>
             </span>
           </div>
           <span x-h-notification-title class="flex-1" x-text="message"></span>

--- a/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/index.html
+++ b/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/index.html
@@ -371,7 +371,8 @@
             <span x-h-avatar class="rounded-full" :data-variant="variant">
               <template x-if="variant === 'positive'"><svg x-h-icon data-icon="circle-success" role="img" aria-label="success"></svg></template>
               <template x-if="variant === 'negative'"><svg x-h-icon data-icon="circle-error" role="img" aria-label="error"></svg></template>
-              <template x-if="variant !== 'positive' && variant !== 'negative'"><svg x-h-icon data-icon="circle-info" role="img" aria-label="info"></svg></template>
+              <template x-if="variant === 'warning'"><svg x-h-icon data-icon="circle-warning" role="img" aria-label="warning"></svg></template>
+              <template x-if="variant !== 'positive' && variant !== 'negative' && variant !== 'warning'"><svg x-h-icon data-icon="circle-info" role="img" aria-label="info"></svg></template>
             </span>
           </div>
           <span x-h-notification-title class="flex-1" x-text="message"></span>

--- a/components/resources/resources-personal/src/main/resources/META-INF/dirigible/personal/index.html
+++ b/components/resources/resources-personal/src/main/resources/META-INF/dirigible/personal/index.html
@@ -425,7 +425,8 @@
             <span x-h-avatar class="rounded-full" :data-variant="variant">
               <template x-if="variant === 'positive'"><svg x-h-icon data-icon="circle-success" role="img" aria-label="success"></svg></template>
               <template x-if="variant === 'negative'"><svg x-h-icon data-icon="circle-error" role="img" aria-label="error"></svg></template>
-              <template x-if="variant !== 'positive' && variant !== 'negative'"><svg x-h-icon data-icon="circle-info" role="img" aria-label="info"></svg></template>
+              <template x-if="variant === 'warning'"><svg x-h-icon data-icon="circle-warning" role="img" aria-label="warning"></svg></template>
+              <template x-if="variant !== 'positive' && variant !== 'negative' && variant !== 'warning'"><svg x-h-icon data-icon="circle-info" role="img" aria-label="info"></svg></template>
             </span>
           </div>
           <span x-h-notification-title class="flex-1" x-text="message"></span>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/calendar/calendar-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/calendar/calendar-page.js.template
@@ -54,6 +54,10 @@ document.addEventListener('alpine:init', () => {
 #if($titleRelation)
       this.loadTitleLookup();
 #end
+      // A custom action changes rows this view shows (a transition flips a status, a create-from adds
+      // a record) through its own endpoint, not this page's editing path. Re-read on every action so
+      // what is on screen agrees with the server (issue #7073).
+      this.onActionDone(() => this.load());
     },
 #if($titleRelation)
 

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -418,6 +418,24 @@ document.addEventListener('alpine:init', () => {
       });
 #end
 #end
+      // A custom action (a transition, a create-from, an action page) changes this document behind
+      // the page's back: its status flips, its totals move, its panels gain rows. Re-read the header
+      // so the status pill, the stepper and the transition buttons - which are filtered by the
+      // CURRENT status - all speak about the record as it now is (issue #7073). The detail panels
+      // re-read themselves (detailPanel does the same on this event).
+      this.onActionDone(async () => {
+        if (!this.isEdit && !this.isPreview) return;
+        try {
+          await this.loadHeader();
+#if($history == "true")
+          await this.loadHistory();
+#end
+          await this.loadItems();
+        } catch (e) {
+          console.error('[${name}DocumentPage] could not refresh after a custom action', e);
+        }
+      });
+
       this.refreshIcons();
     },
 

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -554,8 +554,10 @@
       </button>
 #end
       <!-- Developer-contributed per-record actions for this document (customActions extension point).
-           Shown for an existing document (edit/preview); passes the document id to the action page. -->
-      <template x-for="action in $store.customActions.getActions(caView, 'entity')" :key="action.id">
+           Shown for an existing document (edit/preview); passes the document id to the action page.
+           The open record goes to getActions so a transition its CURRENT status can never accept is
+           not offered at all - Void on a paid invoice was answered with a 409 the user never saw. -->
+      <template x-for="action in $store.customActions.getActions(caView, 'entity', record)" :key="action.id">
         <button type="button" x-h-button data-variant="outline" x-show="isEdit || isPreview" @click="$store.customActions.trigger(action, id)">
           <span x-text="action.translation &amp;&amp; action.translation.key ? T(action.translation.key, action.label, action.translation.options || {}) : action.label"></span>
         </button>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/list/page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/list/page.js.template
@@ -41,6 +41,11 @@ document.addEventListener('alpine:init', () => {
 #end
       await this.load();
       this.loadLookups();
+      // A custom action changes rows this view lists (a transition flips a status, a create-from adds
+      // a record) through its own endpoint, not this page's editing path. Re-read on every action so
+      // the table, the selected record's pane and the status-filtered action buttons agree with the
+      // server (issue #7073).
+      this.onActionDone(async () => { await this.load(); this.loadLookups(); });
     },
 
     async load() {

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/list/view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/list/view.html.template
@@ -170,9 +170,11 @@
 #end
 
         <!-- Developer-contributed per-record actions for this entity (customActions extension point).
-             Passes the selected record's id to the action page. -->
-        <div x-show="$store.customActions.getActions(caView, 'entity').length" class="hbox gap-2 flex-wrap px-4 pt-4 pb-2">
-          <template x-for="action in $store.customActions.getActions(caView, 'entity')" :key="action.id">
+             Passes the selected record's id to the action page. The selected ROW also goes to
+             getActions, so a transition its current status can never accept is not offered at all
+             (issue #7073). -->
+        <div x-show="$store.customActions.getActions(caView, 'entity', selected).length" class="hbox gap-2 flex-wrap px-4 pt-4 pb-2">
+          <template x-for="action in $store.customActions.getActions(caView, 'entity', selected)" :key="action.id">
             <button x-h-button data-variant="outline" data-size="sm" @click="$store.customActions.trigger(action, selectedId)">
               <span x-text="action.translation &amp;&amp; action.translation.key ? T(action.translation.key, action.label, action.translation.options || {}) : action.label"></span>
             </button>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-page.js.template
@@ -65,6 +65,11 @@ document.addEventListener('alpine:init', () => {
       await this.load();
       this.loadLookups();
       this.selectFromRoute();
+      // A custom action changes rows this view lists (a transition flips a status, a create-from adds
+      // a record) through its own endpoint, not this page's editing path. Re-read on every action so
+      // the table, the selected record's pane and the status-filtered action buttons agree with the
+      // server (issue #7073).
+      this.onActionDone(async () => { await this.load(); this.loadLookups(); });
     },
 
     // Deep link / reload support: /${name}/:id pre-selects that row once the list is loaded.

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
@@ -327,9 +327,11 @@
 #end
 
         <!-- Developer-contributed per-record actions for this entity (customActions extension point).
-             Passes the selected record's id to the action page. -->
-        <div x-show="$store.customActions.getActions(caView, 'entity').length" class="hbox gap-2 flex-wrap px-4 pt-4 pb-2">
-          <template x-for="action in $store.customActions.getActions(caView, 'entity')" :key="action.id">
+             Passes the selected record's id to the action page. The selected ROW also goes to
+             getActions, so a transition its current status can never accept is not offered at all
+             (issue #7073). -->
+        <div x-show="$store.customActions.getActions(caView, 'entity', selected).length" class="hbox gap-2 flex-wrap px-4 pt-4 pb-2">
+          <template x-for="action in $store.customActions.getActions(caView, 'entity', selected)" :key="action.id">
             <button x-h-button data-variant="outline" data-size="sm" @click="$store.customActions.trigger(action, selectedId)">
               <span x-text="action.translation &amp;&amp; action.translation.key ? T(action.translation.key, action.label, action.translation.options || {}) : action.label"></span>
             </button>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-page.js.template
@@ -50,6 +50,11 @@ document.addEventListener('alpine:init', () => {
       await this.load();
       this.loadLookups();
       this.selectFromRoute();
+      // A custom action changes rows this view lists (a transition flips a status, a create-from adds
+      // a record) through its own endpoint, not this page's editing path. Re-read on every action so
+      // the table, the selected record's pane and the status-filtered action buttons agree with the
+      // server (issue #7073).
+      this.onActionDone(async () => { await this.load(); this.loadLookups(); });
     },
 
     // Deep link / reload support: /${name}/:id pre-selects that record once the list is loaded.

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
@@ -162,9 +162,11 @@
         </div>
 #end
 
-        <!-- Developer-contributed per-record actions for this entity (customActions extension point). -->
-        <div x-show="$store.customActions.getActions(caView, 'entity').length" class="hbox gap-2 flex-wrap">
-          <template x-for="action in $store.customActions.getActions(caView, 'entity')" :key="action.id">
+        <!-- Developer-contributed per-record actions for this entity (customActions extension point).
+             The selected row goes to getActions, so a transition its current status can never accept
+             is not offered at all (issue #7073). -->
+        <div x-show="$store.customActions.getActions(caView, 'entity', selected).length" class="hbox gap-2 flex-wrap">
+          <template x-for="action in $store.customActions.getActions(caView, 'entity', selected)" :key="action.id">
             <button x-h-button data-variant="outline" data-size="sm" @click="$store.customActions.trigger(action, selectedId)">
               <span x-text="action.translation &amp;&amp; action.translation.key ? T(action.translation.key, action.label, action.translation.options || {}) : action.label"></span>
             </button>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/slots/slots-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/slots/slots-page.js.template
@@ -30,7 +30,13 @@ document.addEventListener('alpine:init', () => {
     apiPath: '/${javaPerspectiveName}/${name}Controller',
     caView: '${name}',
 
-    async init() { await this.load(); },
+    async init() {
+      await this.load();
+      // A custom action changes rows this view shows (a transition flips a status, a create-from adds
+      // a record) through its own endpoint, not this page's editing path. Re-read on every action so
+      // what is on screen agrees with the server (issue #7073).
+      this.onActionDone(() => this.load());
+    },
 
     async load() {
       this.state = 'loading';

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
@@ -395,7 +395,8 @@
             <span x-h-avatar class="rounded-full" :data-variant="variant">
               <template x-if="variant === 'positive'"><svg x-h-icon data-icon="circle-success" role="img" aria-label="success"></svg></template>
               <template x-if="variant === 'negative'"><svg x-h-icon data-icon="circle-error" role="img" aria-label="error"></svg></template>
-              <template x-if="variant !== 'positive' && variant !== 'negative'"><svg x-h-icon data-icon="circle-info" role="img" aria-label="info"></svg></template>
+              <template x-if="variant === 'warning'"><svg x-h-icon data-icon="circle-warning" role="img" aria-label="warning"></svg></template>
+              <template x-if="variant !== 'positive' && variant !== 'negative' && variant !== 'warning'"><svg x-h-icon data-icon="circle-info" role="img" aria-label="info"></svg></template>
             </span>
           </div>
           <span x-h-notification-title class="flex-1" x-text="message"></span>


### PR DESCRIPTION
Every on-demand action in a generated app - a transition, a create-from, an
action page - ended in silence. `customActions.notify()` wrote its outcome into
the notification bell and nothing else, so a 409 and a 200 looked identical on
screen: Void on a paid invoice was refused by the server ("VoidSalesInvoice is
allowed only from status [3, 4] - current status is [6]"), showed nothing, and
the clerk went on believing the invoice was voided. Three separate gaps produced
that, and each is closed here.

**Nothing was ever shown.** `notifications` now has `announce()`: it records the
entry in the bell AND raises the transient toast over Harmonia's notification
overlay, which every shell already declares a `toast` template for and nothing
had ever pushed to. `customActions.notify()` goes through it. The overlay's
template gains a `warning` icon, so the fail-soft mail outcomes of #7023 stop
borrowing the neutral one.

**The reason never survived the trip.** `api.js` had no 409 case (a Conflict
arrived as `InternalServerError`) and read only `errorMessage`/`message`, while
the generated transition and check controllers answer with `error`. The catalog
then replaced whatever was left with "Something went wrong on our end." A
refusal is not a fault: its text is authored, in the intent, for the person who
pressed the button, so `apiErrors.refusalMessageFor` returns the server's own
sentence for 400 and 409 - and only for those, only when it reads like a
sentence (no markup, under 300 characters), with every other failure still going
through `messageFor`, where a developer-facing message never reaches a screen.

**The refused button should not have been there.** `TransitionsIntentGenerator`
now mirrors the `from:` guard onto the descriptor (`statusProperty` + `from`),
and `getActions(view, type, record)` drops an action the record's current status
can never accept - so Void stops being offered on a paid invoice at all. It
fails OPEN in every uncertain case (no guard, no record, a row that does not
carry the status property): hiding a button that would have worked is worse than
showing one the server refuses, and the server's check - including the `when:`
guard, deliberately NOT mirrored because a client re-implementation of a Calc
expression would drift from it - stays authoritative.

**And the page never looked again.** The store had raised `harmonia:action-done`
since it was written; nothing listened. That is why Record Reminder created its
row and the Payment Reminders panel underneath went on saying "No records".
`basePage` gains `onActionDone()` (with a `destroy()` that unhooks it, so a page
navigated away from stops reloading), and the detail/related panels, the
document page and the list/master/calendar/slots pages all re-read on it. The
document page re-reads its header too, so the status pill, the stepper and the
now status-filtered buttons agree with the record as it now is.

A page action (`path`) reports through the same path: `harmonia.form.close`
means the page finished, so it toasts - the page may say `status`/`message`
itself, and one that says nothing still gets "<label> completed" instead of the
silence Save as Template used to end in. Dismissing the dialog with the X is not
an outcome and stays quiet.

Verified: `TransitionActionDescriptorTest` pins the mirrored guard, that it
names the entity's OWN status relation rather than the conventional `Status`,
and that a `when:` guard has no client half; full engine-intent suite green
(1077 tests). The client halves were exercised directly - a paid invoice hides
Void, an issued one keeps it, a string status still matches, and a row without
the status property or no row at all keeps the button; a 409 shows the authored
reason, a 500 keeps the catalog line, and a 409 carrying an HTML error page
falls back to the catalog line rather than pasting a document into a toast.

Not covered here: the last observation on the issue, that a task form's status
stepper lists PARTIAL/PAID as steps after CONFIRMED although they are settlement
states reached from ISSUED. The stepper is built from the status entity's seed
order, which has no notion of a branch; making it honest needs the reachability
graph (the process's own status writes), which is a different change on
different metadata. Filed separately.

Fixes #7073

🤖 Generated with [Claude Code](https://claude.com/claude-code)