### PR TITLE
jobs: a manual Run now is recorded like a scheduled fire (#7075)

### DIFF
--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/handler/JobExecutionService.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/handler/JobExecutionService.java
@@ -43,11 +43,13 @@ public class JobExecutionService {
         this.jobHandlerRunner = jobHandlerRunner;
     }
 
+    /**
+     * Runs the job a Quartz trigger just fired, reading its handler and engine off the fire context.
+     *
+     * @param context the Quartz execution context
+     * @throws JobExecutionException when the job body throws
+     */
     public void executeJob(JobExecutionContext context) throws JobExecutionException {
-        executeJobInternal(context);
-    }
-
-    private void executeJobInternal(JobExecutionContext context) throws JobExecutionException {
         String tenantJobName = context.getJobDetail()
                                       .getKey()
                                       .getName();
@@ -57,22 +59,38 @@ public class JobExecutionService {
                                    .getJobDataMap();
         String handler = params.getString(JOB_PARAMETER_HANDLER);
         String engine = params.getString(JOB_PARAMETER_ENGINE);
+
+        context.put("handler", handler);
+        executeJob(name, handler, engine);
+    }
+
+    /**
+     * Runs a job's handler and records the run in the job's execution log.
+     *
+     * <p>
+     * This is the one execution path: the scheduled fire reaches it through the Quartz context above, a
+     * manual "Run now" through {@code JobService.trigger}. Both leave the same trail - a TRIGGRED
+     * entry, then a FINISHED or FAILED one, and the owning job's last-run status, message and timestamp
+     * - because an operator cannot tell a manual run from a scheduled one after the fact, and a run
+     * that leaves no trace is indistinguishable from one that never happened (#7075).
+     *
+     * @param name the job's name, as the artefact declares it
+     * @param handler the job's handler - a client-Java FQN for the Java engine, a repository path
+     *        otherwise
+     * @param engine the job's engine, or null for the default JavaScript one
+     * @throws JobExecutionException when the job body throws
+     */
+    public void executeJob(String name, String handler, String engine) throws JobExecutionException {
         boolean java = JavaJobExecutor.ENGINE_JAVA.equals(engine);
         Span.current()
             .setAttribute("handler", handler);
 
         JobLog triggered = registerTriggered(name, handler);
         try {
-            Span.current()
-                .setAttribute("handler", handler);
-
-            if (triggered != null) {
-                context.put("handler", handler);
-                // A client-Java job dispatches to the Java engine's executor, a JS one to the code
-                // runner - inside the same JobLog wrapping either way, so both are equally
-                // visible/monitored in the Jobs perspective.
-                jobHandlerRunner.run(handler, engine);
-            }
+            // A client-Java job dispatches to the Java engine's executor, a JS one to the code
+            // runner - inside the same JobLog wrapping either way, so both are equally
+            // visible/monitored in the Jobs perspective.
+            jobHandlerRunner.run(handler, engine);
 
             registeredFinished(name, handler, triggered);
         } catch (Exception ex) {
@@ -105,9 +123,12 @@ public class JobExecutionService {
      *
      * @param name the name
      * @param module the module
-     * @param triggered the triggered
+     * @param triggered the TRIGGRED entry this run opened, or null when it could not be written
      */
     private void registeredFinished(String name, String module, JobLog triggered) {
+        if (triggered == null) {
+            return;
+        }
         try {
             jobLogService.jobFinished(name, module, triggered.getId(), new Date(triggered.getTriggeredAt()
                                                                                          .getTime()));
@@ -121,10 +142,13 @@ public class JobExecutionService {
      *
      * @param name the name
      * @param module the module
-     * @param triggered the triggered
+     * @param triggered the TRIGGRED entry this run opened, or null when it could not be written
      * @param ex the ex
      */
     private void registeredFailed(String name, String module, JobLog triggered, Exception ex) {
+        if (triggered == null) {
+            return;
+        }
         try {
             jobLogService.jobFailed(name, module, triggered.getId(), new Date(triggered.getTriggeredAt()
                                                                                        .getTime()),

--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/service/JobLogService.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/service/JobLogService.java
@@ -18,6 +18,9 @@ import org.eclipse.dirigible.components.jobs.domain.JobLog;
 import org.eclipse.dirigible.components.jobs.domain.JobStatus;
 import org.eclipse.dirigible.components.jobs.email.JobEmailProcessor;
 import org.eclipse.dirigible.components.jobs.repository.JobLogRepository;
+import org.eclipse.dirigible.components.jobs.repository.JobRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Example;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,14 +37,17 @@ import java.util.List;
 @Transactional
 public class JobLogService extends BaseArtefactService<JobLog, Long> {
 
+    /** The logger. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(JobLogService.class);
+
     /** The date format. */
     private final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
     /** The job email processor. */
     private final JobEmailProcessor jobEmailProcessor;
 
-    /** The job service. */
-    private final JobService jobService;
+    /** The job repository - the owning job's last-run fields are stamped through it. */
+    private final JobRepository jobRepository;
 
     /** The tenant context. */
     private final TenantContext tenantContext;
@@ -54,15 +60,15 @@ public class JobLogService extends BaseArtefactService<JobLog, Long> {
      *
      * @param repository the repository
      * @param jobEmailProcessor the job email processor
-     * @param jobService the job service
+     * @param jobRepository the job repository
      * @param tenantContext the tenant context
      * @param defaultTenant the default tenant
      */
-    public JobLogService(JobLogRepository repository, JobEmailProcessor jobEmailProcessor, JobService jobService,
+    public JobLogService(JobLogRepository repository, JobEmailProcessor jobEmailProcessor, JobRepository jobRepository,
             TenantContext tenantContext, @DefaultTenant Tenant defaultTenant) {
         super(repository);
         this.jobEmailProcessor = jobEmailProcessor;
-        this.jobService = jobService;
+        this.jobRepository = jobRepository;
         this.tenantContext = tenantContext;
         this.defaultTenant = defaultTenant;
     }
@@ -193,11 +199,15 @@ public class JobLogService extends BaseArtefactService<JobLog, Long> {
         jobLog.setLocation(new SimpleDateFormat(DATE_FORMAT).format(new Date()));
         jobLog.updateKey();
         save(jobLog);
-        Job job = jobService.findByName(name);
+        Job job = findJob(name);
+        if (job == null) {
+            return jobLog;
+        }
         boolean statusChanged = job.getStatus() != JobStatus.FINISHED;
         job.setStatus(JobStatus.FINISHED);
         job.setMessage("");
         job.setExecutedAt(jobLog.getFinishedAt());
+        jobRepository.saveAndFlush(job);
         if (statusChanged) {
             String content =
                     jobEmailProcessor.prepareEmail(job, JobEmailProcessor.emailTemplateNormal, JobEmailProcessor.EMAIL_TEMPLATE_NORMAL);
@@ -229,17 +239,38 @@ public class JobLogService extends BaseArtefactService<JobLog, Long> {
         jobLog.setLocation(new SimpleDateFormat(DATE_FORMAT).format(new Date()));
         jobLog.updateKey();
         save(jobLog);
-        Job job = jobService.findByName(name);
+        Job job = findJob(name);
+        if (job == null) {
+            return jobLog;
+        }
         boolean statusChanged = job.getStatus() != JobStatus.FAILED;
         job.setStatus(JobStatus.FAILED);
         job.setMessage(message);
         job.setExecutedAt(jobLog.getFinishedAt());
+        jobRepository.saveAndFlush(job);
         if (statusChanged) {
             String content =
                     jobEmailProcessor.prepareEmail(job, JobEmailProcessor.emailTemplateError, JobEmailProcessor.EMAIL_TEMPLATE_ERROR);
             jobEmailProcessor.sendEmail(job, JobEmailProcessor.emailSubjectError, content);
         }
         return jobLog;
+    }
+
+    /**
+     * Looks up the job whose run is being recorded. A log may outlive its artefact - a job deleted
+     * between the trigger and the finish leaves nothing to stamp, which is not a failure of the run.
+     *
+     * @param name the job name
+     * @return the job, or null when no artefact by that name exists any more
+     */
+    private Job findJob(String name) {
+        String jobName = (name != null && name.startsWith("/")) ? name.substring(1) : name;
+        Job job = jobRepository.findByName(jobName)
+                               .orElse(null);
+        if (job == null) {
+            LOGGER.warn("Job [{}] has no artefact - its last run was logged but not stamped on the job.", jobName);
+        }
+        return job;
     }
 
     /**

--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/service/JobService.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/service/JobService.java
@@ -20,10 +20,11 @@ import org.eclipse.dirigible.components.base.artefact.BaseArtefactService;
 import org.eclipse.dirigible.components.jobs.domain.Job;
 import org.eclipse.dirigible.components.jobs.domain.JobParameter;
 import org.eclipse.dirigible.components.jobs.email.JobEmailProcessor;
-import org.eclipse.dirigible.components.jobs.handler.JobHandlerRunner;
+import org.eclipse.dirigible.components.jobs.handler.JobExecutionService;
 import org.eclipse.dirigible.components.jobs.manager.JobsManager;
 import org.eclipse.dirigible.components.jobs.repository.JobRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -39,8 +40,8 @@ public class JobService extends BaseArtefactService<Job, Long> {
     /** The jobs manager. */
     private final JobsManager jobsManager;
 
-    /** Runs a job's handler on the engine it declares - shared with the scheduled fire. */
-    private final JobHandlerRunner jobHandlerRunner;
+    /** Runs a job's handler and records the run - the same path the scheduled fire takes. */
+    private final JobExecutionService jobExecutionService;
 
     /**
      * Instantiates a new job service.
@@ -48,14 +49,14 @@ public class JobService extends BaseArtefactService<Job, Long> {
      * @param repository the repository
      * @param jobEmailProcessor the job email processor
      * @param jobsManager the jobs manager
-     * @param jobHandlerRunner the job handler runner
+     * @param jobExecutionService the job execution service
      */
     public JobService(JobRepository repository, JobEmailProcessor jobEmailProcessor, JobsManager jobsManager,
-            JobHandlerRunner jobHandlerRunner) {
+            JobExecutionService jobExecutionService) {
         super(repository);
         this.jobEmailProcessor = jobEmailProcessor;
         this.jobsManager = jobsManager;
-        this.jobHandlerRunner = jobHandlerRunner;
+        this.jobExecutionService = jobExecutionService;
     }
 
     /**
@@ -156,6 +157,10 @@ public class JobService extends BaseArtefactService<Job, Long> {
      *         was passed
      * @throws Exception the exception
      */
+    // The run itself must not sit in this service's transaction: the execution log is written as the
+    // run progresses, and a failing job would otherwise roll back the very FAILED entry that records
+    // it. Each log write then gets its own transaction, exactly as on the scheduled path.
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public boolean trigger(String name, Map<String, String> parametersMap) throws Exception {
         Job job = findByName(name);
         Map<String, String> parameters = (parametersMap != null) ? parametersMap : Collections.emptyMap();
@@ -168,7 +173,9 @@ public class JobService extends BaseArtefactService<Job, Long> {
         try {
             // Run it on the engine the job declares - the same dispatch the scheduled fire uses. A
             // client-Java job's handler is a class name, not a JavaScript path (dirigible #6305).
-            jobHandlerRunner.run(job.getHandler(), job.getEngine());
+            // It goes through the execution service rather than the runner directly, so a manual run
+            // leaves the same execution-log trail and last-run stamp a scheduled one does (#7075).
+            jobExecutionService.executeJob(job.getName(), job.getHandler(), job.getEngine());
         } finally {
             Configuration.setThreadConfiguration(outerConfiguration);
         }

--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/synchronizer/JobSynchronizer.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/synchronizer/JobSynchronizer.java
@@ -148,6 +148,11 @@ public class JobSynchronizer extends MultitenantBaseSynchronizer<Job, Long> {
             Job maybe = getService().findByKey(job.getKey());
             if (maybe != null) {
                 job.setId(maybe.getId());
+                // The last run is history, not something the artefact declares - re-parsing the file
+                // must not reset the job to "never ran" (#7075).
+                job.setStatus(maybe.getStatus());
+                job.setMessage(maybe.getMessage());
+                job.setExecutedAt(maybe.getExecutedAt());
                 job.getParameters()
                    .forEach(p -> {
                        JobParameter m = maybe.getParameter(p.getName());

--- a/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/handler/JobExecutionServiceTest.java
+++ b/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/handler/JobExecutionServiceTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.jobs.handler;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Timestamp;
+import java.util.Date;
+
+import org.eclipse.dirigible.components.data.sources.manager.DataSourcesManager;
+import org.eclipse.dirigible.components.jobs.domain.JobLog;
+import org.eclipse.dirigible.components.jobs.service.JobLogService;
+import org.eclipse.dirigible.components.jobs.tenant.JobNameCreator;
+import org.junit.jupiter.api.Test;
+import org.quartz.JobExecutionException;
+
+/**
+ * A run leaves an execution log whichever way it was started (dirigible #7075). A manual "Run now"
+ * reaches this service through {@code JobService.trigger}, a scheduled fire through the Quartz
+ * context - both end up in the same TRIGGRED-then-FINISHED/FAILED trail.
+ */
+class JobExecutionServiceTest {
+
+    /** The job name as the artefact declares it. */
+    private static final String JOB_NAME = "project/report.job";
+
+    /** The job's handler - a repository path, so the default JavaScript engine runs it. */
+    private static final String HANDLER = "/project/report.mjs";
+
+    private final JobLogService jobLogService = mock(JobLogService.class);
+
+    private final JobHandlerRunner jobHandlerRunner = mock(JobHandlerRunner.class);
+
+    private final JobExecutionService jobExecutionService =
+            new JobExecutionService(jobLogService, mock(JobNameCreator.class), mock(DataSourcesManager.class), jobHandlerRunner);
+
+    @Test
+    void aSuccessfulRunIsLoggedAsTriggeredThenFinished() throws Exception {
+        JobLog triggered = triggeredLog();
+
+        jobExecutionService.executeJob(JOB_NAME, HANDLER, null);
+
+        verify(jobHandlerRunner).run(HANDLER, null);
+        verify(jobLogService).jobFinished(eq(JOB_NAME), eq(HANDLER), eq(triggered.getId()), any(Date.class));
+        verify(jobLogService, never()).jobFailed(any(), any(), anyLong(), any(), any());
+    }
+
+    @Test
+    void aFailedRunIsLoggedAsFailedWithTheCauseAndRethrown() throws Exception {
+        JobLog triggered = triggeredLog();
+        doThrow(new IllegalStateException("boom")).when(jobHandlerRunner)
+                                                  .run(HANDLER, null);
+
+        assertThrows(JobExecutionException.class, () -> jobExecutionService.executeJob(JOB_NAME, HANDLER, null));
+
+        verify(jobLogService).jobFailed(eq(JOB_NAME), eq(HANDLER), eq(triggered.getId()), any(Date.class), eq("boom"));
+        verify(jobLogService, never()).jobFinished(any(), any(), anyLong(), any());
+    }
+
+    /**
+     * The log is a record of the run, not a precondition for it - an unwritable log must not silently
+     * stop the schedule.
+     */
+    @Test
+    void theJobStillRunsWhenItsTriggeredEntryCannotBeWritten() throws Exception {
+        when(jobLogService.jobTriggered(JOB_NAME, HANDLER)).thenThrow(new IllegalStateException("the log is unavailable"));
+
+        jobExecutionService.executeJob(JOB_NAME, HANDLER, null);
+
+        verify(jobHandlerRunner).run(HANDLER, null);
+        verify(jobLogService, never()).jobFinished(any(), any(), anyLong(), any());
+    }
+
+    private JobLog triggeredLog() {
+        JobLog triggered = new JobLog();
+        triggered.setId(42L);
+        triggered.setTriggeredAt(new Timestamp(System.currentTimeMillis()));
+        when(jobLogService.jobTriggered(JOB_NAME, HANDLER)).thenReturn(triggered);
+        return triggered;
+    }
+}

--- a/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/service/JobLogServiceTest.java
+++ b/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/service/JobLogServiceTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Date;
+import java.util.Optional;
 
 import org.eclipse.dirigible.components.base.tenant.Tenant;
 import org.eclipse.dirigible.components.base.tenant.TenantContext;
@@ -24,6 +25,7 @@ import org.eclipse.dirigible.components.jobs.domain.JobLog;
 import org.eclipse.dirigible.components.jobs.domain.JobStatus;
 import org.eclipse.dirigible.components.jobs.email.JobEmailProcessor;
 import org.eclipse.dirigible.components.jobs.repository.JobLogRepository;
+import org.eclipse.dirigible.components.jobs.repository.JobRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -150,7 +152,7 @@ public class JobLogServiceTest {
     public void logsFallBackToDefaultTenantWhenContextUninitialized() {
         TenantContext tenantContext = mock(TenantContext.class);
         when(tenantContext.isNotInitialized()).thenReturn(true);
-        JobLogService service = new JobLogService(jobLogRepository, mock(JobEmailProcessor.class), mock(JobService.class), tenantContext,
+        JobLogService service = new JobLogService(jobLogRepository, mock(JobEmailProcessor.class), mock(JobRepository.class), tenantContext,
                 mockTenant(DEFAULT_TENANT_ID));
 
         JobLog log = service.jobLogged("job", "handler.js", "msg");
@@ -167,9 +169,9 @@ public class JobLogServiceTest {
     public void jobFinishedPersistsFinishedLogAndUpdatesJob() {
         Job job = mock(Job.class);
         when(job.getStatus()).thenReturn(JobStatus.TRIGGRED);
-        JobService jobService = mock(JobService.class);
-        when(jobService.findByName("job")).thenReturn(job);
-        JobLogService service = new JobLogService(jobLogRepository, mock(JobEmailProcessor.class), jobService,
+        JobRepository jobRepository = mock(JobRepository.class);
+        when(jobRepository.findByName("job")).thenReturn(Optional.of(job));
+        JobLogService service = new JobLogService(jobLogRepository, mock(JobEmailProcessor.class), jobRepository,
                 initializedContext("tenant-a"), mockTenant(DEFAULT_TENANT_ID));
 
         JobLog log = service.jobFinished("job", "handler.js", 5L, new Date());
@@ -178,6 +180,8 @@ public class JobLogServiceTest {
         assertEquals(5L, log.getTriggeredId());
         assertNotNull(log.getFinishedAt());
         verify(job).setStatus(JobStatus.FINISHED);
+        verify(job).setExecutedAt(log.getFinishedAt());
+        verify(jobRepository).saveAndFlush(job);
         assertEquals(1, service.findByJob("job")
                                .size());
     }
@@ -190,9 +194,9 @@ public class JobLogServiceTest {
     public void jobFailedPersistsFailedLogAndUpdatesJob() {
         Job job = mock(Job.class);
         when(job.getStatus()).thenReturn(JobStatus.TRIGGRED);
-        JobService jobService = mock(JobService.class);
-        when(jobService.findByName("job")).thenReturn(job);
-        JobLogService service = new JobLogService(jobLogRepository, mock(JobEmailProcessor.class), jobService,
+        JobRepository jobRepository = mock(JobRepository.class);
+        when(jobRepository.findByName("job")).thenReturn(Optional.of(job));
+        JobLogService service = new JobLogService(jobLogRepository, mock(JobEmailProcessor.class), jobRepository,
                 initializedContext("tenant-a"), mockTenant(DEFAULT_TENANT_ID));
 
         JobLog log = service.jobFailed("job", "handler.js", 7L, new Date(), "boom");
@@ -202,6 +206,8 @@ public class JobLogServiceTest {
         assertEquals(7L, log.getTriggeredId());
         assertNotNull(log.getFinishedAt());
         verify(job).setStatus(JobStatus.FAILED);
+        verify(job).setExecutedAt(log.getFinishedAt());
+        verify(jobRepository).saveAndFlush(job);
         assertEquals(1, service.findByJob("job")
                                .size());
     }
@@ -218,7 +224,7 @@ public class JobLogServiceTest {
         Tenant tenantA = mockTenant("tenant-a");
         Tenant tenantB = mockTenant("tenant-b");
         JobLogService service =
-                new JobLogService(jobLogRepository, mock(JobEmailProcessor.class), mock(JobService.class), tenantContext, defaultTenant);
+                new JobLogService(jobLogRepository, mock(JobEmailProcessor.class), mock(JobRepository.class), tenantContext, defaultTenant);
 
         // two logs for the same job under tenant A
         when(tenantContext.getCurrentTenant()).thenReturn(tenantA);
@@ -253,7 +259,7 @@ public class JobLogServiceTest {
      * @return the job log service
      */
     private JobLogService serviceForTenant(String tenantId) {
-        return new JobLogService(jobLogRepository, mock(JobEmailProcessor.class), mock(JobService.class), initializedContext(tenantId),
+        return new JobLogService(jobLogRepository, mock(JobEmailProcessor.class), mock(JobRepository.class), initializedContext(tenantId),
                 mockTenant(DEFAULT_TENANT_ID));
     }
 

--- a/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/service/JobTriggerParametersTest.java
+++ b/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/service/JobTriggerParametersTest.java
@@ -27,7 +27,7 @@ import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.components.jobs.domain.Job;
 import org.eclipse.dirigible.components.jobs.domain.JobParameter;
 import org.eclipse.dirigible.components.jobs.email.JobEmailProcessor;
-import org.eclipse.dirigible.components.jobs.handler.JobHandlerRunner;
+import org.eclipse.dirigible.components.jobs.handler.JobExecutionService;
 import org.eclipse.dirigible.components.jobs.manager.JobsManager;
 import org.eclipse.dirigible.components.jobs.repository.JobRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -51,10 +51,10 @@ class JobTriggerParametersTest {
 
     private final JobRepository jobRepository = mock(JobRepository.class);
 
-    private final JobHandlerRunner jobHandlerRunner = mock(JobHandlerRunner.class);
+    private final JobExecutionService jobExecutionService = mock(JobExecutionService.class);
 
     private final JobService jobService =
-            new JobService(jobRepository, mock(JobEmailProcessor.class), mock(JobsManager.class), jobHandlerRunner);
+            new JobService(jobRepository, mock(JobEmailProcessor.class), mock(JobsManager.class), jobExecutionService);
 
     @AfterEach
     void cleanUpConfiguration() {
@@ -68,12 +68,12 @@ class JobTriggerParametersTest {
         doAnswer(invocation -> {
             assertEquals("2026-08-14", Configuration.get("REPORT_DATE"), "the job body reads its parameter as a configuration value");
             return null;
-        }).when(jobHandlerRunner)
-          .run("/project/report.mjs", null);
+        }).when(jobExecutionService)
+          .executeJob(JOB_NAME, "/project/report.mjs", null);
 
         jobService.trigger(TRIGGER_PATH, Map.of("REPORT_DATE", "2026-08-14"));
 
-        verify(jobHandlerRunner).run("/project/report.mjs", null);
+        verify(jobExecutionService).executeJob(JOB_NAME, "/project/report.mjs", null);
         assertNull(Configuration.get("REPORT_DATE"), "the parameter must not outlive the run");
     }
 
@@ -85,7 +85,7 @@ class JobTriggerParametersTest {
                 () -> jobService.trigger(TRIGGER_PATH, Map.of(INFRASTRUCTURE_KEY, "http://attacker.example.com")));
 
         assertNull(Configuration.get(INFRASTRUCTURE_KEY), "an undeclared key must never reach the configuration");
-        verifyNoInteractions(jobHandlerRunner);
+        verifyNoInteractions(jobExecutionService);
     }
 
     /**
@@ -101,8 +101,8 @@ class JobTriggerParametersTest {
             reader.start();
             reader.join();
             return null;
-        }).when(jobHandlerRunner)
-          .run("/project/report.mjs", null);
+        }).when(jobExecutionService)
+          .executeJob(JOB_NAME, "/project/report.mjs", null);
 
         jobService.trigger(TRIGGER_PATH, Map.of("REPORT_DATE", "2026-08-14"));
 
@@ -120,8 +120,8 @@ class JobTriggerParametersTest {
         doAnswer(invocation -> {
             assertEquals("Tenant One", Configuration.get("DIRIGIBLE_BRANDING_NAME"));
             return null;
-        }).when(jobHandlerRunner)
-          .run("/project/report.mjs", null);
+        }).when(jobExecutionService)
+          .executeJob(JOB_NAME, "/project/report.mjs", null);
 
         jobService.trigger(TRIGGER_PATH, Map.of("REPORT_DATE", "2026-08-14"));
 

--- a/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/synchronizer/JobSynchronizerTest.java
+++ b/components/engine/engine-jobs/src/test/java/org/eclipse/dirigible/components/jobs/synchronizer/JobSynchronizerTest.java
@@ -12,6 +12,7 @@ package org.eclipse.dirigible.components.jobs.synchronizer;
 import jakarta.persistence.EntityManager;
 import org.eclipse.dirigible.components.jobs.domain.Job;
 import org.eclipse.dirigible.components.jobs.domain.JobParameter;
+import org.eclipse.dirigible.components.jobs.domain.JobStatus;
 import org.eclipse.dirigible.components.jobs.repository.JobRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +26,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.file.Path;
+import java.sql.Timestamp;
 import java.text.ParseException;
 import java.util.Collections;
 import java.util.List;
@@ -146,5 +148,32 @@ public class JobSynchronizerTest {
         assertNotNull(list);
         assertEquals("/test/control.job", list.get(0)
                                               .getLocation());
+    }
+
+    /**
+     * The last run is history, not something the artefact declares: re-parsing a published job file
+     * must not reset the job to "never ran" (dirigible #7075).
+     *
+     * @throws ParseException the parse exception
+     */
+    @Test
+    public void reparsingKeepsTheLastRun() throws ParseException {
+        String content =
+                "{\"expression\":\"0/1 * * * * ?\",\"group\":\"defined\",\"handler\":\"test/handler.js\",\"description\":\"Control Job\"}";
+        Job job = jobSynchronizer.parse("/test/recorded.job", content.getBytes())
+                                 .get(0);
+        Timestamp executedAt = new Timestamp(System.currentTimeMillis());
+        job.setStatus(JobStatus.FAILED);
+        job.setMessage("boom");
+        job.setExecutedAt(executedAt);
+        jobRepository.saveAndFlush(job);
+        entityManager.clear();
+
+        Job reparsed = jobSynchronizer.parse("/test/recorded.job", content.getBytes())
+                                      .get(0);
+
+        assertEquals(JobStatus.FAILED, reparsed.getStatus());
+        assertEquals("boom", reparsed.getMessage());
+        assertEquals(executedAt, reparsed.getExecutedAt());
     }
 }


### PR DESCRIPTION
A **Run now** from Monitoring → Jobs executed the job and left no trace: the Jobs table kept `Last run UNKNOWN` and the detail pane said "This job has not run yet". Operations could not tell a schedule that fired from one that never did - which is exactly what verifying the Quartz-delegate fix needed.

Two independent causes, both fixed here.

**1. The manual trigger bypassed the execution log.** `JobService.trigger` called `JobHandlerRunner` directly, while the scheduled fire went through `JobExecutionService`, which wraps the run in a `JobLog`. The wrapping moves into a shared `JobExecutionService.executeJob(name, handler, engine)` - the one execution path both callers now take, so a manual run and a scheduled one leave the same trail: a `TRIGGRED` entry, then `FINISHED` or `FAILED` with the failure message, plus the owning job's last-run status, message and timestamp.

`trigger` runs with the service transaction suspended (`NOT_SUPPORTED`). `JobService` is class-level `@Transactional`, so without that a failing job would roll back the very `FAILED` entry that records it - the log writes now each get their own transaction, exactly as on the scheduled path.

**2. Re-parsing a job artefact reset it to "never ran".** `JobSynchronizer.parseImpl` rebuilds the `Job` from the file and carried over only the id and the parameters, so `status`, `message` and `executedAt` fell back to `UNKNOWN`/null on every publish of the project. The last run is history, not something the artefact declares; it is carried over now.

**Wiring.** `JobLogService` stamps the owning job through `JobRepository` instead of `JobService` - that breaks the cycle the shared execution path would otherwise form (`JobService` → `JobExecutionService` → `JobLogService` → `JobService`), and makes the write explicit (`saveAndFlush`) rather than relying on dirty checking inside the enclosing transaction. A log written for a name whose artefact is gone is warned about instead of throwing.

One deliberate behaviour change: a run whose `TRIGGRED` entry could not be written now **proceeds anyway**. Previously the job was skipped and the code then dereferenced the null log entry. The log records the run; it is not a precondition for it.

**Tests** (`mvn -pl components/engine/engine-jobs test`, 40 green):
- new `JobExecutionServiceTest` - a successful run logs TRIGGRED→FINISHED, a failing one logs FAILED with the cause and rethrows, and an unwritable log does not stop the run
- `JobTriggerParametersTest` follows the trigger onto the execution service, keeping its #6729 assertions intact
- `JobSynchronizerTest.reparsingKeepsTheLastRun` - the regression for cause 2 (verified red without the fix)
- `JobLogServiceTest` asserts the job's `executedAt` stamp and the explicit save

Fixes #7075

🤖 Generated with [Claude Code](https://claude.com/claude-code)