### PR TITLE
ui: one comparison rule and one status relation for both create-from guards

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GeneratesGuardSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GeneratesGuardSupport.java
@@ -15,6 +15,7 @@ import org.eclipse.dirigible.components.intent.generator.edm.CrossModelSupport;
 import org.eclipse.dirigible.components.intent.model.EntityIntent;
 import org.eclipse.dirigible.components.intent.model.GeneratesIntent;
 import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.model.LifecycleStages;
 import org.eclipse.dirigible.components.intent.model.RelationIntent;
 import org.eclipse.dirigible.components.intent.model.UsesIntent;
 
@@ -117,6 +118,12 @@ public final class GeneratesGuardSupport {
      * the owner model is not resolvable here - the button then carries no guard and the generated
      * controller's 409 stays the contract.
      *
+     * <p>
+     * An entity declaring two {@code function: EntityStatus} relations resolves to the FIRST, through
+     * {@link LifecycleStages#statusRelation}: one rule, shared with every other reader of THE status
+     * (the transitions guard, the abort support, the lifecycle stages), so the guard the controller
+     * enforces and the guard the button mirrors can never be read off different columns (issue #7150).
+     *
      * @param g the create-from
      * @param model the model being generated
      * @param context the generation context (may be null outside a Generate)
@@ -144,11 +151,8 @@ public final class GeneratesGuardSupport {
         for (EntityIntent entity : model.getEntities()) {
             if (g.getFrom()
                  .equals(entity.getName())) {
-                for (RelationIntent relation : entity.getRelations()) {
-                    if (relation.isEntityStatus()) {
-                        return IntentNaming.pascalCase(relation.getName());
-                    }
-                }
+                RelationIntent status = LifecycleStages.statusRelation(entity);
+                return status == null ? "" : IntentNaming.pascalCase(status.getName());
             }
         }
         return "";

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -1017,11 +1017,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                     }
                     sourceStatusProperty = sourceInfo.statusProperty();
                 } else {
-                    for (org.eclipse.dirigible.components.intent.model.RelationIntent relation : source.getRelations()) {
-                        if (relation.isEntityStatus()) {
-                            sourceStatusProperty = IntentNaming.pascalCase(relation.getName());
-                        }
-                    }
+                    sourceStatusProperty = entityStatusProperty(source);
                 }
             }
             // The from-status guard (issue #7068): the click is refused with 409 unless the source
@@ -1492,12 +1488,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                         LoggedValue.of(t.getName()));
                 continue;
             }
-            String statusProperty = "";
-            for (org.eclipse.dirigible.components.intent.model.RelationIntent relation : entity.getRelations()) {
-                if (relation.isEntityStatus()) {
-                    statusProperty = IntentNaming.pascalCase(relation.getName());
-                }
-            }
+            String statusProperty = entityStatusProperty(entity);
             if (statusProperty.isEmpty()) {
                 continue; // parser already reported the missing EntityStatus relation
             }
@@ -1879,11 +1870,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                             LoggedValue.of(p.getName()), LoggedValue.of(p.getEvent()));
                     continue;
                 }
-                for (RelationIntent relation : source.getRelations()) {
-                    if (relation.isEntityStatus()) {
-                        statusProperty = IntentNaming.pascalCase(relation.getName());
-                    }
-                }
+                statusProperty = entityStatusProperty(source);
                 if (statusProperty.isEmpty()) {
                     LOGGER.warn("posts [{}]: source [{}] has no function: EntityStatus relation for a status-triggered post - skipped",
                             LoggedValue.of(p.getName()), LoggedValue.of(p.getForEntity()));
@@ -2273,14 +2260,16 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         return found;
     }
 
-    /** The {@code function: EntityStatus} relation's property of the entity, or {@code ""}. */
+    /**
+     * The {@code function: EntityStatus} relation's property of the entity, or {@code ""}. THE status
+     * of an entity declaring two is the FIRST - the one rule, shared through
+     * {@link LifecycleStages#statusRelation} with every other reader (the create-from guard, the abort
+     * support, the lifecycle stages), so a server-side check and the client guard mirroring it can
+     * never land on different columns (issue #7150).
+     */
     private static String entityStatusProperty(EntityIntent entity) {
-        for (RelationIntent relation : entity.getRelations() == null ? List.<RelationIntent>of() : entity.getRelations()) {
-            if (relation.isEntityStatus()) {
-                return IntentNaming.pascalCase(relation.getName());
-            }
-        }
-        return "";
+        RelationIntent status = LifecycleStages.statusRelation(entity);
+        return status == null ? "" : IntentNaming.pascalCase(status.getName());
     }
 
     /** An authored property name as the generated Java field, or {@code ""} when absent. */

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueGeneratesTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueGeneratesTest.java
@@ -363,6 +363,47 @@ class GlueGeneratesTest {
     }
 
     @Test
+    void anAuthoredFromStatusResolvesTheStatusPropertyWithNoCompletionHook() {
+        // The guard-only path: no `sourceStatus:`, so nothing pre-resolved the source's status FK and
+        // GeneratesGuardSupport has to find it itself. It reads THE status the same way every other
+        // reader does - LifecycleStages.statusRelation, the first (and, per the parser, only)
+        // `function: EntityStatus` relation - so the button's guard and the controller's 409 are read
+        // off one column (issue #7150).
+        IntentModel model = IntentParser.parse("""
+                name: sales
+                entities:
+                  - name: ProformaStatus
+                    function: Setting
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                  - name: Proforma
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: number, type: string }
+                    relations:
+                      - { name: Stage, kind: manyToOne, to: ProformaStatus, function: EntityStatus, init: 1 }
+                  - name: Invoice
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: number, type: string }
+                generates:
+                  - name: invoice-from-proforma
+                    from: Proforma
+                    to: Invoice
+                    forEntity: Proforma
+                    fromStatus: [2]
+                """);
+        Map<String, Object> g = GlueIntentGenerator.buildGeneratesForTest(model)
+                                                   .get(0);
+
+        assertEquals("", g.get("sourceStatusProperty"));
+        assertEquals(true, g.get("hasStatusGuard"));
+        assertEquals("Stage", g.get("guardStatusProperty"));
+        assertEquals("currentStatus == 2", g.get("guardStatusExpr"));
+    }
+
+    @Test
     void aCreateFromWithNoStatusAtAllKeepsNoGuard() {
         Map<String, Object> g = GlueIntentGenerator.buildGeneratesForTest(IntentParser.parse(YAML))
                                                    .get(0);

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/customActions.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/customActions.js
@@ -27,12 +27,12 @@
  * the toast, so a fail-soft send that did not leave is a warning rather than a success (issue #7023).
  *
  * It is a global Alpine store so every generated view reads it the same way:
- *   $store.customActions.getActions(perspective, view, 'page')    -> the view's toolbar actions
- *   $store.customActions.getActions(perspective, view, 'entity', record) -> the view's per-record actions,
- *                                                                  minus those the record's status bars
- *   $store.customActions.trigger(action, id)                      -> open the action page in the
- *                                                                    app-wide dialog (an entity action
- *                                                                    passes the record id as ?id=)
+ *   $store.customActions.getActions(view, 'page')            -> the view's toolbar actions
+ *   $store.customActions.getActions(view, 'entity', record)  -> the view's per-record actions, minus
+ *                                                               those the record's status bars
+ *   $store.customActions.trigger(action, id)                 -> open the action page in the app-wide
+ *                                                               dialog (an entity action passes the
+ *                                                               record id as ?id=)
  * The action page opens in the dialog wired in index.html; on its `harmonia.form.close` message (or an
  * explicit close) the store closes it and raises a `harmonia:action-done` window event, so a view that
  * a mutating action changed (duplicate / create-from / aggregate) can refresh without a manual reload.
@@ -181,18 +181,21 @@ document.addEventListener('alpine:init', () => {
     // fails open for the same reason `appliesTo` does: an absent guard, an absent record or a record
     // carrying no value for the guarded property all leave the action visible - hiding a button on a
     // value we do not have is how an action vanishes for no reason the user can see.
+    //
+    // The comparison is `appliesTo`'s, to the character: both guards read the SAME status property of
+    // the SAME record, so a rule that differs between them makes the two disagree on one row. String
+    // comparison is the rule (issue #7150) - the earlier `Number()` conversion made this guard fail
+    // open on any status value that is not numeric, leaving the button live while the server 409s it.
     isAvailable(action, record) {
       const guard = action && action.guard;
-      if (!guard || !guard.property || !record) return true;
-      const raw = record[guard.property];
-      if (raw === null || raw === undefined || raw === '') return true;
-      const current = Number(raw);
-      if (Number.isNaN(current)) return true;
+      if (!guard || !guard.property || !record || typeof record !== 'object') return true;
+      const current = record[guard.property];
+      if (current === undefined || current === null || current === '') return true;
       if (Array.isArray(guard.allowed) && guard.allowed.length) {
-        return guard.allowed.some((s) => Number(s) === current);
+        return guard.allowed.some((s) => String(s) === String(current));
       }
       if (Array.isArray(guard.blocked) && guard.blocked.length) {
-        return !guard.blocked.some((s) => Number(s) === current);
+        return !guard.blocked.some((s) => String(s) === String(current));
       }
       return true;
     },


### PR DESCRIPTION
Fixes #7150

## What was wrong

Two parallel status guards over the **same property of the same record** disagreed with each other:

- `appliesTo` (a transition's `from:` guard) compared as **strings**.
- `isAvailable` (the #7068 create-from guard) converted to `Number` and returned `true` on `Number.isNaN` — so on any model whose status property carries a non-numeric value the create-from guard was **inert (failed open)** while the server refused the click with a 409. The user saw a live button that could not work, and the two guards answered differently on one row.

Server-side, "which relation is THE status" also forked: `GeneratesGuardSupport.statusProperty` took the **first** `function: EntityStatus` relation, while three loops in `GlueIntentGenerator` (the completion hook ~1019, the transition controllers ~1495, the status-triggered posts ~1882) had no `break` and kept the **last**.

## What changed

- `isAvailable` compares exactly as `appliesTo` does (`String(a) === String(b)`), and fails open on the same three cases — no guard, no record, no value — and no others. Numeric statuses behave identically to before (`2` still matches `'2'`); non-numeric ones are now actually guarded.
- FIRST is the rule the parser already states when it rejects a second `function: EntityStatus` relation ("every lifecycle, transition, check and report scope resolves the FIRST one"). All four resolution sites now go through `LifecycleStages.statusRelation`, the same helper the abort support and lifecycle stages use, so the guard the controller enforces and the guard the button mirrors can never be read off different columns.
- The store's doc comment described a `getActions(perspective, view, type)` signature that no longer exists; it now matches `getActions(view, type, record)`.

## Verification

- `engine-intent`: **1182/1182 green**, including a new `GlueGeneratesTest` case pinning the guard-only path (an authored `fromStatus:` with no `sourceStatus:` hook), which is the branch of `GeneratesGuardSupport.statusProperty` that was previously uncovered.
- The two-status-relations divergence is unreachable through the parser (already rejected, and covered by `FunctionIntentTest`); the code now agrees with the rule that rejection states.
- The JS guard has no test harness in the repo, so both functions were extracted and exercised directly under node: numeric hit/miss, blocked hit, numeric-as-string row value, the three fail-open cases, the two previously-fail-open string-status cases, and an assertion that `isAvailable` and `appliesTo` now answer the same on the same record. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)