### PR TITLE
ui: an Inbox row says which record it is about (#7077)

### DIFF
--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/dto/TaskDTO.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/dto/TaskDTO.java
@@ -53,6 +53,9 @@ public class TaskDTO {
     /** The i18n key of the process' name, null when the process declares no catalog. */
     private String processDefinitionNameKey;
 
+    /** Where to read the business identity of the record the task is about; null when undeclared. */
+    private TaskSubject subject;
+
     /**
      * Gets the candidate users.
      *
@@ -275,6 +278,24 @@ public class TaskDTO {
      */
     public void setProcessDefinitionNameKey(String processDefinitionNameKey) {
         this.processDefinitionNameKey = processDefinitionNameKey;
+    }
+
+    /**
+     * Where a row listing this task reads what the task is ABOUT - the record's number, counterparty
+     * and total - instead of the bare business key. Locators only, resolved live by the reader; see
+     * {@link TaskSubject}.
+     *
+     * @return the subject locators, or null when the process declares none
+     */
+    public TaskSubject getSubject() {
+        return subject;
+    }
+
+    /**
+     * @param subject the subject locators of the record the task is about
+     */
+    public void setSubject(TaskSubject subject) {
+        this.subject = subject;
     }
 
 }

--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/dto/TaskSubject.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/dto/TaskSubject.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.bpm.flowable.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Where a task's row can read the business identity of the record it is about - the document's
+ * number, its counterparty and its total, instead of the bare {@code Ref <id>} the BPM business key
+ * left behind (issue #7077).
+ * <p>
+ * It carries LOCATORS, never values: the record's own REST URL and id, plus the properties to show
+ * and how to read each one. The client resolves them live, exactly as the task form resolves the
+ * record it edits - a subject snapshotted when the process started would state the total of a
+ * document whose lines are added afterwards.
+ * <p>
+ * Everything here comes from process variables the generated trigger seeded: {@code __entityUrl} /
+ * {@code __entityId} (the record), {@code __subjectFields} (the {@code <Property>:<kind>} list the
+ * intent derived from the entity) and, per relation property, the {@code __<Property>EntityUrl} /
+ * {@code __<Property>EntityLabel} pair the task form already uses to render a foreign key as a
+ * name. A process that seeds none - a hand-authored BPMN, a deployment generated before #7077 - has
+ * no subject and its rows keep reading as they did.
+ *
+ * @param url the record's REST controller URL
+ * @param id the record's primary key
+ * @param fields the properties to show, in reading order
+ */
+public record TaskSubject(String url, String id, List<Field> fields) {
+
+    /** The process variable naming the properties a task's subject line is built from. */
+    private static final String SUBJECT_FIELDS = "__subjectFields";
+
+    /** The process variable holding the record's REST controller URL. */
+    private static final String ENTITY_URL = "__entityUrl";
+
+    /** The process variable holding the record's primary key. */
+    private static final String ENTITY_ID = "__entityId";
+
+    /** The kind of a property that is a to-one relation, resolved to the target's label. */
+    private static final String RELATION = "relation";
+
+    /**
+     * One property of a subject line.
+     *
+     * @param property the property to read off the record
+     * @param kind how to render it - {@code number}, {@code date}, {@code relation} or {@code text}
+     * @param url for a {@code relation}, the target's REST controller URL; {@code null} otherwise
+     * @param label for a {@code relation}, the target property to show; {@code null} otherwise
+     */
+    public record Field(String property, String kind, String url, String label) {
+    }
+
+    /**
+     * Reads the subject a generated trigger seeded into the process variables.
+     *
+     * @param variables the task's process variables
+     * @return the subject, or {@code null} when the process declares none
+     */
+    public static TaskSubject from(Map<String, Object> variables) {
+        String declaration = text(variables.get(SUBJECT_FIELDS));
+        String url = text(variables.get(ENTITY_URL));
+        String id = text(variables.get(ENTITY_ID));
+        if (declaration == null || url == null || id == null) {
+            return null;
+        }
+        List<Field> fields = new ArrayList<>();
+        for (String entry : declaration.split(",")) {
+            int separator = entry.lastIndexOf(':');
+            if (separator <= 0) {
+                continue;
+            }
+            String property = entry.substring(0, separator)
+                                   .trim();
+            String kind = entry.substring(separator + 1)
+                               .trim();
+            if (property.isEmpty()) {
+                continue;
+            }
+            if (RELATION.equals(kind)) {
+                // The same locator pair the task form resolves a foreign key through; without it the
+                // relation would render as a raw id, so the property is dropped instead.
+                String relationUrl = text(variables.get("__" + property + "EntityUrl"));
+                String relationLabel = text(variables.get("__" + property + "EntityLabel"));
+                if (relationUrl == null || relationLabel == null) {
+                    continue;
+                }
+                fields.add(new Field(property, RELATION, relationUrl, relationLabel));
+            } else {
+                fields.add(new Field(property, kind, null, null));
+            }
+        }
+        return fields.isEmpty() ? null : new TaskSubject(url, id, fields);
+    }
+
+    private static String text(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String text = String.valueOf(value)
+                            .trim();
+        return text.isEmpty() ? null : text;
+    }
+}

--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/endpoint/BpmInboxEndpoint.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/endpoint/BpmInboxEndpoint.java
@@ -16,6 +16,7 @@ import org.eclipse.dirigible.components.engine.bpm.flowable.dto.ProcessInstanceD
 import org.eclipse.dirigible.components.engine.bpm.flowable.dto.ProcessLabelKeys;
 import org.eclipse.dirigible.components.engine.bpm.flowable.dto.TaskActionData;
 import org.eclipse.dirigible.components.engine.bpm.flowable.dto.TaskDTO;
+import org.eclipse.dirigible.components.engine.bpm.flowable.dto.TaskSubject;
 import org.eclipse.dirigible.components.engine.bpm.flowable.service.BpmService;
 import org.eclipse.dirigible.components.engine.bpm.flowable.service.PrincipalType;
 import org.flowable.common.engine.api.FlowableObjectNotFoundException;
@@ -111,8 +112,31 @@ public class BpmInboxEndpoint extends BaseEndpoint {
                      dto.setNameKey(keys.taskNameKey(task.getTaskDefinitionKey()));
                      dto.setProcessDefinitionNameKey(keys.processNameKey());
                  });
+        dto.setSubject(subjectOf(task));
 
         return dto;
+    }
+
+    /**
+     * What the task is ABOUT, for a row that lists it away from the record's own application. A row
+     * used to read {@code Sales Invoice Approval - Approve - Ref 6} - the BPM business key, which
+     * defaults to the primary key - so an approver had to open every task to learn which customer and
+     * which amount they were approving (issue #7077). The generated trigger seeds the record's locators
+     * and the properties that identify it into the process variables; only those travel, and the client
+     * resolves their values live.
+     * <p>
+     * Best-effort: a task whose variables cannot be read is still listed, without a subject.
+     *
+     * @param task the task
+     * @return the subject locators, or null when the process declares none
+     */
+    private TaskSubject subjectOf(Task task) {
+        try {
+            return TaskSubject.from(bpmService.getTaskVariables(task.getId()));
+        } catch (RuntimeException ex) {
+            logger.debug("Could not read the variables of task [{}] - listing it without a subject", task.getId(), ex);
+            return null;
+        }
     }
 
     @GetMapping(value = "/tasks")

--- a/components/engine/engine-bpm-flowable/src/test/java/org/eclipse/dirigible/components/engine/bpm/flowable/dto/TaskSubjectTest.java
+++ b/components/engine/engine-bpm-flowable/src/test/java/org/eclipse/dirigible/components/engine/bpm/flowable/dto/TaskSubjectTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.bpm.flowable.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reading the subject a generated trigger seeded into a process's variables (issue #7077) - the
+ * locators an Inbox row resolves the record's number, counterparty and total through.
+ */
+class TaskSubjectTest {
+
+    private static Map<String, Object> variables() {
+        Map<String, Object> variables = new LinkedHashMap<>();
+        variables.put("__entityUrl", "/services/java/billing/gen/billing/api/sales_invoice/SalesInvoiceController");
+        variables.put("__entityId", 6);
+        variables.put("__subjectFields", "Number:text,Customer:relation,Total:number");
+        variables.put("__CustomerEntityUrl", "/services/java/billing/gen/billing/api/customer/CustomerController");
+        variables.put("__CustomerEntityLabel", "Name");
+        return variables;
+    }
+
+    @Test
+    void aRelationCarriesTheLocatorsItsLabelIsReadThrough() {
+        TaskSubject subject = TaskSubject.from(variables());
+
+        assertEquals("6", subject.id());
+        assertEquals(3, subject.fields()
+                               .size());
+        assertEquals(new TaskSubject.Field("Number", "text", null, null), subject.fields()
+                                                                                 .get(0));
+        assertEquals(
+                new TaskSubject.Field("Customer", "relation", "/services/java/billing/gen/billing/api/customer/CustomerController", "Name"),
+                subject.fields()
+                       .get(1));
+        assertEquals("number", subject.fields()
+                                      .get(2)
+                                      .kind());
+    }
+
+    /**
+     * A relation whose target locator the process does not carry is DROPPED, not shown: rendering the
+     * raw foreign key would put a second opaque id where the id was the complaint.
+     */
+    @Test
+    void aRelationWithoutItsLocatorIsDropped() {
+        Map<String, Object> variables = variables();
+        variables.remove("__CustomerEntityUrl");
+
+        assertEquals(2, TaskSubject.from(variables)
+                                   .fields()
+                                   .size());
+    }
+
+    /** A hand-authored BPMN, or a deployment generated before #7077, declares no subject at all. */
+    @Test
+    void aProcessThatDeclaresNoSubjectHasNone() {
+        Map<String, Object> variables = variables();
+        variables.remove("__subjectFields");
+
+        assertNull(TaskSubject.from(variables));
+        assertNull(TaskSubject.from(Map.of()));
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -247,6 +247,9 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             // Per to-one relation: enough to build the target controller URL so the task form can resolve
             // each FK to a display name (the form falls back to the raw id when a URL is missing).
             trigger.put("relationLinks", buildRelationLinks(byName.get(entity), model, byName, compositionParents, context));
+            // What a task of this process is ABOUT, wherever it is listed away from its own
+            // application: the property names the reader resolves live against the record (#7077).
+            trigger.put("subjectFields", TaskSubjectSupport.subjectFields(byName.get(entity)));
             putPersonalAssignee(trigger, byName.get(entity), model, byName, compositionParents, context);
             triggers.add(trigger);
         }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/TaskSubjectSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/TaskSubjectSupport.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.eclipse.dirigible.components.intent.model.EntityIntent;
+import org.eclipse.dirigible.components.intent.model.FieldIntent;
+import org.eclipse.dirigible.components.intent.model.RelationIntent;
+
+/**
+ * What a record of the trigger entity is CALLED where it is listed away from its own application -
+ * an Inbox row, a notification. A task row read {@code Sales Invoice Approval - Approve - Ref 6}:
+ * the BPM business key, which defaults to the primary key, so the approver had to open every task
+ * to learn which customer and which amount they were approving (issue #7077).
+ * <p>
+ * The subject is DERIVED, not authored: an entity already declares what identifies its records, and
+ * a second, parallel declaration could only drift from the list its own application renders. Up to
+ * three properties are picked by the role they play -
+ * <ol>
+ * <li>what the record is CALLED - {@link IntentEntities#labelFieldOf(EntityIntent)} (an authored
+ * {@code name} field, the stored {@code label:} expression, or the document's number),</li>
+ * <li>who it is ABOUT - its first {@code major} to-one relation that is not the status badge,</li>
+ * <li>how MUCH it is - the {@code aggregate: true} field a document totals in its footer</li>
+ * </ol>
+ * - and the remainder is topped up from the record's leading {@code major} fields, i.e. the columns
+ * its own list view shows. Nothing a role restricts ({@code sensitive}, {@code visibleTo}) is ever
+ * part of a subject: the Inbox row is read by whoever holds the task, not by whoever may see the
+ * record.
+ * <p>
+ * Only the property NAMES travel (as the {@code __subjectFields} process variable, {@code
+ * <Property>:<kind>} entries). The values are resolved live by the reader, exactly as the task form
+ * resolves the record it edits - a subject minted at process start would state the total of a
+ * document whose lines are added afterwards.
+ */
+public final class TaskSubjectSupport {
+
+    /**
+     * How many properties a subject line carries - enough to identify a record, short enough to scan.
+     */
+    private static final int MAX_FIELDS = 3;
+
+    private TaskSubjectSupport() {}
+
+    /**
+     * The trigger entity's subject declaration - {@code "Number:text,Customer:relation,Total:number"},
+     * or {@code ""} when nothing identifies the entity beyond its key.
+     *
+     * @param entity the process's trigger entity, may be {@code null}
+     * @return the encoded subject fields, never {@code null}
+     */
+    public static String subjectFields(EntityIntent entity) {
+        if (entity == null) {
+            return "";
+        }
+        Set<String> taken = new LinkedHashSet<>();
+        List<String> encoded = new ArrayList<>();
+        add(encoded, taken, labelField(entity));
+        add(encoded, taken, partyRelation(entity));
+        add(encoded, taken, totalField(entity));
+        for (FieldIntent field : entity.getFields()) {
+            if (encoded.size() >= MAX_FIELDS) {
+                break;
+            }
+            if (isListColumn(field)) {
+                add(encoded, taken, IntentNaming.pascalCase(field.getName()) + ":" + kindOf(field.getType()));
+            }
+        }
+        return String.join(",", encoded);
+    }
+
+    private static void add(List<String> encoded, Set<String> taken, String entry) {
+        if (entry == null || entry.isBlank() || encoded.size() >= MAX_FIELDS) {
+            return;
+        }
+        String property = entry.substring(0, entry.indexOf(':'));
+        if (taken.add(property)) {
+            encoded.add(entry);
+        }
+    }
+
+    /** What the record is called - the same property a to-one relation to it would label it by. */
+    private static String labelField(EntityIntent entity) {
+        String label = IntentEntities.labelFieldOf(entity);
+        return label.isBlank() ? "" : label + ":text";
+    }
+
+    /**
+     * Who the record is about - its first {@code major} to-one relation other than the status badge,
+     * which every generated surface already renders separately (and which says nothing about WHICH
+     * record this is).
+     */
+    private static String partyRelation(EntityIntent entity) {
+        for (RelationIntent relation : entity.getRelations()) {
+            boolean toOne = "manyToOne".equals(relation.getKind()) || "oneToOne".equals(relation.getKind());
+            if (toOne && relation.isMajor() && !relation.isEntityStatus() && relation.getName() != null) {
+                return IntentNaming.pascalCase(relation.getName()) + ":relation";
+            }
+        }
+        return "";
+    }
+
+    /** How much the record is - the field a document totals in its footer. */
+    private static String totalField(EntityIntent entity) {
+        for (FieldIntent field : entity.getFields()) {
+            if (field.isAggregate() && field.getName() != null) {
+                return IntentNaming.pascalCase(field.getName()) + ":" + kindOf(field.getType());
+            }
+        }
+        return "";
+    }
+
+    /**
+     * Whether the field is one of the record's own list columns: authored, shown ({@code major}),
+     * readable by anyone holding the task, and not the key the subject exists to replace.
+     */
+    private static boolean isListColumn(FieldIntent field) {
+        return field.getName() != null && field.isMajor() && !field.isPrimaryKey() && !field.isReadOnly() && !field.isSensitive()
+                && field.getVisibleTo()
+                        .isEmpty();
+    }
+
+    /**
+     * How the reader formats the value: a grouped decimal, a whole number, a date, or plain text.
+     * Counted quantities are separated from money because the instance's number pattern carries the
+     * decimals money is written with - {@code 3 days} must not read {@code 3.00}.
+     */
+    private static String kindOf(String type) {
+        if (type == null) {
+            return "text";
+        }
+        switch (type.toLowerCase(Locale.ROOT)) {
+            case "decimal":
+            case "double":
+                return "number";
+            case "integer":
+            case "int":
+            case "long":
+                return "integer";
+            case "date":
+            case "timestamp":
+                return "date";
+            default:
+                return "text";
+        }
+    }
+}

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/TaskSubjectSupportTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/TaskSubjectSupportTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.parser.IntentParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What a task's row says it is ABOUT (issue #7077). The subject is derived from what the entity
+ * already declares - the property records are labeled by, the first major to-one, the aggregated
+ * total - so the Inbox stops reading {@code Ref 6}, the record's primary key.
+ */
+class TaskSubjectSupportTest {
+
+    private static final String DOCUMENT = """
+            name: billing
+            entities:
+              - name: Customer
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: SalesInvoiceStatus
+                kind: setting
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: SalesInvoice
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: number, type: string, documentTitle: true }
+                  - { name: issuedOn, type: date }
+                  - { name: total, type: decimal, aggregate: true }
+                relations:
+                  - { name: customer, kind: manyToOne, to: Customer }
+                  - { name: status, kind: manyToOne, to: SalesInvoiceStatus, function: EntityStatus }
+              - name: SalesInvoiceItem
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: amount, type: decimal }
+                relations:
+                  - { name: salesInvoice, kind: manyToOne, to: SalesInvoice, composition: true }
+            processes:
+              - name: SalesInvoiceApproval
+                trigger: { onCreate: SalesInvoice }
+                steps:
+                  - { name: approve, kind: userTask, args: { assignee: Manager, next: done } }
+                  - { name: done, kind: end }
+            """;
+
+    @Test
+    void aDocumentIsIdentifiedByItsNumberCounterpartyAndTotal() {
+        List<Map<String, Object>> triggers = GlueIntentGenerator.buildTriggersForTest(IntentParser.parse(DOCUMENT));
+
+        assertEquals(1, triggers.size());
+        assertEquals("Number:text,Customer:relation,Total:number", triggers.get(0)
+                                                                           .get("subjectFields"));
+    }
+
+    /** The status badge is never the counterparty - it says nothing about WHICH record this is. */
+    @Test
+    void theStatusRelationIsNotTheParty() {
+        IntentModel model = IntentParser.parse("""
+                name: requests
+                entities:
+                  - name: RequestStatus
+                    kind: setting
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                  - name: Employee
+                    identity: email
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                      - { name: email, type: string, unique: true }
+                  - name: LeaveRequest
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: fromDate, type: date }
+                      - { name: days, type: integer }
+                    relations:
+                      - { name: status, kind: manyToOne, to: RequestStatus, function: EntityStatus }
+                      - { name: employee, kind: manyToOne, to: Employee, personal: true }
+                processes:
+                  - name: LeaveApproval
+                    trigger: { onCreate: LeaveRequest }
+                    steps:
+                      - { name: approve, kind: userTask, args: { assignee: Manager, next: done } }
+                      - { name: done, kind: end }
+                """);
+
+        // No label property of its own, so the subject is the owner plus the record's leading list
+        // columns - still the answer to "which request is this", which the bare id never was.
+        assertEquals("Employee:relation,FromDate:date,Days:integer", GlueIntentGenerator.buildTriggersForTest(model)
+                                                                                        .get(0)
+                                                                                        .get("subjectFields"));
+    }
+
+    /**
+     * An entity with no {@code name} field is labeled by the stored {@code Name} its {@code label:}
+     * expression keeps - the same property a relation to it would show. This is the shape
+     * {@code IntentEmissionCoverageIT} pins on the generated trigger.
+     */
+    @Test
+    void aLabelExpressionIsTheRecordsName() {
+        IntentModel model = IntentParser.parse("""
+                name: emission
+                entities:
+                  - name: Person
+                    identity: email
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                      - { name: email, type: string, unique: true }
+                  - name: Claim
+                    label: "{note} ({Person.name})"
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: note, type: string, length: 200 }
+                      - { name: rate, type: decimal, sensitive: true }
+                      - { name: bonus, type: decimal, visibleTo: [Payroll] }
+                    relations:
+                      - { name: Person, kind: manyToOne, to: Person, required: true, personal: true }
+                permissions:
+                  - { role: Payroll, can: [Claim:read] }
+                processes:
+                  - name: ClaimConfirm
+                    trigger: { onCreate: Claim }
+                    steps:
+                      - { name: confirm, kind: userTask, args: { assignee: personal, next: done } }
+                      - { name: done, kind: end }
+                """);
+
+        assertEquals("Name:text,Person:relation,Note:text", GlueIntentGenerator.buildTriggersForTest(model)
+                                                                               .get(0)
+                                                                               .get("subjectFields"));
+    }
+
+    /** A role-restricted value is never part of a line read by whoever happens to hold the task. */
+    @Test
+    void aSensitiveFieldIsNeverPartOfTheSubject() {
+        IntentModel model = IntentParser.parse("""
+                name: payroll
+                entities:
+                  - name: Payslip
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: period, type: string }
+                      - { name: netPay, type: decimal, sensitive: true }
+                      - { name: costCentre, type: string }
+                processes:
+                  - name: PayslipRelease
+                    trigger: { onCreate: Payslip }
+                    steps:
+                      - { name: release, kind: userTask, args: { assignee: Payroll, next: done } }
+                      - { name: done, kind: end }
+                """);
+
+        assertEquals("Period:text,CostCentre:text", GlueIntentGenerator.buildTriggersForTest(model)
+                                                                       .get(0)
+                                                                       .get("subjectFields"));
+    }
+}

--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/GlueGenerator.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/GlueGenerator.java
@@ -181,7 +181,7 @@ class GlueGenerator {
      */
     private static void bindTrigger(Map<String, Object> item, Map<String, Object> context, Map<String, Object> parameters) {
         copy(context, item, "process", "entity", "perspective", "keyProperty", "businessKeyProperty", "generateBusinessKey", "topicSuffix",
-                "guardExpression", "personalFkProperty", "personalIdentityProperty");
+                "guardExpression", "subjectFields", "personalFkProperty", "personalIdentityProperty");
         context.put("javaPerspective", sanitize(item, "perspective"));
         // The identity repository the listener resolves a personal task assignee through. A
         // cross-model target resolves against the owner model's generation folder.

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/inboxPage.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/inboxPage.js
@@ -61,7 +61,8 @@ document.addEventListener('alpine:init', () => {
       // Filter on what the row actually reads — the translated names — as well as the raw ones, so
       // typing what is on screen finds it in any language.
       const base = q
-        ? this.tasks.filter(t => [store.taskLabel(t), t.name, t.processDefinitionName, t.processInstanceBusinessKey, t.assignee]
+        ? this.tasks.filter(t => [store.taskLabel(t), store.subject(t), t.name, t.processDefinitionName,
+                                  t.processInstanceBusinessKey, t.assignee]
             .some(v => v && String(v).toLowerCase().includes(q)))
         : this.tasks;
       return this.sortByTime(base);

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/notifications.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/notifications.js
@@ -108,9 +108,12 @@ document.addEventListener('alpine:init', () => {
       const tasks = Alpine.store('processTasks');
       const name = tasks ? tasks.taskName(task) : (task.name || 'Task');
       const process = tasks ? tasks.processName(task) : (task.processDefinitionName || '');
+      // ... and WHICH record it is about, once the store has resolved it (#7077): "New task: Approve"
+      // says nothing about which invoice is waiting.
+      const subject = tasks ? tasks.subject(task) : '';
       return {
         title: window.T ? T('application-core:shell.notifications.newTask', 'New task: {{name}}', { name }) : 'New task: ' + name,
-        description: process,
+        description: subject && process ? process + ' · ' + subject : (subject || process),
       };
     },
   });

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/processTasks.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/processTasks.js
@@ -23,6 +23,21 @@
  * The task form is opened in the app-wide dialog wired in index.html; on close the store re-fetches.
  */
 document.addEventListener('alpine:init', () => {
+  // Records already fetched while building subject lines, keyed by '<controller url>/<id>'. Deliberately
+  // outside the store: it is a request cache, not view state, and several tasks of the same document (or
+  // several documents of the same customer) must share one fetch rather than one each. Cleared by an
+  // explicit refresh(), which is what makes a manual Refresh authoritative while the 30s poll stays cheap.
+  const recordCache = new Map();
+
+  const fetchRecord = (url, id) => {
+    const key = url + '/' + id;
+    if (!recordCache.has(key)) {
+      recordCache.set(key, App.services.api.get(url + '/' + encodeURIComponent(id), { baseUrl: '' })
+        .catch(() => null));   // unreachable or not permitted: the subject simply omits what it cannot read
+    }
+    return recordCache.get(key);
+  };
+
   Alpine.store('processTasks', {
     byProcessId: {},
     tasks: [],          // flat list of all the user's tasks (assignee + groups) — the Inbox view
@@ -31,6 +46,7 @@ document.addEventListener('alpine:init', () => {
     formUrl: '',
     formTitle: '',
     formTitleKey: '',   // the open task's translation key; '' for a process that declares no catalog
+    subjects: {},       // taskId -> the resolved business-identity line; '' while unresolved or when there is none
     serverUnavailable: false,   // set once the backend is unreachable; stops the poll until a reload
     _poll: null,
 
@@ -53,9 +69,16 @@ document.addEventListener('alpine:init', () => {
       // store (serverUnavailable back to false) and resumes.
       if (this.serverUnavailable) return;
       try {
+        // A personal shell (`taskScope: 'assignee'`) serves strictly the person's own work, so it asks
+        // only for the tasks assigned to them. The back-office group queues a user's ROLES make them a
+        // candidate for - Credit Note Confirm, Journal Entry Post - belong to the back-office shell;
+        // listing them next to an employee's own Submit tasks made the Personal Inbox a second, wider
+        // back office (#7077). The scope is a display choice: the server gates every task either way.
+        const personalOnly = (window.App && App.config && App.config.taskScope) === 'assignee';
         const [mine, groups] = await Promise.all([
           App.services.api.get('/services/inbox/tasks?type=assignee&limit=100', { baseUrl: '' }),
-          App.services.api.get('/services/inbox/tasks?type=groups&limit=100', { baseUrl: '' }),
+          personalOnly ? Promise.resolve([])
+            : App.services.api.get('/services/inbox/tasks?type=groups&limit=100', { baseUrl: '' }),
         ]);
         const map = {};
         const flat = [];
@@ -74,6 +97,7 @@ document.addEventListener('alpine:init', () => {
         this.tasks = flat;
         this.loaded = true;
         this.loadTaskLabelCatalogs(flat);
+        this.resolveSubjects(flat);
         // Surface the user's actionable tasks in the shell's notification bell.
         const notifications = Alpine.store('notifications');
         if (notifications && notifications.syncTasks) notifications.syncTasks(flat);
@@ -96,7 +120,72 @@ document.addEventListener('alpine:init', () => {
       }
     },
 
-    refresh() { return this.load(); },
+    // An explicit refresh re-reads the records the subject lines are built from; the periodic poll only
+    // resolves the tasks it has not seen yet, so a shell sitting open does not re-fetch every document
+    // every 30 seconds.
+    refresh() {
+      recordCache.clear();
+      this.subjects = {};
+      return this.load();
+    },
+
+    /**
+     * The business identity of the record a task is about - the document's number, its counterparty and
+     * its total - for the row that lists the task away from its own application. Before this, a row
+     * carried only the BPM business key ('Ref 6', the record id), so the approver had to open every task
+     * to learn what they were approving (#7077).
+     *
+     * The task carries LOCATORS, not values (see the TaskSubject DTO): the record's REST URL and the
+     * properties that identify it. They are resolved here, live, the same way the task form resolves the
+     * record it edits - a subject stamped when the process started would state the total of a document
+     * whose lines are added afterwards.
+     */
+    subject(task) {
+      return (task && this.subjects[task.id]) || '';
+    },
+
+    async resolveSubjects(tasks) {
+      const current = new Set(tasks.map((t) => t.id));
+      Object.keys(this.subjects).forEach((id) => { if (!current.has(id)) delete this.subjects[id]; });
+      const pending = tasks.filter((t) => t.subject && this.subjects[t.id] === undefined);
+      if (!pending.length) return;
+      await Promise.all(pending.map((t) => this.resolveSubject(t)));
+      // The bell bakes an item's text in when it arrives, so it is re-titled once the subjects are in.
+      const notifications = Alpine.store('notifications');
+      if (notifications && notifications.syncTasks) notifications.syncTasks(this.tasks);
+    },
+
+    async resolveSubject(task) {
+      this.subjects[task.id] = '';   // claim it, so a concurrent load does not resolve the same task twice
+      try {
+        const declared = task.subject;
+        const record = await fetchRecord(declared.url, declared.id);
+        if (!record) return;
+        const parts = [];
+        for (const field of declared.fields) {
+          const value = await this.subjectPart(field, record[field.property]);
+          if (value) parts.push(value);
+        }
+        this.subjects[task.id] = parts.join(' · ');
+      } catch (e) {
+        console.warn('processTasks: unable to resolve the subject of task ' + task.id, e);
+      }
+    },
+
+    // One property of a subject line, rendered the way the record's own application renders it.
+    async subjectPart(field, value) {
+      if (value === null || value === undefined || value === '') return '';
+      if (field.kind === 'relation') {
+        const related = await fetchRecord(field.url, value);
+        const label = related && related[field.label];
+        return label === null || label === undefined || label === '' ? '' : String(label);
+      }
+      if (!window.HarmoniaFormat) return String(value);
+      if (field.kind === 'number') return HarmoniaFormat.number(value, null, '');
+      if (field.kind === 'integer') return HarmoniaFormat.number(value, '0', '');
+      if (field.kind === 'date') return HarmoniaFormat.value(value, true);
+      return String(value);
+    },
 
     // A task names its own translation key ('<project>:<model>-model.processes.<task>', minted into
     // the process definition at generation time), and the module that raised it is not necessarily

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/views/_inbox.html
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/views/_inbox.html
@@ -82,9 +82,13 @@
                   <td x-h-table-cell>
                     <div class="vbox gap-1">
                       <span class="font-medium" x-text="$store.processTasks.taskLabel(task)"></span>
+                      <!-- What the task is ABOUT: the record's number, counterparty and total, resolved
+                           live from the locators the task carries. The BPM business key ('Ref 6', the
+                           record id) is shown only when there is no subject to read instead (#7077). -->
+                      <span x-show="$store.processTasks.subject(task)" class="text-sm" x-text="$store.processTasks.subject(task)"></span>
                       <span x-h-text.muted class="text-xs">
                         <span x-h-badge :data-variant="task.mine ? 'positive' : 'outline'" data-size="sm" x-text="task.mine ? T('application-core:shell.inbox.mine', 'Mine') : T('application-core:shell.inbox.available', 'Available')"></span>
-                        <span x-show="task.processInstanceBusinessKey" x-text="' · ' + T('application-core:shell.inbox.ref', 'Ref {{key}}', { key: task.processInstanceBusinessKey })"></span>
+                        <span x-show="task.processInstanceBusinessKey && !$store.processTasks.subject(task)" x-text="' · ' + T('application-core:shell.inbox.ref', 'Ref {{key}}', { key: task.processInstanceBusinessKey })"></span>
                         <span x-show="task.createTime" x-text="' · ' + fmtTime(task.createTime)"></span>
                       </span>
                     </div>
@@ -109,9 +113,10 @@
 
       <div x-show="selected" class="vbox size-full">
         <div x-h-toolbar data-variant="transparent">
-          <span x-h-toolbar-title x-text="selected ? $store.processTasks.taskLabel(selected) : ''"></span>
+          <span x-h-toolbar-title class="shrink-0" x-text="selected ? $store.processTasks.taskLabel(selected) : ''"></span>
+          <span x-show="selected && $store.processTasks.subject(selected)" x-h-text.muted class="text-sm truncate" x-text="selected ? $store.processTasks.subject(selected) : ''"></span>
           <div x-h-toolbar-spacer></div>
-          <span x-show="selected && selected.processInstanceBusinessKey" x-h-badge data-variant="information" x-text="selected ? T('application-core:shell.inbox.ref', 'Ref {{key}}', { key: selected.processInstanceBusinessKey }) : ''"></span>
+          <span x-show="selected && selected.processInstanceBusinessKey && !$store.processTasks.subject(selected)" x-h-badge data-variant="information" x-text="selected ? T('application-core:shell.inbox.ref', 'Ref {{key}}', { key: selected.processInstanceBusinessKey }) : ''"></span>
           <span x-h-badge :data-variant="selected && selected.mine ? 'positive' : 'outline'" x-text="selected && selected.mine ? T('application-core:shell.inbox.assignedToMe', 'Assigned to me') : T('application-core:shell.inbox.available', 'Available')"></span>
         </div>
 

--- a/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/js/config.js
+++ b/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/js/config.js
@@ -13,6 +13,9 @@ App.config = {
   basePath: '/services/web/partner',
   // No own entities; the built-in stores (inbox/documents) call platform services directly.
   restBase: '',
+  // Strictly this person's own work: the Inbox lists the tasks ASSIGNED to them, never the back-office
+  // group queues their roles also make them a candidate for - those belong to the back-office shell.
+  taskScope: 'assignee',
   // The Partner shell is an external-surfaces shell - it does not aggregate reports across apps.
   aggregateReports: false
 };

--- a/components/resources/resources-personal/src/main/resources/META-INF/dirigible/personal/js/config.js
+++ b/components/resources/resources-personal/src/main/resources/META-INF/dirigible/personal/js/config.js
@@ -13,6 +13,9 @@ App.config = {
   basePath: '/services/web/personal',
   // No own entities; the built-in stores (inbox/documents) call platform services directly.
   restBase: '',
+  // Strictly this person's own work: the Inbox lists the tasks ASSIGNED to them, never the back-office
+  // group queues their roles also make them a candidate for - those belong to the back-office shell.
+  taskScope: 'assignee',
   // The Personal shell is a personal-surfaces shell - it does not aggregate reports across apps.
   aggregateReports: false
 };

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Trigger.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Trigger.java.template
@@ -122,6 +122,13 @@ public class ${process}Trigger implements MessageHandler {
         variables.put("__${rl.fkProperty}EntityUrl", "${rl.url}");
         variables.put("__${rl.fkProperty}EntityLabel", "${rl.labelField}");
 #end
+#if($subjectFields && $subjectFields != "")
+        // What a task of this process is ABOUT wherever it is listed away from this application (an
+        // Inbox row, a notification): the property NAMES only, never their values. The reader
+        // resolves them live against __entityUrl/__entityId - a subject minted here would state the
+        // total of a document whose lines are added after the process started.
+        variables.put("__subjectFields", "${subjectFields}");
+#end
 #if($personalFkProperty)
         // Personal task assignment: resolve the record's owner to the mapped login username BEFORE
         // starting - a task's `assignee: personal` expression evaluates at task creation, inside

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -2305,6 +2305,13 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         String claimTrigger = contentOf("gen/events/emission/ClaimConfirmTrigger.java");
         assertTrue(claimTrigger.contains("variables.put(\"__personalUser\""),
                 "the trigger listener must seed the __personalUser variable from the identity mapping");
+        // #7077: what a task of this process is ABOUT, for the row that lists it away from this
+        // application. The property NAMES travel - the label the record carries, its first major
+        // to-one, its leading list column - and the reader resolves their values live, so the line
+        // cannot state the total of a document whose lines are added after the process started. The
+        // role-restricted fields (`sensitive: rate`, `visibleTo: bonus`) are never among them.
+        assertTrue(claimTrigger.contains("variables.put(\"__subjectFields\", \"Name:text,Person:relation,Note:text\")"),
+                "the trigger listener must seed the properties a task row identifies its record by");
         // The assignee expression is evaluated when the task is created, INSIDE Process.start, so the
         // variable has to ride the start payload - a setVariable afterwards is too late (and, for a
         // process without a wait state, runs against an instance that already finished).


### PR DESCRIPTION
Fixes #7077

## The row

A task read `Sales Invoice Approval — Approve · Ref 6`. `Ref 6` is the BPM business key, which defaults to the record's primary key, so the approver had to open every task to learn which customer and which amount they were approving — the one thing the row exists to tell them.

The row now carries the record's business identity, resolved **live** from locators the task already travels with:

- the generated trigger seeds one more process variable, **`__subjectFields`** — the property *names* a record of the trigger entity is identified by, never their values. A subject minted at process start would state the total of a document whose lines are added afterwards (the same reason the Clear-D context carries only locators), so the reader resolves them through `__entityUrl`/`__entityId` exactly as the task form resolves the record it edits;
- `BpmInboxEndpoint` hands the client a `TaskSubject` of locators (the record's URL + id, each property, and for a relation the `__<Fk>EntityUrl`/`__<Fk>EntityLabel` pair the task form already uses);
- the shared shell store resolves them once per record — a request cache shared by every task of the same document, cleared by an explicit Refresh so the 30 s poll stays cheap — and renders each property the way the record's own application does (money grouped, a count whole, a date through the instance pattern). The bell carries the same line ("New task: Approve" said nothing about which invoice was waiting) and the Inbox filter matches on it.

### The subject is derived, not authored

An entity already declares what identifies its records; a second, parallel declaration could only drift from the list its own application renders. `TaskSubjectSupport` picks up to three properties by the **role** they play — what the record is CALLED (its `name` field, its `label:` expression, or its document number), who it is ABOUT (its first `major` to-one that is not the status badge), how MUCH it is (the `aggregate: true` field a document totals) — and tops the remainder up from its leading `major` fields, i.e. the columns its own list view shows. Nothing a role restricts (`sensitive`, `visibleTo`) is ever part of a subject: the row is read by whoever holds the task, not by whoever may see the record.

No DSL key is added. An entity identified by nothing but its key still has no subject and keeps reading `Ref <key>`, as does every process that seeds no declaration — a hand-authored BPMN, or a deployment generated before this.

## The Personal Inbox

It listed the back-office group queues the person's **roles** make them a candidate for — Credit Note Confirm, Journal Entry Post — next to the employee's own Submit tasks, which made a shell that promises strictly your own records a second, wider back office. A personal shell declares `taskScope: 'assignee'` and asks only for the tasks assigned to it. Applied to **Personal and Partner**, the two personal-surface shells; the back-office and application shells are unchanged. The scope is a display choice — the server gates every task either way.

## Tests

- `TaskSubjectSupportTest` (new) — the document shape (`Number:text,Customer:relation,Total:number`), the status relation never being the counterparty, a `label:` expression as the record's name, and a `sensitive`/`visibleTo` field never reaching a subject.
- `TaskSubjectTest` (new) — reading the seeded variables: a relation missing its locator is dropped rather than shown as a raw id; a process declaring no subject has none.
- `IntentEmissionCoverageIT` — pins the seeded declaration on the generated `ClaimConfirmTrigger`.
- `mvn test` green on engine-intent (1105), engine-bpm-flowable, ide-template; `formatter:validate` and the release-profile javadoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)