### PR TITLE
intent: a gate reachable through two decision routes loses its async boundary on both (#7139)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/ProcessParallelSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/ProcessParallelSupport.java
@@ -171,6 +171,23 @@ public final class ProcessParallelSupport {
      * the fork sits on.
      */
     public static List<String> routingTargets(StepIntent step) {
+        List<String> targets = new ArrayList<>(continuationTargets(step));
+        addIfPresent(targets, timerTarget(step, "timeout"));
+        addIfPresent(targets, timerTarget(step, "expire"));
+        addIfPresent(targets, stringArg(step, "onError"));
+        return targets;
+    }
+
+    /**
+     * The steps a step routes on to when the flow simply continues - a decision's {@code then} and
+     * {@code else}, any other step's {@code next}. Deliberately NOT the {@code then} of a boundary
+     * {@code timeout} / {@code expire} timer, nor a delegate's {@code onError} route: those are taken
+     * when a wait expires or a step fails, which is nobody's completing action.
+     *
+     * @param step the authored step
+     * @return the steps the flow continues into, in declaration order
+     */
+    public static List<String> continuationTargets(StepIntent step) {
         List<String> targets = new ArrayList<>(2);
         if ("decision".equalsIgnoreCase(step.getKind())) {
             addIfPresent(targets, stringArg(step, "then"));
@@ -178,9 +195,6 @@ public final class ProcessParallelSupport {
         } else {
             addIfPresent(targets, stringArg(step, "next"));
         }
-        addIfPresent(targets, timerTarget(step, "timeout"));
-        addIfPresent(targets, timerTarget(step, "expire"));
-        addIfPresent(targets, stringArg(step, "onError"));
         return targets;
     }
 

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/bpmn/BpmnIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/bpmn/BpmnIntentGenerator.java
@@ -488,58 +488,92 @@ public class BpmnIntentGenerator implements IntentTargetGenerator {
             // delegates inserted BEFORE it ran when the execution arrived, in the previous transaction.
             List<String> ownNodes = nodesByStep.getOrDefault(step.getName(), List.of(step.getName()));
             List<String> afterTheWait = ownNodes.subList(Math.min(ownNodes.indexOf(step.getName()) + 1, ownNodes.size()), ownNodes.size());
-            for (List<String> path : gatedPaths(step, byName, process.getSteps(), gatedSteps)) {
-                synchronous.addAll(afterTheWait);
-                for (String node : path) {
-                    synchronous.addAll(nodesByStep.getOrDefault(node, List.of(node)));
-                }
+            Set<String> onGateRoutes = gateReachingSteps(step, byName, process.getSteps(), gatedSteps);
+            if (onGateRoutes.isEmpty()) {
+                continue;
+            }
+            synchronous.addAll(afterTheWait);
+            for (String node : onGateRoutes) {
+                synchronous.addAll(nodesByStep.getOrDefault(node, List.of(node)));
             }
         }
         return synchronous;
     }
 
     /**
-     * The routes from a user task to a gated step, as the authored step names strictly between the task
-     * and the gate plus the gate itself. Empty when no gate is reachable through {@code decision} steps
-     * alone.
+     * The union of the authored steps lying on <b>every</b> route from a user task to a gated step -
+     * the steps strictly between the two, plus the gates themselves. Empty when no gate is reachable
+     * through {@code decision} steps alone.
+     *
+     * <p>
+     * A gate is regularly reachable through more than one decision route (an amount threshold that
+     * short-circuits a rating check, say), and the completing user rides exactly one of them. Each
+     * route carries its own decisions and the resolver / field-loader delegates inserted in front of
+     * them, so the nodes of all of them lose their boundary - not only the ones on the first route
+     * walked, which is what a single visited set across the routes leaves behind (issue #7139). Hence
+     * the two passes: a forward walk collects the decision sub-graph reachable from the task, and a
+     * backward walk from the gates inside it keeps the steps a gate is really reachable from. A
+     * decision route that reaches no gate keeps its async boundary.
+     *
+     * @param userTask the completing user task
+     * @param byName the authored steps by name
+     * @param authored the authored steps, in declaration order
+     * @param gatedSteps the authored step names carrying a check-gated status write
+     * @return the authored step names on the gate-reaching routes
      */
-    private static List<List<String>> gatedPaths(StepIntent userTask, Map<String, StepIntent> byName, List<StepIntent> authored,
+    private static Set<String> gateReachingSteps(StepIntent userTask, Map<String, StepIntent> byName, List<StepIntent> authored,
             Set<String> gatedSteps) {
-        List<List<String>> paths = new ArrayList<>();
-        Deque<List<String>> pending = new ArrayDeque<>();
-        for (String target : successors(userTask, authored)) {
-            pending.add(List.of(target));
-        }
-        Set<String> walked = new HashSet<>();
-        while (!pending.isEmpty()) {
-            List<String> path = pending.poll();
-            String name = path.get(path.size() - 1);
-            if (!walked.add(name)) {
-                continue; // a loop back into a step already on some route - its nodes are already taken
+        Map<String, List<String>> continuationsByStep = new LinkedHashMap<>();
+        Set<String> reachable = new LinkedHashSet<>();
+        Deque<String> forward = new ArrayDeque<>(continuations(userTask, authored));
+        while (!forward.isEmpty()) {
+            String name = forward.poll();
+            if (!reachable.add(name)) {
+                continue; // already collected, through this route or another one
             }
             if (gatedSteps.contains(name)) {
-                paths.add(path);
-                continue;
+                continue; // the gate is where the completing transaction ends
             }
             StepIntent step = byName.get(name);
             if (step == null || !"decision".equals(step.getKind())) {
                 continue; // a wait state, real asynchronous work, or `end` - the transaction ends here
             }
-            for (String target : successors(step, authored)) {
-                List<String> next = new ArrayList<>(path);
-                next.add(target);
-                pending.add(next);
+            List<String> targets = continuations(step, authored);
+            continuationsByStep.put(name, targets);
+            forward.addAll(targets);
+        }
+        Map<String, List<String>> predecessors = new LinkedHashMap<>();
+        for (Map.Entry<String, List<String>> continuation : continuationsByStep.entrySet()) {
+            for (String target : continuation.getValue()) {
+                predecessors.computeIfAbsent(target, name -> new ArrayList<>())
+                            .add(continuation.getKey());
             }
         }
-        return paths;
+        Deque<String> backward = new ArrayDeque<>();
+        for (String name : reachable) {
+            if (gatedSteps.contains(name)) {
+                backward.add(name);
+            }
+        }
+        Set<String> onGateRoutes = new LinkedHashSet<>();
+        while (!backward.isEmpty()) {
+            String name = backward.poll();
+            if (onGateRoutes.add(name)) {
+                backward.addAll(predecessors.getOrDefault(name, List.of()));
+            }
+        }
+        return onGateRoutes;
     }
 
     /**
-     * The authored steps a step routes on to: its declared routing, or - when it declares none - the
-     * step that follows it in declaration order, which is what the linear chain falls through to.
+     * The authored steps a step continues into: its declared {@code then} / {@code else} / {@code next}
+     * routing, or - when it declares none - the step that follows it in declaration order, which is
+     * what the linear chain falls through to. A boundary timer's branch and a delegate's
+     * {@code onError} route are deliberately not continuations: they are taken when a wait expires or a
+     * step fails, and nobody's completing action is waiting on the gate behind them.
      */
-    private static List<String> successors(StepIntent step, List<StepIntent> authored) {
-        List<String> targets = ProcessParallelSupport.routingTargets(step);
+    private static List<String> continuations(StepIntent step, List<StepIntent> authored) {
+        List<String> targets = ProcessParallelSupport.continuationTargets(step);
         if (!targets.isEmpty()) {
             return targets;
         }

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/CheckGateBpmnTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/CheckGateBpmnTest.java
@@ -91,6 +91,22 @@ class CheckGateBpmnTest {
                           - { name: activate, kind: serviceTask, args: { setRelationField: Status, value: 2, next: done } }
                           - { name: reject,   kind: serviceTask, args: { setRelationField: Status, value: 8, next: done } }
                           - { name: done,     kind: end }
+                      - name: InvoiceConverge
+                        trigger: { onCreate: Invoice }
+                        steps:
+                          - { name: review,   kind: userTask, args: { assignee: clerk, form: DecideInvoice } }
+                          - { name: decide,   kind: decision, args: { if: "action == 'approve'", then: activate, else: rated } }
+                          - { name: rated,    kind: decision, args: { if: "Customer.rating > 0", then: activate, else: reject } }
+                          - { name: activate, kind: serviceTask, args: { setRelationField: Status, value: 2, next: done } }
+                          - { name: reject,   kind: serviceTask, args: { setRelationField: Status, value: 8, next: done } }
+                          - { name: done,     kind: end }
+                      - name: InvoiceTimeout
+                        trigger: { onCreate: Invoice }
+                        steps:
+                          - { name: review,   kind: userTask, args: { assignee: clerk, form: ApproveInvoice, next: done, timeout: { after: PT24H, then: escalate } } }
+                          - { name: escalate, kind: decision, args: { if: "Customer.rating > 0", then: activate, else: done } }
+                          - { name: activate, kind: serviceTask, args: { setRelationField: Status, value: 2, next: done } }
+                          - { name: done,     kind: end }
                     forms:
                       - { name: ApproveInvoice, forEntity: Invoice, fields: [note], editable: [note], actions: [approve] }
                       - { name: DecideInvoice, forEntity: Invoice, fields: [note], editable: [note], actions: [approve, reject] }
@@ -169,6 +185,32 @@ class CheckGateBpmnTest {
         // The resolver the second decision needs sits between the task and the gate too - and it is a
         // service task like any other, so its boundary would commit the completion just the same.
         assertSynchronous(bpmn, "resolveCustomerRating");
+        assertSynchronous(bpmn, "activate");
+    }
+
+    @Test
+    void aGateReachedThroughTwoDecisionRoutesTakesBothOutOfAsync() {
+        String bpmn = bpmn("InvoiceConverge");
+
+        // The gate is one hop away on the first route (decide -> activate) and two on the second
+        // (decide -> rated -> activate). The approver who takes the second one is waiting on the gate
+        // just as much, so the resolver the second decision needs may not commit the completion first
+        // (issue #7139).
+        assertSynchronous(bpmn, "invoiceConvergeReviewWrite");
+        assertSynchronous(bpmn, "resolveCustomerRating");
+        assertSynchronous(bpmn, "activate");
+    }
+
+    @Test
+    void aGateBehindATimerBranchKeepsTheAsyncBoundary() {
+        String bpmn = bpmn("InvoiceTimeout");
+
+        // The gate is reachable only through the task's `timeout:` boundary branch - taken when the
+        // wait expires, with nobody's action to refuse - so neither the branch nor the writer the task
+        // leaves behind loses its boundary. The gated set itself stays synchronous either way (#7014):
+        // it is the write the gate stands in front of.
+        assertAsynchronous(bpmn, "invoiceTimeoutReviewWrite");
+        assertAsynchronous(bpmn, "resolveCustomerRating");
         assertSynchronous(bpmn, "activate");
     }
 


### PR DESCRIPTION
`BpmnIntentGenerator`'s walk back from a check-gated status write to the user tasks that reach it used ONE visited set across every route, consulted before the gate test, and recorded a route only where it terminated at a gate. A gate reachable through more than one decision route was therefore dropped on the second one, and its own decisions - plus the resolver / field-loader delegates inserted in front of them - kept their `flowable:async` boundary:

```yaml
- { name: decide,   kind: decision, args: { if: "amount < 100", then: activate, else: rated } }
- { name: rated,    kind: decision, args: { if: "Customer.rating > 0", then: activate, else: reject } }
- { name: activate, kind: serviceTask, args: { setRelationField: Status, value: 2 } }   # check-gated
```

An approver taking the `rated` branch got exactly the pre-#7063 behaviour: the task completion commits, the gate fails a detached job, the button vanishes and the refusal lands in Monitoring as a dead-letter incident.

The walk is now two passes over the same sub-graph: forward from the task over `decision` routing to collect what is reachable, then backward from every gate inside it to keep the steps a gate is really reachable from - the union of ALL gate-reaching routes. A decision route that reaches no gate still keeps its boundary.

Same walk, second defect from the issue: it followed `routingTargets`, which also yields a user task's `timeout` / `expire` boundary branch and a delegate's `onError` route, so a gate reachable only that way pulled the branch - and the task's own after-the-wait group - out of async although that moment has no completing action to refuse. The walk now follows only continuations (`then` / `else` / `next`), split out of `routingTargets` as `ProcessParallelSupport.continuationTargets` so each reading of "where does this step go" has one implementation.

## Tests

Two additions to `CheckGateBpmnTest`, both failing on `master` and green with the fix:

- `aGateReachedThroughTwoDecisionRoutesTakesBothOutOfAsync` - the convergent fixture above; the writer, the second route's resolver and the gated setter all run in the completing transaction.
- `aGateBehindATimerBranchKeepsTheAsyncBoundary` - a gate reachable only through a `timeout:` branch; the branch's resolver and the task's writer keep their boundary (the gated set itself stays synchronous, as #7014 made it).

`mvn -pl components/engine/engine-intent test` - 1159 tests, green. `formatter:validate` and the release javadoc pass on the module.

Fixes #7139