### PR TITLE
templates: the self-service duplicate matcher is the anchored one too (#7176)

### DIFF
--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityMyController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityMyController.java.template
@@ -707,6 +707,13 @@ public class ${name}MyController {
     }
 
     /**
+     * The markers the drivers append the executed statement to their message behind - Hibernate's
+     * "[insert into ...]" and H2's "SQL statement:". Everything from there on is the SQL, not the
+     * violation.
+     */
+    private static final List<String> STATEMENT_MARKERS = List.of("SQL STATEMENT:", "[INSERT ", "[UPDATE ", "[DELETE ", "[MERGE ");
+
+    /**
      * A write that collided with one of those keys is a conflict the caller can act on - answered with
      * the message that names the field - and anything else is rethrown untouched. Matching is on the
      * key name inside the driver's message, which is the only handle the database gives back; every
@@ -714,20 +721,66 @@ public class ${name}MyController {
      */
     private static RuntimeException duplicateOrRethrow(RuntimeException e) {
         if (isConstraintViolation(e) && isDuplicateViolation(e)) {
-            for (Throwable cause = e; cause != null; cause = cause.getCause() == cause ? null : cause.getCause()) {
-                String message = cause.getMessage();
-                if (message == null) {
-                    continue;
-                }
-                String upper = message.toUpperCase(Locale.ROOT);
-                for (Map.Entry<String, String> constraint : DUPLICATE_MESSAGES.entrySet()) {
-                    if (upper.contains(constraint.getKey())) {
-                        return new ResponseStatusException(HttpStatus.CONFLICT, constraint.getValue());
-                    }
-                }
+            String message = duplicateMessageFor(violationText(e));
+            if (message != null) {
+                return new ResponseStatusException(HttpStatus.CONFLICT, message);
             }
         }
         return e;
+    }
+
+    /**
+     * The message of the business key the given violation names, or {@code null} when it names none of
+     * them - a primary key, or a uniqueness constraint of another table.
+     */
+    private static String duplicateMessageFor(String violation) {
+        if (violation == null) {
+            return null;
+        }
+        String upper = violation.toUpperCase(Locale.ROOT);
+        for (Map.Entry<String, String> constraint : DUPLICATE_MESSAGES.entrySet()) {
+            if (upper.contains(constraint.getKey())) {
+                return constraint.getValue();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The text of the violation the database raised: the message of the INNERMOST
+     * {@code java.sql.SQLException} in the chain - the one that carries the constraint name and the
+     * Detail line - with the statement the driver appends to it cut off.
+     * <p>
+     * Anchoring the match there is load-bearing, not tidiness. Hibernate re-reports the failure with
+     * the executed SQL attached ("... [insert into PRODUCT (PRODUCT_CODE, PRODUCT_NAME, ...)]") and H2
+     * appends its own "SQL statement:" block, so a message read whole lists EVERY column of the table:
+     * a collision on one unique field would be answered with the message of another, and a
+     * primary-key violation - SQLSTATE 23505 as well - with a business key's.
+     */
+    private static String violationText(Throwable e) {
+        String text = null;
+        for (Throwable cause = e; cause != null; cause = cause.getCause() == cause ? null : cause.getCause()) {
+            if (cause instanceof java.sql.SQLException && cause.getMessage() != null) {
+                text = cause.getMessage();
+            }
+        }
+        if (text == null) {
+            text = e.getMessage();
+        }
+        return text == null ? null : withoutStatement(text);
+    }
+
+    /** The message up to the first statement marker in it, which is where the column list starts. */
+    private static String withoutStatement(String message) {
+        String upper = message.toUpperCase(Locale.ROOT);
+        int cut = message.length();
+        for (String marker : STATEMENT_MARKERS) {
+            int at = upper.indexOf(marker);
+            if (at >= 0 && at < cut) {
+                cut = at;
+            }
+        }
+        return message.substring(0, cut);
     }
 
     /**
@@ -736,23 +789,21 @@ public class ${name}MyController {
      * different conflict and must not be answered as a duplicate. Every supported dialect either
      * reports SQLSTATE 23505 or says so in words - PostgreSQL "duplicate key value violates unique
      * constraint", H2 "Unique index or primary key violation", MySQL "Duplicate entry", Oracle
-     * "unique constraint (...) violated".
+     * "unique constraint (...) violated" - and says it in the violation itself, so the words are read
+     * off the same anchored text the key match uses rather than off the statement appended to it.
      */
     private static boolean isDuplicateViolation(Throwable e) {
         for (Throwable cause = e; cause != null; cause = cause.getCause() == cause ? null : cause.getCause()) {
             if (cause instanceof java.sql.SQLException sqlException && "23505".equals(sqlException.getSQLState())) {
                 return true;
             }
-            String message = cause.getMessage();
-            if (message == null) {
-                continue;
-            }
-            String upper = message.toUpperCase(Locale.ROOT);
-            if (upper.contains("DUPLICATE") || upper.contains("UNIQUE")) {
-                return true;
-            }
         }
-        return false;
+        String violation = violationText(e);
+        if (violation == null) {
+            return false;
+        }
+        String upper = violation.toUpperCase(Locale.ROOT);
+        return upper.contains("DUPLICATE") || upper.contains("UNIQUE");
     }
 
 #end

--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityPartnerController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityPartnerController.java.template
@@ -662,6 +662,13 @@ public class ${name}PartnerController {
     }
 
     /**
+     * The markers the drivers append the executed statement to their message behind - Hibernate's
+     * "[insert into ...]" and H2's "SQL statement:". Everything from there on is the SQL, not the
+     * violation.
+     */
+    private static final List<String> STATEMENT_MARKERS = List.of("SQL STATEMENT:", "[INSERT ", "[UPDATE ", "[DELETE ", "[MERGE ");
+
+    /**
      * A write that collided with one of those keys is a conflict the caller can act on - answered with
      * the message that names the field - and anything else is rethrown untouched. Matching is on the
      * key name inside the driver's message, which is the only handle the database gives back; every
@@ -669,20 +676,66 @@ public class ${name}PartnerController {
      */
     private static RuntimeException duplicateOrRethrow(RuntimeException e) {
         if (isConstraintViolation(e) && isDuplicateViolation(e)) {
-            for (Throwable cause = e; cause != null; cause = cause.getCause() == cause ? null : cause.getCause()) {
-                String message = cause.getMessage();
-                if (message == null) {
-                    continue;
-                }
-                String upper = message.toUpperCase(Locale.ROOT);
-                for (Map.Entry<String, String> constraint : DUPLICATE_MESSAGES.entrySet()) {
-                    if (upper.contains(constraint.getKey())) {
-                        return new ResponseStatusException(HttpStatus.CONFLICT, constraint.getValue());
-                    }
-                }
+            String message = duplicateMessageFor(violationText(e));
+            if (message != null) {
+                return new ResponseStatusException(HttpStatus.CONFLICT, message);
             }
         }
         return e;
+    }
+
+    /**
+     * The message of the business key the given violation names, or {@code null} when it names none of
+     * them - a primary key, or a uniqueness constraint of another table.
+     */
+    private static String duplicateMessageFor(String violation) {
+        if (violation == null) {
+            return null;
+        }
+        String upper = violation.toUpperCase(Locale.ROOT);
+        for (Map.Entry<String, String> constraint : DUPLICATE_MESSAGES.entrySet()) {
+            if (upper.contains(constraint.getKey())) {
+                return constraint.getValue();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The text of the violation the database raised: the message of the INNERMOST
+     * {@code java.sql.SQLException} in the chain - the one that carries the constraint name and the
+     * Detail line - with the statement the driver appends to it cut off.
+     * <p>
+     * Anchoring the match there is load-bearing, not tidiness. Hibernate re-reports the failure with
+     * the executed SQL attached ("... [insert into PRODUCT (PRODUCT_CODE, PRODUCT_NAME, ...)]") and H2
+     * appends its own "SQL statement:" block, so a message read whole lists EVERY column of the table:
+     * a collision on one unique field would be answered with the message of another, and a
+     * primary-key violation - SQLSTATE 23505 as well - with a business key's.
+     */
+    private static String violationText(Throwable e) {
+        String text = null;
+        for (Throwable cause = e; cause != null; cause = cause.getCause() == cause ? null : cause.getCause()) {
+            if (cause instanceof java.sql.SQLException && cause.getMessage() != null) {
+                text = cause.getMessage();
+            }
+        }
+        if (text == null) {
+            text = e.getMessage();
+        }
+        return text == null ? null : withoutStatement(text);
+    }
+
+    /** The message up to the first statement marker in it, which is where the column list starts. */
+    private static String withoutStatement(String message) {
+        String upper = message.toUpperCase(Locale.ROOT);
+        int cut = message.length();
+        for (String marker : STATEMENT_MARKERS) {
+            int at = upper.indexOf(marker);
+            if (at >= 0 && at < cut) {
+                cut = at;
+            }
+        }
+        return message.substring(0, cut);
     }
 
     /**
@@ -691,23 +744,21 @@ public class ${name}PartnerController {
      * different conflict and must not be answered as a duplicate. Every supported dialect either
      * reports SQLSTATE 23505 or says so in words - PostgreSQL "duplicate key value violates unique
      * constraint", H2 "Unique index or primary key violation", MySQL "Duplicate entry", Oracle
-     * "unique constraint (...) violated".
+     * "unique constraint (...) violated" - and says it in the violation itself, so the words are read
+     * off the same anchored text the key match uses rather than off the statement appended to it.
      */
     private static boolean isDuplicateViolation(Throwable e) {
         for (Throwable cause = e; cause != null; cause = cause.getCause() == cause ? null : cause.getCause()) {
             if (cause instanceof java.sql.SQLException sqlException && "23505".equals(sqlException.getSQLState())) {
                 return true;
             }
-            String message = cause.getMessage();
-            if (message == null) {
-                continue;
-            }
-            String upper = message.toUpperCase(Locale.ROOT);
-            if (upper.contains("DUPLICATE") || upper.contains("UNIQUE")) {
-                return true;
-            }
         }
-        return false;
+        String violation = violationText(e);
+        if (violation == null) {
+            return false;
+        }
+        String upper = violation.toUpperCase(Locale.ROOT);
+        return upper.contains("DUPLICATE") || upper.contains("UNIQUE");
     }
 
 #end

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/UniqueFieldConflictControllerTemplateIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/UniqueFieldConflictControllerTemplateIT.java
@@ -28,8 +28,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.tools.DiagnosticCollector;
 import javax.tools.FileObject;
@@ -424,39 +422,8 @@ class UniqueFieldConflictControllerTemplateIT {
         return new Mapping(render(parameters));
     }
 
-    /**
-     * The message the mapping RENDERED into one surface answers a driver message with - the same
-     * compile-and-run the power surface's own assertions go through, over a template this test rendered
-     * itself rather than through {@link #context()}.
-     *
-     * @param rendered the rendered controller
-     * @param driverMessage the driver's constraint-violation text
-     * @return the answered message, or {@code null} when the mapping rethrew the violation untouched
-     * @throws Exception when the extracted mapping does not compile
-     */
-    private static String answerFor(String rendered, String driverMessage) throws Exception {
-        return new Mapping(rendered).answerFor(driverMessage, UNIQUE_VIOLATION);
-    }
-
-    /**
-     * The constraint key to message pairs a rendered controller's duplicate map carries, read off the
-     * emitted {@code messages.put(...)} lines. Comparing the maps is what pins every surface to ONE set
-     * of words: a message that differed by surface would be a second refusal for the caller to learn.
-     *
-     * @param rendered the rendered controller
-     * @return the emitted pairs, keyed by the constraint name as the mapping keys it
-     */
-    private static Map<String, String> emittedMessages(String rendered) {
-        Matcher emitted = Pattern.compile("messages\\.put\\(\"([^\"]*)\"\\.toUpperCase\\(Locale\\.ROOT\\), \"([^\"]*)\"\\);")
-                                 .matcher(rendered);
-        Map<String, String> messages = new LinkedHashMap<>();
-        while (emitted.find()) {
-            messages.put(emitted.group(1)
-                                .toUpperCase(Locale.ROOT),
-                    emitted.group(2));
-        }
-        assertFalse(messages.isEmpty(), "the rendered controller carries no duplicate messages: " + rendered);
-        return messages;
+    private Mapping mapping(String location, Map<String, Object> parameters) throws Exception {
+        return new Mapping(render(location, parameters));
     }
 
     private String render(Map<String, Object> parameters) throws Exception {
@@ -542,12 +509,54 @@ class UniqueFieldConflictControllerTemplateIT {
     @Test
     void aSelfServiceSurfaceAnswersADuplicateExactlyAsThePowerSurfaceDoes() throws Exception {
         for (String template : SELF_SERVICE_SURFACES) {
-            String rendered = render(BASE + template, selfServiceContext());
+            Mapping mapping = mapping(BASE + template, selfServiceContext());
 
-            assertEquals("A PublicHoliday with this 'Day' already exists", answerFor(rendered, POSTGRES_DUPLICATE),
-                    template + " must map the PostgreSQL duplicate to the message naming the field: " + rendered);
-            assertEquals("A PublicHoliday with this 'Day' already exists", answerFor(rendered, H2_DUPLICATE),
-                    template + " must map the H2 one too: " + rendered);
+            assertEquals("A PublicHoliday with this 'Day' already exists", mapping.answerFor(POSTGRES_DUPLICATE, UNIQUE_VIOLATION),
+                    template + " must map the PostgreSQL duplicate to the message naming the field");
+            assertEquals("A PublicHoliday with this 'Day' already exists", mapping.answerFor(H2_DUPLICATE, UNIQUE_VIOLATION),
+                    template + " must map the H2 one too");
+        }
+    }
+
+    /**
+     * The anchoring #7138 fixed on the power surface, run against the self-service ones: the driver
+     * messages these surfaces actually see carry the statement Hibernate appends, whose column list
+     * names EVERY business key of the table. Fed the bare driver string a surface never sees, a matcher
+     * that reads the message whole passes - which is how the defect rode into two more copies (#7176).
+     */
+    @Test
+    void aSelfServiceCollisionIsNamedOnTheCollidedFieldEvenWithTheStatementAttached() throws Exception {
+        Map<String, Object> context = selfServiceContext();
+        context.put("properties", List.of(primaryKey(), uniqueDay(), unique("DayOfNotice", "PUBLIC_HOLIDAY_DAY_OF_NOTICE")));
+
+        for (String template : SELF_SERVICE_SURFACES) {
+            Mapping mapping = mapping(BASE + template, context);
+
+            assertEquals("A PublicHoliday with this 'Day' already exists",
+                    mapping.answerFor(POSTGRES_DUPLICATE + HIBERNATE_INSERT, POSTGRES_DUPLICATE, UNIQUE_VIOLATION),
+                    template + ": the statement's column list must not decide which field the collision is reported on");
+            assertEquals("A PublicHoliday with this 'DayOfNotice' already exists", mapping.answerFor(
+                    "ERROR: duplicate key value violates unique constraint \"VACATIONS_PUBLIC_HOLIDAY_PUBLIC_HOLIDAY_DAY_OF_NOTICE_key\""
+                            + HIBERNATE_INSERT,
+                    "ERROR: duplicate key value violates unique constraint \"VACATIONS_PUBLIC_HOLIDAY_PUBLIC_HOLIDAY_DAY_OF_NOTICE_key\"",
+                    UNIQUE_VIOLATION), template + ": the other field must be answered on its own collision");
+        }
+    }
+
+    /**
+     * A primary-key collision reports SQLSTATE 23505 and carries the same statement tail, so on the
+     * pre-anchoring matcher it came back as a duplicate of a business key the caller never wrote - on
+     * whichever surface still carried that matcher.
+     */
+    @Test
+    void aSelfServicePrimaryKeyCollisionIsNotAnsweredAsABusinessKeyDuplicate() throws Exception {
+        for (String template : SELF_SERVICE_SURFACES) {
+            Mapping mapping = mapping(BASE + template, selfServiceContext());
+
+            assertNull(mapping.answerFor(POSTGRES_PRIMARY_KEY + HIBERNATE_INSERT, POSTGRES_PRIMARY_KEY, UNIQUE_VIOLATION),
+                    template + ": a primary-key violation must be rethrown, not renamed after a business key");
+            assertNull(mapping.answerFor(POSTGRES_FOREIGN_KEY + HIBERNATE_INSERT, POSTGRES_FOREIGN_KEY, FOREIGN_KEY_VIOLATION),
+                    template + ": a missing reference must not be answered as a duplicate");
         }
     }
 
@@ -567,16 +576,22 @@ class UniqueFieldConflictControllerTemplateIT {
         }
     }
 
-    /** Same key, same words: a message that differed by surface would be a second refusal to learn. */
+    /**
+     * Same key, same words, and the same matcher reading them: three hand-written copies of the same
+     * Java only stay one behaviour if they stay one text. Comparing the emitted MESSAGES alone is what
+     * let #7174's anchoring land on the power surface while the two copies #7173 made kept the matcher
+     * it replaced (#7176) - the maps were identical the whole time. The whole mapping is compared here,
+     * from the map down to the end of the discriminator.
+     */
     @Test
-    void everySurfaceCarriesTheSameMessagesForTheSameKeys() throws Exception {
+    void everySurfaceCarriesTheSameMappingVerbatim() throws Exception {
         Map<String, Object> context = selfServiceContext();
         context.put("uniqueConstraints", List.of(compositeKey()));
 
-        Map<String, String> power = emittedMessages(render(TEMPLATE, context));
+        String power = Mapping.mappingSource(render(TEMPLATE, context));
         for (String template : SELF_SERVICE_SURFACES) {
-            assertEquals(power, emittedMessages(render(BASE + template, context)),
-                    template + " must carry the power surface's mapping verbatim");
+            assertEquals(power, Mapping.mappingSource(render(BASE + template, context)),
+                    template + " must carry the power surface's map AND matcher verbatim");
         }
     }
 


### PR DESCRIPTION
Fixes #7176

## What was wrong

#7173 (fixes #7137) and #7174 (fixes #7138) merged two minutes apart and do not compose. #7173 copied the duplicate mapping into `EntityMyController.java.template` and `EntityPartnerController.java.template` with the ORIGINAL matcher (`upper.contains(key)` over every cause's whole message); #7174's anchoring (`violationText` innermost-`SQLException` + `withoutStatement` truncation + `duplicateMessageFor`) landed only in `EntityController.java.template`. The #7138 defect was fixed on the power surface and live in two fresh copies:

- two unique columns, duplicate on `Name` through `POST .../my/Product` — the Hibernate tail `[insert into PRODUCT (PRODUCT_CODE, PRODUCT_NAME, ...)]` lists every column, matches both keys, and the caller is told *"A Product with this 'Code' already exists"*;
- a primary-key collision (SQLSTATE 23505 + the same tail) answered as a business-key duplicate.

## The fix

Both self-service templates now carry `STATEMENT_MARKERS` / `violationText` / `withoutStatement` / `duplicateMessageFor` byte-for-byte as the power surface has them — the match is read off the innermost `java.sql.SQLException`, truncated where the driver appends the statement.

## Tests

`UniqueFieldConflictControllerTemplateIT` was blind twice over: the self-service cases fed bare driver strings without the `HIBERNATE_INSERT` tail (a shape no surface ever sees), and `everySurfaceCarriesTheSameMessagesForTheSameKeys` compared the emitted message MAP — identical the whole time — never the matcher.

- the self-service half now runs the tailed, two-unique-key and primary-key fixtures the power tests use (plus the foreign-key negative);
- the cross-surface test became `everySurfaceCarriesTheSameMappingVerbatim`, comparing the whole extracted mapping source — map AND matcher — so three hand-written copies of the same Java cannot drift apart again.

Reverting just the templates turns exactly those three red:

```
aSelfServiceCollisionIsNamedOnTheCollidedFieldEvenWithTheStatementAttached
  expected: <A PublicHoliday with this 'Day' already exists>
  but was:  <A PublicHoliday with this 'DayOfNotice' already exists>
aSelfServicePrimaryKeyCollisionIsNotAnsweredAsABusinessKeyDuplicate
  expected: <null> but was: <A PublicHoliday with this 'Day' already exists>
everySurfaceCarriesTheSameMappingVerbatim
```

With the fix: `Tests run: 18, Failures: 0, Errors: 0`.

## Also

The same merge left the IT **uncompilable** on `master`: #7174 dropped the outer `answerFor`/`emittedMessages` helpers when it introduced the compiled `Mapping` harness, while #7173's four call sites remained (`cannot find symbol` at lines 510, 512, 539, 541 — `mvn -pl tests/tests-integrations compile` fails). Those callers now go through `Mapping`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)