### PR TITLE
templates: the self-service surfaces validate, and a refused create keeps its number (#7099)

### DIFF
--- a/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
+++ b/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
@@ -121,14 +121,16 @@ package gen.${javaGenFolderName}.data.${javaPerspectiveName};
 ## HTTP 500 carrying a message about a physical column nobody outside the schema has heard of, from which
 ## the caller cannot tell what to fix (dirigible #7069). It is the same set the schema declares NOT NULL,
 ## so nothing that used to be written still is refused: an insert of null into such a column never had
-## another ending. Everything the repository computes itself - a document number, a uuid, a calculated
-## field, a document's totals - is assigned above this point, so what is still null here is genuinely
-## missing from the write. A column carrying a DEFAULT is excluded: the database supplies its value, so
+## another ending. Everything the repository computes itself - a uuid, a calculated field, a document's
+## totals - is assigned above this point, so what is still null here is genuinely missing from the
+## write. A `number: { stampOn: create }` column is the exception and is excluded: it is filled just
+## BELOW this check, deliberately, so a refusal cannot burn a number (#7099) - it is never the caller's
+## omission. A column carrying a DEFAULT is excluded: the database supplies its value, so
 ## an empty one is not missing - an intent relation with `init:` is exactly that, and refusing it would
 ## reject every create that leaves the opening status to the model.
 #macro(requiredCheck)
 #foreach($property in $properties)
-#if(!$property.dataPrimaryKey && $property.dataNotNull && !$property.dataDefaultValue)
+#if(!$property.dataPrimaryKey && $property.dataNotNull && !$property.dataDefaultValue && !$property.numberStampOnCreate)
         if (entity.${property.name} == null) {
             throw new ValidationException("${name}.${property.name} is required");
         }
@@ -302,6 +304,20 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
         }
 #end
 #end
+#if($documentMaster)
+        recalculate(entity);
+#end
+#if($documentChecks && $documentChecks.size() > 0)
+        enforceChecks(entity);
+#end
+#requiredCheck()
+## Allocated LAST, once every guard that can refuse this create has passed: the counter is a SEQUENCE,
+## incremented in its own transaction so concurrent creates never serialize on it, which means an
+## allocation cannot be rolled back with the insert - whatever it hands out is spent. A number consumed
+## by a write that then failed leaves a permanent hole in a series a jurisdiction requires to be
+## gap-free, so the allocation must be the last thing that happens before the statement, not the first
+## (dirigible #7099). A failure of the INSERT itself can still spend one; nothing short of allocating
+## inside the insert's transaction closes that, and doing so would serialize every create in the tenant.
 ## First-class numbering, stampOn:create: allocate the real document number on insert (when empty)
 ## from the tenant's series. The number's SHAPE is not here - prefix and width live in the series
 ## configuration (the module's .numbers artefact, then per-tenant settings), so a deployment can change
@@ -318,13 +334,6 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
         }
 #end
 #end
-#if($documentMaster)
-        recalculate(entity);
-#end
-#if($documentChecks && $documentChecks.size() > 0)
-        enforceChecks(entity);
-#end
-#requiredCheck()
         // The create event is handed to the write itself, which records it in the tenant's event outbox
         // INSIDE the insert's transaction: row and event commit together, so a broker outage can
         // neither swallow an event whose row exists nor fail a call whose row was written. Listeners

--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
@@ -782,7 +782,10 @@ public class ${name}Controller {
 #end
 #end
 #foreach($property in $properties)
-#if($property.isRequiredProperty && !$property.dataDefaultValue)
+## A required value the PLATFORM supplies is not the caller's to send: the generated repository fills a
+## document number and a uuid on insert, so demanding them here would refuse every create of a numbered
+## document with a message about a field no form has (#7099).
+#if($property.isRequiredProperty && !$property.dataDefaultValue && !$property.numberStampOnCreate && !$property.generatedUuid)
         if (entity.${property.name} == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The '${property.name}' property is required");
         }

--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityMyController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityMyController.java.template
@@ -186,6 +186,11 @@ public class ${name}MyController {
         }
 #end
 #end
+        // Validated LAST, on what will actually be written: the owner is forced above and the
+        // sensitive / role-scoped fields are cleared, so validating earlier would judge a payload the
+        // server has not finished deciding. Before the save, so a refused create never reaches the
+        // insert - and never allocates a document number.
+        validate(entity);
         return scrub(repository.save(entity));
     }
 
@@ -222,6 +227,7 @@ public class ${name}MyController {
         }
 #end
 #end
+        validate(entity);
         return scrub(repository.update(entity));
     }
 
@@ -524,6 +530,57 @@ public class ${name}MyController {
             }
         }
         return false;
+    }
+#end
+
+#if(!$personalReadOnly)
+    /**
+     * The same value validation the power surface applies (${name}Controller.validate) - required
+     * fields, declared lengths, format patterns and row-level checks. The personal surface is the one
+     * a person actually types into, so skipping it here meant a missing required field reached the
+     * insert and came back as a 500 with the raw NOT NULL violation instead of a 400 naming the field
+     * - and, for a numbered document, only after the insert had already burned a number from the
+     * series. Static and payload-only, so it costs no read.
+     */
+    private static void validate(${name}Entity entity) {
+#if($rowChecks && $rowChecks.size() > 0)
+#foreach($check in $rowChecks)
+        // Row-level check (intent `checks: exactlyOne`).
+        {
+            int assigned = 0;
+#foreach($field in $check.fields)
+            if (entity.${field} != null) {
+                assigned++;
+            }
+#end
+            if (assigned != 1) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "${check.message}");
+            }
+        }
+#end
+#end
+#foreach($property in $properties)
+## A required value the PLATFORM supplies is not the caller's to send: the generated repository fills a
+## document number and a uuid on insert, so demanding them here would refuse every create of a numbered
+## document with a message about a field no form has (#7099).
+#if($property.isRequiredProperty && !$property.dataDefaultValue && !$property.numberStampOnCreate && !$property.generatedUuid)
+        if (entity.${property.name} == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The '${property.name}' property is required");
+        }
+#end
+#if($property.dataTypeJavaClass == "String" && $property.dataLength && $property.dataTypeJava != "time")
+        if (entity.${property.name} != null && entity.${property.name}.length() > ${property.dataLength}) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The '${property.name}' exceeds the maximum length of ${property.dataLength}");
+        }
+#end
+#if($property.widgetPattern && $property.widgetPattern != "")
+## A format constraint describes what a value must look like WHEN THERE IS ONE - on an OPTIONAL
+## property a blank string is "no value", exactly as on the power surface.
+        if (entity.${property.name} != null#if($property.isRequiredProperty != "true") && !entity.${property.name}.toString().isBlank()#end && !entity.${property.name}.toString().matches("${property.widgetPatternJava}")) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The value of '${property.name}' does not match the required pattern '${property.widgetPatternJava}'");
+        }
+#end
+#end
     }
 #end
 

--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityPartnerController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityPartnerController.java.template
@@ -160,6 +160,11 @@ public class ${name}PartnerController {
         }
 #end
 #end
+        // Validated LAST, on what will actually be written: the owner is forced above and the
+        // sensitive / role-scoped fields are cleared, so validating earlier would judge a payload the
+        // server has not finished deciding. Before the save, so a refused create never reaches the
+        // insert - and never allocates a document number.
+        validate(entity);
         return scrub(repository.save(entity));
     }
 
@@ -196,6 +201,7 @@ public class ${name}PartnerController {
         }
 #end
 #end
+        validate(entity);
         return scrub(repository.update(entity));
     }
 
@@ -508,6 +514,56 @@ public class ${name}PartnerController {
         return false;
     }
 #end
+
+
+    /**
+     * The same value validation the power surface applies (${name}Controller.validate) - required
+     * fields, declared lengths, format patterns and row-level checks. The personal surface is the one
+     * a person actually types into, so skipping it here meant a missing required field reached the
+     * insert and came back as a 500 with the raw NOT NULL violation instead of a 400 naming the field
+     * - and, for a numbered document, only after the insert had already burned a number from the
+     * series. Static and payload-only, so it costs no read.
+     */
+    private static void validate(${name}Entity entity) {
+#if($rowChecks && $rowChecks.size() > 0)
+#foreach($check in $rowChecks)
+        // Row-level check (intent `checks: exactlyOne`).
+        {
+            int assigned = 0;
+#foreach($field in $check.fields)
+            if (entity.${field} != null) {
+                assigned++;
+            }
+#end
+            if (assigned != 1) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "${check.message}");
+            }
+        }
+#end
+#end
+#foreach($property in $properties)
+## A required value the PLATFORM supplies is not the caller's to send: the generated repository fills a
+## document number and a uuid on insert, so demanding them here would refuse every create of a numbered
+## document with a message about a field no form has (#7099).
+#if($property.isRequiredProperty && !$property.dataDefaultValue && !$property.numberStampOnCreate && !$property.generatedUuid)
+        if (entity.${property.name} == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The '${property.name}' property is required");
+        }
+#end
+#if($property.dataTypeJavaClass == "String" && $property.dataLength && $property.dataTypeJava != "time")
+        if (entity.${property.name} != null && entity.${property.name}.length() > ${property.dataLength}) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The '${property.name}' exceeds the maximum length of ${property.dataLength}");
+        }
+#end
+#if($property.widgetPattern && $property.widgetPattern != "")
+## A format constraint describes what a value must look like WHEN THERE IS ONE - on an OPTIONAL
+## property a blank string is "no value", exactly as on the power surface.
+        if (entity.${property.name} != null#if($property.isRequiredProperty != "true") && !entity.${property.name}.toString().isBlank()#end && !entity.${property.name}.toString().matches("${property.widgetPatternJava}")) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The value of '${property.name}' does not match the required pattern '${property.widgetPatternJava}'");
+        }
+#end
+#end
+    }
 
     /** Whether a persistence failure is (caused by) a database constraint violation. */
     private static boolean isConstraintViolation(Throwable e) {

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/PersonalSurfaceCreateValidationTemplateIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/PersonalSurfaceCreateValidationTemplateIT.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.engine.template.velocity.VelocityGenerationEngine;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The create path of the SELF-SERVICE surfaces, rendered through the platform's
+ * {@link VelocityGenerationEngine} (dirigible #7099).
+ *
+ * <p>
+ * The personal (my) and partner controllers are the ones a person actually types into, and they
+ * used to be the only ones that skipped the power surface's value validation: a missing required
+ * field reached the insert and came back as an HTTP 500 quoting a NOT NULL violation on a physical
+ * column, where the power surface answers 400 naming the property. For a numbered document it was
+ * worse than a bad status - the repository had already allocated the document number, so the
+ * refused create left a permanent hole in a series a jurisdiction requires to be gap-free.
+ *
+ * <p>
+ * Both halves are asserted here: the validator on the two self-service surfaces, and the ORDER of
+ * the number allocation in the generated repository - last, after every guard that can refuse the
+ * create. Rendering needs nothing from a running instance, so this boots no application context,
+ * exactly like {@code RoleScopedFieldControllerTemplateIT}, whose fixture shape it mirrors.
+ */
+class PersonalSurfaceCreateValidationTemplateIT {
+
+    private static final String REST_BASE = "/META-INF/dirigible/template-application-rest-java/api/";
+    private static final String DAO_BASE = "/META-INF/dirigible/template-application-dao-java/data/";
+
+    private static final List<String> SELF_SERVICE_SURFACES =
+            List.of("EntityMyController.java.template", "EntityPartnerController.java.template");
+
+    private final VelocityGenerationEngine velocityGenerationEngine = new VelocityGenerationEngine();
+
+    /** The message is the power surface's, verbatim: one refusal, whichever door the caller used. */
+    @Test
+    void aSelfServiceSurfaceNamesTheMissingRequiredFieldExactlyAsThePowerSurfaceDoes() throws Exception {
+        String expected = "throw new ResponseStatusException(HttpStatus.BAD_REQUEST, \"The 'FromDate' property is required\");";
+        assertTrue(render("EntityController.java.template", context()).contains(expected), "the power surface's own refusal changed");
+
+        for (String template : SELF_SERVICE_SURFACES) {
+            String rendered = render(template, context());
+            assertTrue(rendered.contains(expected), template + " must refuse a missing required field by name: " + rendered);
+        }
+    }
+
+    /**
+     * Length and pattern constraints and row-level checks come with it - the whole validator, not a
+     * subset.
+     */
+    @Test
+    void aSelfServiceSurfaceAppliesTheLengthPatternAndRowChecksToo() throws Exception {
+        for (String template : SELF_SERVICE_SURFACES) {
+            String rendered = render(template, context());
+
+            assertTrue(rendered.contains("The 'Note' exceeds the maximum length of 40"), template + " must enforce the declared length");
+            assertTrue(rendered.contains("does not match the required pattern"), template + " must enforce the format pattern");
+            assertTrue(rendered.contains("exactly one of FromDate / Note"), template + " must enforce the row-level check");
+        }
+    }
+
+    /**
+     * Validated after the owner is forced and the sensitive / role-scoped fields cleared - the payload
+     * the server has finished deciding - and before the save, so a refusal never reaches the insert.
+     */
+    @Test
+    void aSelfServiceSurfaceValidatesTheFinalPayloadAndDoesItBeforeTheWrite() throws Exception {
+        for (String template : SELF_SERVICE_SURFACES) {
+            String rendered = render(template, context());
+
+            int owner = rendered.indexOf("// The owner is the server's decision");
+            int validate = rendered.indexOf("        validate(entity);");
+            int save = rendered.indexOf("repository.save(entity)");
+            assertTrue(owner >= 0 && validate > owner, template + " must validate what it decided, not the raw payload: " + rendered);
+            assertTrue(save > validate, template + " must validate before the insert: " + rendered);
+
+            int update = rendered.indexOf("repository.update(entity)");
+            assertTrue(rendered.lastIndexOf("        validate(entity);") < update, template + " must validate before the update too");
+        }
+    }
+
+    /**
+     * The counter is a sequence incremented in its own transaction, so what it hands out is spent
+     * whatever the insert does: it has to be the LAST thing before the statement.
+     */
+    @Test
+    void theDocumentNumberIsAllocatedAfterEveryGuardThatCanRefuseTheCreate() throws Exception {
+        String rendered = render(DAO_BASE, "Repository.java.template", context());
+
+        int required = rendered.indexOf("throw new ValidationException(\"VacationRequest.FromDate is required\")");
+        int allocation = rendered.indexOf("DocumentNumbers.next(");
+        int insert = rendered.indexOf("super.save(entity,");
+        assertTrue(required >= 0, "the repository must still refuse a missing required value: " + rendered);
+        assertTrue(allocation > required, "a refused create must not burn a number: " + rendered);
+        assertTrue(insert > allocation, "the number must be stamped on the row that is inserted: " + rendered);
+    }
+
+    /**
+     * ...and the number column, being NOT NULL and filled a few lines below, must not be refused by the
+     * required check it now precedes - that would reject every create of a numbered document.
+     */
+    @Test
+    void theNumberColumnIsNotItselfRefusedByTheRequiredCheck() throws Exception {
+        String rendered = render(DAO_BASE, "Repository.java.template", context());
+
+        assertTrue(!rendered.contains("VacationRequest.Number is required"),
+                "the platform fills the number itself - it can never be the caller's omission: " + rendered);
+    }
+
+    /**
+     * A required value the platform itself supplies is not the caller's to send: the number (allocated
+     * on insert) and a uuid would otherwise be refused on every surface, naming a field no form has.
+     */
+    @Test
+    void noSurfaceDemandsAValueThePlatformSuppliesItself() throws Exception {
+        for (String template : List.of("EntityController.java.template", "EntityMyController.java.template",
+                "EntityPartnerController.java.template")) {
+            String rendered = render(template, context());
+
+            assertTrue(!rendered.contains("The 'Number' property is required"),
+                    template + " must not demand the number it does not receive: " + rendered);
+            assertTrue(rendered.contains("The 'FromDate' property is required"), template + " must still demand what the caller does send");
+        }
+    }
+
+    private String render(String templateName, Map<String, Object> parameters) throws Exception {
+        return render(REST_BASE, templateName, parameters);
+    }
+
+    private String render(String base, String templateName, Map<String, Object> parameters) throws Exception {
+        String location = base + templateName;
+        String template;
+        try (InputStream in = getClass().getResourceAsStream(location)) {
+            assertNotNull(in, "template resource not found on classpath: " + location);
+            template = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        byte[] out = velocityGenerationEngine.generate(parameters, location, template.getBytes(StandardCharsets.UTF_8));
+        return new String(out, StandardCharsets.UTF_8);
+    }
+
+    /** A numbered, personally owned document: the shape the defect was observed on. */
+    private static Map<String, Object> context() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("name", "VacationRequest");
+        parameters.put("projectName", "vacations");
+        parameters.put("perspectiveName", "VacationRequest");
+        parameters.put("javaGenFolderName", "vacations");
+        parameters.put("javaPerspectiveName", "vacationrequest");
+        parameters.put("tablePrefix", "VACATIONS_");
+        parameters.put("dataName", "VACATION_REQUEST");
+        parameters.put("pkPropertyName", "Id");
+        parameters.put("properties", List.of(primaryKey(), number(), fromDate(), note()));
+        parameters.put("sensitiveProperties", List.of());
+        parameters.put("rowChecks", List.of(rowCheck()));
+        parameters.put("personalProperty", "Employee");
+        parameters.put("personalFkJavaClass", "Integer");
+        parameters.put("personalIdentityProperty", "Email");
+        parameters.put("personalIdentityLabel", "Name");
+        parameters.put("personalIdentityRepositoryClass", "gen.vacations.data.vacationrequest.EmployeeRepository");
+        parameters.put("partnerProperty", "Employee");
+        parameters.put("partnerFkJavaClass", "Integer");
+        parameters.put("partnerIdentityProperty", "Email");
+        parameters.put("partnerIdentityLabel", "Name");
+        parameters.put("partnerIdentityRepositoryClass", "gen.vacations.data.vacationrequest.EmployeeRepository");
+        return parameters;
+    }
+
+    private static Map<String, Object> primaryKey() {
+        Map<String, Object> property = new LinkedHashMap<>();
+        property.put("name", "Id");
+        property.put("dataName", "VACATION_REQUEST_ID");
+        property.put("dataType", "INTEGER");
+        property.put("dataTypeJavaClass", "Integer");
+        property.put("dataPrimaryKey", Boolean.TRUE);
+        property.put("dataNotNull", Boolean.TRUE);
+        return property;
+    }
+
+    /** intent `number: { series: Vacation Request, stampOn: create }` on a required column. */
+    private static Map<String, Object> number() {
+        Map<String, Object> property = new LinkedHashMap<>();
+        property.put("name", "Number");
+        property.put("dataName", "VACATION_REQUEST_NUMBER");
+        property.put("dataType", "VARCHAR");
+        property.put("dataTypeJavaClass", "String");
+        property.put("dataPrimaryKey", Boolean.FALSE);
+        property.put("dataNotNull", Boolean.TRUE);
+        property.put("isRequiredProperty", "true");
+        property.put("numberSeries", "Vacation Request");
+        property.put("numberPer", "");
+        property.put("numberStampOnCreate", "true");
+        return property;
+    }
+
+    /** The field the live defect was observed on: `required: true`, supplied by the caller. */
+    private static Map<String, Object> fromDate() {
+        Map<String, Object> property = new LinkedHashMap<>();
+        property.put("name", "FromDate");
+        property.put("dataName", "VACATION_REQUEST_FROM_DATE");
+        property.put("dataType", "DATE");
+        property.put("dataTypeJavaClass", "java.time.LocalDate");
+        property.put("dataPrimaryKey", Boolean.FALSE);
+        property.put("dataNotNull", Boolean.TRUE);
+        property.put("isRequiredProperty", "true");
+        return property;
+    }
+
+    private static Map<String, Object> note() {
+        Map<String, Object> property = new LinkedHashMap<>();
+        property.put("name", "Note");
+        property.put("dataName", "VACATION_REQUEST_NOTE");
+        property.put("dataType", "VARCHAR");
+        property.put("dataTypeJavaClass", "String");
+        property.put("dataPrimaryKey", Boolean.FALSE);
+        property.put("dataLength", 40);
+        property.put("widgetPattern", "^[A-Za-z ]*$");
+        property.put("widgetPatternJava", "^[A-Za-z ]*$");
+        return property;
+    }
+
+    /** intent `checks: exactlyOne` - a row-level refusal, the same one the power surface applies. */
+    private static Map<String, Object> rowCheck() {
+        Map<String, Object> check = new LinkedHashMap<>();
+        check.put("fields", List.of("FromDate", "Note"));
+        check.put("message", "exactly one of FromDate / Note must be set");
+        return check;
+    }
+}


### PR DESCRIPTION
Two defects on the create path of the generated personal (`My`) controller, both absent on the power controller of the same entity - and the personal surface is the one a person actually types into.

### 1. No value validation at all

A missing `required:` field reached the insert and came back as **HTTP 500** quoting a NOT NULL violation on a physical column, where the power surface answers **400** naming the property:

```
POST .../VacationRequestMyController {"ToDate":"2026-10-05","Note":"QA"}
→ 500 "could not execute statement [ERROR: null value in column \"VACATION_REQUEST_FROM_DATE\" ...
POST .../VacationRequestController  {"ToDate":"2026-10-05","Employee":1}
→ 400 "The 'FromDate' property is required"
```

The personal **and partner** surfaces now apply the same validator - required fields, declared lengths, format patterns and row-level `checks:` - and the message is the power surface's verbatim: one refusal, whichever door the caller used. It is placed **after** the owner is forced and the sensitive / role-scoped fields are cleared (the payload the server has finished deciding) and **before** the write, so a refusal never reaches the insert. The partner surface is fixed with it because it is the same construct with the same gap; leaving it would have half-applied the fix.

### 2. The refused create burned a document number

The number was allocated as the **first** thing `save()` did, so every refusal that followed - a `checks:` document check, the required-value check (#7069), the insert itself - spent a number and left a permanent hole in a series a jurisdiction requires to be gap-free (`VAC0000007` never existed; the next create was `VAC0000008`).

The allocation moves to the **last step before the statement**, once every guard that can refuse the create has passed. It cannot go *inside* the insert's transaction: the counter is a sequence incremented in its own transaction precisely so concurrent creates never serialize on it, so what it hands out is spent whatever the insert does. A failure of the INSERT itself can therefore still spend one - stated in the template rather than implied, because closing that would mean serializing every create in the tenant.

### A required value the platform supplies

Falling out of the two above: a `number: { stampOn: create }` column and a `uuid` are filled by the repository on insert, so a required check that demanded them refused every create of a numbered document with a message about a field no form has. Both markers are now excluded - from the new personal/partner validator, from the power controller's (a latent bug there) and from the repository's `requiredCheck` macro, which the number now follows.

### Tests

`PersonalSurfaceCreateValidationTemplateIT` renders the three controllers and the repository through the platform's `VelocityGenerationEngine` and pins the refusal message on every surface, the length/pattern/row checks, the validate-then-write order on both create and update, and the allocation order in `save()` (after the required check, before `super.save`). No application context, so it runs in the PR smoke gate.

Verified locally, all green: the new IT, `RoleScopedFieldControllerTemplateIT`, `ChildLockControllerTemplateIT`, `ModelGenerationIT`, and `IntentEmissionCoverageIT` - the last of which actually compiles the generated client Java.

Fixes #7099

🤖 Generated with [Claude Code](https://claude.com/claude-code)