### PR TITLE
reports: only the first composition is INNER JOINed, and a join alias is keyed by the relation (#7140)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/report/ReportIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/report/ReportIntentGenerator.java
@@ -16,6 +16,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BinaryOperator;
 import java.util.regex.Matcher;
@@ -64,7 +65,7 @@ import org.springframework.stereotype.Component;
  * join is {@code INNER} for a relation the row cannot lack ({@code required: true} or a
  * composition) and {@code LEFT} for an optional one, so a row without the relation keeps its place
  * in the report (and in the count tile fed by it) with the dimension empty - see
- * {@link #joinType(RelationIntent)};</li>
+ * {@link #joinType(EntityIntent, RelationIntent)};</li>
  * <li>a bare to-one relation name ({@code book}) -&gt; the foreign-key column on the source;</li>
  * <li>a measure {@code count(*)} / {@code sum(total)} / {@code avg(price)} /
  * {@code min}/{@code max} -&gt; an aggregate column (and the dimensions become the
@@ -1642,10 +1643,10 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
     /**
      * Resolve a reference against {@code baseAlias}, aliasing every table it joins with
      * {@code aliasSuffix} and joining it with {@code joinType}. For an ordinary dimension the suffix is
-     * empty and the type null - derived per relation by {@link #joinType(RelationIntent)}; the
-     * correspondence axis resolves the same paths a second time against the counter-side line, where
-     * the suffix keeps the two sets of aliases apart and an explicit LEFT keeps a line whose document
-     * has no counter side.
+     * empty and the type null - derived per relation by
+     * {@link #joinType(EntityIntent, RelationIntent)}; the correspondence axis resolves the same paths
+     * a second time against the counter-side line, where the suffix keeps the two sets of aliases apart
+     * and an explicit LEFT keeps a line whose document has no counter side.
      */
     private static ColumnRef resolve(IntentGenerationContext context, IntentModel model, EntityIntent source, String baseAlias,
             String reference, String aliasSuffix, String joinType) {
@@ -1658,14 +1659,14 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
             if (relation != null && relation.getTo() != null) {
                 EntityIntent target = entityByName(model, relation.getTo());
                 String targetName = relation.getTo();
-                String targetAlias = targetName + aliasSuffix;
+                String targetAlias = joinAlias(source, relation, targetName) + aliasSuffix;
                 ref.tableAlias = targetAlias;
                 ref.physicalColumn = column(targetName, fieldName);
                 FieldIntent targetField = fieldByName(target, fieldName);
                 // A cross-model target's fields are not in this model; string is the safe display type.
                 ref.reportType = targetField == null ? "CHARACTER VARYING" : reportType(targetField.getType());
                 // The column is empty when the target field is, AND when the (left-joined) relation is.
-                ref.nullable = targetField == null || !targetField.isRequired() || !mandatory(relation);
+                ref.nullable = targetField == null || !targetField.isRequired() || !mandatory(source, relation);
                 ref.displayAlias = humanize(reference.replace('.', ' '));
                 ref.join = join(context, model, source, relation, target, targetName, targetAlias, baseAlias, joinType);
                 translate(context, ref, target, crossModelInfo(context, model, relation), fieldName);
@@ -1691,7 +1692,7 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
                 && ("manyToOne".equals(relation.getKind()) || "oneToOne".equals(relation.getKind()))) {
             EntityIntent target = entityByName(model, relation.getTo());
             String targetName = relation.getTo();
-            String targetAlias = targetName + aliasSuffix;
+            String targetAlias = joinAlias(source, relation, targetName) + aliasSuffix;
             // A cross-model target's label comes from the resolved owner model (its Name-like field).
             CrossModelSupport.TargetInfo info = crossModelInfo(context, model, relation);
             String labelField = info != null ? info.labelField() : labelFieldName(target);
@@ -1815,12 +1816,12 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
      * two differ when the same entity is joined twice in one query (the correspondence axis joins the
      * dimension's account and the counter-side account of the same document - see
      * {@link #CORRESPONDENT_SUFFIX}). A null {@code joinType} is derived from the relation - see
-     * {@link #joinType(RelationIntent)}.
+     * {@link #joinType(EntityIntent, RelationIntent)}.
      */
     private static Join join(IntentGenerationContext context, IntentModel model, EntityIntent source, RelationIntent relation,
             EntityIntent target, String targetName, String targetAlias, String baseAlias, String joinType) {
         if (joinType == null) {
-            joinType = joinType(relation);
+            joinType = joinType(source, relation);
         }
         String fkColumn = quote(column(source.getName(), relation.getName()));
         // A cross-model target's table and primary-key column come from the resolved owner model -
@@ -1844,17 +1845,82 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
      * relation still behaves as authored: {@code Store.name = 'X'} is false for a row with no store
      * under either join, and a left join additionally lets {@code Store.name IS NULL} be expressed.
      */
-    static String joinType(RelationIntent relation) {
-        return mandatory(relation) ? REQUIRED_JOIN_TYPE : OPTIONAL_JOIN_TYPE;
+    static String joinType(EntityIntent source, RelationIntent relation) {
+        return mandatory(source, relation) ? REQUIRED_JOIN_TYPE : OPTIONAL_JOIN_TYPE;
     }
 
     /**
      * Whether every row has the relation set - the same rule that makes the EDM generator emit the FK
-     * column NOT NULL: {@code required: true}, or a composition (a detail cannot exist without its
-     * parent).
+     * column NOT NULL: {@code required: true}, or the composition whose FK the EDM makes NOT NULL.
+     * Which composition that is depends on the entity, not on the relation alone - see
+     * {@link #impliedRequiredComposition(EntityIntent, RelationIntent)}.
      */
-    private static boolean mandatory(RelationIntent relation) {
-        return relation.isRequired() || relation.isComposition();
+    private static boolean mandatory(EntityIntent source, RelationIntent relation) {
+        return relation.isRequired() || impliedRequiredComposition(source, relation);
+    }
+
+    /**
+     * Whether this is the composition the EDM generator implicitly makes NOT NULL - which is only the
+     * FIRST one the entity declares.
+     *
+     * <p>
+     * A second composition is legal (the parser tolerates it, refusing only {@code whenMasterDeleted}
+     * there) and {@code EdmIntentGenerator} emits its FK as a plain nullable association unless
+     * {@code required: true} says otherwise. Reading {@code isComposition()} alone therefore claimed a
+     * strictness the schema does not have, and a report reaching through a second, optional composition
+     * INNER JOINed a nullable FK - dropping every row that left it unset, the exact {@code #7105}
+     * symptom in the one case that fix believed it had covered (dirigible #7140). A cross-model
+     * relation is never implicitly required either: the owner model owns the row, and the local FK
+     * follows {@code required:} alone. The iteration mirrors the EDM's own - same kinds, same skips,
+     * declaration order - so the two cannot drift on which composition it is.
+     */
+    private static boolean impliedRequiredComposition(EntityIntent source, RelationIntent relation) {
+        if (source == null || !relation.isComposition() || relation.isCrossModel()) {
+            return false;
+        }
+        for (RelationIntent declared : source.getRelations()) {
+            if (!isToOne(declared) || declared.isCrossModel() || declared.getName() == null || declared.getTo() == null) {
+                continue;
+            }
+            if (declared.isComposition()) {
+                return declared.getName()
+                               .equals(relation.getName());
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The two relation kinds that own an FK column on the declaring entity - the ones a report joins.
+     */
+    private static boolean isToOne(RelationIntent relation) {
+        return "manyToOne".equals(relation.getKind()) || "oneToOne".equals(relation.getKind());
+    }
+
+    /**
+     * The SQL alias a relation's target table is joined under: the target entity name, which is what
+     * every report has always emitted - except when the source declares MORE THAN ONE to-one relation
+     * to that same target ({@code billTo} / {@code shipTo} -> {@code Customer}). Keying the alias on
+     * the target alone collapsed those onto one join through {@code putIfAbsent}: the first ON
+     * condition won, both references read the same joined row, and since #7105 whichever was resolved
+     * first also decided INNER vs LEFT for both (dirigible #7140). Ambiguous targets are therefore
+     * suffixed with the relation, while the relation NAMED after its target keeps the plain alias - so
+     * a model with one relation per target, which is nearly all of them, emits byte-identical SQL to
+     * before.
+     */
+    private static String joinAlias(EntityIntent source, RelationIntent relation, String targetName) {
+        if (source == null || relation == null || relation.getName() == null) {
+            return targetName;
+        }
+        int references = 0;
+        for (RelationIntent declared : source.getRelations()) {
+            if (isToOne(declared) && Objects.equals(declared.getTo(), relation.getTo())
+                    && Objects.equals(declared.getModel(), relation.getModel())) {
+                references++;
+            }
+        }
+        String pascal = IntentNaming.pascalCase(relation.getName());
+        return references > 1 && !pascal.equals(targetName) ? targetName + "_" + pascal : targetName;
     }
 
     /**
@@ -2144,9 +2210,12 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
                 return null;
             }
             EntityIntent target = entityByName(model, relation.getTo());
-            String targetAlias = relation.getTo();
-            joins.putIfAbsent(targetAlias, join(context, model, source, relation, target, targetAlias, targetAlias, baseAlias, null));
-            return targetAlias + "." + quote(column(targetAlias, fieldName));
+            String targetName = relation.getTo();
+            // The alias may be suffixed per relation (two hops to one target); the physical column is
+            // always prefixed with the target ENTITY - the table it lives on has one name.
+            String targetAlias = joinAlias(source, relation, targetName);
+            joins.putIfAbsent(targetAlias, join(context, model, source, relation, target, targetName, targetAlias, baseAlias, null));
+            return targetAlias + "." + quote(column(targetName, fieldName));
         });
         for (FieldIntent field : source.getFields()) {
             if (field.getName() != null && !field.getName()
@@ -2606,8 +2675,8 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
 
     /**
      * A join to another table - INNER for a relation every row has, LEFT for an optional one (see
-     * {@link #joinType(RelationIntent)}), for a language table, and for the correspondent line of a
-     * correspondence balance report.
+     * {@link #joinType(EntityIntent, RelationIntent)}), for a language table, and for the correspondent
+     * line of a correspondence balance report.
      */
     private static final class Join {
         private final String table;

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
@@ -1959,6 +1959,49 @@ class EdmIntentGeneratorTest {
                                                         .toList());
     }
 
+    /**
+     * Only the FIRST composition an entity declares gets the implicit NOT NULL FK; a second one is a
+     * plain nullable association unless {@code required: true} says otherwise. The report generator
+     * mirrors this rule to pick INNER vs LEFT for the hop, so it is asserted here as the rule's own
+     * statement - reading {@code composition: true} as "always NOT NULL" made a report INNER JOIN a
+     * nullable FK and drop every row that left it unset (dirigible #7140).
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    void onlyTheFirstCompositionGetsTheImplicitNotNullForeignKey() {
+        String yaml = """
+                name: shipping
+                entities:
+                  - name: Order
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: Batch
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: Crate
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: Shipment
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                    relations:
+                      - { name: order, kind: manyToOne, to: Order, composition: true }
+                      - { name: batch, kind: manyToOne, to: Batch, composition: true }
+                      - { name: crate, kind: manyToOne, to: Crate, composition: true, required: true }
+                """;
+        Map<String, Object> shipment =
+                entityByName(entities(EdmIntentGenerator.buildModelJsonForTest(IntentParser.parse(yaml), "shipping")), "Shipment");
+
+        // The first composition: NOT NULL without anyone asking - a detail cannot exist without its
+        // master, and this is the master the entity is a detail OF.
+        assertEquals("false", propertyByName(shipment, "Order").get("dataNullable"));
+        // The second: nothing declares it required, so the column is nullable - the row can exist
+        // without it, which is exactly why a report must LEFT JOIN this hop.
+        assertEquals("true", propertyByName(shipment, "Batch").get("dataNullable"));
+        // ...and `required: true` still makes any of them NOT NULL, ordering notwithstanding.
+        assertEquals("false", propertyByName(shipment, "Crate").get("dataNullable"));
+    }
+
     private static List<Map<String, Object>> entities(Map<String, Object> modelJson) {
         return (List<Map<String, Object>>) ((Map<String, Object>) modelJson.get("model")).get("entities");
     }

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/report/ReportIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/report/ReportIntentGeneratorTest.java
@@ -1104,4 +1104,110 @@ class ReportIntentGeneratorTest {
                 query);
         assertTrue(query.contains("COALESCE(Store.\"STORE_NAME\", '') LIKE '%' || :store || '%'"), query);
     }
+
+    /**
+     * A shipment with TWO compositions - only the first of which the EDM makes NOT NULL - and two
+     * separate hops to one and the same target entity.
+     */
+    private static final String AMBIGUOUS_RELATION_INTENT = """
+            name: shipping
+            entities:
+              - name: Customer
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string, required: true }
+              - name: Order
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: number, type: string }
+              - name: Batch
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: code, type: string }
+              - name: Shipment
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: weight, type: decimal }
+                relations:
+                  - { name: order, kind: manyToOne, to: Order, composition: true }
+                  - { name: batch, kind: manyToOne, to: Batch, composition: true }
+                  - { name: billTo, kind: manyToOne, to: Customer }
+                  - { name: shipTo, kind: manyToOne, to: Customer, required: true }
+            reports:
+              - name: ShipmentsByBatch
+                source: Shipment
+                dimensions: [order.number, batch.code, billTo.name, shipTo.name]
+                measures: ["sum(weight)"]
+              - name: ShipmentsForBillTo
+                source: Shipment
+                dimensions: [batch.code]
+                measures: ["sum(weight)"]
+                filter: "billTo.name <> 'X' and shipTo.name <> 'Y'"
+            """;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void onlyTheFirstCompositionIsInnerJoined() {
+        IntentModel model = IntentParser.parse(AMBIGUOUS_RELATION_INTENT);
+        Map<String, Object> document = ReportIntentGenerator.buildForTest(TestContexts.context(model), model.getReports()
+                                                                                                            .get(0));
+        String query = (String) document.get("query");
+
+        // The FIRST composition is the one the EDM emits NOT NULL, so its hop stays INNER...
+        assertTrue(query.contains("INNER JOIN \"SHIPPING_ORDER\" as Order ON Shipment.\"SHIPMENT_ORDER\" = Order.\"ORDER_ID\""), query);
+        // ...and the second one is a plain nullable association in the schema: INNER JOINing it dropped
+        // every shipment with no batch, which is #7105 all over again (dirigible #7140).
+        assertTrue(query.contains("LEFT JOIN \"SHIPPING_BATCH\" as Batch ON Shipment.\"SHIPMENT_BATCH\" = Batch.\"BATCH_ID\""), query);
+
+        List<Map<String, Object>> joins = (List<Map<String, Object>>) document.get("joins");
+        Map<String, String> types = new LinkedHashMap<>();
+        for (Map<String, Object> join : joins) {
+            types.put((String) join.get("alias"), (String) join.get("type"));
+        }
+        assertEquals("INNER", types.get("Order"), joins.toString());
+        assertEquals("LEFT", types.get("Batch"), joins.toString());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void twoRelationsToTheSameTargetAreJoinedSeparately() {
+        IntentModel model = IntentParser.parse(AMBIGUOUS_RELATION_INTENT);
+        Map<String, Object> document = ReportIntentGenerator.buildForTest(TestContexts.context(model), model.getReports()
+                                                                                                            .get(0));
+        String query = (String) document.get("query");
+
+        // billTo and shipTo both reach Customer: one alias per RELATION, each with its own ON condition.
+        // Keyed on the target entity they collapsed onto a single join - the first ON won, both columns
+        // read the same row, and the first-resolved relation decided INNER vs LEFT for both.
+        assertEquals(2, query.split("JOIN \"SHIPPING_CUSTOMER\"", -1).length - 1, query);
+        assertTrue(query.contains("LEFT JOIN \"SHIPPING_CUSTOMER\" as Customer_BillTo ON "
+                + "Shipment.\"SHIPMENT_BILL_TO\" = Customer_BillTo.\"CUSTOMER_ID\""), query);
+        assertTrue(query.contains("INNER JOIN \"SHIPPING_CUSTOMER\" as Customer_ShipTo ON "
+                + "Shipment.\"SHIPMENT_SHIP_TO\" = Customer_ShipTo.\"CUSTOMER_ID\""), query);
+        // Each dimension selects from ITS own join, so the two customers can differ on a row.
+        assertTrue(query.contains("Customer_BillTo.\"CUSTOMER_NAME\""), query);
+        assertTrue(query.contains("Customer_ShipTo.\"CUSTOMER_NAME\""), query);
+
+        List<Map<String, Object>> joins = (List<Map<String, Object>>) document.get("joins");
+        Map<String, String> types = new LinkedHashMap<>();
+        for (Map<String, Object> join : joins) {
+            types.put((String) join.get("alias"), (String) join.get("type"));
+        }
+        // The optional hop is LEFT and the required one INNER even though they share a target.
+        assertEquals("LEFT", types.get("Customer_BillTo"), joins.toString());
+        assertEquals("INNER", types.get("Customer_ShipTo"), joins.toString());
+    }
+
+    @Test
+    void aFilterOverTwoRelationsToTheSameTargetQualifiesEachWithItsOwnAlias() {
+        IntentModel model = IntentParser.parse(AMBIGUOUS_RELATION_INTENT);
+        String query = (String) ReportIntentGenerator.buildForTest(TestContexts.context(model), model.getReports()
+                                                                                                     .get(1))
+                                                     .get("query");
+
+        // The filter path builds its joins itself - it must key them the same way, or a two-hop filter
+        // compares both predicates against one and the same joined row.
+        assertEquals(2, query.split("JOIN \"SHIPPING_CUSTOMER\"", -1).length - 1, query);
+        assertTrue(query.contains("WHERE Customer_BillTo.\"CUSTOMER_NAME\" <> 'X' and Customer_ShipTo.\"CUSTOMER_NAME\" <> 'Y'"), query);
+    }
 }


### PR DESCRIPTION
Fixes #7140

## What was wrong

**1. `mandatory()` did not mirror the EDM rule it claimed to.** #7112 keyed the join type on `isRequired() || isComposition()`, with a javadoc saying that is "the same rule that makes the EDM generator emit the FK column NOT NULL". `EdmIntentGenerator` actually marks only the **first** composition NOT NULL (`!compositionAssigned && relation.isComposition()`), and a second composition is legal — the parser tolerates it, refusing only `whenMasterDeleted` there — so its FK is a plain nullable association unless `required: true`. A report reaching through a second, optional composition still emitted `INNER JOIN` on a nullable FK and dropped every row that left it unset: the #7105 symptom in the one case that fix believed it had covered. A cross-model relation is not implicitly required either (the owner model owns the row), so it follows `required:` alone.

`mandatory` now takes the source entity, and `impliedRequiredComposition` iterates the entity's relations with the **same kinds, same skips, same declaration order** as the EDM generator — so the two cannot drift on *which* composition it is.

**2. Two relations to one target collapsed onto one join** (pre-existing, join-type-relevant since #7112). `billTo` / `shipTo` → `Customer` both aliased to `Customer` and `putIfAbsent` kept the first: one ON condition won, both references read the same joined row, and whichever was resolved first decided INNER vs LEFT for both. Vividly, the pre-fix query for the test model selects the same column twice for the two customers:

```sql
SELECT ... Customer."CUSTOMER_NAME" as "Bill To Name", Customer."CUSTOMER_NAME" as "Ship To Name" ...
```

The alias is now keyed by the **relation**: an ambiguous target is suffixed with the relation name (`Customer_BillTo`, `Customer_ShipTo`), while the relation named after its target keeps the plain alias — so a model with one relation per target, which is nearly all of them, emits byte-identical SQL to before. The dimension/measure resolver and the filter path (which builds its own joins) use the same key, and the physical column stays prefixed with the target entity.

## Verification

`engine-intent` suite: **1161/1161 green**. Three new report cases + one EDM-side case:

- a second composition is LEFT JOINed while the first stays INNER (query and the structured `joins` the editor owns);
- two relations to one target produce two joins, two ON conditions and independent join types, in the SELECT and in the filter;
- the EDM statement of the mirrored rule: first composition NOT NULL, second nullable, `required: true` overriding the order.

With the generator reverted, all three report cases fail exactly as the issue describes (`expected: <2> but was: <1>` join on `SHIPPING_CUSTOMER`, and the INNER-joined second composition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)