### PR TITLE
intent: entity unique accepts a cross-model to-one relation (#7092)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -3705,9 +3705,13 @@ public final class IntentParser {
      * single field says it. Every name must resolve to an own field or an own <b>to-one</b> relation of
      * the entity: a to-one contributes its foreign-key column, which is what a pair like
      * {@code (tenant, application)} means, while a to-many has no column on this side to constrain. A
-     * cross-model relation is rejected outright - the consumer stores a projection of the target, so
-     * there is no local column either. And a single-name key is rejected naming the field attribute it
-     * duplicates, because two ways to say the same thing is how the two drift apart.
+     * cross-model to-one qualifies exactly like a same-model one (#7092): the consumer stores the
+     * target's id in its own {@code <ENTITY>_<RELATION>} column - the projection is only the read-side
+     * copy that feeds the dropdown - and that column is what the natural key of most transactional rows
+     * in a modular fleet spans ({@code (projectMonth, Employee)}, {@code (payrollRun, Employee)},
+     * {@code (Customer, period)}): the master data is owned elsewhere by design. And a single-name key
+     * is rejected naming the field attribute it duplicates, because two ways to say the same thing is
+     * how the two drift apart.
      *
      * @param entity the entity carrying the keys
      * @param issues the collecting issue list
@@ -3759,10 +3763,9 @@ public final class IntentParser {
                     } else if (!("manyToOne".equals(relation.getKind()) || "oneToOne".equals(relation.getKind()))) {
                         issues.add(subject + " names [" + name + "], which is a " + relation.getKind()
                                 + " relation - only a field or a to-one relation has a column on this entity to constrain");
-                    } else if (relation.isCrossModel()) {
-                        issues.add(subject + " names the cross-model relation [" + name
-                                + "] - a cross-model target is stored as a projection, so this entity has no column for it");
                     }
+                    // A to-one passes whether or not its target is cross-model: both store the target id in
+                    // this entity's own FK column, which is the column the key constrains.
                     continue;
                 }
                 if (!fields.contains(name)) {

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -509,6 +509,15 @@ field may declare:
   FK to a node with children (e.g. a journal line references an analytical account, never a
   synthetic one). The target entity must declare `hierarchy`. Canonical pair:
     `- { name: Account, kind: manyToOne, to: Account, model: accounts, required: true, leafOnly: true }`
+- `unique:` (entity-level) - **the composite business key**, what a row IS when no single field says
+  it: `unique: [{ fields: [ProjectTimesheet, Employee], message: "..." }]`. Each member is an own field
+  or an own **to-one** relation (which contributes its foreign-key column); the key is created in the
+  schema and a colliding write is answered 409 with the message. A cross-model to-one qualifies like a
+  same-model one - the consumer stores the target's id in its own FK column, the projection is only
+  the read-side copy - which is how (project-month, employee), (payroll run, employee) and
+  (customer, period) are declared when the master data is owned by another module. Refused: a
+  to-many or `subset` member (no column here), a single-name key (use `unique: true` on the field), a
+  repeated name, the same key twice.
 - `checks:` (entity-level) - **declarative cross-field / cross-line validations**:
   - `{ kind: exactlyOne, fields: [debit, credit], message: "..." }` (row-level): exactly one of the
     listed own fields is non-null - enforced on every user write (400).

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmEntityUniqueTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmEntityUniqueTest.java
@@ -68,6 +68,29 @@ class EdmEntityUniqueTest {
         assertEquals(List.of("TENANT_APPLICATION_TENANT", "TENANT_APPLICATION_PLAN"), columnNames(constraint));
     }
 
+    /**
+     * #7092: the FK column of a cross-model to-one has the same {@code <ENTITY>_<RELATION>} form as a
+     * same-model one (see {@code crossModelRelationProperty}), so the key over it is emitted with no
+     * other change - the schema template, the alter reconciliation and the controller's 409 mapping all
+     * key on these column names.
+     */
+    @Test
+    void aCrossModelToOneContributesItsForeignKeyColumnLikeASameModelOne() {
+        // The text block already stripped the common indentation: the document starts at column 0.
+        String yaml = PROVISIONING.replace("entities:\n", "uses:\n  - { model: catalog }\nentities:\n")
+                                  .replace("  - { name: application, kind: manyToOne, to: Application, required: true }",
+                                          "  - { name: application, kind: manyToOne, to: Application, model: catalog, required: true }");
+
+        Map<String, Object> constraint = onlyConstraint(yaml);
+
+        assertEquals("TenantApplication_Tenant_Application", constraint.get("name"));
+        assertEquals(List.of("TENANT_APPLICATION_TENANT", "TENANT_APPLICATION_APPLICATION"), columnNames(constraint),
+                "the cross-model FK column is local to this entity and carries the same name form as a same-model one");
+        assertEquals("Tenant,Application", constraint.get("properties"), "the .edm twin names the FK property the modeler resolves");
+        String xml = EdmIntentGenerator.buildEdmXmlForTest(IntentParser.parse(yaml), "provisioning");
+        assertTrue(xml.contains("<properties>Tenant,Application</properties>"), "the key reaches the .edm section: " + xml);
+    }
+
     @Test
     void anUnauthoredMessageStillReadsAsSomethingAUserCanActOn() {
         Map<String, Object> constraint =

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/EntityUniqueIntentTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/EntityUniqueIntentTest.java
@@ -98,27 +98,49 @@ class EntityUniqueIntentTest {
         assertIssue(yaml, "only a field or a to-one relation has a column on this entity to constrain");
     }
 
-    @Test
-    void aCrossModelRelationIsRejected() {
-        String yaml = """
-                name: provisioning
-                uses:
-                  - { name: catalog }
-                entities:
-                  - name: Tenant
-                    fields:
-                      - { name: id, type: integer, primaryKey: true, generated: true }
-                  - name: TenantApplication
-                    unique:
-                      - { fields: [tenant, application] }
-                    fields:
-                      - { name: id, type: integer, primaryKey: true, generated: true }
-                    relations:
-                      - { name: tenant, kind: manyToOne, to: Tenant, required: true }
-                      - { name: application, kind: manyToOne, to: Application, model: catalog, required: true }
-                """;
+    /** The consumer of a cross-model target keeps the shape it references in {@code uses:}. */
+    private static final String CROSS_MODEL_PROVISIONING = """
+            name: provisioning
+            uses:
+              - { model: catalog }
+            entities:
+              - name: Tenant
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+              - name: TenantApplication
+                unique:
+                  - { fields: [tenant, application] }
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                relations:
+                  - { name: tenant, kind: manyToOne, to: Tenant, required: true }
+                  - { name: application, kind: manyToOne, to: Application, model: catalog, required: true }
+            """;
 
-        assertIssue(yaml, "cross-model relation [application]");
+    /**
+     * #7092: a cross-model to-one stores the target's id in this entity's own FK column - the
+     * projection is only the read-side copy - so it constrains exactly like a same-model to-one.
+     * Refusing it made the natural key of most transactional rows ((project-month, employee),
+     * (customer, period)) unavailable in a modular fleet, where the master data is cross-model by
+     * design.
+     */
+    @Test
+    void aCrossModelToOneIsAcceptedBecauseItsForeignKeyColumnIsLocal() {
+        IntentModel model = IntentParser.parse(CROSS_MODEL_PROVISIONING);
+
+        List<UniqueIntent> keys = entity(model, "TenantApplication").getUnique();
+        assertEquals(1, keys.size());
+        assertEquals(List.of("tenant", "application"), keys.get(0)
+                                                           .getFields());
+    }
+
+    @Test
+    void aCrossModelToManyIsStillRejectedBecauseItHasNoColumnHere() {
+        String yaml = CROSS_MODEL_PROVISIONING.replace(
+                "  - { name: application, kind: manyToOne, to: Application, model: catalog, required: true }",
+                "  - { name: application, kind: oneToMany, to: Application, model: catalog }");
+
+        assertIssue(yaml, "only a field or a to-one relation has a column on this entity to constrain");
     }
 
     @Test

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentCrossModelUniqueIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentCrossModelUniqueIT.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.repository.api.IResource;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * dirigible #7092: an entity-level {@code unique:} key may span a <b>cross-model</b> to-one
+ * relation.
+ *
+ * <p>
+ * The natural key of most transactional rows in a modular fleet spans a master-data relation the
+ * module does not own - one timesheet per (project-month, employee), one slip per (payroll run,
+ * employee), one statement per (customer, period) - and {@code Employee} / {@code Customer} are
+ * cross-model by design there. The parser used to refuse such a key on the premise that a
+ * cross-model target "is stored as a projection, so this entity has no column for it". The premise
+ * was false: the consumer stores the target's id in its own {@code <ENTITY>_<RELATION>} FK column,
+ * exactly like a same-model to-one; the projection is only the read-side copy behind the dropdown.
+ *
+ * <p>
+ * The assertions walk the layers the key has to reach, with the owner model generated and published
+ * as its own project:
+ * <ol>
+ * <li><b>Generation</b> - the consumer's intent with a key over (ProjectTimesheet, Employee) is
+ * accepted, and the key lands in the consumer's schema over the two local FK columns, with the
+ * authored message in the generated controller.</li>
+ * <li><b>Runtime</b> - the second timesheet for the same person and project-month is answered 409
+ * (the database holds the constraint AND the controller recognises which key was hit), while the
+ * same person on another project-month is accepted - so the key is composite, not a single-column
+ * unique wearing a composite name.</li>
+ * </ol>
+ */
+class IntentCrossModelUniqueIT extends IntegrationTest {
+
+    private static final String WORKSPACE = "workspace";
+    /** Owns the master data the key spans. Its project name differs from the model alias on purpose. */
+    private static final String OWNER = "unique-owner";
+    /** Declares the key over its own to-one AND the cross-model to-one. */
+    private static final String CONSUMER = "unique-consumer";
+
+    private static final String OWNER_MODEL = "employees";
+    private static final String CONSUMER_MODEL = "timesheets";
+
+    private static final String OWNER_INTENT = """
+            name: employees
+            description: cross-model unique fixture - the owner of the referenced master data
+
+            entities:
+              - name: Employee
+                fields:
+                  - { name: id,   type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string,  required: true, length: 100 }
+            """;
+
+    private static final String CONSUMER_INTENT = """
+            name: timesheets
+            description: cross-model unique fixture - one timesheet per person per project-month
+
+            uses:
+              - { model: employees, project: unique-owner }
+
+            entities:
+              - name: ProjectTimesheet
+                fields:
+                  - { name: id,    type: integer, primaryKey: true, generated: true }
+                  - { name: month, type: string,  required: true, length: 7 }
+              - name: EmployeeTimesheet
+                unique:
+                  - { fields: [ProjectTimesheet, Employee], message: "This employee already has a timesheet for this project-month" }
+                fields:
+                  - { name: id,    type: integer, primaryKey: true, generated: true }
+                  - { name: hours, type: decimal }
+                relations:
+                  - { name: ProjectTimesheet, kind: manyToOne, to: ProjectTimesheet, required: true }
+                  - { name: Employee, kind: manyToOne, to: Employee, model: employees, required: true }
+            """;
+
+    @Autowired
+    private IRepository repository;
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    @Test
+    void a_business_key_may_span_a_cross_model_to_one_and_is_enforced_at_runtime() {
+        writeIntent(OWNER, OWNER_INTENT);
+        generateProject(OWNER);
+        writeIntent(CONSUMER, CONSUMER_INTENT);
+        generateProject(CONSUMER);
+
+        assertKeyReachesTheSchemaAndTheController();
+
+        publishProject(OWNER);
+        publishProject(CONSUMER);
+        synchronizationProcessor.forceProcessSynchronizers();
+
+        assertSecondTimesheetForTheSamePersonAndMonthIsRefused();
+    }
+
+    /**
+     * Layer 1: the key is emitted over the two LOCAL FK columns - the cross-model one has the same
+     * {@code <ENTITY>_<RELATION>} form as the same-model one - and the controller carries the authored
+     * message it answers the 409 with.
+     */
+    private void assertKeyReachesTheSchemaAndTheController() {
+        String schema = contentOf(CONSUMER, "gen/" + CONSUMER_MODEL + "/schema/" + CONSUMER + ".schema");
+        assertTrue(schema.contains("\"EmployeeTimesheet_ProjectTimesheet_Employee\""),
+                "the composite key over a cross-model to-one must reach the schema: " + schema);
+        assertTrue(schema.contains("EMPLOYEE_TIMESHEET_EMPLOYEE"),
+                "the cross-model FK column is a column of THIS entity, so the key can constrain it: " + schema);
+
+        String controller = contentOf(CONSUMER, "gen/" + CONSUMER_MODEL + "/api/employeetimesheet/EmployeeTimesheetController.java");
+        assertTrue(controller.contains("This employee already has a timesheet for this project-month"),
+                "the generated controller must carry the authored conflict message");
+    }
+
+    /**
+     * Layer 2 - the promise: the duplicate that was found as an end user (a second timesheet for the
+     * same person, billed twice) cannot land, and the caller is told why. The third write keeps the
+     * same employee on another project-month and must be accepted.
+     */
+    private void assertSecondTimesheetForTheSamePersonAndMonthIsRefused() {
+        String ownerApi = "/services/java/" + OWNER + "/gen/" + OWNER_MODEL + "/api";
+        String consumerApi = "/services/java/" + CONSUMER + "/gen/" + CONSUMER_MODEL + "/api";
+
+        AtomicInteger employeeId = new AtomicInteger();
+        restAssuredExecutor.execute(() -> employeeId.set(given().contentType("application/json")
+                                                                .body("{\"Name\":\"Ada\"}")
+                                                                .when()
+                                                                .post(ownerApi + "/employee/EmployeeController")
+                                                                .then()
+                                                                .statusCode(200)
+                                                                .extract()
+                                                                .path("Id")),
+                60);
+
+        AtomicInteger januaryId = new AtomicInteger();
+        AtomicInteger februaryId = new AtomicInteger();
+        restAssuredExecutor.execute(() -> januaryId.set(given().contentType("application/json")
+                                                               .body("{\"Month\":\"2026-01\"}")
+                                                               .when()
+                                                               .post(consumerApi + "/projecttimesheet/ProjectTimesheetController")
+                                                               .then()
+                                                               .statusCode(200)
+                                                               .extract()
+                                                               .path("Id")));
+        restAssuredExecutor.execute(() -> februaryId.set(given().contentType("application/json")
+                                                                .body("{\"Month\":\"2026-02\"}")
+                                                                .when()
+                                                                .post(consumerApi + "/projecttimesheet/ProjectTimesheetController")
+                                                                .then()
+                                                                .statusCode(200)
+                                                                .extract()
+                                                                .path("Id")));
+
+        String timesheets = consumerApi + "/employeetimesheet/EmployeeTimesheetController";
+        restAssuredExecutor.execute(() -> given().contentType("application/json")
+                                                 .body(timesheet(januaryId.get(), employeeId.get()))
+                                                 .when()
+                                                 .post(timesheets)
+                                                 .then()
+                                                 .statusCode(200));
+        restAssuredExecutor.execute(() -> {
+            String body = given().contentType("application/json")
+                                 .body(timesheet(januaryId.get(), employeeId.get()))
+                                 .when()
+                                 .post(timesheets)
+                                 .then()
+                                 .statusCode(409)
+                                 .extract()
+                                 .asString();
+            assertTrue(body.contains("This employee already has a timesheet for this project-month"),
+                    "the 409 must carry the authored message, not a bare constraint name; got: " + body);
+        });
+        restAssuredExecutor.execute(() -> given().contentType("application/json")
+                                                 .body(timesheet(februaryId.get(), employeeId.get()))
+                                                 .when()
+                                                 .post(timesheets)
+                                                 .then()
+                                                 .statusCode(200));
+    }
+
+    private static String timesheet(int projectTimesheetId, int employeeId) {
+        return "{\"ProjectTimesheet\":" + projectTimesheetId + ",\"Employee\":" + employeeId + ",\"Hours\":8}";
+    }
+
+    /**
+     * Write the intent, generate the model files and drive model-to-code from the generate response's
+     * own plan.
+     */
+    private void generateProject(String project) {
+        AtomicReference<List<Map<String, Object>>> plan = new AtomicReference<>();
+        restAssuredExecutor.execute(() -> plan.set(given().when()
+                                                          .post("/services/ide/intent/generate?workspace=" + WORKSPACE + "&project="
+                                                                  + project + "&path=app.intent")
+                                                          .then()
+                                                          .statusCode(200)
+                                                          .extract()
+                                                          .jsonPath()
+                                                          .getList("codeGenerations")));
+        for (Map<String, Object> codeGeneration : plan.get()) {
+            assertEquals(Boolean.TRUE, codeGeneration.get("generated"),
+                    "generating code from " + codeGeneration.get("path") + " failed: " + codeGeneration.get("error"));
+        }
+    }
+
+    private void publishProject(String project) {
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .post("/services/ide/publisher/" + WORKSPACE + "/" + project + "/")
+                                                 .then()
+                                                 .statusCode(200));
+    }
+
+    private void writeIntent(String project, String yaml) {
+        String path = projectPath(project) + "/app.intent";
+        IResource existing = repository.getResource(path);
+        if (existing.exists()) {
+            existing.setContent(yaml.getBytes(StandardCharsets.UTF_8));
+        } else {
+            repository.createResource(path, yaml.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    private String contentOf(String project, String fileName) {
+        return new String(repository.getResource(projectPath(project) + "/" + fileName)
+                                    .getContent(),
+                StandardCharsets.UTF_8);
+    }
+
+    private static String projectPath(String project) {
+        return IRepositoryStructure.PATH_USERS + "/admin/" + WORKSPACE + "/" + project;
+    }
+
+    @AfterEach
+    void cleanup() {
+        for (String project : List.of(CONSUMER, OWNER)) {
+            restAssuredExecutor.execute(() -> given().when()
+                                                     .delete("/services/ide/publisher/" + WORKSPACE + "/" + project)
+                                                     .then()
+                                                     .statusCode(greaterThanOrEqualTo(200)));
+            if (repository.hasCollection(projectPath(project))) {
+                repository.removeCollection(projectPath(project));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What
`validateUnique` refused an entity-level `unique:` key naming a cross-model `manyToOne` / `oneToOne`, with the message *"a cross-model target is stored as a projection, so this entity has no column for it"*. The premise does not hold: the consumer stores the target's id in its own `<ENTITY>_<RELATION>` FK column (`crossModelRelationProperty` emits it; the generated entity carries `@Column(name = "EMPLOYEE_TIMESHEET_EMPLOYEE") public Integer Employee`), and the projection is only the read-side copy behind the dropdown.

This PR drops that one branch. Nothing else changes: `uniqueConstraint` already builds the column names by the same `<ENTITY>_<RELATION>` formula for a relation whatever its target, the `.edm` `<uniqueKey>` section names the FK property the modeler resolves, and the schema template, the alter reconciliation (#7019/#7020) and the controller's 409 mapping all key on those column names. The decision PR #6793 deferred is taken here.

The refusals that do hold stay: to-many, `subset`, an unknown name, a single name, a repeated name, a twice-declared key.

## Why
The natural key of most transactional rows in a modular fleet spans a master-data relation the module does not own - (project-month, employee), (payroll run, employee), (customer, period) - and `Employee` / `Customer` are cross-model by design there. Found adapting base-timesheets for the 14.48.0 train (BusinessIntents/base-timesheets#19): a second timesheet for the same person, billed twice.

## Tests
- `EntityUniqueIntentTest`: the rejection test becomes an acceptance (the old fixture's `uses: - { name: catalog }` was itself invalid and only passed because several issues were collected; it now uses `model:`); a cross-model to-many stays rejected.
- `EdmEntityUniqueTest`: the cross-model FK column reaches the constraint (`TENANT_APPLICATION_APPLICATION`) and the `.edm` `<properties>` section.
- New `IntentCrossModelUniqueIT`: generates an `employees` owner and a `timesheets` consumer declaring `unique: [ProjectTimesheet, Employee]`, asserts the key in the consumer's schema and the message in its controller, publishes both, and at runtime gets 200 / **409 carrying the authored message** / 200 (same person, other project-month) - so the key is composite, not a single-column unique wearing a composite name. Green locally (38 s).
- engine-intent suite: 1129 tests green.
- The assistant guide gains the entity-level `unique:` bullet it never had, stating the rule as it now stands.

Fixes #7092

🤖 Generated with [Claude Code](https://claude.com/claude-code)