### PR TITLE
bpm: the Inbox's subject variables ride the task query, not one read per task (#7141)

### DIFF
--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/TaskService.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/TaskService.java
@@ -173,6 +173,30 @@ public interface TaskService {
     List<Task> findTasks(PrincipalType type);
 
     /**
+     * The same tasks as {@link #findTasks(String, PrincipalType)}, with every task's process variables
+     * already loaded - see {@link #findTasksWithProcessVariables(PrincipalType)}.
+     *
+     * @param processInstanceId the process instance to list the tasks of
+     * @param type the principal the tasks are addressed to
+     * @return the tasks, each carrying its process variables
+     */
+    List<Task> findTasksWithProcessVariables(String processInstanceId, PrincipalType type);
+
+    /**
+     * The same tasks as {@link #findTasks(PrincipalType)}, with every task's process variables already
+     * loaded, so that a listing which needs them - the Inbox derives each row's subject from the
+     * variables the process seeded - reads them off the task instead of issuing one variable query per
+     * task on every poll (issue #7141).
+     * <p>
+     * Only for a caller that actually reads the variables: the join makes the query itself heavier, so
+     * a listing that needs nothing but the tasks stays on {@link #findTasks(PrincipalType)}.
+     *
+     * @param type the principal the tasks are addressed to
+     * @return the tasks, each carrying its process variables
+     */
+    List<Task> findTasksWithProcessVariables(PrincipalType type);
+
+    /**
      * Counts the tenant's tasks assigned to the given user, whoever is asking - unlike
      * {@link #findTasks(PrincipalType)}, which serves the caller's own (act-as aware) world.
      *

--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/TaskServiceImpl.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/TaskServiceImpl.java
@@ -196,12 +196,24 @@ class TaskServiceImpl implements TaskService {
 
     @Override
     public List<Task> findTasks(String processInstanceId, PrincipalType type) {
+        return findTasks(processInstanceId, type, false);
+    }
+
+    @Override
+    public List<Task> findTasksWithProcessVariables(String processInstanceId, PrincipalType type) {
+        return findTasks(processInstanceId, type, true);
+    }
+
+    private List<Task> findTasks(String processInstanceId, PrincipalType type, boolean withProcessVariables) {
         if (UserFacade.getUserRoles()
                       .isEmpty()) {
             return Collections.emptyList();
         }
         TaskInfoQuery<TaskQuery, Task> taskQuery = prepareQuery(type);
         taskQuery.processInstanceId(processInstanceId);
+        if (withProcessVariables) {
+            taskQuery.includeProcessVariables();
+        }
         return taskQuery.list();
     }
 
@@ -222,11 +234,33 @@ class TaskServiceImpl implements TaskService {
 
     @Override
     public List<Task> findTasks(PrincipalType type) {
+        return findTasks(type, false);
+    }
+
+    @Override
+    public List<Task> findTasksWithProcessVariables(PrincipalType type) {
+        return findTasks(type, true);
+    }
+
+    /**
+     * The tasks addressed to the given principal, optionally with their process variables joined in.
+     * {@code includeProcessVariables} makes Flowable fetch the variables WITH the tasks - one statement
+     * for the whole listing, instead of the variable query per task a caller reading
+     * {@code getVariables(taskId)} in a loop would issue (issue #7141).
+     *
+     * @param type the principal the tasks are addressed to
+     * @param withProcessVariables whether to load each task's process variables
+     * @return the tasks
+     */
+    private List<Task> findTasks(PrincipalType type, boolean withProcessVariables) {
         if (UserFacade.getUserRoles()
                       .isEmpty()) {
             return Collections.emptyList();
         }
         TaskInfoQuery<TaskQuery, Task> taskQuery = prepareQuery(type);
+        if (withProcessVariables) {
+            taskQuery.includeProcessVariables();
+        }
         return taskQuery.list();
     }
 

--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/endpoint/BpmInboxEndpoint.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/endpoint/BpmInboxEndpoint.java
@@ -54,14 +54,19 @@ public class BpmInboxEndpoint extends BaseEndpoint {
     @GetMapping(value = "/instance/{id}/tasks")
     public ResponseEntity<List<TaskDTO>> getProcessInstanceTasks(@PathVariable("id") String id,
             @RequestParam(value = "type", required = false) String type) {
-        return ResponseEntity.ok(mapToDTOs(bpmService.findTasks(id, extractPrincipalType(type))));
+        return ResponseEntity.ok(mapToDTOs(bpmService.findTasksWithProcessVariables(id, extractPrincipalType(type))));
     }
 
     /**
      * Maps a task list, resolving each process definition's task-label catalog once - a whole inbox is
      * typically a handful of definitions, and every task of one shares its catalog.
+     * <p>
+     * The tasks must come from a query that loaded their process variables
+     * ({@code findTasksWithProcessVariables}): every row's subject is derived from them, and reading
+     * them off the task is what keeps a listing at one statement instead of one variable query per task
+     * on every poll (issue #7141).
      *
-     * @param tasks the tasks
+     * @param tasks the tasks, with their process variables loaded
      * @return the DTOs
      */
     private List<TaskDTO> mapToDTOs(List<Task> tasks) {
@@ -125,23 +130,26 @@ public class BpmInboxEndpoint extends BaseEndpoint {
      * and the properties that identify it into the process variables; only those travel, and the client
      * resolves their values live.
      * <p>
-     * Best-effort: a task whose variables cannot be read is still listed, without a subject.
+     * Read off the variables the listing query already fetched with the task - never re-queried per
+     * task, which is what made an inbox of 100 tasks cost 100 variable reads on every 30 s poll (issue
+     * #7141).
+     * <p>
+     * Best-effort: a task whose variables are not there is still listed, without a subject.
      *
-     * @param task the task
+     * @param task the task, from a query that loaded its process variables
      * @return the subject locators, or null when the process declares none
      */
     private TaskSubject subjectOf(Task task) {
-        try {
-            return TaskSubject.from(bpmService.getTaskVariables(task.getId()));
-        } catch (RuntimeException ex) {
-            logger.debug("Could not read the variables of task [{}] - listing it without a subject", task.getId(), ex);
+        Map<String, Object> variables = task.getProcessVariables();
+        if (variables == null || variables.isEmpty()) {
             return null;
         }
+        return TaskSubject.from(variables);
     }
 
     @GetMapping(value = "/tasks")
     public ResponseEntity<List<TaskDTO>> getTasks(@RequestParam(value = "type", required = false) String type) {
-        return ResponseEntity.ok(mapToDTOs(bpmService.findTasks(extractPrincipalType(type))));
+        return ResponseEntity.ok(mapToDTOs(bpmService.findTasksWithProcessVariables(extractPrincipalType(type))));
     }
 
     @GetMapping(value = "/tasks/{taskId}/variables")

--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/service/BpmService.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/service/BpmService.java
@@ -439,6 +439,30 @@ public class BpmService {
                                   .findTasks(type);
     }
 
+    /**
+     * The same tasks as {@link #findTasks(String, PrincipalType)}, each carrying its process variables.
+     *
+     * @param processInstanceId the process instance to list the tasks of
+     * @param type the principal the tasks are addressed to
+     * @return the tasks, with their process variables loaded
+     */
+    public List<Task> findTasksWithProcessVariables(String processInstanceId, PrincipalType type) {
+        return bpmProviderFlowable.getTaskService()
+                                  .findTasksWithProcessVariables(processInstanceId, type);
+    }
+
+    /**
+     * The same tasks as {@link #findTasks(PrincipalType)}, each carrying its process variables - for a
+     * listing that reads them, which would otherwise cost one variable query per task (issue #7141).
+     *
+     * @param type the principal the tasks are addressed to
+     * @return the tasks, with their process variables loaded
+     */
+    public List<Task> findTasksWithProcessVariables(PrincipalType type) {
+        return bpmProviderFlowable.getTaskService()
+                                  .findTasksWithProcessVariables(type);
+    }
+
     public long countTasksByAssignee(String assignee) {
         return bpmProviderFlowable.getTaskService()
                                   .countTasksByAssignee(assignee);

--- a/components/engine/engine-bpm-flowable/src/test/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/TaskListingProcessVariablesEngineTest.java
+++ b/components/engine/engine-bpm-flowable/src/test/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/TaskListingProcessVariablesEngineTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.bpm.flowable.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.engine.bpm.flowable.dto.TaskSubject;
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
+import org.flowable.task.api.Task;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * That the Inbox's listing really can read a task's subject off the task itself, against a REAL
+ * Flowable engine: {@code includeProcessVariables()} populates {@link Task#getProcessVariables()},
+ * so the whole listing costs the one task query instead of a variable read per task on every poll
+ * (issue #7141). A mirror of the mechanism would not prove it - the engine's own query is the thing
+ * being relied on.
+ */
+class TaskListingProcessVariablesEngineTest {
+
+    private static final String PROCESS_XML =
+            """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:flowable="http://flowable.org/bpmn" targetNamespace="http://www.flowable.org/processdef">
+                      <process id="approve" name="Approve" isExecutable="true">
+                        <startEvent id="start"></startEvent>
+                        <userTask id="approveTask" name="Approve" flowable:assignee="admin"></userTask>
+                        <endEvent id="end"></endEvent>
+                        <sequenceFlow id="flow_start_task" sourceRef="start" targetRef="approveTask"></sequenceFlow>
+                        <sequenceFlow id="flow_task_end" sourceRef="approveTask" targetRef="end"></sequenceFlow>
+                      </process>
+                    </definitions>
+                    """;
+
+    private static ProcessEngine engine;
+
+    @BeforeAll
+    static void startEngine() {
+        StandaloneInMemProcessEngineConfiguration configuration = new StandaloneInMemProcessEngineConfiguration();
+        configuration.setJdbcUrl("jdbc:h2:mem:task-listing-variables-test;DB_CLOSE_DELAY=1000");
+        engine = configuration.buildProcessEngine();
+        engine.getRepositoryService()
+              .createDeployment()
+              .addString("approve.bpmn20.xml", PROCESS_XML)
+              .deploy();
+        // Two instances of the same process - the listing has to keep every task's own variables,
+        // which is exactly what a single joined query could get wrong.
+        engine.getRuntimeService()
+              .startProcessInstanceByKey("approve", subjectVariables(6));
+        engine.getRuntimeService()
+              .startProcessInstanceByKey("approve", subjectVariables(7));
+    }
+
+    @AfterAll
+    static void stopEngine() {
+        if (engine != null) {
+            engine.close();
+        }
+    }
+
+    private static Map<String, Object> subjectVariables(int id) {
+        return Map.of("__entityUrl", "/services/java/billing/gen/billing/api/sales_invoice/SalesInvoiceController", "__entityId", id,
+                "__subjectFields", "Number:text,Total:number");
+    }
+
+    @Test
+    void theSubjectVariablesRideTheTaskQuery() {
+        List<Task> tasks = engine.getTaskService()
+                                 .createTaskQuery()
+                                 .taskAssignee("admin")
+                                 .includeProcessVariables()
+                                 .list();
+
+        assertEquals(2, tasks.size());
+        for (Task task : tasks) {
+            TaskSubject subject = TaskSubject.from(task.getProcessVariables());
+            assertNotNull(subject, "the subject must be derivable from the variables the query loaded");
+            assertEquals(2, subject.fields()
+                                   .size());
+            // Each task keeps ITS OWN instance's record, not the other one's.
+            assertEquals(String.valueOf(task.getProcessVariables()
+                                            .get("__entityId")),
+                    subject.id());
+        }
+        assertEquals(2, tasks.stream()
+                             .map(task -> task.getProcessVariables()
+                                              .get("__entityId"))
+                             .distinct()
+                             .count(),
+                "the two instances' records must not collapse into one");
+    }
+
+    /**
+     * Why the listing endpoint must ask for the variables: a plain task query leaves
+     * {@code getProcessVariables()} empty, which is a subject-less row - never a per-task fallback
+     * read, the N+1 this replaced.
+     */
+    @Test
+    void aPlainTaskQueryCarriesNoVariables() {
+        List<Task> tasks = engine.getTaskService()
+                                 .createTaskQuery()
+                                 .taskAssignee("admin")
+                                 .list();
+
+        assertTrue(tasks.stream()
+                        .allMatch(task -> task.getProcessVariables()
+                                              .isEmpty()));
+    }
+}

--- a/components/engine/engine-bpm-flowable/src/test/java/org/eclipse/dirigible/components/engine/bpm/flowable/endpoint/BpmInboxEndpointSubjectTest.java
+++ b/components/engine/engine-bpm-flowable/src/test/java/org/eclipse/dirigible/components/engine/bpm/flowable/endpoint/BpmInboxEndpointSubjectTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.bpm.flowable.endpoint;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.dirigible.components.engine.bpm.flowable.dto.ProcessInstanceData;
+import org.eclipse.dirigible.components.engine.bpm.flowable.dto.TaskDTO;
+import org.eclipse.dirigible.components.engine.bpm.flowable.service.BpmService;
+import org.eclipse.dirigible.components.engine.bpm.flowable.service.PrincipalType;
+import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
+
+/**
+ * How an Inbox row gets its subject: off the process variables the LISTING QUERY already fetched
+ * with the task, never with a variable query per task on every poll (issue #7141).
+ */
+class BpmInboxEndpointSubjectTest {
+
+    private final BpmService bpmService = mock(BpmService.class);
+
+    private final BpmInboxEndpoint endpoint = new BpmInboxEndpoint(bpmService);
+
+    private static Map<String, Object> subjectVariables(int id) {
+        Map<String, Object> variables = new LinkedHashMap<>();
+        variables.put("__entityUrl", "/services/java/billing/gen/billing/api/sales_invoice/SalesInvoiceController");
+        variables.put("__entityId", id);
+        variables.put("__subjectFields", "Number:text,Total:number");
+        return variables;
+    }
+
+    private Task task(String id, Map<String, Object> processVariables) {
+        Task task = mock(Task.class);
+        when(task.getId()).thenReturn(id);
+        when(task.getProcessInstanceId()).thenReturn("instance-" + id);
+        when(task.getProcessVariables()).thenReturn(processVariables);
+        ProcessInstanceData instance = new ProcessInstanceData();
+        when(bpmService.getProcessInstanceById("instance-" + id)).thenReturn(instance);
+        when(bpmService.getTaskIdentityLinks(id)).thenReturn(List.of());
+        return task;
+    }
+
+    /**
+     * The whole listing costs the one task query - a hundred open tasks used to cost a hundred variable
+     * reads, twice per poll, every 30 seconds.
+     */
+    @Test
+    void theSubjectIsReadOffTheTaskNotQueriedPerTask() {
+        List<Task> found = List.of(task("t1", subjectVariables(6)), task("t2", subjectVariables(7)));
+        when(bpmService.findTasksWithProcessVariables(PrincipalType.ASSIGNEE)).thenReturn(found);
+        when(bpmService.getProcessLabelKeys(anyString())).thenReturn(Optional.empty());
+
+        List<TaskDTO> tasks = endpoint.getTasks("assignee")
+                                      .getBody();
+
+        assertEquals(2, tasks.size());
+        assertNotNull(tasks.get(0)
+                           .getSubject());
+        assertEquals("7", tasks.get(1)
+                               .getSubject()
+                               .id());
+        verify(bpmService, never()).getTaskVariables(anyString());
+        verify(bpmService, never()).findTasks(PrincipalType.ASSIGNEE);
+    }
+
+    /** A process seeding no subject variables is still listed - it just has no subject. */
+    @Test
+    void aTaskWithoutSubjectVariablesIsStillListed() {
+        List<Task> found = List.of(task("t1", Map.of()), task("t2", null));
+        when(bpmService.findTasksWithProcessVariables(PrincipalType.CANDIDATE_GROUPS)).thenReturn(found);
+        when(bpmService.getProcessLabelKeys(anyString())).thenReturn(Optional.empty());
+
+        List<TaskDTO> tasks = endpoint.getTasks("groups")
+                                      .getBody();
+
+        assertEquals(2, tasks.size());
+        assertNull(tasks.get(0)
+                        .getSubject());
+        assertNull(tasks.get(1)
+                        .getSubject());
+        verify(bpmService, never()).getTaskVariables(anyString());
+    }
+
+    /** The tasks of one process instance are listed the same way - variables ride the query. */
+    @Test
+    void aProcessInstanceListingAlsoRidesTheQuery() {
+        List<Task> found = List.of(task("t1", subjectVariables(6)));
+        when(bpmService.findTasksWithProcessVariables("instance-t1", PrincipalType.ASSIGNEE)).thenReturn(found);
+        when(bpmService.getProcessLabelKeys(anyString())).thenReturn(Optional.empty());
+
+        List<TaskDTO> tasks = endpoint.getProcessInstanceTasks("instance-t1", "assignee")
+                                      .getBody();
+
+        assertEquals("6", tasks.get(0)
+                               .getSubject()
+                               .id());
+        verify(bpmService, never()).getTaskVariables(anyString());
+    }
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -17,6 +17,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -4537,6 +4538,18 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                                                  .then()
                                                  .statusCode(200)
                                                  .body(org.hamcrest.Matchers.containsString("Confirm")),
+                30);
+
+        // ...and the row says what it is ABOUT (#7077): the subject locators the trigger seeded travel
+        // with the listing. They ride the task query itself now - one statement for the whole inbox
+        // instead of a variable read per task on every 30 s poll (#7141) - so a listing that lost them
+        // would silently go back to reading `Ref <id>`.
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get("/services/inbox/tasks?type=assigned")
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body("find { it.name == 'Confirm' }.subject.url", notNullValue())
+                                                 .body("find { it.name == 'Confirm' }.subject.fields.property", hasItem("Name")),
                 30);
 
         // ...and the record knows about the instance that task belongs to: the trigger stamped the


### PR DESCRIPTION
## What

#7077's subject derivation called `subjectOf(task)` → `bpmService.getTaskVariables(task.getId())` inside `mapToDTOs` - one Flowable variable query **per task, on every listing**. The shared shell store polls `/services/inbox/tasks` every 30 s, twice per poll for the assignee/groups scopes: an approver with 100 open tasks paid 200 variable reads every 30 seconds, most of them for rows that resolve no subject at all.

The variables now ride the task query itself. `TaskService.findTasksWithProcessVariables(...)` adds `includeProcessVariables()`, so Flowable fetches them **with** the tasks in one statement, and `subjectOf` reads them off the task. The derivation stays live - nothing is cached or snapshotted - the cost just stops being N+1 per poll.

The variables-loading query is a separate method on purpose: the join makes the query heavier, so `verifyCurrentUserHasPermissionForTask`'s id-only listings stay on plain `findTasks`.

## Verification

- `TaskListingProcessVariablesEngineTest` - against a **real** (in-memory) Flowable engine, not a mirror of the mechanism: `includeProcessVariables()` populates `getProcessVariables()` per task with each instance's OWN variables (two instances, no bleed), and a plain query leaves them empty - which is why the endpoint has to ask for them.
- `BpmInboxEndpointSubjectTest` - the listing derives every row's subject from the task, `getTaskVariables` is never called, and a process seeding no subject variables is still listed (subject-less), for both the inbox and the per-instance listing.
- `IntentEmissionCoverageIT` - the Inbox row's `subject` is now asserted end to end where the trigger's seeded locators had no runtime oracle at all; a listing that lost them would silently go back to rendering `Ref <id>`.
- `engine-bpm-flowable` suite green: 26/26.

Fixes #7141

🤖 Generated with [Claude Code](https://claude.com/claude-code)