### PR TITLE
data-store-java: a by-id read after a targeted mutation inside a unit sees the row the statement left (#7135)

### DIFF
--- a/components/data/data-store-java/src/main/java/org/eclipse/dirigible/components/data/store/java/store/JavaEntityStore.java
+++ b/components/data/data-store-java/src/main/java/org/eclipse/dirigible/components/data/store/java/store/JavaEntityStore.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -30,6 +31,10 @@ import org.eclipse.dirigible.components.data.store.java.repository.DomainEvent;
 import org.eclipse.dirigible.sdk.utils.Json;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
+import org.hibernate.engine.spi.EntityHolder;
+import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.MutationQuery;
 import org.hibernate.query.Query;
 import org.slf4j.Logger;
@@ -255,11 +260,14 @@ public class JavaEntityStore {
                                 .getName();
         return write((session, events) -> {
             flushBeforeMutation(session);
-            return session.createMutationQuery(
-                    "update " + meta.entityName() + " set " + property + " = :value where " + idProperty + " = :id")
-                          .setParameter("value", value)
-                          .setParameter("id", id)
-                          .executeUpdate();
+            int updated = session
+                                 .createMutationQuery(
+                                         "update " + meta.entityName() + " set " + property + " = :value where " + idProperty + " = :id")
+                                 .setParameter("value", value)
+                                 .setParameter("id", id)
+                                 .executeUpdate();
+            evictAfterMutation(session, meta, id);
+            return updated;
         });
     }
 
@@ -353,6 +361,7 @@ public class JavaEntityStore {
             }
             int updated = query.setParameter("id", id)
                                .executeUpdate();
+            evictAfterMutation(session, meta, id);
             events.add(outbox.record(session, updated == 0 ? List.of()
                     : eventsOf(eventTopic, eventTopic == null ? null : readInTransaction(session, type, meta, id), additionalEvents)));
             return updated;
@@ -653,6 +662,60 @@ public class JavaEntityStore {
         if (UNIT_OF_WORK.get() != null) {
             session.flush();
         }
+    }
+
+    /**
+     * Drops the session's cached copy of the row a bulk mutation query just wrote, inside a unit of
+     * work — the symmetric half of {@link #flushBeforeMutation(Session)}. A targeted update executes
+     * straight against the connection and never touches the persistence context, so the instance the
+     * session is holding for that id still carries the PRE-mutation values; and an HQL entity query by
+     * id resolves to the already-managed instance rather than to the row it just read, so the follow-up
+     * read hands back exactly those stale values. That made a topic-bearing
+     * {@link #updateProperties(Class, Object, Map, String)} publish the OLD totals from inside a unit
+     * (a create-from copying lines and then re-summing the header), and a generated repository's
+     * {@code history} trail record {@code before == after} — an entry saying the write happened with
+     * nothing moved (issue #7135). Evicting after the mutation makes the next read reload the row, so
+     * the payload really is the row as the statement left it. It runs after
+     * {@link #flushBeforeMutation} and the mutation itself, so there is nothing pending on the instance
+     * to lose. Outside a unit each call has its own session with no cached instance, so it no-ops.
+     */
+    private static void evictAfterMutation(Session session, RegisteredEntity meta, Object id) {
+        if (UNIT_OF_WORK.get() == null) {
+            return;
+        }
+        PersistenceContext context = session.unwrap(SharedSessionContractImplementor.class)
+                                            .getPersistenceContextInternal();
+        for (Map.Entry<EntityKey, EntityHolder> held : new ArrayList<>(context.getEntityHoldersByKey()
+                                                                              .entrySet())) {
+            if (!meta.entityName()
+                     .equals(held.getKey()
+                                 .getEntityName())
+                    || !sameId(held.getKey()
+                                   .getIdentifier(),
+                            id)) {
+                continue;
+            }
+            Object managed = held.getValue()
+                                 .getEntity();
+            if (managed != null) {
+                session.evict(managed);
+            }
+        }
+    }
+
+    /**
+     * Whether a key the session filed the row under is the id this mutation wrote. The store's ids
+     * arrive as whatever the caller had — an {@code Integer} literal from a path parameter, a
+     * {@code String} from a query — while the session keys the row under the mapped identifier type, so
+     * the two can denote one row and still not be {@code equals}. Their textual forms decide it then,
+     * which is exact for the integral and string keys an entity id is.
+     */
+    private static boolean sameId(Object key, Object id) {
+        if (Objects.equals(key, id)) {
+            return true;
+        }
+        return key != null && id != null && String.valueOf(key)
+                                                  .equals(String.valueOf(id));
     }
 
     /**

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaUnitOfWorkIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaUnitOfWorkIT.java
@@ -11,9 +11,14 @@ package org.eclipse.dirigible.integration.tests.api;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.eclipse.dirigible.components.api.messaging.MessagingFacade;
 
 import org.eclipse.dirigible.components.data.sources.manager.DataSourcesManager;
 import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
@@ -51,6 +56,8 @@ class JavaUnitOfWorkIT extends IntegrationTest {
     private static final String DOCUMENTS = "/services/java/" + PROJECT + "/ledger/DocumentController";
     private static final String[] TABLE_NAMES = {"UOW_LEDGER_ENTRY", "UOW_LINE", "UOW_DOCUMENT"};
     private static final long TIMEOUT_SECONDS = 30;
+    private static final String ECHO_QUEUE = "uow-it-updated-echo";
+    private static final long RECEIVE_TIMEOUT_MILLIS = 2000;
 
     @Autowired
     private IRepository repository;
@@ -123,6 +130,66 @@ class JavaUnitOfWorkIT extends IntegrationTest {
                 TIMEOUT_SECONDS);
         String withEvents = observed[0].substring("id=".length(), observed[0].indexOf(' '));
         assertGet(DOCUMENTS + "/document/" + withEvents + "/total", 200, "12");
+    }
+
+    @Test
+    void a_read_after_a_targeted_write_in_the_same_unit_sees_the_row_the_statement_left() {
+        ClientJavaProjectDeployer.deploy(repository, projectUtil, synchronizationProcessor, PROJECT, PROJECT);
+
+        // The topic-bearing re-sum, with the header loaded earlier in the same unit. The whole exchange
+        // retries because a topic keeps nothing for a subscriber that is not there yet, and the client
+        // classes are compiled and subscribed asynchronously.
+        String[] observed = new String[1];
+        Awaitility.await()
+                  .pollInterval(1, TimeUnit.SECONDS)
+                  .atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                  .ignoreExceptions()
+                  .until(() -> {
+                      drainEcho();
+                      restAssuredExecutor.execute(() -> observed[0] = given().when()
+                                                                             .get(DOCUMENTS + "/document/unit/topic/summed")
+                                                                             .then()
+                                                                             .statusCode(200)
+                                                                             .extract()
+                                                                             .asString(),
+                              TIMEOUT_SECONDS);
+                      String payload = receiveEcho();
+                      if (payload == null) {
+                          return false;
+                      }
+                      observed[0] = observed[0] + " payload=" + payload;
+                      return true;
+                  });
+
+        // The two reads the history block makes around the write: before it the header still carries the
+        // zero it was inserted with, after it the sum of the lines - a trail entry that records a change
+        // instead of before == after.
+        assertTrue(observed[0].contains("updated=1 before=0 after=12"),
+                "the read after the targeted write must be the row the statement left: " + observed[0]);
+
+        // ...and the payload the topic carried is that same row, not the one the session was holding -
+        // a roll-up or a notify {placeholder} downstream computes from exactly this.
+        assertTrue(observed[0].contains("\"total\":12"), "the '-updated' payload must carry the written total: " + observed[0]);
+
+        // What committed is the sum too, so the assertions above are about the read and not about a
+        // mutation that never landed.
+        String id = observed[0].substring("id=".length(), observed[0].indexOf(' '));
+        assertGet(DOCUMENTS + "/document/" + id + "/total", 200, "12");
+    }
+
+    /** Empties the echo queue so an assertion cannot read a previous attempt's message. */
+    private void drainEcho() {
+        while (receiveEcho() != null) {
+            // keep reading until the queue is empty
+        }
+    }
+
+    private String receiveEcho() {
+        try {
+            return MessagingFacade.receiveFromQueue(ECHO_QUEUE, RECEIVE_TIMEOUT_MILLIS);
+        } catch (RuntimeException nothingYet) {
+            return null;
+        }
     }
 
     private void assertGet(String path, int expectedStatus) {

--- a/tests/tests-integrations/src/main/resources/JavaUnitOfWorkIT/ledger/DocumentController.java
+++ b/tests/tests-integrations/src/main/resources/JavaUnitOfWorkIT/ledger/DocumentController.java
@@ -82,16 +82,48 @@ public class DocumentController {
         });
     }
 
+    /**
+     * The same document, re-summed through the TOPIC-bearing targeted write - and the before/after
+     * pair a generated repository's {@code history} block records around it. The header is loaded
+     * earlier in the unit (the reload every recalculate does), so the session is holding an instance
+     * for its id when the mutation runs; the read that follows must be the row as the statement left
+     * it, not that instance (issue #7135). Reports what the block itself saw on both sides of the
+     * write, and the payload the topic carried is asserted from the queue the listener echoes to.
+     */
+    @Get("/document/unit/topic/{tag}")
+    public String documentSummedOnTopic(@PathParam("tag") String tag) {
+        return UnitOfWork.call(() -> {
+            Document header = new Document();
+            header.name = tag;
+            header.total = BigDecimal.ZERO;
+            Document saved = documents.save(header);
+            lines.save(line(saved.id, new BigDecimal("5.00")));
+            lines.save(line(saved.id, new BigDecimal("7.00")));
+            BigDecimal sum = BigDecimal.ZERO;
+            for (Line line : lines.findAll(Criteria.create()
+                                                   .eq("document", saved.id))) {
+                sum = sum.add(line.amount);
+            }
+            // The history block's shape: read, write, read - and the two reads must differ.
+            Document before = documents.findById(saved.id);
+            int updated = documents.updateProperties(saved.id, Map.of("total", sum), DocumentUpdatedListener.UPDATED_TOPIC);
+            Document after = documents.findById(saved.id);
+            return "id=" + saved.id + " updated=" + updated + " before=" + plain(before) + " after=" + plain(after);
+        });
+    }
+
     /** The committed total, read outside any unit - what the browser sees after the create-from. */
     @Get("/document/{id}/total")
     public String committedTotal(@PathParam("id") Integer id) {
-        Document document = documents.findById(id);
-        if (document == null) {
+        return plain(documents.findById(id));
+    }
+
+    private static String plain(Document document) {
+        if (document == null || document.total == null) {
             return "missing";
         }
-        return document.total == null ? "null"
-                : document.total.stripTrailingZeros()
-                                .toPlainString();
+        return document.total.stripTrailingZeros()
+                             .toPlainString();
     }
 
     private Recalculated recalculate(Integer documentId) {

--- a/tests/tests-integrations/src/main/resources/JavaUnitOfWorkIT/ledger/DocumentUpdatedListener.java
+++ b/tests/tests-integrations/src/main/resources/JavaUnitOfWorkIT/ledger/DocumentUpdatedListener.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package ledger;
+
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.messaging.ListenerKind;
+import org.eclipse.dirigible.sdk.messaging.MessageHandler;
+import org.eclipse.dirigible.sdk.messaging.Producer;
+
+/**
+ * Echoes the payload a targeted header write publishes onto a queue the test can drain - a roll-up or
+ * a notify {@code {placeholder}} downstream is exactly such a subscriber, and it computes from what
+ * this payload says the row is (issue #7135).
+ */
+@Component
+public class DocumentUpdatedListener implements MessageHandler {
+
+    public static final String UPDATED_TOPIC = "uow-document-updated";
+
+    public static final String ECHO_QUEUE = "uow-it-updated-echo";
+
+    @Override
+    public String destination() {
+        return UPDATED_TOPIC;
+    }
+
+    @Override
+    public ListenerKind kind() {
+        return ListenerKind.TOPIC;
+    }
+
+    @Override
+    public void onMessage(String message) {
+        Producer.sendToQueue(ECHO_QUEUE, message);
+    }
+}


### PR DESCRIPTION
Fixes #7135

## What was wrong

A targeted `updateProperty` / `updateProperties` runs a bulk `update … where id = :id` straight against the connection and never touches the persistence context, so the instance the session holds for that id keeps the **pre-mutation** values — and an HQL entity query by id resolves to that already-managed instance rather than to the row it just read. #7107 added the flush *before* the mutation; nothing evicted *after* it, so a by-id read that followed a targeted mutation inside a unit of work handed back stale values.

Two generated paths consume exactly that read:

- topic-bearing `updateProperties` builds its `-updated` payload from `readInTransaction` right after the mutation — inside a unit (a create-from copying lines, then `recalculate` writing the header totals) the event carried the **old** totals, and a roll-up or a notify `{placeholder}` downstream computed from them;
- `Repository.java.template`'s `history == true` block does `findById` → `updateProperties` → `findById`, so `History.recordUpdate` recorded `before == after` — a trail entry saying the write happened with nothing moved.

Both are invisible outside a unit, where each store call has its own session with no cached instance — which is why the per-write tests passed.

## The change

`evictAfterMutation` is the symmetric half of `flushBeforeMutation`: after `executeUpdate()` it drops the session's copy of the mutated key, so the next read reloads the row and the payload really is the row as the statement left it. It runs after the flush and the mutation, so there is nothing pending on the instance to lose, and it no-ops outside a unit. Both targeted primitives go through it.

No template change is needed — the generated `history` block gets a truthful `after` from the fixed read.

## Verification

New `JavaUnitOfWorkIT` case in the shape both consumers have: a header loaded earlier in the unit, re-summed through the topic-bearing targeted write, asserting the before/after pair the history block records **and** the payload the topic actually carried (echoed to a queue by a listener fixture).

- with the fix: `JavaUnitOfWorkIT` 3/3 green;
- with the two `evictAfterMutation` calls commented out, the new case fails exactly as the issue describes:

```
the read after the targeted write must be the row the statement left:
id=1 updated=1 before=0 after=0 payload={"id":1,"name":"summed","total":0,...}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)