### PR TITLE
fix(templates): a self-service duplicate answers 409 naming the field (#7137)

### DIFF
--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityMyController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityMyController.java.template
@@ -1,5 +1,28 @@
 package gen.${javaGenFolderName}.api.${javaPerspectiveName};
 
+## A duplicate is the same refusal whichever door the caller used: a collision with a business key is
+## answered here with the 409 naming the field that the power surface answers with, rather than
+## letting the driver's text out as a 500 (#7137). Either kind of key earns the mapping: a composite
+## `unique:` the model NAMED, or a single-column `unique: true`, which is a column-level UNIQUE the
+## SCHEMA leaves for the database to name - the name every dialect generates is built from the
+## column, which is the handle the mapping keys on.
+#foreach($property in $properties)
+#if($property.dataUnique)
+#set($hasUniqueColumns = "true")
+#end
+#end
+## A see-only surface refuses every write with 403 before it reaches a statement, so there is no
+## collision to map there.
+#set($hasDuplicateKeys = false)
+#if(!$personalReadOnly)
+#if($uniqueConstraints && !$uniqueConstraints.isEmpty())
+#set($hasDuplicateKeys = true)
+#end
+#if($hasUniqueColumns)
+#set($hasDuplicateKeys = true)
+#end
+#end
+
 import gen.${javaGenFolderName}.data.${javaPerspectiveName}.${name}Entity;
 import gen.${javaGenFolderName}.data.${javaPerspectiveName}.${name}Repository;
 
@@ -20,6 +43,9 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+#if($hasDuplicateKeys)
+import java.util.Locale;
+#end
 import java.util.Map;
 
 ## Role-scoped properties (the modeler's per-property read/write role, or the intent's `visibleTo:`
@@ -191,7 +217,15 @@ public class ${name}MyController {
         // server has not finished deciding. Before the save, so a refused create never reaches the
         // insert - and never allocates a document number.
         validate(entity);
+#if($hasDuplicateKeys)
+        try {
+            return scrub(repository.save(entity));
+        } catch (RuntimeException e) {
+            throw duplicateOrRethrow(e);
+        }
+#else
         return scrub(repository.save(entity));
+#end
     }
 
     @Put("/{id}")
@@ -228,7 +262,15 @@ public class ${name}MyController {
 #end
 #end
         validate(entity);
+#if($hasDuplicateKeys)
+        try {
+            return scrub(repository.update(entity));
+        } catch (RuntimeException e) {
+            throw duplicateOrRethrow(e);
+        }
+#else
         return scrub(repository.update(entity));
+#end
     }
 
     @Delete("/{id}")
@@ -613,6 +655,85 @@ public class ${name}MyController {
     }
 #end
 
+#if($hasDuplicateKeys)
+    /**
+     * The business keys of ${name}, keyed by the name the database puts into the violation it raises -
+     * a composite key by the constraint name the model emitted (so this map and the schema cannot
+     * drift), a single-column {@code unique} by its column name, which is what every dialect builds
+     * its own generated constraint name out of ("VACATIONS_PUBLIC_HOLIDAY_PUBLIC_HOLIDAY_DAY_key").
+     * Iterated longest key first, so a column whose name is a prefix of a longer one still answers
+     * with its own message rather than the shorter key's. The power surface's map verbatim - the same
+     * collision has to read the same whichever surface the caller wrote through.
+     */
+    private static final Map<String, String> DUPLICATE_MESSAGES = duplicateMessages();
+
+    private static Map<String, String> duplicateMessages() {
+        Map<String, String> messages = new java.util.TreeMap<>(java.util.Comparator.comparingInt(String::length)
+                                                                                   .reversed()
+                                                                                   .thenComparing(java.util.Comparator.naturalOrder()));
+#if($uniqueConstraints)
+#foreach($uniqueConstraint in $uniqueConstraints)
+        messages.put("${uniqueConstraint.name}".toUpperCase(Locale.ROOT), "${uniqueConstraint.message}");
+#end
+#end
+#foreach($property in $properties)
+#if($property.dataUnique)
+        messages.put("${property.dataName}".toUpperCase(Locale.ROOT), "A ${name} with this '${property.name}' already exists");
+#end
+#end
+        return java.util.Collections.unmodifiableMap(messages);
+    }
+
+    /**
+     * A write that collided with one of those keys is a conflict the caller can act on - answered with
+     * the message that names the field - and anything else is rethrown untouched. Matching is on the
+     * key name inside the driver's message, which is the only handle the database gives back; every
+     * dialect names the violated constraint there.
+     */
+    private static RuntimeException duplicateOrRethrow(RuntimeException e) {
+        if (isConstraintViolation(e) && isDuplicateViolation(e)) {
+            for (Throwable cause = e; cause != null; cause = cause.getCause() == cause ? null : cause.getCause()) {
+                String message = cause.getMessage();
+                if (message == null) {
+                    continue;
+                }
+                String upper = message.toUpperCase(Locale.ROOT);
+                for (Map.Entry<String, String> constraint : DUPLICATE_MESSAGES.entrySet()) {
+                    if (upper.contains(constraint.getKey())) {
+                        return new ResponseStatusException(HttpStatus.CONFLICT, constraint.getValue());
+                    }
+                }
+            }
+        }
+        return e;
+    }
+
+    /**
+     * Whether the violation is specifically about UNIQUENESS. A column name matches the text of a
+     * foreign-key violation too ("Key (COMPANY_ID)=(5) is not present in table ..."), which is a
+     * different conflict and must not be answered as a duplicate. Every supported dialect either
+     * reports SQLSTATE 23505 or says so in words - PostgreSQL "duplicate key value violates unique
+     * constraint", H2 "Unique index or primary key violation", MySQL "Duplicate entry", Oracle
+     * "unique constraint (...) violated".
+     */
+    private static boolean isDuplicateViolation(Throwable e) {
+        for (Throwable cause = e; cause != null; cause = cause.getCause() == cause ? null : cause.getCause()) {
+            if (cause instanceof java.sql.SQLException sqlException && "23505".equals(sqlException.getSQLState())) {
+                return true;
+            }
+            String message = cause.getMessage();
+            if (message == null) {
+                continue;
+            }
+            String upper = message.toUpperCase(Locale.ROOT);
+            if (upper.contains("DUPLICATE") || upper.contains("UNIQUE")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+#end
     /** Whether a persistence failure is (caused by) a database constraint violation. */
     private static boolean isConstraintViolation(Throwable e) {
         for (Throwable cause = e; cause != null; cause = cause.getCause() == cause ? null : cause.getCause()) {

--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityPartnerController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityPartnerController.java.template
@@ -1,5 +1,24 @@
 package gen.${javaGenFolderName}.api.${javaPerspectiveName};
 
+## A duplicate is the same refusal whichever door the caller used: a collision with a business key is
+## answered here with the 409 naming the field that the power surface answers with, rather than
+## letting the driver's text out as a 500 (#7137). Either kind of key earns the mapping: a composite
+## `unique:` the model NAMED, or a single-column `unique: true`, which is a column-level UNIQUE the
+## SCHEMA leaves for the database to name - the name every dialect generates is built from the
+## column, which is the handle the mapping keys on.
+#foreach($property in $properties)
+#if($property.dataUnique)
+#set($hasUniqueColumns = "true")
+#end
+#end
+#set($hasDuplicateKeys = false)
+#if($uniqueConstraints && !$uniqueConstraints.isEmpty())
+#set($hasDuplicateKeys = true)
+#end
+#if($hasUniqueColumns)
+#set($hasDuplicateKeys = true)
+#end
+
 import gen.${javaGenFolderName}.data.${javaPerspectiveName}.${name}Entity;
 import gen.${javaGenFolderName}.data.${javaPerspectiveName}.${name}Repository;
 
@@ -20,6 +39,9 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+#if($hasDuplicateKeys)
+import java.util.Locale;
+#end
 import java.util.Map;
 
 ## Role-scoped properties (the modeler's per-property read/write role, or the intent's `visibleTo:`
@@ -165,7 +187,15 @@ public class ${name}PartnerController {
         // server has not finished deciding. Before the save, so a refused create never reaches the
         // insert - and never allocates a document number.
         validate(entity);
+#if($hasDuplicateKeys)
+        try {
+            return scrub(repository.save(entity));
+        } catch (RuntimeException e) {
+            throw duplicateOrRethrow(e);
+        }
+#else
         return scrub(repository.save(entity));
+#end
     }
 
     @Put("/{id}")
@@ -202,7 +232,15 @@ public class ${name}PartnerController {
 #end
 #end
         validate(entity);
+#if($hasDuplicateKeys)
+        try {
+            return scrub(repository.update(entity));
+        } catch (RuntimeException e) {
+            throw duplicateOrRethrow(e);
+        }
+#else
         return scrub(repository.update(entity));
+#end
     }
 
     @Delete("/{id}")
@@ -594,6 +632,85 @@ public class ${name}PartnerController {
 #end
     }
 
+#if($hasDuplicateKeys)
+    /**
+     * The business keys of ${name}, keyed by the name the database puts into the violation it raises -
+     * a composite key by the constraint name the model emitted (so this map and the schema cannot
+     * drift), a single-column {@code unique} by its column name, which is what every dialect builds
+     * its own generated constraint name out of ("VACATIONS_PUBLIC_HOLIDAY_PUBLIC_HOLIDAY_DAY_key").
+     * Iterated longest key first, so a column whose name is a prefix of a longer one still answers
+     * with its own message rather than the shorter key's. The power surface's map verbatim - the same
+     * collision has to read the same whichever surface the caller wrote through.
+     */
+    private static final Map<String, String> DUPLICATE_MESSAGES = duplicateMessages();
+
+    private static Map<String, String> duplicateMessages() {
+        Map<String, String> messages = new java.util.TreeMap<>(java.util.Comparator.comparingInt(String::length)
+                                                                                   .reversed()
+                                                                                   .thenComparing(java.util.Comparator.naturalOrder()));
+#if($uniqueConstraints)
+#foreach($uniqueConstraint in $uniqueConstraints)
+        messages.put("${uniqueConstraint.name}".toUpperCase(Locale.ROOT), "${uniqueConstraint.message}");
+#end
+#end
+#foreach($property in $properties)
+#if($property.dataUnique)
+        messages.put("${property.dataName}".toUpperCase(Locale.ROOT), "A ${name} with this '${property.name}' already exists");
+#end
+#end
+        return java.util.Collections.unmodifiableMap(messages);
+    }
+
+    /**
+     * A write that collided with one of those keys is a conflict the caller can act on - answered with
+     * the message that names the field - and anything else is rethrown untouched. Matching is on the
+     * key name inside the driver's message, which is the only handle the database gives back; every
+     * dialect names the violated constraint there.
+     */
+    private static RuntimeException duplicateOrRethrow(RuntimeException e) {
+        if (isConstraintViolation(e) && isDuplicateViolation(e)) {
+            for (Throwable cause = e; cause != null; cause = cause.getCause() == cause ? null : cause.getCause()) {
+                String message = cause.getMessage();
+                if (message == null) {
+                    continue;
+                }
+                String upper = message.toUpperCase(Locale.ROOT);
+                for (Map.Entry<String, String> constraint : DUPLICATE_MESSAGES.entrySet()) {
+                    if (upper.contains(constraint.getKey())) {
+                        return new ResponseStatusException(HttpStatus.CONFLICT, constraint.getValue());
+                    }
+                }
+            }
+        }
+        return e;
+    }
+
+    /**
+     * Whether the violation is specifically about UNIQUENESS. A column name matches the text of a
+     * foreign-key violation too ("Key (COMPANY_ID)=(5) is not present in table ..."), which is a
+     * different conflict and must not be answered as a duplicate. Every supported dialect either
+     * reports SQLSTATE 23505 or says so in words - PostgreSQL "duplicate key value violates unique
+     * constraint", H2 "Unique index or primary key violation", MySQL "Duplicate entry", Oracle
+     * "unique constraint (...) violated".
+     */
+    private static boolean isDuplicateViolation(Throwable e) {
+        for (Throwable cause = e; cause != null; cause = cause.getCause() == cause ? null : cause.getCause()) {
+            if (cause instanceof java.sql.SQLException sqlException && "23505".equals(sqlException.getSQLState())) {
+                return true;
+            }
+            String message = cause.getMessage();
+            if (message == null) {
+                continue;
+            }
+            String upper = message.toUpperCase(Locale.ROOT);
+            if (upper.contains("DUPLICATE") || upper.contains("UNIQUE")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+#end
     /** Whether a persistence failure is (caused by) a database constraint violation. */
     private static boolean isConstraintViolation(Throwable e) {
         for (Throwable cause = e; cause != null; cause = cause.getCause() == cause ? null : cause.getCause()) {

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/UniqueFieldConflictControllerTemplateIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/UniqueFieldConflictControllerTemplateIT.java
@@ -59,7 +59,12 @@ import org.junit.jupiter.api.Test;
  */
 class UniqueFieldConflictControllerTemplateIT {
 
-    private static final String TEMPLATE = "/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template";
+    private static final String BASE = "/META-INF/dirigible/template-application-rest-java/api/";
+    private static final String TEMPLATE = BASE + "EntityController.java.template";
+
+    /** The two doors a person actually types into - #7137. */
+    private static final List<String> SELF_SERVICE_SURFACES =
+            List.of("EntityMyController.java.template", "EntityPartnerController.java.template");
 
     /** The message observed on BusinessIntents STA (PostgreSQL) in the report - #7098. */
     private static final String POSTGRES_DUPLICATE = "could not execute statement [ERROR: duplicate key value violates unique constraint "
@@ -245,12 +250,16 @@ class UniqueFieldConflictControllerTemplateIT {
     }
 
     private String render(Map<String, Object> parameters) throws Exception {
+        return render(TEMPLATE, parameters);
+    }
+
+    private String render(String location, Map<String, Object> parameters) throws Exception {
         String template;
-        try (InputStream in = getClass().getResourceAsStream(TEMPLATE)) {
-            assertNotNull(in, "template resource not found on classpath: " + TEMPLATE);
+        try (InputStream in = getClass().getResourceAsStream(location)) {
+            assertNotNull(in, "template resource not found on classpath: " + location);
             template = new String(in.readAllBytes(), StandardCharsets.UTF_8);
         }
-        byte[] out = velocityGenerationEngine.generate(parameters, TEMPLATE, template.getBytes(StandardCharsets.UTF_8));
+        byte[] out = velocityGenerationEngine.generate(parameters, location, template.getBytes(StandardCharsets.UTF_8));
         return new String(out, StandardCharsets.UTF_8);
     }
 
@@ -312,5 +321,112 @@ class UniqueFieldConflictControllerTemplateIT {
         property.put("dataTypeJavaClass", "String");
         property.put("dataPrimaryKey", Boolean.FALSE);
         return property;
+    }
+
+    /**
+     * The same collision through a self-service door. #7108 taught the power controller to answer a
+     * duplicate with a 409 naming the field and #7110 copied the value validators onto the personal and
+     * partner surfaces - but not this mapping, so the surface a person actually types into still handed
+     * back the #7098 500 with the raw JDBC text. One refusal, whichever door the caller used.
+     */
+    @Test
+    void aSelfServiceSurfaceAnswersADuplicateExactlyAsThePowerSurfaceDoes() throws Exception {
+        for (String template : SELF_SERVICE_SURFACES) {
+            String rendered = render(BASE + template, selfServiceContext());
+
+            assertEquals("A PublicHoliday with this 'Day' already exists", answerFor(rendered, POSTGRES_DUPLICATE),
+                    template + " must map the PostgreSQL duplicate to the message naming the field: " + rendered);
+            assertEquals("A PublicHoliday with this 'Day' already exists", answerFor(rendered, H2_DUPLICATE),
+                    template + " must map the H2 one too: " + rendered);
+        }
+    }
+
+    /** The 500 came from the write not being wrapped at all - on either verb, on either surface. */
+    @Test
+    void bothSelfServiceWritePathsRouteThroughTheMapping() throws Exception {
+        for (String template : SELF_SERVICE_SURFACES) {
+            String rendered = render(BASE + template, selfServiceContext());
+
+            assertEquals(2, occurrences(rendered, "throw duplicateOrRethrow(e);"),
+                    template + " must hand both the create and the update to the mapping: " + rendered);
+            assertTrue(rendered.contains("return scrub(repository.save(entity));"), template + " must save inside the try");
+            assertTrue(rendered.contains("return scrub(repository.update(entity));"), template + " must update inside the try");
+            assertTrue(rendered.contains("if (isConstraintViolation(e) && isDuplicateViolation(e)) {"),
+                    template + " must answer only for a UNIQUENESS violation: " + rendered);
+            assertNoUnresolvedReferences(rendered);
+        }
+    }
+
+    /** Same key, same words: a message that differed by surface would be a second refusal to learn. */
+    @Test
+    void everySurfaceCarriesTheSameMessagesForTheSameKeys() throws Exception {
+        Map<String, Object> context = selfServiceContext();
+        context.put("uniqueConstraints", List.of(compositeKey()));
+
+        Map<String, String> power = emittedMessages(render(TEMPLATE, context));
+        for (String template : SELF_SERVICE_SURFACES) {
+            assertEquals(power, emittedMessages(render(BASE + template, context)),
+                    template + " must carry the power surface's mapping verbatim");
+        }
+    }
+
+    /** A see-only personal surface refuses every write with 403, so there is no collision to map. */
+    @Test
+    void aReadOnlyPersonalSurfaceGetsNoneOfIt() throws Exception {
+        Map<String, Object> context = selfServiceContext();
+        context.put("personalReadOnly", "true");
+
+        String rendered = render(BASE + "EntityMyController.java.template", context);
+
+        assertFalse(rendered.contains("duplicateOrRethrow"), "no write reaches a statement here: " + rendered);
+        assertFalse(rendered.contains("DUPLICATE_MESSAGES"), "and no map to carry: " + rendered);
+    }
+
+    /** An entity with no business key must come out of the self-service templates exactly as it did. */
+    @Test
+    void aSelfServiceSurfaceWithoutAnyBusinessKeyGetsNoneOfItEither() throws Exception {
+        Map<String, Object> context = selfServiceContext();
+        context.put("properties", List.of(primaryKey(), column("Name", "PUBLIC_HOLIDAY_NAME")));
+
+        for (String template : SELF_SERVICE_SURFACES) {
+            String rendered = render(BASE + template, context);
+
+            assertFalse(rendered.contains("duplicateOrRethrow"), template + " has nothing to map: " + rendered);
+            assertTrue(rendered.contains("return scrub(repository.save(entity));"),
+                    template + " must keep the unwrapped save: " + rendered);
+        }
+    }
+
+    /** The mapping is hand-written Java in a Velocity template on these surfaces too. */
+    @Test
+    void everyRenderedSelfServiceShapeIsSyntacticallyValidJava() throws Exception {
+        Map<String, Object> composite = selfServiceContext();
+        composite.put("uniqueConstraints", List.of(compositeKey()));
+        Map<String, Object> noKey = selfServiceContext();
+        noKey.put("properties", List.of(primaryKey(), column("Name", "PUBLIC_HOLIDAY_NAME")));
+        Map<String, Object> readOnly = selfServiceContext();
+        readOnly.put("personalReadOnly", "true");
+
+        for (Map<String, Object> context : List.of(selfServiceContext(), composite, noKey, readOnly)) {
+            for (String template : SELF_SERVICE_SURFACES) {
+                assertEquals(List.of(), syntaxErrors(render(BASE + template, context)), template + " must parse as Java");
+            }
+        }
+    }
+
+    /** The reported entity, owned by an identity - what the personal and partner templates ask for. */
+    private static Map<String, Object> selfServiceContext() {
+        Map<String, Object> parameters = context();
+        parameters.put("personalProperty", "Employee");
+        parameters.put("personalFkJavaClass", "Integer");
+        parameters.put("personalIdentityProperty", "Email");
+        parameters.put("personalIdentityLabel", "Name");
+        parameters.put("personalIdentityRepositoryClass", "gen.vacations.data.vacations.EmployeeRepository");
+        parameters.put("partnerProperty", "Employee");
+        parameters.put("partnerFkJavaClass", "Integer");
+        parameters.put("partnerIdentityProperty", "Email");
+        parameters.put("partnerIdentityLabel", "Name");
+        parameters.put("partnerIdentityRepositoryClass", "gen.vacations.data.vacations.EmployeeRepository");
+        return parameters;
     }
 }


### PR DESCRIPTION
Fixes #7137

## What was wrong

#7108 taught `EntityController` to answer a unique-key collision with a 409 naming the field (`duplicateOrRethrow` + `DUPLICATE_MESSAGES`), and #7110 copied the value validators onto the self-service controllers — but not the duplicate mapping. `EntityMyController` and `EntityPartnerController` called `repository.save/update` unwrapped, so a duplicate through a self-service door still answered

```
500 could not execute statement [ERROR: duplicate key value violates unique constraint "..."]
```

— the #7098 defect verbatim, on exactly the surface a person types into, and against #7099's own line that the refusal is the same "whichever door the caller used".

## What changed

Both self-service templates now carry the power surface's `DUPLICATE_MESSAGES` / `duplicateOrRethrow` / `isDuplicateViolation` verbatim, and route both the create and the update through it:

- emitted only when the entity has a business key — a named composite `unique:` or a single-column `unique: true` — so an entity without one renders exactly as before;
- not emitted at all on a see-only personal surface (`personalReadOnly`), whose writes refuse with 403 before reaching a statement;
- `java.util.Locale` imported only with the mapping.

## Verification

`UniqueFieldConflictControllerTemplateIT` grows the self-service half — the same PostgreSQL and H2 driver messages from the report, applied through the mapping read back out of each rendered surface:

- both verbs on both surfaces route through `duplicateOrRethrow`;
- the three surfaces' emitted maps are asserted **identical**, so a message cannot drift by door;
- the read-only and no-business-key shapes are asserted to get none of it;
- every rendered shape parses as Java.

Without the template change 3 of the new tests fail (`aSelfServiceSurfaceAnswersADuplicateExactlyAsThePowerSurfaceDoes`, `bothSelfServiceWritePathsRouteThroughTheMapping`, `everySurfaceCarriesTheSameMessagesForTheSameKeys`); with it the class is 13/13 green, alongside `PersonalSurfaceCreateValidationTemplateIT`, `RoleScopedFieldControllerTemplateIT`, `ChildLockControllerTemplateIT` and `JavaTemplateIT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)