### PR TITLE
intent: a null generate.unique: key term is null-safe in the guard and named in the log

### DIFF
--- a/components/data/data-store-java/src/main/java/org/eclipse/dirigible/components/data/store/java/repository/Criteria.java
+++ b/components/data/data-store-java/src/main/java/org/eclipse/dirigible/components/data/store/java/repository/Criteria.java
@@ -53,25 +53,35 @@ public final class Criteria {
     }
 
     /**
-     * Equals ({@code property = value}).
+     * Equals ({@code property = value}); NULL-SAFE - a null value renders {@code property is null}.
+     *
+     * <p>
+     * SQL three-valued logic makes {@code property = :p} with a null bind never true, not even for a
+     * null column, so a lookup built from values that may be null used to match NOTHING rather than the
+     * rows it names. That is silent by construction: an idempotency guard keyed on a nullable property
+     * (dirigible #7134 - a generated schedule's {@code generate.unique:}) found nothing on every re-run
+     * and created a duplicate, while its own summary reported "already existed [0]". A caller that
+     * means "this property equals this value, which happens to be absent" means {@code is null}, which
+     * is what this renders - and no caller means a condition that no row can ever satisfy.
      *
      * @param property the entity property name
-     * @param value the value to match
+     * @param value the value to match; null matches rows whose property is null
      * @return this criteria
      */
     public Criteria eq(String property, Object value) {
-        return binary(property, "=", value);
+        return value == null ? isNull(property) : binary(property, "=", value);
     }
 
     /**
-     * Not equals ({@code property <> value}).
+     * Not equals ({@code property <> value}); NULL-SAFE - a null value renders
+     * {@code property is not null}, the complement of {@link #eq(String, Object)}'s null form.
      *
      * @param property the entity property name
-     * @param value the value to exclude
+     * @param value the value to exclude; null keeps rows whose property is not null
      * @return this criteria
      */
     public Criteria ne(String property, Object value) {
-        return binary(property, "<>", value);
+        return value == null ? isNotNull(property) : binary(property, "<>", value);
     }
 
     /**

--- a/components/data/data-store-java/src/test/java/org/eclipse/dirigible/components/data/store/java/repository/CriteriaTest.java
+++ b/components/data/data-store-java/src/test/java/org/eclipse/dirigible/components/data/store/java/repository/CriteriaTest.java
@@ -64,6 +64,26 @@ class CriteriaTest {
     }
 
     @Test
+    void aNullValueRendersANullSafePredicateRatherThanANeverTrueComparison() {
+        // Issue #7134: `property = :p` with a null bind is never true in SQL's three-valued logic, not
+        // even for a null column, so a lookup built from values that may be null matched NOTHING and
+        // said nothing about it - an idempotency guard keyed on a nullable property created a duplicate
+        // on every re-run while reporting that its target "already existed [0]" times.
+        Criteria criteria = Criteria.create()
+                                    .eq("customer", null)
+                                    .eq("status", "ACTIVE")
+                                    .ne("returnedOn", null);
+
+        assertEquals("from LoanEntity where customer is null and status = :p0 and returnedOn is not null",
+                criteria.append("from LoanEntity"));
+        // Only the non-null value binds: a null is part of the predicate, never a parameter.
+        assertEquals(1, criteria.parameters()
+                                .size());
+        assertEquals("ACTIVE", criteria.parameters()
+                                       .get("p0"));
+    }
+
+    @Test
     void rejectsNonIdentifierPropertyNamesToPreventInjection() {
         assertThrows(IllegalArgumentException.class, () -> Criteria.create()
                                                                    .eq("status; drop table", "x"));

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -2935,6 +2935,14 @@ Pick the pair that identifies the RUN, not the source: `[Project, period]`, not 
 alone. A schedule's source is a standing row - the same `Project` matches the query every month - so a
 back-reference-only key would generate the first project-month and never another.
 
+Key on a term that is always ASSIGNED and never NULL. The assignment is what the parser can prove; the
+value is not. A term mapped from a nullable field, or from a `relation.field` off a null foreign key,
+binds null at run time - and a null is not a value the key can tell rows apart by. The lookup itself is
+null-safe (it queries `is null`, so the guard still finds this tick's own earlier output rather than
+matching nothing and duplicating on every re-run), but two source rows that are both null in that term
+are ONE output under the declared key, so the second is skipped as already existing. The tick logs a
+warning naming the null term when it happens; the fix is in the key, not the log.
+
 **`{ run: <period> }` - the period of the run, for a target with no period column.** The
 recurring-template family cannot name a period property, because there is none: a monthly rent bill or
 a quarterly retainer invoice generated from a standing template is a plain document with a `date`. Key

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Job.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Job.java.template
@@ -77,12 +77,43 @@ public class ${className}Job implements JobHandler {
             // ("one bill per template per month") is still keyed. Best-effort against two concurrent
             // ticks, exactly as the event-driven create-from's guard is - a UNIQUE database key on the
             // same columns is the durable backstop.
+#set($genUniqueValueTerms = 0)
+#foreach($u in $genUnique)
+#if($u.kind != "range")
+#set($genUniqueValueTerms = $genUniqueValueTerms + 1)
+#end
+#end
+#if($genUniqueValueTerms > 0)
+            // Each key value is read ONCE, into a local, because the lookup and the diagnostic below
+            // both need it and a term can be a field off a loaded relation.
+            java.util.List<String> nullKeyTerms = new java.util.ArrayList<>();
+#foreach($u in $genUnique)
+#if($u.kind != "range")
+            Object key${u.property} = ${u.expr};
+            if (key${u.property} == null) {
+                nullKeyTerms.add("${u.property}");
+            }
+#end
+#end
+            if (!nullKeyTerms.isEmpty()) {
+                // A NULL key term (issue #7134). The lookup itself is null-safe - Criteria.eq binds
+                // `is null` for a null value, so the guard still finds this tick's own earlier output
+                // instead of matching nothing and minting a duplicate on every re-run. What it cannot
+                // do is tell two source rows apart by a term that is null in both: under the declared
+                // key they ARE one output, so the second row is counted as already existing. That is
+                // the key being weaker than the author meant, and it is said out loud here rather than
+                // discovered as a missing document.
+                LOG.warn("Schedule ${name}: unique key term(s) {} are null for ${entity} [{}] - the natural key cannot tell rows sharing"
+                        + " that null apart, so they collapse to one ${genToEntity}; key on a property this generate always assigns",
+                        nullKeyTerms, entity.${attachKeyProperty});
+            }
+#end
             if (!new gen.${genToGenFolder}.data.${genToJavaPerspective}.${genToEntity}Repository().findAll(Criteria.create()
 #foreach($u in $genUnique)
 #if($u.kind == "range")
                     .between("${u.property}", ${u.lower}, ${u.upper})
 #else
-                    .eq("${u.property}", ${u.expr})
+                    .eq("${u.property}", key${u.property})
 #end
 #end
                     ).isEmpty()) {

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -2155,12 +2155,23 @@ class IntentEngineIT extends IntegrationTest {
         String job = codeOf("gen/events/hr/MonthlyTimesheetsJob.java");
         assertTrue(job.contains(".EmployeeTimesheetRepository().findAll(Criteria.create()"),
                 "the guard should query the TARGET before building anything");
-        assertTrue(job.contains(".eq(\"Employee\", entity.Id)"), "the key term reuses the map assignment's own expression");
+        assertTrue(job.contains("Object keyEmployee = entity.Id;"), "the key term reuses the map assignment's own expression");
+        assertTrue(job.contains(".eq(\"Employee\", keyEmployee)"), "the guard queries by the value read for that term");
         // The sharp one: a month field's `now` is YearMonth.now().toString(), which is what makes "the
         // same month" comparable at all - a re-derived LocalDate.now() would never match the row the
         // first tick wrote.
-        assertTrue(job.contains(".eq(\"Period\", java.time.YearMonth.now().toString())"),
+        assertTrue(job.contains("Object keyPeriod = java.time.YearMonth.now().toString();"),
                 "the key term renders in the target field's own shape, exactly as the assignment does");
+        assertTrue(job.contains(".eq(\"Period\", keyPeriod)"), "the period half of the key is queried by that same value");
+        // Issue #7134: a key term whose value is null cannot tell two source rows apart, and the
+        // lookup used to match NOTHING for it - a duplicate on every re-run, reported as
+        // "already existed [0]". The value is now null-safe in the criteria (Criteria.eq binds
+        // `is null`) and the weak key is named in the log rather than left to be discovered.
+        assertTrue(job.contains("if (keyEmployee == null) {") && job.contains("nullKeyTerms.add(\"Employee\");"),
+                "a null key term is detected per row and named");
+        assertTrue(job.contains("unique key term(s) {} are null"), "the tick says which key term was null");
+        assertTrue(job.indexOf("nullKeyTerms.add(\"Employee\");") < job.indexOf(".eq(\"Employee\", keyEmployee)"),
+                "the diagnostic is emitted before the guard runs, so the reason is in the log either way");
         // Skipping the ROW, not just the header: `continue` is what leaves the children alone.
         assertTrue(job.contains("existed++;"), "a row whose target already exists is counted");
         assertTrue(
@@ -2221,7 +2232,8 @@ class IntentEngineIT extends IntegrationTest {
 
         String job = codeOf("gen/events/purchases/MonthlyRecurringBillsJob.java");
         assertTrue(job.contains(".PurchaseInvoiceRepository().findAll(Criteria.create()"), "the guard should query the TARGET");
-        assertTrue(job.contains(".eq(\"Supplier\", entity.Supplier)"), "the row half of the key reuses the map assignment's expression");
+        assertTrue(job.contains("Object keySupplier = entity.Supplier;") && job.contains(".eq(\"Supplier\", keySupplier)"),
+                "the row half of the key reuses the map assignment's expression");
         // The period term: a RANGE over the date the run writes, built from that assignment's own
         // LocalDate.now() - which is what makes the period queried the period the row is dated into.
         assertTrue(


### PR DESCRIPTION
## What

The scheduled-generation idempotency guard emitted `.eq("<Prop>", <expr>)` per key term, and `Criteria.eq` rendered `prop = :p` - never true for a null bind, not even against a null column. The parse-time rule proves every key property is *statically assigned* by `map` / `defaults`, not that its value is non-null at run time: a term mapped from a nullable field, or from a one-hop `relation.field` off a null FK, binds null. The guard then matched NOTHING, so the tick created a duplicate on every re-run while its own summary reported `already existed [0]`.

## How

- **`Criteria.eq` / `ne` are null-safe** (`data-store-java`): a null value renders `property is null` / `is not null` instead of a comparison no row can satisfy. The guard now finds this tick's own earlier output, so a re-run is the no-op it claims to be. Every existing caller of these that can pass null already null-guards before the lookup (the inbound `lookups`, the aggregate handlers' `keyNullGuards`), so nothing else changes shape.
- **The generated job names a null key term** (`Job.java.template`): each non-range key value is read once into a local (the lookup and the diagnostic both need it, and a term can be a field off a loaded relation), and when any is null the tick logs a warning naming it. What a null term cannot do is tell two source rows apart - under the declared key they *are* one output, so the second is skipped as already existing. That is the key being weaker than the author meant, and it is now said out loud rather than discovered as a missing document.
- **The guide** says to key on a term that is always assigned and never null, and what happens when it is not.

## Tests

- `CriteriaTest.aNullValueRendersANullSafePredicateRatherThanANeverTrueComparison` - `is null` / `is not null` render, and a null is part of the predicate rather than a bound parameter.
- `IntentEngineIT` (both natural-key ITs) - the rendered job reads each key value into a local, queries by it, detects and names a null term before the guard runs, and still emits the range term unchanged.
- `components/data/data-store-java` and `components/engine/engine-intent` suites green; the template's rendered output verified for both a value+range key and a range-only key.

Fixes #7134

🤖 Generated with [Claude Code](https://claude.com/claude-code)