### PR TITLE
templates: relationshipMasterDeleteRefused="false" is the cascade, not the refusal (#7144)

### DIFF
--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/CompositionChildren.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/CompositionChildren.java
@@ -17,9 +17,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.eclipse.dirigible.components.ide.template.service.model.ModelValues.asMaps;
+import static org.eclipse.dirigible.components.ide.template.service.model.ModelValues.bool;
 import static org.eclipse.dirigible.components.ide.template.service.model.ModelValues.str;
 import static org.eclipse.dirigible.components.ide.template.service.model.ModelValues.strOr;
-import static org.eclipse.dirigible.components.ide.template.service.model.ModelValues.truthy;
 
 /**
  * The reverse index of the composition edges: which children each MASTER owns, so the master's
@@ -76,12 +76,17 @@ final class CompositionChildren {
      * author's decision ({@code whenMasterDeleted: refuse}) that the master's delete is rejected while
      * children exist, rather than cascading into them.
      *
+     * <p>
+     * The attribute is read as a boolean, not for mere presence: the intent generator only ever emits
+     * it as {@code "true"}, but a hand-authored or tool-produced {@code .edm} may spell out
+     * {@code "false"}, which is the cascade the absent attribute means.
+     *
      * @param child the composition child
      * @return true when the master's delete must be refused
      */
     private static boolean refusesMasterDelete(Map<String, Object> child) {
         for (Map<String, Object> property : asMaps(child.get("properties"))) {
-            if ("COMPOSITION".equals(str(property, "relationshipType")) && truthy(property, "relationshipMasterDeleteRefused")) {
+            if ("COMPOSITION".equals(str(property, "relationshipType")) && bool(property, "relationshipMasterDeleteRefused")) {
                 return true;
             }
         }

--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/ModelValues.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/ModelValues.java
@@ -121,6 +121,29 @@ final class ModelValues {
     }
 
     /**
+     * Reads a key whose value is a boolean the model persists as a string. Unlike
+     * {@link #truthy(Map, String)} - which any non-empty string satisfies, so a written-out
+     * {@code "false"} would read as true - this parses the value: only {@code true} in any case is
+     * true, and everything else, including an absent key, is false.
+     *
+     * <p>
+     * Use it for a flag a hand-authored or tool-produced {@code .edm} may spell out in full. The
+     * generators only ever emit the flag when it holds, so the two agree on what they write.
+     *
+     * @param map the node
+     * @param key the key
+     * @return the value as a boolean
+     */
+    static boolean bool(Map<String, Object> map, String key) {
+        Object value = map == null ? null : map.get(key);
+        if (value instanceof Boolean flag) {
+            return flag;
+        }
+        return value != null && Boolean.parseBoolean(value.toString()
+                                                          .trim());
+    }
+
+    /**
      * Tests a node the way JavaScript truthiness does: present, not empty, not zero, not false.
      *
      * @param value the node

--- a/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/CompositionChildrenTest.java
+++ b/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/CompositionChildrenTest.java
@@ -77,6 +77,42 @@ class CompositionChildrenTest {
         assertThat(projection.get("compositionChildren")).isNull();
     }
 
+    /**
+     * The intent generator only ever emits the flag as {@code "true"}, so a written-out {@code "false"}
+     * can only come from a hand-authored or tool-produced {@code .edm} - and it means the cascade, not
+     * the refusal a presence test would read it as (dirigible #7144).
+     */
+    @Test
+    void aWrittenOutFalseIsTheCascade() {
+        Map<String, Object> master = entity("Order", "PRIMARY", "sales");
+        Map<String, Object> item = child("OrderItem", "sales", "Order", "Order", false);
+        Map<String, Object> line = child("OrderLine", "sales", "Order", "Order", false);
+        propertyOf(item).put("relationshipMasterDeleteRefused", "false");
+        propertyOf(line).put("relationshipMasterDeleteRefused", "FALSE");
+        List<Map<String, Object>> entities = new ArrayList<>(List.of(master, item, line));
+
+        CompositionChildren.annotate(entities);
+
+        List<Object> owned = ModelValues.asList(master.get("compositionChildren"));
+        assertThat(asMap(owned.get(0))).containsEntry("refuse", "false");
+        assertThat(asMap(owned.get(1))).as("the attribute parses as a boolean, in any case")
+                                       .containsEntry("refuse", "false");
+    }
+
+    /** The refusal holds however the author cased it. */
+    @Test
+    void aWrittenOutTrueIsTheRefusal() {
+        Map<String, Object> master = entity("Order", "PRIMARY", "sales");
+        Map<String, Object> item = child("OrderItem", "sales", "Order", "Order", false);
+        propertyOf(item).put("relationshipMasterDeleteRefused", "True");
+        List<Map<String, Object>> entities = new ArrayList<>(List.of(master, item));
+
+        CompositionChildren.annotate(entities);
+
+        assertThat(asMap(ModelValues.asList(master.get("compositionChildren"))
+                                    .get(0))).containsEntry("refuse", "true");
+    }
+
     /** An entity with no composition parent is not anybody's child. */
     @Test
     void anEntityWithoutAMasterIsNotIndexed() {
@@ -115,6 +151,11 @@ class CompositionChildrenTest {
     }
 
     @SuppressWarnings("unchecked")
+    private static Map<String, Object> propertyOf(Map<String, Object> child) {
+        return asMap(ModelValues.asList(child.get("properties"))
+                                .get(0));
+    }
+
     private static Map<String, Object> asMap(Object value) {
         return (Map<String, Object>) value;
     }


### PR DESCRIPTION
`CompositionChildren` read the composition child's `relationshipMasterDeleteRefused` flag through `ModelValues.truthy`, which any non-empty string satisfies — so an `.edm` carrying the attribute spelled out as `"false"` generated exactly the REFUSE behavior it is asking not to have: the master's delete rejected while children exist, instead of the cascade.

The intent generator only ever emits the attribute when the refusal holds (`EdmIntentGenerator` writes the literal `"true"`, and omits the key otherwise), so this could only bite the hand-authored / tool-produced path #7100 explicitly supports — the reverse index is derived from `masterEntity`/`masterEntityId`, precisely so a hand-authored `.edm` gets the cascade too.

`ModelValues.bool` parses the value instead of testing for presence: only `true`, in any case, is true; anything else — an absent key included — is false, which is the cascade the absent attribute already meant. `truthy` is untouched, since JavaScript truthiness is the right reading everywhere else in the parameter graph (widget lengths, free-text fields); this one attribute is a boolean an author can write out in full.

Nothing an intent Generate produces changes.

## Tests

`CompositionChildrenTest` (module suite green, 6 tests in that class): a written-out `"false"` / `"FALSE"` is the cascade, and a `"True"` is still the refusal.

Fixes #7144