### PR TITLE
ui: a page action's own Cancel button is not a completion (#7149)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/form/FormIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/form/FormIntentGenerator.java
@@ -96,10 +96,11 @@ import org.springframework.stereotype.Component;
  * On success the handler closes its host via both {@code DialogHub.closeWindow()} and
  * {@code window.close()} - the former closes the dialog when the form is opened from an entity
  * view, the latter a standalone (script-opened) window; each is a harmless no-op where it does not
- * apply, including the Inbox's inline iframe (which clears its own pane on its refresh cycle).
- * Forms opened outside a task report the missing {@code taskId} instead of failing silently.
- * Business logic beyond completing the task belongs in a hand-written form override under
- * {@code custom/}.
+ * apply, including the Inbox's inline iframe (which clears its own pane on its refresh cycle). The
+ * non-completing {@code close} action closes through {@code DialogHub.cancelWindow()} instead, so
+ * the host can tell an abandoned action from a finished one and say nothing (issue #7149). Forms
+ * opened outside a task report the missing {@code taskId} instead of failing silently. Business
+ * logic beyond completing the task belongs in a hand-written form override under {@code custom/}.
  *
  * <p>
  * Idempotent: identical input always produces byte-identical output.
@@ -485,9 +486,16 @@ public class FormIntentGenerator implements IntentTargetGenerator {
                 // Close does NOT complete the task: it just closes the dialog/window (same as the X), so
                 // the task stays open in the inbox. closeWindow() covers the dialog/inbox iframe host;
                 // window.close() covers a standalone window. Each is a harmless no-op where it doesn't apply.
+                //
+                // It closes with cancelWindow(), not closeWindow(): a plain close says nothing about the
+                // outcome, and a host that announces every outcome then reports the default
+                // "<label> completed" for an action the user deliberately ABANDONED (issue #7149).
+                // cancelWindow() says so, and the host stays quiet. The closeWindow() fallback keeps a
+                // form generated here running on a host runtime that predates cancelWindow().
                 sb.append("$scope.on")
                   .append(pascalCase(action))
-                  .append("Clicked = function () { __dialogs.closeWindow(); window.close(); };\n");
+                  .append("Clicked = function () { ")
+                  .append("(__dialogs.cancelWindow ? __dialogs.cancelWindow() : __dialogs.closeWindow()); window.close(); };\n");
             } else {
                 sb.append("$scope.on")
                   .append(pascalCase(action))

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -1713,7 +1713,10 @@ module), which the generated Harmonia views render through the shared `customAct
 `page` action becomes a toolbar button, an `entity` action a per-record button that passes the
 selected record's id to the opened page (as `?id=`). External projects may contribute to the same
 point; the app's own declared actions and third-party contributions render through one path. The
-opened page dismisses the dialog by posting `{ type: 'harmonia.form.close' }` to its parent.
+opened page dismisses the dialog by posting `{ type: 'harmonia.form.close' }` to its parent, and the
+shell ANNOUNCES that outcome: the message may carry `status` (`ok` / `error` / `cancelled`) and
+`message`, one that carries nothing gets the default "<label> completed", and a page closed by its
+own Cancel button reports `cancelled` so an abandoned action is dismissed in silence.
 
 ### transitions - guarded on-demand status flips (void / cancel / close / reopen)
 

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/form/FormCancelActionTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/form/FormCancelActionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator.form;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.parser.IntentParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the non-completing {@code close} action the {@link FormIntentGenerator} appends to
+ * a task form closes with a DISTINGUISHABLE outcome (issue #7149).
+ *
+ * The host shell announces every outcome an action page reports, and a plain
+ * {@code DialogHub.closeWindow()} carries no outcome at all - so the user who opened a contributed
+ * action, decided not to proceed and clicked the page's own Cancel button got a green
+ * "&lt;label&gt; completed" toast plus a permanent notification-centre entry for work that was
+ * explicitly abandoned. The close handler therefore closes through {@code cancelWindow()} (which
+ * the form runtime maps to {@code status: 'cancelled'}), keeping {@code closeWindow()} only as the
+ * fallback for a host runtime that predates it.
+ */
+class FormCancelActionTest {
+
+    private static final String YAML = """
+            name: sales
+            entities:
+              - name: SalesOrder
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: total, type: decimal }
+            processes:
+              - name: OrderApproval
+                trigger: { onCreate: SalesOrder }
+                steps:
+                  - { name: confirm, kind: userTask, args: { assignee: manager, form: ConfirmOrder } }
+                  - { name: end, kind: end }
+            forms:
+              - { name: ConfirmOrder, forEntity: SalesOrder, fields: [total], actions: [confirm] }
+            """;
+
+    private static String codeOf(String form) {
+        IntentModel model = IntentParser.parse(YAML);
+        Map<String, Map<String, Object>> forms = FormIntentGenerator.buildFormsForTest(model);
+        return String.valueOf(forms.get(form)
+                                   .get("code"));
+    }
+
+    /**
+     * The auto-appended Cancel button says the action was abandoned, so the host stays quiet.
+     */
+    @Test
+    void theAppendedCloseActionCancelsRatherThanCompletes() {
+        String code = codeOf("ConfirmOrder");
+
+        assertTrue(code.contains("$scope.onCloseClicked = function () {"), "the close action should be wired: " + code);
+        assertTrue(code.contains("__dialogs.cancelWindow ? __dialogs.cancelWindow() : __dialogs.closeWindow()"),
+                "close should report a cancellation, falling back to a plain close on an older runtime: " + code);
+        assertTrue(code.contains("$scope.onCloseClicked = function () { (__dialogs.cancelWindow ? __dialogs.cancelWindow()"
+                + " : __dialogs.closeWindow()); window.close(); };"), "unexpected close handler: " + code);
+        // Closing is NOT completing: the task stays open in the inbox.
+        assertFalse(code.contains("onCloseClicked = function () { __completeTask("), "close must not complete the task: " + code);
+    }
+
+    /**
+     * A real action still completes the task and still announces itself - only the abandonment is
+     * silent.
+     */
+    @Test
+    void aCompletingActionIsUnchanged() {
+        String code = codeOf("ConfirmOrder");
+
+        assertTrue(code.contains("$scope.onConfirmClicked = function () { __completeTask('confirm'); };"),
+                "the declared action should still complete the task: " + code);
+        assertFalse(code.contains("onConfirmClicked = function () { (__dialogs.cancelWindow"),
+                "a completing action must not cancel: " + code);
+    }
+}

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/customActions.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/customActions.js
@@ -40,7 +40,8 @@
  * Every outcome is ANNOUNCED - a transient toast plus an entry in the notification centre (issue
  * #7073). A refusal shows the reason the server sent (a transition outside its `from:` statuses says
  * so in its 409), a success says what happened, and a page action that finished reports through the
- * same path. Nothing an action does ends in silence.
+ * same path. Nothing an action DOES ends in silence - but an action the user ABANDONED did nothing,
+ * so a page that closes itself as `cancelled` is dismissed silently (issue #7149).
  */
 document.addEventListener('alpine:init', () => {
   Alpine.store('customActions', {
@@ -77,12 +78,20 @@ document.addEventListener('alpine:init', () => {
     init() {
       this.load();
       // An action page (opened in the app-wide dialog) asks its host to close when it is done. That
-      // message means the page FINISHED its work (the user dismissing the dialog closes it directly
-      // instead), so it is also the outcome the toast reports - a page may say so itself with
-      // `status` ('ok' | 'error') and `message`, and one that says nothing still gets the default
+      // message carries the outcome the toast reports - a page may say so itself with `status`
+      // ('ok' | 'error' | 'cancelled') and `message`, and one that says nothing still gets the default
       // "<label> completed" rather than the silence Save as Template used to end in (issue #7073).
+      //
+      // `cancelled` is the page's OWN Cancel/Close button (issue #7149): the user opened the action,
+      // decided not to proceed, and abandoned it - so it is dismissed exactly as the dialog frame's X
+      // is, with no toast and no notification-centre entry. Announcing it reported "<label> completed"
+      // for work that deliberately never happened.
       window.addEventListener('message', (e) => {
         if (!e || !e.data || e.data.type !== 'harmonia.form.close' || !this.dialogOpen) return;
+        if (e.data.status === 'cancelled') {
+          this.closeDialog();
+          return;
+        }
         this.closeDialog({ status: e.data.status, message: e.data.message });
       });
       // Re-read the contributions on navigation so a newly published action shows without a full reload.

--- a/components/template/template-form-builder-harmonia/README.md
+++ b/components/template/template-form-builder-harmonia/README.md
@@ -52,6 +52,7 @@ Rather than force a rewrite, `form.js` defines **compatibility shims** inside
 | `$http.{get,post,put,delete}` | `ctx.http.*`, returning an AngularJS-style `{ data }` promise (rejects with `{ data: { message }, status }`) |
 | `NotificationHub().show({title,description})` | `ctx.notify(...)` |
 | `DialogHub().closeWindow()` | `ctx.close()` |
+| `DialogHub().cancelWindow()` | `ctx.cancel()` - closes reporting `status: 'cancelled'`, so the host knows the action was abandoned and announces nothing (issue #7149) |
 
 So an intent-generated task form (`$scope.onApproveClicked = …; $http.post('/services/bpm/…')`)
 runs unchanged. New forms can still be authored directly against the neutral `ctx`.

--- a/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/form.js.template
+++ b/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/form.js.template
@@ -91,7 +91,10 @@ function formController(ctx) {
     return { show: (o) => ctx.notify(((o && o.title) ? o.title + ': ' : '') + ((o && o.description) || '')) };
   }
   function DialogHub() {
-    return { closeWindow: () => ctx.close(), close: () => ctx.close() };
+    // cancelWindow() is the "the user backed out" close: the host announces every outcome an action
+    // page reports, so a plain closeWindow() from a Cancel button read as a completion and toasted
+    // "<label> completed" for work that never happened (issue #7149).
+    return { closeWindow: () => ctx.close(), close: () => ctx.close(), cancelWindow: () => ctx.cancel() };
   }
 ]]#
 ${code}
@@ -122,13 +125,12 @@ document.addEventListener('alpine:init', () => {
           },
         },
         notify(message) { self.message = message; },
-        close() {
-          try {
-            if (window.parent && window.parent !== window) {
-              window.parent.postMessage({ type: 'harmonia.form.close' }, '*');
-            }
-          } catch (e) { /* standalone: nothing to close */ }
-        },
+        // The host ANNOUNCES the outcome a closing action page reports (issue #7073). `close()` says
+        // nothing about it, so the host applies its default "<label> completed"; `close(outcome)` may
+        // say so itself with { status: 'ok' | 'error', message }; and `cancel()` says the work was
+        // ABANDONED, on which the host stays quiet (issue #7149).
+        close(outcome) { self.postClose(outcome); },
+        cancel() { self.postClose({ status: 'cancelled' }); },
       };
       try {
         if (typeof formController === 'function') formController(this._ctx);
@@ -304,6 +306,18 @@ document.addEventListener('alpine:init', () => {
         out[c.model] = this.toInstant(v);
       });
       return out;
+    },
+
+    // Tell the host (the app-wide action dialog, the Inbox's iframe) that this page is done with
+    // itself. The optional outcome rides along on the SAME message, because it is the outcome the host
+    // announces: `status: 'error'` a refusal, `status: 'cancelled'` an abandoned action the host must
+    // NOT announce, nothing at all the host's default completion.
+    postClose(outcome) {
+      try {
+        if (window.parent && window.parent !== window) {
+          window.parent.postMessage(Object.assign({ type: 'harmonia.form.close' }, outcome || {}), '*');
+        }
+      } catch (e) { /* standalone: nothing to close */ }
     },
 
     // An HTML datetime-local value ("YYYY-MM-DDTHH:mm", local, no zone) -> a full ISO instant (…Z).


### PR DESCRIPTION
## What

The `customActions` store announces every outcome an action page reports: `harmonia.form.close` with `status: 'error'` is a refusal, with a `message` says what happened, and one that carries nothing at all still gets the default `"<label> completed"` toast plus a notification-centre entry (issue #7073).

The generated `.form`'s Close/Cancel button posted **that same status-less message**: its handler was `__dialogs.closeWindow()`, which the Harmonia form runtime maps to `ctx.close()` -> `postMessage({ type: 'harmonia.form.close' })`. So a user who opened a contributed action, decided not to proceed and clicked the page's own Cancel got a green *"Save as Template completed"* toast and a permanent bell entry for work that was explicitly abandoned.

## How

Three edits, one per layer:

- `FormIntentGenerator` — the non-completing `close` action's handler closes through `DialogHub.cancelWindow()`, keeping `closeWindow()` as the fallback (`__dialogs.cancelWindow ? … : …`) so a form generated here still runs on a host runtime that predates it.
- `form.js.template` — the `DialogHub` compat shim gains `cancelWindow() -> ctx.cancel()`; `ctx.close(outcome)` / `ctx.cancel()` both go through a new `postClose(outcome)` helper, so `cancel()` rides `status: 'cancelled'` on the one message the host already reads. Legacy `closeWindow()` stays neutral, so an authored AngularJS-era `.form` behaves exactly as before.
- `customActions.js` — `status: 'cancelled'` closes the dialog exactly as its X does: no toast, no notification-centre entry.

Real completions and refusals are announced as before — only the abandonment is silent. `processTasks` and `inboxPage` already ignored the status and only close + refresh, so they need no change.

## Testing

- New `FormCancelActionTest` (2 tests): the appended close action cancels rather than completes, and a declared completing action is unchanged.
- Full `engine-intent` suite green: **1183 tests, 0 failures**.
- Both edited JS files syntax-checked (`node --check`, the template with its Velocity markers substituted).

Fixes #7149

🤖 Generated with [Claude Code](https://claude.com/claude-code)