### PR TITLE
templates: a unique-field collision answers 409 naming the field, not 500 with the JDBC text

### DIFF
--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
@@ -10,10 +10,25 @@ package gen.${javaGenFolderName}.api.${javaPerspectiveName};
 #if($property.roleRead)
 #set($hasRestrictedReads = "true")
 #end
+## A single-column `unique: true` is a column-level UNIQUE the SCHEMA leaves for the database to name,
+## so - unlike a composite key - there is no authored constraint name to match on. The name every
+## dialect generates is built from the column, which is the handle the duplicate mapping keys on.
+#if($property.dataUnique)
+#set($hasUniqueColumns = "true")
+#end
 #end
 #set($needsRoles = false)
 #if($perspectiveRole || $roleRead || $roleWrite || $isEntityPropertySecurityEnabled)
 #set($needsRoles = true)
+#end
+## Either kind of business key turns a database violation into a 409 naming the field, so the write
+## paths and the mapping below are emitted for both.
+#set($hasDuplicateKeys = false)
+#if($uniqueConstraints && !$uniqueConstraints.isEmpty())
+#set($hasDuplicateKeys = true)
+#end
+#if($hasUniqueColumns)
+#set($hasDuplicateKeys = true)
 #end
 import gen.${javaGenFolderName}.data.${javaPerspectiveName}.${name}Entity;
 import gen.${javaGenFolderName}.data.${javaPerspectiveName}.${name}Repository;
@@ -213,7 +228,7 @@ public class ${name}Controller {
 #if($hasReferenceValidations)
         validateReferences(entity);
 #end
-#if($uniqueConstraints && !$uniqueConstraints.isEmpty())
+#if($hasDuplicateKeys)
         ${name}Entity saved;
         try {
             saved = repository.save(entity);
@@ -306,7 +321,7 @@ public class ${name}Controller {
 #if($hasReferenceValidations)
         validateReferences(existing);
 #end
-#if($uniqueConstraints && !$uniqueConstraints.isEmpty())
+#if($hasDuplicateKeys)
         try {
             return repository.update(existing);
         } catch (RuntimeException e) {
@@ -321,7 +336,7 @@ public class ${name}Controller {
 #if($hasReferenceValidations)
         validateReferences(entity);
 #end
-#if($uniqueConstraints && !$uniqueConstraints.isEmpty())
+#if($hasDuplicateKeys)
         try {
             return repository.update(entity);
         } catch (RuntimeException e) {
@@ -374,26 +389,42 @@ public class ${name}Controller {
         }
     }
 
-#if($uniqueConstraints && !$uniqueConstraints.isEmpty())
+#if($hasDuplicateKeys)
     /**
-     * The composite business keys of ${name}, keyed by the constraint name the database names in the
-     * violation it raises. The names are the ones the model emitted, so this map and the schema cannot
-     * drift.
+     * The business keys of ${name}, keyed by the name the database puts into the violation it raises -
+     * a composite key by the constraint name the model emitted (so this map and the schema cannot
+     * drift), a single-column {@code unique} by its column name, which is what every dialect builds
+     * its own generated constraint name out of ("VACATIONS_PUBLIC_HOLIDAY_PUBLIC_HOLIDAY_DAY_key").
+     * Iterated longest key first, so a column whose name is a prefix of a longer one still answers
+     * with its own message rather than the shorter key's.
      */
-    private static final Map<String, String> DUPLICATE_MESSAGES = Map.ofEntries(
+    private static final Map<String, String> DUPLICATE_MESSAGES = duplicateMessages();
+
+    private static Map<String, String> duplicateMessages() {
+        Map<String, String> messages = new java.util.TreeMap<>(java.util.Comparator.comparingInt(String::length)
+                                                                                   .reversed()
+                                                                                   .thenComparing(java.util.Comparator.naturalOrder()));
+#if($uniqueConstraints)
 #foreach($uniqueConstraint in $uniqueConstraints)
-            Map.entry("${uniqueConstraint.name}", "${uniqueConstraint.message}")#if($foreach.hasNext),#end
+        messages.put("${uniqueConstraint.name}".toUpperCase(Locale.ROOT), "${uniqueConstraint.message}");
 #end
-    );
+#end
+#foreach($property in $properties)
+#if($property.dataUnique)
+        messages.put("${property.dataName}".toUpperCase(Locale.ROOT), "A ${name} with this '${property.name}' already exists");
+#end
+#end
+        return java.util.Collections.unmodifiableMap(messages);
+    }
 
     /**
      * A write that collided with one of those keys is a conflict the caller can act on - answered with
-     * the authored message - and anything else is rethrown untouched. Matching is on the constraint
-     * name inside the driver's message, which is the only handle the database gives back; every
+     * the message that names the field - and anything else is rethrown untouched. Matching is on the
+     * key name inside the driver's message, which is the only handle the database gives back; every
      * dialect names the violated constraint there.
      */
     private static RuntimeException duplicateOrRethrow(RuntimeException e) {
-        if (isConstraintViolation(e)) {
+        if (isConstraintViolation(e) && isDuplicateViolation(e)) {
             for (Throwable cause = e; cause != null; cause = cause.getCause() == cause ? null : cause.getCause()) {
                 String message = cause.getMessage();
                 if (message == null) {
@@ -401,13 +432,38 @@ public class ${name}Controller {
                 }
                 String upper = message.toUpperCase(Locale.ROOT);
                 for (Map.Entry<String, String> constraint : DUPLICATE_MESSAGES.entrySet()) {
-                    if (upper.contains(constraint.getKey().toUpperCase(Locale.ROOT))) {
+                    if (upper.contains(constraint.getKey())) {
                         return new ResponseStatusException(HttpStatus.CONFLICT, constraint.getValue());
                     }
                 }
             }
         }
         return e;
+    }
+
+    /**
+     * Whether the violation is specifically about UNIQUENESS. A column name matches the text of a
+     * foreign-key violation too ("Key (COMPANY_ID)=(5) is not present in table ..."), which is a
+     * different conflict and must not be answered as a duplicate. Every supported dialect either
+     * reports SQLSTATE 23505 or says so in words - PostgreSQL "duplicate key value violates unique
+     * constraint", H2 "Unique index or primary key violation", MySQL "Duplicate entry", Oracle
+     * "unique constraint (...) violated".
+     */
+    private static boolean isDuplicateViolation(Throwable e) {
+        for (Throwable cause = e; cause != null; cause = cause.getCause() == cause ? null : cause.getCause()) {
+            if (cause instanceof java.sql.SQLException sqlException && "23505".equals(sqlException.getSQLState())) {
+                return true;
+            }
+            String message = cause.getMessage();
+            if (message == null) {
+                continue;
+            }
+            String upper = message.toUpperCase(Locale.ROOT);
+            if (upper.contains("DUPLICATE") || upper.contains("UNIQUE")) {
+                return true;
+            }
+        }
+        return false;
     }
 
 #end

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/UniqueFieldConflictControllerTemplateIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/UniqueFieldConflictControllerTemplateIT.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.ToolProvider;
+
+import com.sun.source.util.JavacTask;
+
+import org.eclipse.dirigible.components.engine.template.velocity.VelocityGenerationEngine;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A single-column {@code unique: true} must answer a duplicate with the same kind of 4xx a
+ * {@code required:} miss already answers with - not the HTTP 500 carrying the raw JDBC text that
+ * the generated controller used to hand back (#7098).
+ *
+ * <p>
+ * A composite key is easy to map because the model NAMES the constraint. A single-column unique is
+ * left on the column for the database to name, so the only handle is the column name the dialect
+ * builds that generated name out of. That premise is what makes the mapping work, so it is asserted
+ * against the driver text actually observed on PostgreSQL and H2 rather than assumed: the entries
+ * the template emits are read back out of the rendered source and applied to those real messages by
+ * the same rule the rendered {@code duplicateOrRethrow} applies.
+ *
+ * <p>
+ * Rendering needs nothing from a running instance, so this boots no application context and uses
+ * its own engine instance, exactly like {@code RoleScopedFieldControllerTemplateIT}, whose fixture
+ * shape this mirrors.
+ */
+class UniqueFieldConflictControllerTemplateIT {
+
+    private static final String TEMPLATE = "/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template";
+
+    /** The message observed on BusinessIntents STA (PostgreSQL) in the report - #7098. */
+    private static final String POSTGRES_DUPLICATE = "could not execute statement [ERROR: duplicate key value violates unique constraint "
+            + "\"VACATIONS_PUBLIC_HOLIDAY_PUBLIC_HOLIDAY_DAY_key\" Detail: Key (\"PUBLIC_HOLIDAY_DAY\")=(2026-09-07) "
+            + "already exists.] [insert into VACATIONS_PUBLIC_HOLIDAY ...]";
+
+    /** The same collision on the default H2 datasource, which names the index, not the column. */
+    private static final String H2_DUPLICATE = "Unique index or primary key violation: "
+            + "\"CONSTRAINT_INDEX_7 ON PUBLIC.VACATIONS_PUBLIC_HOLIDAY(PUBLIC_HOLIDAY_DAY NULLS FIRST) VALUES ( /* 1 */ DATE '2026-09-07' )\"";
+
+    /** A different conflict on the same column: referencing rows, not a duplicate. */
+    private static final String POSTGRES_FOREIGN_KEY = "insert or update on table \"vacations_vacation\" violates foreign key constraint "
+            + "\"VACATION_PUBLIC_HOLIDAY_DAY_FK\" Detail: Key (PUBLIC_HOLIDAY_DAY)=(2026-09-07) is not present in table ...";
+
+    /** {@code messages.put("KEY".toUpperCase(Locale.ROOT), "message");} in the rendered source. */
+    private static final Pattern EMITTED_ENTRY =
+            Pattern.compile("messages\\.put\\(\"([^\"]+)\"\\.toUpperCase\\(Locale\\.ROOT\\), \"([^\"]+)\"\\);");
+
+    private final VelocityGenerationEngine velocityGenerationEngine = new VelocityGenerationEngine();
+
+    @Test
+    void aUniqueFieldsCollisionIsAnsweredWithAConflictThatNamesTheField() throws Exception {
+        String rendered = render(context());
+
+        assertEquals("A PublicHoliday with this 'Day' already exists", answerFor(rendered, POSTGRES_DUPLICATE),
+                "the PostgreSQL duplicate must map to the message naming the field");
+        assertEquals("A PublicHoliday with this 'Day' already exists", answerFor(rendered, H2_DUPLICATE),
+                "and so must the H2 one, which names the index instead of the constraint");
+    }
+
+    /** The 500 in the report came from the write not being wrapped at all on either verb. */
+    @Test
+    void bothWritePathsRouteThroughTheMapping() throws Exception {
+        String rendered = render(context());
+
+        assertEquals(2, occurrences(rendered, "throw duplicateOrRethrow(e);"),
+                "create and update must both hand the violation to the mapping: " + rendered);
+        assertTrue(rendered.contains("saved = repository.save(entity);"), "the create must save inside the try");
+        assertTrue(rendered.contains("return repository.update(entity);"), "the update must run inside the try");
+        assertTrue(rendered.contains("if (isConstraintViolation(e) && isDuplicateViolation(e)) {"),
+                "the mapping must answer only for a UNIQUENESS violation: " + rendered);
+        assertNoUnresolvedReferences(rendered);
+    }
+
+    /**
+     * The same column appears in a foreign-key violation's text, and that is a different conflict - the
+     * generated delete has its own answer for it. Answering it as a duplicate would name a field the
+     * caller did not collide on.
+     */
+    @Test
+    void aForeignKeyViolationOnTheSameColumnIsNotADuplicate() throws Exception {
+        String rendered = render(context());
+
+        assertTrue(rendered.contains("upper.contains(\"DUPLICATE\") || upper.contains(\"UNIQUE\")"),
+                "the discriminator must be the violation's own class, not the column: " + rendered);
+        assertTrue(rendered.contains("\"23505\".equals(sqlException.getSQLState())"), "SQLSTATE 23505 must be honoured too");
+        assertFalse(POSTGRES_FOREIGN_KEY.toUpperCase(Locale.ROOT)
+                                        .contains("DUPLICATE"),
+                "the fixture must not be a duplicate by text either - otherwise it proves nothing");
+    }
+
+    /**
+     * A column name can be a prefix of a longer one on the same table, and both keys then match the
+     * same message. The more specific one is the one the caller collided on.
+     */
+    @Test
+    void theMoreSpecificColumnWins() throws Exception {
+        Map<String, Object> context = context();
+        context.put("properties", List.of(primaryKey(), uniqueDay(), unique("DayOfNotice", "PUBLIC_HOLIDAY_DAY_OF_NOTICE")));
+
+        String rendered = render(context);
+
+        assertEquals("A PublicHoliday with this 'DayOfNotice' already exists",
+                answerFor(rendered,
+                        "duplicate key value violates unique constraint \"VACATIONS_PUBLIC_HOLIDAY_PUBLIC_HOLIDAY_DAY_OF_NOTICE_key\""),
+                "the longer column must not be answered with the shorter one's message");
+        assertTrue(rendered.contains("Comparator.comparingInt(String::length)"), "the ordering must be part of the emitted map");
+    }
+
+    /** The composite-key mapping the single-column case joins must keep behaving as it did. */
+    @Test
+    void aCompositeKeyStillAnswersWithItsAuthoredMessage() throws Exception {
+        Map<String, Object> context = context();
+        context.put("properties", List.of(primaryKey(), column("Company", "PUBLIC_HOLIDAY_COMPANY"), column("Day", "PUBLIC_HOLIDAY_DAY")));
+        context.put("uniqueConstraints", List.of(compositeKey()));
+
+        String rendered = render(context);
+
+        assertEquals("This day is already a holiday of the company",
+                answerFor(rendered, "duplicate key value violates unique constraint \"PublicHoliday_Company_Day\""),
+                "the authored message must still be the answer for the constraint the model named");
+        assertNoUnresolvedReferences(rendered);
+    }
+
+    /**
+     * The mapping is hand-written Java inside a Velocity template, and nothing in the build compiles a
+     * rendered controller - a stray brace would only surface as a broken generated application. The
+     * compiler's PARSE phase is the gate that fits here: it reports the syntax of the rendered source
+     * without needing the SDK types it imports on the classpath.
+     */
+    @Test
+    void everyRenderedShapeIsSyntacticallyValidJava() throws Exception {
+        Map<String, Object> composite = context();
+        composite.put("uniqueConstraints", List.of(compositeKey()));
+        Map<String, Object> noKey = context();
+        noKey.put("properties", List.of(primaryKey(), column("Name", "PUBLIC_HOLIDAY_NAME")));
+
+        for (Map<String, Object> context : List.of(context(), composite, noKey)) {
+            assertEquals(List.of(), syntaxErrors(render(context)), "the rendered controller must parse as Java");
+        }
+    }
+
+    /** An entity with no business key at all must come out exactly as it always did. */
+    @Test
+    void anEntityWithoutAnyBusinessKeyGetsNoneOfIt() throws Exception {
+        Map<String, Object> context = context();
+        context.put("properties", List.of(primaryKey(), column("Name", "PUBLIC_HOLIDAY_NAME")));
+
+        String rendered = render(context);
+
+        assertFalse(rendered.contains("duplicateOrRethrow"), "there is nothing to map: " + rendered);
+        assertFalse(rendered.contains("DUPLICATE_MESSAGES"), "and no map to carry");
+        assertTrue(rendered.contains("${name}Entity saved = repository.save(entity);".replace("${name}", "PublicHoliday")),
+                "the unwrapped save must be the one emitted");
+    }
+
+    /**
+     * Applies the rendered mapping to a driver message exactly as the rendered
+     * {@code duplicateOrRethrow} does - the entries come out of the generated source, so the fixture
+     * cannot drift from what the template emits.
+     */
+    private static String answerFor(String rendered, String driverMessage) {
+        String upper = driverMessage.toUpperCase(Locale.ROOT);
+        for (Map.Entry<String, String> entry : emittedMessages(rendered).entrySet()) {
+            if (upper.contains(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    /** The emitted keys, in the longest-first order the rendered map iterates them in. */
+    private static Map<String, String> emittedMessages(String rendered) {
+        Map<String, String> messages = new TreeMap<>(Comparator.comparingInt(String::length)
+                                                               .reversed()
+                                                               .thenComparing(Comparator.naturalOrder()));
+        Matcher matcher = EMITTED_ENTRY.matcher(rendered);
+        while (matcher.find()) {
+            messages.put(matcher.group(1)
+                                .toUpperCase(Locale.ROOT),
+                    matcher.group(2));
+        }
+        assertFalse(messages.isEmpty(), "the template emitted no duplicate messages at all: " + rendered);
+        return messages;
+    }
+
+    /** The syntax diagnostics of the rendered source - the parse phase reports nothing else. */
+    private static List<String> syntaxErrors(String rendered) throws Exception {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assertNotNull(compiler, "the tests must run on a JDK - there is no system Java compiler");
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+        JavaFileObject source = new SimpleJavaFileObject(URI.create("string:///PublicHolidayController.java"), JavaFileObject.Kind.SOURCE) {
+            @Override
+            public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                return rendered;
+            }
+        };
+        JavaCompiler.CompilationTask task = compiler.getTask(null, null, diagnostics, List.of("-proc:none"), null, List.of(source));
+        ((JavacTask) task).parse();
+        return diagnostics.getDiagnostics()
+                          .stream()
+                          .filter(diagnostic -> diagnostic.getKind() == javax.tools.Diagnostic.Kind.ERROR)
+                          .map(diagnostic -> diagnostic.getLineNumber() + ": " + diagnostic.getMessage(Locale.ROOT))
+                          .toList();
+    }
+
+    private static int occurrences(String rendered, String needle) {
+        int count = 0;
+        for (int at = rendered.indexOf(needle); at >= 0; at = rendered.indexOf(needle, at + needle.length())) {
+            count++;
+        }
+        return count;
+    }
+
+    private String render(Map<String, Object> parameters) throws Exception {
+        String template;
+        try (InputStream in = getClass().getResourceAsStream(TEMPLATE)) {
+            assertNotNull(in, "template resource not found on classpath: " + TEMPLATE);
+            template = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        byte[] out = velocityGenerationEngine.generate(parameters, TEMPLATE, template.getBytes(StandardCharsets.UTF_8));
+        return new String(out, StandardCharsets.UTF_8);
+    }
+
+    private static void assertNoUnresolvedReferences(String rendered) {
+        for (String line : rendered.split("\n")) {
+            if (line.contains("messages.put") || line.contains("duplicateOrRethrow") || line.contains("already exists")) {
+                assertFalse(line.contains("${"), "an unresolved template reference survived: " + line);
+            }
+        }
+    }
+
+    private static Map<String, Object> context() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("name", "PublicHoliday");
+        parameters.put("projectName", "vacations");
+        parameters.put("perspectiveName", "Vacations");
+        parameters.put("javaGenFolderName", "vacations");
+        parameters.put("javaPerspectiveName", "vacations");
+        parameters.put("tablePrefix", "VACATIONS_");
+        parameters.put("dataName", "PUBLIC_HOLIDAY");
+        parameters.put("properties", List.of(primaryKey(), uniqueDay(), column("Name", "PUBLIC_HOLIDAY_NAME")));
+        parameters.put("sensitiveProperties", new ArrayList<>());
+        return parameters;
+    }
+
+    /** The shape {@code EdmIntentGenerator} puts on a composite {@code unique:} declaration. */
+    private static Map<String, Object> compositeKey() {
+        Map<String, Object> constraint = new LinkedHashMap<>();
+        constraint.put("name", "PublicHoliday_Company_Day");
+        constraint.put("columns", List.of(Map.of("name", "PUBLIC_HOLIDAY_COMPANY"), Map.of("name", "PUBLIC_HOLIDAY_DAY")));
+        constraint.put("message", "This day is already a holiday of the company");
+        return constraint;
+    }
+
+    private static Map<String, Object> primaryKey() {
+        Map<String, Object> property = column("Id", "PUBLIC_HOLIDAY_ID");
+        property.put("dataType", "INTEGER");
+        property.put("dataTypeJavaClass", "Integer");
+        property.put("dataPrimaryKey", Boolean.TRUE);
+        return property;
+    }
+
+    /** The reported field: intent {@code day: { type: date, unique: true }}. */
+    private static Map<String, Object> uniqueDay() {
+        return unique("Day", "PUBLIC_HOLIDAY_DAY");
+    }
+
+    private static Map<String, Object> unique(String name, String dataName) {
+        Map<String, Object> property = column(name, dataName);
+        property.put("dataUnique", "true");
+        return property;
+    }
+
+    private static Map<String, Object> column(String name, String dataName) {
+        Map<String, Object> property = new LinkedHashMap<>();
+        property.put("name", name);
+        property.put("dataName", dataName);
+        property.put("dataType", "VARCHAR");
+        property.put("dataTypeJavaClass", "String");
+        property.put("dataPrimaryKey", Boolean.FALSE);
+        return property;
+    }
+}


### PR DESCRIPTION
## What

A unique-constraint violation on a generated entity surfaced as **HTTP 500** carrying the raw JDBC text:

```
POST .../publicholiday/PublicHolidayController   {"Day":"2026-09-07","Name":"QA dup"}
→ 500 {"message":"could not execute statement [ERROR: duplicate key value violates unique constraint
   \"VACATIONS_PUBLIC_HOLIDAY_PUBLIC_HOLIDAY_DAY_key\" Detail: Key (\"PUBLIC_HOLIDAY_DAY\")=(2026-09-07) already exists.] ..."}
```

It now answers **409 Conflict** with `A PublicHoliday with this 'Day' already exists` - the same shape a `required:` miss already answers 400 with.

## Why it was missing

A **composite** business key was already mapped: the model names that constraint, and the driver echoes the name back, so `DUPLICATE_MESSAGES` could key on it. A **single-column** `unique: true` is left on the column for the *database* to name, so there was no key to match and the violation fell straight through the controller.

## How

- The handle a generated constraint name gives back is the **column** it is built from, so the map carries one entry per single-column unique keyed on its column name. Both write paths (`create`, `update`) are wrapped whenever the entity has a business key of either kind.
- Entries are iterated **longest key first**, so a column whose name is a prefix of a longer one on the same table (`..._DAY` inside `..._DAY_OF_NOTICE`) still answers with its own message.
- Matching a column name is looser than matching an authored constraint name - the same column appears in the text of a **foreign-key** violation, which is a different conflict - so the mapping now also requires the failure to be a *uniqueness* violation: SQLSTATE `23505`, or the word every dialect uses for it (PostgreSQL "duplicate key value violates unique constraint", H2 "Unique index or primary key violation", MySQL "Duplicate entry", Oracle "unique constraint (...) violated"). This narrows the existing composite path too - an FK violation whose name happened to contain a key name can no longer be reported as a duplicate.

An entity with no business key at all renders exactly as before (no map, no `duplicateOrRethrow`, unwrapped `save`) - asserted.

## Tests

`UniqueFieldConflictControllerTemplateIT` - 7 tests, no application context (renders through `VelocityGenerationEngine`, like `RoleScopedFieldControllerTemplateIT`):

- the entries the template emits are read back out of the **rendered source** and applied to the driver texts **actually observed** on PostgreSQL (from the report) and H2, so the premise the mapping rests on is asserted rather than assumed;
- the FK-violation fixture on the same column is asserted not to read as a duplicate;
- the longest-key-first case, the composite regression, and the no-key-at-all shape;
- the rendered controller is hand-written Java inside a Velocity template and nothing in the build compiles one, so the IT runs the **compiler's parse phase** over all three rendered shapes. Verified to fail on a deliberately unbalanced brace.

5 of the 7 fail on `master`. Green with the change, together with `RoleScopedFieldControllerTemplateIT`, `ChildLockControllerTemplateIT`, `SchemaTemplateUniqueConstraintIT` and `EdmUniqueKeyRoundTripIT` (21 tests).

Fixes #7098

🤖 Generated with [Claude Code](https://claude.com/claude-code)