### PR TITLE
reports: a count widget over an aggregating report sums its count measure (#7102)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/report/ReportIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/report/ReportIntentGenerator.java
@@ -1530,10 +1530,11 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
     /**
      * The report's dashboard KPI, resolved from authored expressions to the report's own column aliases
      * so the runtime can query the generated report controller directly: {@code kind: count} uses the
-     * count endpoint, {@code kind: value} reads {@code valueColumn} off the row matching the {@code at}
-     * pins (typed EQ conditions), {@code kind: list} shows the first {@code limit} rows. The
-     * {@code now} token stays symbolic - the dashboard resolves it client-side, type-aware per the
-     * pinned column's {@code bucket}/{@code type}. No SQL and no URLs live in this block.
+     * count endpoint, or sums the {@code countColumn} rows of an aggregating report,
+     * {@code kind: value} reads {@code valueColumn} off the row matching the {@code at} pins (typed EQ
+     * conditions), {@code kind: list} shows the first {@code limit} rows. The {@code now} token stays
+     * symbolic - the dashboard resolves it client-side, type-aware per the pinned column's
+     * {@code bucket}/{@code type}. No SQL and no URLs live in this block.
      */
     static Map<String, Object> widget(ReportIntent report, Map<String, WidgetDimension> dimensionColumns,
             Map<String, Map<String, Object>> measureColumns) {
@@ -1560,6 +1561,21 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
                 if (measureColumn.containsKey("pattern")) {
                     widget.put("pattern", measureColumn.get("pattern"));
                 }
+            }
+        }
+        // An aggregating report's rows are groups, so its record count is the `count(*)` measure SUMMED
+        // over them (dirigible #7102) - `countColumn` names that column and the dashboard sums it
+        // instead of calling the count endpoint, which would report the number of groups. An
+        // un-aggregated report keeps the endpoint: there one row is one record. A ledger kind counts its
+        // own rows (one per account / statement line), so it carries no count column either.
+        if ("count".equals(kind) && report.isAggregated() && !report.isLedgerKind()) {
+            String countMeasure = report.getCountMeasure();
+            Map<String, Object> countColumn = countMeasure == null ? null : measureColumns.get(expressionKey(countMeasure));
+            if (countColumn == null) {
+                LOGGER.warn("Widget of report [{}] is of kind [count] over an aggregating report with no count(*) measure"
+                        + " - the KPI would show the number of groups", LoggedValue.of(report.getName()));
+            } else {
+                widget.put("countColumn", countColumn.get("alias"));
             }
         }
         if ("list".equals(kind)) {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/ReportIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/ReportIntent.java
@@ -12,7 +12,6 @@ package org.eclipse.dirigible.components.intent.model;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.regex.Pattern;
 
 /**
  * Report / aggregation. {@link #source} names the entity to aggregate; {@link #dimensions} are the
@@ -20,9 +19,6 @@ import java.util.regex.Pattern;
  * {@code sum(total)}). {@link #filter} is an optional WHERE-style predicate.
  */
 public class ReportIntent {
-
-    /** {@code count(*)} - the row-counting measure, in the two spellings the generator treats alike. */
-    private static final Pattern COUNT_ALL = Pattern.compile("(?i)count\\s*\\(\\s*\\*?\\s*\\)");
 
     private String name;
     private String source;
@@ -237,10 +233,31 @@ public class ReportIntent {
      */
     public String getCountMeasure() {
         return measures.stream()
-                       .filter(measure -> measure != null && COUNT_ALL.matcher(measure.trim())
-                                                                      .matches())
+                       .filter(ReportIntent::isCountAll)
                        .findFirst()
                        .orElse(null);
+    }
+
+    /**
+     * Whether the measure is {@code count(*)} - or {@code count()}, the spelling the generator treats
+     * alike - however it is spaced. Compared as a whitespace-free key rather than matched by a pattern:
+     * the expression is authored text, and a regex of adjacent {@code \s*} runs over it is a
+     * polynomial-backtracking surface for no gain.
+     */
+    private static boolean isCountAll(String measure) {
+        if (measure == null) {
+            return false;
+        }
+        StringBuilder compact = new StringBuilder(measure.length());
+        for (int i = 0; i < measure.length(); i++) {
+            char character = measure.charAt(i);
+            if (!Character.isWhitespace(character)) {
+                compact.append(character);
+            }
+        }
+        String key = compact.toString()
+                            .toLowerCase(Locale.ROOT);
+        return "count(*)".equals(key) || "count()".equals(key);
     }
 
     public void setMeasures(List<String> measures) {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/ReportIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/ReportIntent.java
@@ -12,6 +12,7 @@ package org.eclipse.dirigible.components.intent.model;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * Report / aggregation. {@link #source} names the entity to aggregate; {@link #dimensions} are the
@@ -19,6 +20,9 @@ import java.util.Locale;
  * {@code sum(total)}). {@link #filter} is an optional WHERE-style predicate.
  */
 public class ReportIntent {
+
+    /** {@code count(*)} - the row-counting measure, in the two spellings the generator treats alike. */
+    private static final Pattern COUNT_ALL = Pattern.compile("(?i)count\\s*\\(\\s*\\*?\\s*\\)");
 
     private String name;
     private String source;
@@ -214,6 +218,29 @@ public class ReportIntent {
 
     public List<String> getMeasures() {
         return measures;
+    }
+
+    /**
+     * Whether the report AGGREGATES - a ledger kind, or any declared measure. Its rows are then groups,
+     * not records, which is what a {@code kind: count} dashboard widget must not confuse (dirigible
+     * #7102).
+     */
+    public boolean isAggregated() {
+        return isLedgerKind() || measures.stream()
+                                         .anyMatch(measure -> measure != null && !measure.isBlank());
+    }
+
+    /**
+     * The declared {@code count(*)} measure, or {@code null}. It is the one measure whose per-group
+     * values SUM to the report's record count, so it - and not the number of result rows - is what a
+     * {@code kind: count} widget over an aggregating report shows.
+     */
+    public String getCountMeasure() {
+        return measures.stream()
+                       .filter(measure -> measure != null && COUNT_ALL.matcher(measure.trim())
+                                                                      .matches())
+                       .findFirst()
+                       .orElse(null);
     }
 
     public void setMeasures(List<String> measures) {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -9064,8 +9064,9 @@ public final class IntentParser {
 
     /**
      * A report {@code widget:} block turns the report into a dashboard KPI tile. {@code kind: count}
-     * (default) shows the report's record count; {@code kind: value} shows one aggregate cell -
-     * {@code value} names a declared measure and {@code at} pins declared dimensions to a token
+     * (default) shows the report's record count - the {@code count(*)} measure summed over the rows
+     * when the report aggregates, which it must then declare; {@code kind: value} shows one aggregate
+     * cell - {@code value} names a declared measure and {@code at} pins declared dimensions to a token
      * ({@code now}) or a literal; {@code kind: list} shows the report's first {@code limit} rows.
      * Alias/type resolution happens in the report generator (same leniency as report filters).
      */
@@ -9090,6 +9091,15 @@ public final class IntentParser {
             }
         } else if (widget.getValue() != null) {
             issues.add(prefix + " of kind [" + kind + "] must not declare `value` - use kind [value]");
+        }
+        // An aggregating report yields one row per group, so its record count is the SUM of a
+        // `count(*)` measure over those rows - never the number of rows, which is the number of groups
+        // (dirigible #7102). Without such a measure the tile has nothing honest to show, so the report
+        // is refused here rather than silently displaying the group count. A ledger kind is exempt: its
+        // rows ARE its unit (one per account / statement line) and it declares no measures.
+        if ("count".equals(kind) && report.isAggregated() && !report.isLedgerKind() && report.getCountMeasure() == null) {
+            issues.add(prefix + " of kind [count] needs a `count(*)` measure to sum - the report aggregates, so counting its rows"
+                    + " would show the number of groups; declare `count(*)` in `measures:` or use kind [value]");
         }
         for (Map.Entry<String, Object> pin : widget.getAt()
                                                    .entrySet()) {

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/report/ReportIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/report/ReportIntentGeneratorTest.java
@@ -142,6 +142,9 @@ class ReportIntentGeneratorTest {
     @Test
     void countWidgetDefaultsKindLabelAndIcon() {
         ReportIntent report = report();
+        // Un-aggregated: a count over an aggregating report resolves a count column of its own, which
+        // the two tests below cover - here only the defaults are under test.
+        report.setMeasures(null);
         report.getWidget()
               .setValue(null);
         report.getWidget()
@@ -191,6 +194,61 @@ class ReportIntentGeneratorTest {
                                   .get("value"));
         assertNull(pins.get(0)
                        .get("token"));
+    }
+
+    private static final String COUNT_INTENT = """
+            name: sales
+            entities:
+              - name: InvoiceStatus
+                kind: setting
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: Invoice
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: total, type: decimal }
+                relations:
+                  - { name: Status, kind: manyToOne, to: InvoiceStatus, function: EntityStatus, init: 1 }
+            reports:
+              - name: InvoicesByStatus
+                source: Invoice
+                dimensions: [Status]
+                measures: ["count(*)", "sum(total)"]
+                widget: { kind: count, label: Invoices, icon: file-text }
+              - name: OpenInvoices
+                source: Invoice
+                dimensions: [total]
+                widget: { kind: count }
+            """;
+
+    @Test
+    void countWidgetOverAnAggregatingReportSumsItsCountMeasure() {
+        // One row per status: the record count is the count(*) column summed over the rows, so the
+        // widget names that column instead of leaving the dashboard to count rows (dirigible #7102).
+        IntentModel model = IntentParser.parse(COUNT_INTENT);
+        Map<String, Map<String, Object>> measures = new LinkedHashMap<>();
+        measures.put("count(*)", column("Count", "INTEGER", null));
+        measures.put("sum(total)", column("Sum Total", "DECIMAL", "### ### ### ##0.00"));
+
+        Map<String, Object> widget = ReportIntentGenerator.widget(model.getReports()
+                                                                       .get(0),
+                new LinkedHashMap<>(), measures);
+
+        assertEquals("count", widget.get("kind"));
+        assertEquals("Count", widget.get("countColumn"));
+    }
+
+    @Test
+    void countWidgetOverAnUnaggregatedReportKeepsTheRowCount() {
+        IntentModel model = IntentParser.parse(COUNT_INTENT);
+
+        Map<String, Object> widget = ReportIntentGenerator.widget(model.getReports()
+                                                                       .get(1),
+                new LinkedHashMap<>(), new LinkedHashMap<>());
+
+        assertEquals("count", widget.get("kind"));
+        assertFalse(widget.containsKey("countColumn"));
     }
 
     private static final String STATUS_FILTER_INTENT = """

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/IntentParserTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/IntentParserTest.java
@@ -1516,6 +1516,39 @@ class IntentParserTest {
                 "expected a value-on-count issue, got: " + ex.getIssues());
     }
 
+    @Test
+    void countWidgetOnAnAggregatingReportNeedsACountMeasure() {
+        // The report yields one row per group, so counting rows shows the number of statuses, not the
+        // number of records (dirigible #7102) - the tile has nothing honest to show without count(*).
+        String yaml = WIDGET_HEAD.replace("value: \"sum(total)\"", "kind: count");
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("of kind [count] needs a `count(*)` measure to sum")),
+                "expected a count-over-aggregate issue, got: " + ex.getIssues());
+    }
+
+    @Test
+    void countWidgetOnAnAggregatingReportAcceptsADeclaredCountMeasure() {
+        String yaml = WIDGET_HEAD.replace("measures: [\"sum(total)\"]", "measures: [\"count(*)\", \"sum(total)\"]")
+                                 .replace("value: \"sum(total)\"", "kind: count");
+        IntentModel model = IntentParser.parse(yaml);
+        assertEquals("count(*)", model.getReports()
+                                      .get(0)
+                                      .getCountMeasure());
+    }
+
+    @Test
+    void countWidgetOnAnUnaggregatedReportNeedsNoMeasure() {
+        // One row is one record there, so the count endpoint is right and nothing is required.
+        String yaml = WIDGET_HEAD.replace("measures: [\"sum(total)\"]", "")
+                                 .replace("value: \"sum(total)\"", "kind: count");
+        IntentModel model = IntentParser.parse(yaml);
+        assertFalse(model.getReports()
+                         .get(0)
+                         .isAggregated());
+    }
+
     private static final String CUSTOM_WIDGET_HEAD = """
             name: sales
             entities:

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/reports.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/reports.js
@@ -186,7 +186,8 @@ document.addEventListener('alpine:init', () => {
     },
 
     // Load a KPI widget's data from the report's generated controller. Returns
-    //   { value }               for kind count/value (missing data coalesces to 0),
+    //   { value }               for kind count/value (missing data coalesces to 0); a count over an
+    //                           aggregating report sums its countColumn over the rows,
     //   { rows }                for kind list,
     //   { forbidden: true }     when the report is role-guarded and the user lacks the role
     //                           (the tile should be hidden, not shown as an error),
@@ -209,7 +210,15 @@ document.addEventListener('alpine:init', () => {
           const rows = await this._fetchJson(it.apiBase + '/search', { conditions, $limit: w.limit || 5 });
           return { rows: rows || [] };
         }
-        // kind: count (the default) — the number of records the report yields.
+        // kind: count (the default) — the number of records the report yields. An aggregating report
+        // yields one row per group, so its record count is its count(*) measure SUMMED over the rows;
+        // the count endpoint would report the number of groups (dirigible #7102). `countColumn` is
+        // present exactly for such a report, so its absence means one row is one record.
+        if (w.countColumn) {
+          const rows = await this._fetchJson(it.apiBase + '/search', { conditions });
+          const total = (rows || []).reduce((sum, row) => sum + (Number(row[w.countColumn]) || 0), 0);
+          return { value: total };
+        }
         const r = conditions.length
           ? await this._fetchJson(it.apiBase + '/count', { conditions })
           : await this._fetchJson(it.apiBase + '/count');

--- a/components/ui/editor-report/src/main/resources/META-INF/dirigible/editor-report/editor.html
+++ b/components/ui/editor-report/src/main/resources/META-INF/dirigible/editor-report/editor.html
@@ -442,6 +442,17 @@
                                             </bk-select>
                                         </div>
                                     </bk-form-item>
+                                    <bk-form-item ng-if="report.widget.kind === 'count'" class="fd-row fd-margin-top--tiny">
+                                        <div class="fd-col fd-col-md--2">
+                                            <bk-form-label for="widgetCount" colon="true">Count column</bk-form-label>
+                                        </div>
+                                        <div class="fd-col fd-col-md--4 fd-col-lg--3">
+                                            <bk-select id="widgetCount" ng-model="report.widget.countColumn" dropdown-fixed="true">
+                                                <bk-option text="Rows - the report is not aggregated" value="''"></bk-option>
+                                                <bk-option ng-repeat="c in widgetCountColumns()" text="{{c.alias}} (summed)" value="c.alias"></bk-option>
+                                            </bk-select>
+                                        </div>
+                                    </bk-form-item>
                                     <bk-form-item ng-if="report.widget.kind === 'list'" class="fd-row fd-margin-top--tiny">
                                         <div class="fd-col fd-col-md--2">
                                             <bk-form-label for="widgetLimit" colon="true">Rows</bk-form-label>

--- a/components/ui/editor-report/src/main/resources/META-INF/dirigible/editor-report/js/editor.js
+++ b/components/ui/editor-report/src/main/resources/META-INF/dirigible/editor-report/js/editor.js
@@ -1598,8 +1598,9 @@ angular.module('page', ['blimpKit', 'platformView', 'platformShortcuts', 'Worksp
 
 	// Begin Dashboard Widget Section ------------------------------------------------------------------------------
 	// The `widget` block turns the report into a dashboard KPI tile: kind `count` shows the report's
-	// record count, `value` one aggregate cell (a measure column, optionally pinned by `at` equals
-	// conditions over grouping columns), `list` the first rows as a mini table. Consumed at runtime
+	// record count (its `countColumn` summed when the report aggregates), `value` one aggregate cell
+	// (a measure column, optionally pinned by `at` equals conditions over grouping columns), `list`
+	// the first rows as a mini table. Consumed at runtime
 	// by the Harmonia shell's reports store; the tile replaces the report's dashboard preview tile.
 
 	$scope.widgetKinds = [
@@ -1635,7 +1636,14 @@ angular.module('page', ['blimpKit', 'platformView', 'platformShortcuts', 'Worksp
 			delete widget.valueType;
 			delete widget.pattern;
 		}
+		if (widget.kind !== 'count') delete widget.countColumn;
 	};
+
+	// The COUNT column a `count` tile sums. An aggregating report yields one row per group, so its
+	// record count is a COUNT measure summed over the rows - the count endpoint would report the
+	// number of groups (dirigible #7102). Left empty for a report that is not aggregated: there one
+	// row is one record and the endpoint is right.
+	$scope.widgetCountColumns = () => ($scope.report.columns || []).filter(c => c.aggregate === 'COUNT');
 
 	// The measure the tile shows: an aggregate column of this report. Type and (money) pattern ride
 	// along so the dashboard can format the number without re-deriving the column.

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -268,6 +268,9 @@ class IntentEngineIT extends IntegrationTest {
                 dimensions: [customer]
                 measures: ["count(*)", "sum(total)"]
                 chart: doughnut
+                # kind: count over an AGGREGATING report: one row per customer, so the tile sums the
+                # count(*) column instead of counting rows, which would show the number of customers.
+                widget: { kind: count, label: Orders, icon: shopping-cart }
               # month(field) buckets a date dimension into a sortable YYYYMM integer. The widget
               # turns the report into a dashboard KPI: one aggregate cell, the month pinned to now.
               - name: OrdersByMonth
@@ -2836,6 +2839,14 @@ class IntentEngineIT extends IntegrationTest {
         String bigItems = contentOf("BigOrderItems.report");
         assertTrue(bigItems.contains("\"kind\": \"count\""), "the count widget should carry its kind");
         assertTrue(bigItems.contains("\"icon\": \"alert-triangle\""), "the widget icon should be carried");
+        // An un-aggregated report has no count column: one of its rows IS one record, so the tile
+        // keeps the count endpoint.
+        assertFalse(bigItems.contains("\"countColumn\""), "an un-aggregated count widget must not name a count column");
+        // An aggregating one names the count(*) measure's own column, which the dashboard SUMS - the
+        // row count there is the number of groups (#7102).
+        String byCustomer = contentOf("OrdersByCustomer.report");
+        assertTrue(byCustomer.contains("\"kind\": \"count\""), "the count widget should carry its kind");
+        assertTrue(byCustomer.contains("\"countColumn\": \"Count\""), "a count over an aggregating report should name the count(*) column");
 
         // The .model root carries the custom widgets. (The per-entity count tiles are now suppressed
         // by the shell template itself when widgets are declared - the old `dashboardKpis` flag was


### PR DESCRIPTION
A `widget: { kind: count }` showed the number of **result rows**. On a report dimensioned by status those rows are groups, so the tile reported the number of statuses (4) where the records numbered 14; on a single-dimension report it showed 1. The spec always said *"the number of records the report yields"* - the `/count` endpoint answers a different question (`SELECT COUNT(*) FROM (<grouped query>)`).

## What changes

- **The record count of an aggregating report is its `count(*)` measure SUMMED over the rows.** The generated `.report` widget names that measure's own column (`countColumn`) and the Harmonia reports store sums it over `POST /search` instead of calling `/count`.
- **An un-aggregated report keeps the endpoint** - there one row IS one record - and a **ledger kind** counts its own rows (one per account / statement line), so neither carries a count column. Such a report generates byte-identically.
- **An aggregating report declaring no `count(*)` measure is refused at parse**, naming the fix (`declare count(*) in measures:` or use `kind: value`), because the tile has nothing honest to show and the group count is exactly the wrong number this issue is about.
- **The report editor gets the same choice** as a *Count column* select over the report's COUNT columns (empty = rows, for a report that does not aggregate), so a hand-authored `.report` is not the one surface left with the bug.

## Tests

- `IntentParserTest` - the refusal, the accepted `count(*)` declaration, and the un-aggregated report that needs no measure.
- `ReportIntentGeneratorTest` - `countColumn` resolved from the count measure's alias; absent on an un-aggregated report.
- `IntentEngineIT` (green locally, 27 s) - the fixture's `OrdersByCustomer` (dimensioned by customer, `count(*)` + `sum(total)`) now carries a count widget and its `.report` asserts `"countColumn": "Count"`, while the un-aggregated `BigOrderItems` asserts none.

Fixes #7102

🤖 Generated with [Claude Code](https://claude.com/claude-code)