### PR TITLE
glue: a key term serializes in declaration order on every JVM (#7130)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -4745,8 +4745,11 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
      * @return the term, iterating in that order
      */
     private static Map<String, Object> term(Object... keysAndValues) {
+        if (keysAndValues.length % 2 != 0) {
+            throw new IllegalArgumentException("a term is written as key/value pairs, got " + keysAndValues.length + " arguments");
+        }
         Map<String, Object> term = new LinkedHashMap<>();
-        for (int i = 0; i < keysAndValues.length; i += 2) {
+        for (int i = 0; i + 1 < keysAndValues.length; i += 2) {
             term.put(String.valueOf(keysAndValues[i]), keysAndValues[i + 1]);
         }
         return term;

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -4666,7 +4666,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             if (expression == null) {
                 return null;
             }
-            terms.add(Map.of("property", targetProp, "expr", expression));
+            terms.add(term("property", targetProp, "expr", expression));
         }
         return terms;
     }
@@ -4712,7 +4712,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         if ("day".equals(period)) {
             // A single day needs no range - and rendering it as one would make the generated guard say
             // `between(today, today)` where the author wrote `run: day`.
-            return Map.of("property", property, "expr", TODAY);
+            return term("property", property, "expr", TODAY);
         }
         String lower = switch (period) {
             case "week" -> TODAY + ".with(java.time.temporal.TemporalAdjusters.previousOrSame(java.time.DayOfWeek.MONDAY))";
@@ -4730,7 +4730,26 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             case "quarter" -> ".plusMonths(3).minusDays(1)";
             default -> ".plusYears(1).minusDays(1)";
         };
-        return Map.of("kind", "range", "property", property, "lower", lower, "upper", upper);
+        return term("kind", "range", "property", property, "lower", lower, "upper", upper);
+    }
+
+    /**
+     * One key term, in the order its keys are written here. The glue is a serialized artifact a regen
+     * rewrites in place, so a term's byte order has to be a property of the intent and nothing else -
+     * {@code Map.of} iterates in an order derived from a per-JVM random salt, which made the same
+     * intent serialize {@code {property, expr}} on one container and {@code {expr, property}} on the
+     * next (issue #7130). A hunk like that carries no meaning, has to be read and explained on every
+     * regen sweep, and would defeat a byte-identity check between two generations of one intent.
+     *
+     * @param keysAndValues the term's keys and values, alternating, in declaration order
+     * @return the term, iterating in that order
+     */
+    private static Map<String, Object> term(Object... keysAndValues) {
+        Map<String, Object> term = new LinkedHashMap<>();
+        for (int i = 0; i < keysAndValues.length; i += 2) {
+            term.put(String.valueOf(keysAndValues[i]), keysAndValues[i + 1]);
+        }
+        return term;
     }
 
     /**

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -2448,9 +2448,9 @@ public final class IntentParser {
      */
     private static void validateResolveOutcomes(ResolveIntent resolve, String subject, EntityIntent record, List<String> issues) {
         boolean anyStatus = false;
-        for (Map.Entry<String, Map<String, Object>> outcome : Map.of("found", resolve.getFound(), "notFound", resolve.getNotFound(),
-                "ambiguous", resolve.getAmbiguous())
-                                                                 .entrySet()) {
+        // Listed, not Map.of: the reported issues come out in this order on every JVM (issue #7130).
+        for (Map.Entry<String, Map<String, Object>> outcome : List.of(Map.entry("found", resolve.getFound()),
+                Map.entry("notFound", resolve.getNotFound()), Map.entry("ambiguous", resolve.getAmbiguous()))) {
             Object status = outcome.getValue()
                                    .get("setStatus");
             if (status == null) {
@@ -8167,9 +8167,8 @@ public final class IntentParser {
                        .equals(resolveRecordName(resolve))) {
                 continue;
             }
-            for (Map.Entry<String, Map<String, Object>> outcome : Map.of("found", resolve.getFound(), "notFound", resolve.getNotFound(),
-                    "ambiguous", resolve.getAmbiguous())
-                                                                     .entrySet()) {
+            for (Map.Entry<String, Map<String, Object>> outcome : List.of(Map.entry("found", resolve.getFound()),
+                    Map.entry("notFound", resolve.getNotFound()), Map.entry("ambiguous", resolve.getAmbiguous()))) {
                 Object routed = outcome.getValue()
                                        .get("setStatus");
                 if (!(routed instanceof Number) || reachable.contains(((Number) routed).intValue())) {

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueSchedulesTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueSchedulesTest.java
@@ -445,4 +445,52 @@ class GlueSchedulesTest {
         assertEquals("OverdueReminders", s.get("className"));
         assertTrue(s.containsKey("toExpression"));
     }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void keyTermsSerializeInDeclarationOrderOnEveryJvm() {
+        // Issue #7130: the terms were built with Map.of, whose iteration order comes from a per-JVM
+        // random salt, so the same intent serialized {property, expr} on one container and
+        // {expr, property} on the next. The glue is a rewritten-in-place artifact - a regen hunk has
+        // to be attributable to a platform change or an authored edit, never to which JVM ran it.
+        String yaml = """
+                name: purchases
+                entities:
+                  - name: BillTemplate
+                    fields:
+                      - { name: id,     type: integer, primaryKey: true, generated: true }
+                      - { name: active, type: boolean }
+                    relations:
+                      - { name: Supplier, kind: manyToOne, to: Supplier }
+                  - name: Supplier
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: PurchaseInvoice
+                    fields:
+                      - { name: id,   type: integer, primaryKey: true, generated: true }
+                      - { name: date, type: date }
+                    relations:
+                      - { name: Supplier, kind: manyToOne, to: Supplier }
+                schedules:
+                  - name: monthly-recurring-bills
+                    cron: "0 0 5 1 * ?"
+                    entity: BillTemplate
+                    generate:
+                      to: PurchaseInvoice
+                      unique: [Supplier, { run: month }]
+                      map:
+                        Supplier: Supplier
+                      defaults:
+                        date: now
+                """;
+        Map<String, Object> s = GlueIntentGenerator.buildSchedulesForTest(IntentParser.parse(yaml))
+                                                   .get(0);
+
+        List<Map<String, Object>> unique = (List<Map<String, Object>>) s.get("genUnique");
+        assertEquals(List.of("property", "expr"), List.copyOf(unique.get(0)
+                                                                    .keySet()));
+        assertEquals(List.of("kind", "property", "lower", "upper"), List.copyOf(unique.get(1)
+                                                                                      .keySet()));
+    }
 }


### PR DESCRIPTION
## What

`GlueIntentGenerator.uniqueTerms` (the #7079 natural key) and `runTerm` (the #7106 period range) built each `genUnique` term with `Map.of`. A JDK immutable map iterates in an order derived from `ImmutableCollections.SALT`, randomized per JVM start, so a term's byte order was a property of the container that ran the generation, not of the intent.

Observed on the BusinessIntents 14.49.0 regen sweep: base-payroll's `monthly-payroll-runs` flipped both terms to `{expr, property}` on a fresh `14.49.0` container, no semantic change, no downstream generated file touched, while base-timesheets / base-purchase-invoices carry the other order on `main`.

## Why it matters

The glue is rewritten in place by a regen, so every hunk has to be attributable to a platform change or an authored edit. A hunk that depends on which JVM ran is noise that has to be read and explained on every train, and it would defeat a byte-identity check between two generations of the same intent.

## Change

- a `term(...)` helper backed by `LinkedHashMap`, documented with why the order is load-bearing; the three term builders (`uniqueTerms`, `runTerm`'s day term and range term) go through it
- `GlueSchedulesTest.keyTermsSerializeInDeclarationOrderOnEveryJvm` pins the rendered key order of both shapes — `[property, expr]` and `[kind, property, lower, upper]`. The existing assertions compare maps by equality, which is order-blind and would not have caught this
- the sweep for the same defect found one non-glue site: `IntentParser`'s resolve-outcome validation iterated a `Map.of`, so its reported issues came out in a salted order too — it iterates a `List` now. Every other non-empty `Map.of` under `intent/` is either single-entry (deterministic) or a lookup table whose iteration order is never observed

## Verification

`engine-intent` suite green: **1182/1182**, including the new case.

Fixes #7130