### PR TITLE
templates: a cancellation that does not happen is logged, not swallowed (#7145)

### DIFF
--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/AbortOnDelete.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/AbortOnDelete.java.template
@@ -24,7 +24,9 @@ import gen.${javaGenFolderName}.data.${javaPerspective}.${entity}Entity;
  * but a repository-level delete still reaches the row, so the listener stays. Correlation rides the
  * ProcessIds stamp the trigger listener writes back for THIS process - not the record's single
  * ProcessId, which holds whichever process started last. Fail-soft: no stamp or an instance already
- * ended is a no-op, never an error.
+ * ended is a no-op, never an error - but a cancellation that fails for any other reason leaves exactly
+ * the orphaned task this listener exists to remove, so it is logged with its cause rather than
+ * swallowed (dirigible #7145).
  *
  * Self-describing MessageHandler (strong-interface style): the destination/kind come from the
  * interface, not an annotation; @Component makes it a managed bean.
@@ -59,15 +61,31 @@ public class ${process}AbortOnDelete implements MessageHandler {
         if (instance == null || instance.isBlank()) {
             return;
         }
+        boolean cancelled;
         try {
             if (!Process.isRunning(instance)) {
                 return;
             }
             Process.cancel(instance, "The ${entity} this ${process} ran for was deleted");
+            // The platform logs and swallows a failed cancellation rather than throwing it, so a
+            // returning call is not yet proof: the only honest report of the outcome is to look again.
+            cancelled = !Process.isRunning(instance);
+        } catch (IllegalArgumentException alreadyEnded) {
+            // The one expected miss: the instance ended between the check and the cancel, which the
+            // platform reports with exactly this type. A no-op by the fail-soft glue convention.
+            LOG.debug("${process} instance [{}] had already ended when its ${entity} was deleted", instance, alreadyEnded);
+            return;
+        } catch (RuntimeException failed) {
+            // Anything else - the cancel did not happen, so the pending user tasks of a flow over a row
+            // that no longer exists are still in someone's inbox. Fail-soft, but never silent.
+            LOG.warn("Could not cancel ${process} instance [{}] after its ${entity} was deleted - its pending tasks remain", instance,
+                    failed);
+            return;
+        }
+        if (cancelled) {
             LOG.info("Cancelled ${process} instance [{}]: its ${entity} was deleted", instance);
-        } catch (RuntimeException alreadyEnded) {
-            // The instance ended between the check and the cancel - a no-op by the fail-soft glue
-            // convention, never an error.
+        } else {
+            LOG.warn("${process} instance [{}] is still running after its ${entity} was deleted - its pending tasks remain", instance);
         }
     }
 

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -2614,6 +2614,15 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 deleteAbort.contains("-deleted") && deleteAbort.contains("ProcessStamps.idFor(entity.ProcessIds, \"ApprovalFlow\")")
                         && deleteAbort.contains("Process.isRunning(instance)") && deleteAbort.contains("Process.cancel(instance,"),
                 "deleting the trigger row must cancel the process's own running instance");
+        // ...and a cancellation that does NOT happen is never silent (#7145). Only the already-ended
+        // case - the platform's IllegalArgumentException - is the expected no-op; every other failure
+        // leaves the orphaned task this listener exists to remove, and is logged with its throwable.
+        assertTrue(deleteAbort.contains("catch (IllegalArgumentException alreadyEnded)"),
+                "the already-ended miss must be caught by its own type, not by a blanket RuntimeException");
+        assertTrue(deleteAbort.contains("catch (RuntimeException failed)") && deleteAbort.contains("LOG.warn(\"Could not cancel")
+                && deleteAbort.contains("failed);"), "any other cancellation failure must be logged with the throwable");
+        assertFalse(deleteAbort.contains("catch (RuntimeException alreadyEnded)"),
+                "the empty catch that treated every failure as already-ended must be gone");
 
         // ...and the follow-up flow on the same record (#6862) is a listener of its own, on the status
         // channel, guarding on ITS OWN name. Reading the record's single ProcessId here is what made the


### PR DESCRIPTION
`AbortOnDelete` wrapped its `Process.cancel` in `catch (RuntimeException alreadyEnded) { }` - an empty catch with no log line.

Only one miss is expected there: the instance ending between the `isRunning` check and the cancel, which the platform reports as an `IllegalArgumentException` from `FlowableArtefactsValidator.validateProcessInstanceId`. Every other failure - a permission, a database error, a Flowable fault - left exactly the orphaned Inbox task #7074 exists to remove, with no trace anywhere. And the generated file taught the pattern to every application developer who opened it, against the repo's own always-log-the-throwable rule.

## What changed

- The already-ended case is caught **by its own type** and logged at `debug` with the throwable.
- Anything else is a `warn` carrying the throwable and saying what it costs: *its pending tasks remain*.
- Both stay fail-soft - the row is already gone, and throwing would only redeliver the message.

The success line is no longer taken on trust either. `BpmProviderFlowable.deleteProcess` logs and swallows a failed `deleteProcessInstance` rather than rethrowing, so a returning `cancel` is not proof the instance is gone: the listener asks `isRunning` once more and reports what it finds - `Cancelled ...` when it is, a `warn` naming the still-running instance when it is not.

## Verification

- The rendered listener was substituted and compiled against stubs - it parses and type-checks.
- `IntentEmissionCoverageIT` (the IT that really compiles the generated client Java) asserts the already-ended catch is typed, the other failure logs its throwable, and the blanket `catch (RuntimeException alreadyEnded)` is gone.

## Out of scope, worth a follow-up

`Abort.java.template` (`catch (RuntimeException notAborting)`) and `Wait.java.template` (`catch (RuntimeException notParked)`) carry the same empty-catch shape around `Process.correlateMessageEvent`. Their expected-miss semantics differ (not parked on this message vs. no such instance), so they need their own reading rather than a copy of this one.

Note: `tests/tests-integrations` does not compile on `master` right now - #7174 moved `answerFor`/`emittedMessages` into a `Mapping` harness while #7173's self-service tests still call the outer helpers. #7176 is fixing that; this PR's CI will stay red until it lands.

Fixes #7145

🤖 Generated with [Claude Code](https://claude.com/claude-code)