### PR TITLE
templates: the reference checks hold on the self-service surfaces too (#7153)

### DIFF
--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityMyController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityMyController.java.template
@@ -217,6 +217,9 @@ public class ${name}MyController {
         // server has not finished deciding. Before the save, so a refused create never reaches the
         // insert - and never allocates a document number.
         validate(entity);
+#if($hasReferenceValidations)
+        validateReferences(entity);
+#end
 #if($hasDuplicateKeys)
         try {
             return scrub(repository.save(entity));
@@ -262,6 +265,9 @@ public class ${name}MyController {
 #end
 #end
         validate(entity);
+#if($hasReferenceValidations)
+        validateReferences(entity);
+#end
 #if($hasDuplicateKeys)
         try {
             return scrub(repository.update(entity));
@@ -673,6 +679,52 @@ public class ${name}MyController {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The value of '${property.name}' does not match the required pattern '${property.widgetPatternJava}'");
         }
 #end
+#end
+    }
+#end
+
+#if($hasReferenceValidations && !$personalReadOnly)
+    /**
+     * The same hierarchy reference checks the power surface applies
+     * (${name}Controller.validateReferences): a {@code leafOnly:} relation must point at a leaf, and a
+     * {@code hierarchy:} parent must not close a cycle. The pickers mirror both rules client-side, but
+     * a hand-crafted request must not bypass them on THIS door either - referential integrity is
+     * deliberately business-layer-only, so nothing downstream would refuse the row (#7153).
+     */
+    private void validateReferences(${name}Entity entity) {
+#foreach($property in $properties)
+#if($property.widgetLeafOnly && $property.leafOnlyRepositoryClass && $property.widgetHierarchyProperty)
+        // ${property.name} is leafOnly: the referenced ${property.relationshipEntityName} must have no children.
+        if (entity.${property.name} != null && !new ${property.leafOnlyRepositoryClass}().findAll(
+                org.eclipse.dirigible.components.data.store.java.repository.Criteria.create()
+                        .eq("${property.widgetHierarchyProperty}", entity.${property.name})).isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "The '${property.name}' must reference a leaf ${property.relationshipEntityName} - the selected one has children");
+        }
+#end
+#end
+#if($hierarchyProperty)
+        // The tree edge must not form a cycle: walk up from the assigned parent; hitting the entity
+        // itself (or an implausible depth) rejects the write.
+        if (entity.${hierarchyProperty} != null) {
+            Object self = entity.#foreach($property in $properties)#if($property.dataPrimaryKey)${property.name}#end#end;
+            Object cursor = entity.${hierarchyProperty};
+            int depth = 0;
+            while (cursor != null && depth++ < 100) {
+                if (cursor.equals(self)) {
+                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                            "The '${hierarchyProperty}' reference would create a cycle in the ${name} hierarchy");
+                }
+                ${name}Entity parent = repository.findOne(cursor).orElse(null);
+                if (parent == null) {
+                    break;
+                }
+                cursor = parent.${hierarchyProperty};
+            }
+            if (depth >= 100) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The ${name} hierarchy is implausibly deep - aborting");
+            }
+        }
 #end
     }
 #end

--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityPartnerController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityPartnerController.java.template
@@ -187,6 +187,9 @@ public class ${name}PartnerController {
         // server has not finished deciding. Before the save, so a refused create never reaches the
         // insert - and never allocates a document number.
         validate(entity);
+#if($hasReferenceValidations)
+        validateReferences(entity);
+#end
 #if($hasDuplicateKeys)
         try {
             return scrub(repository.save(entity));
@@ -232,6 +235,9 @@ public class ${name}PartnerController {
 #end
 #end
         validate(entity);
+#if($hasReferenceValidations)
+        validateReferences(entity);
+#end
 #if($hasDuplicateKeys)
         try {
             return scrub(repository.update(entity));
@@ -631,6 +637,52 @@ public class ${name}PartnerController {
 #end
 #end
     }
+
+#if($hasReferenceValidations)
+    /**
+     * The same hierarchy reference checks the power surface applies
+     * (${name}Controller.validateReferences): a {@code leafOnly:} relation must point at a leaf, and a
+     * {@code hierarchy:} parent must not close a cycle. The pickers mirror both rules client-side, but
+     * a hand-crafted request must not bypass them on THIS door either - referential integrity is
+     * deliberately business-layer-only, so nothing downstream would refuse the row (#7153).
+     */
+    private void validateReferences(${name}Entity entity) {
+#foreach($property in $properties)
+#if($property.widgetLeafOnly && $property.leafOnlyRepositoryClass && $property.widgetHierarchyProperty)
+        // ${property.name} is leafOnly: the referenced ${property.relationshipEntityName} must have no children.
+        if (entity.${property.name} != null && !new ${property.leafOnlyRepositoryClass}().findAll(
+                org.eclipse.dirigible.components.data.store.java.repository.Criteria.create()
+                        .eq("${property.widgetHierarchyProperty}", entity.${property.name})).isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "The '${property.name}' must reference a leaf ${property.relationshipEntityName} - the selected one has children");
+        }
+#end
+#end
+#if($hierarchyProperty)
+        // The tree edge must not form a cycle: walk up from the assigned parent; hitting the entity
+        // itself (or an implausible depth) rejects the write.
+        if (entity.${hierarchyProperty} != null) {
+            Object self = entity.#foreach($property in $properties)#if($property.dataPrimaryKey)${property.name}#end#end;
+            Object cursor = entity.${hierarchyProperty};
+            int depth = 0;
+            while (cursor != null && depth++ < 100) {
+                if (cursor.equals(self)) {
+                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                            "The '${hierarchyProperty}' reference would create a cycle in the ${name} hierarchy");
+                }
+                ${name}Entity parent = repository.findOne(cursor).orElse(null);
+                if (parent == null) {
+                    break;
+                }
+                cursor = parent.${hierarchyProperty};
+            }
+            if (depth >= 100) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The ${name} hierarchy is implausibly deep - aborting");
+            }
+        }
+#end
+    }
+#end
 
 #if($hasDuplicateKeys)
     /**

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/SelfServiceReferenceValidationTemplateIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/SelfServiceReferenceValidationTemplateIT.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.engine.template.velocity.VelocityGenerationEngine;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The REFERENCE checks of the self-service surfaces, rendered through the platform's
+ * {@link VelocityGenerationEngine} (dirigible #7153).
+ *
+ * <p>
+ * A {@code leafOnly:} relation must point at a leaf and a {@code hierarchy:} parent must not close
+ * a cycle. Both rules lived only on the power controller, so a personal or partner POST/PUT that
+ * broke either of them committed silently - and with referential integrity deliberately
+ * business-layer-only, nothing downstream refused the row. #7110 aligned the two surfaces on VALUE
+ * validation; this pins the reference half of the same alignment.
+ *
+ * <p>
+ * Rendering needs nothing from a running instance, so this boots no application context - the
+ * fixture shape of {@code PersonalSurfaceCreateValidationTemplateIT}.
+ */
+class SelfServiceReferenceValidationTemplateIT {
+
+    private static final String REST_BASE = "/META-INF/dirigible/template-application-rest-java/api/";
+
+    private static final String POWER_SURFACE = "EntityController.java.template";
+
+    private static final List<String> SELF_SERVICE_SURFACES =
+            List.of("EntityMyController.java.template", "EntityPartnerController.java.template");
+
+    private static final String LEAF_REFUSAL = "The 'Account' must reference a leaf Account - the selected one has children";
+
+    private static final String CYCLE_REFUSAL = "The 'Parent' reference would create a cycle in the Booking hierarchy";
+
+    private final VelocityGenerationEngine velocityGenerationEngine = new VelocityGenerationEngine();
+
+    /** The refusals are the power surface's, verbatim: one rule, whichever door the caller used. */
+    @Test
+    void aSelfServiceSurfaceRefusesANonLeafAndACycleExactlyAsThePowerSurfaceDoes() throws Exception {
+        String power = render(POWER_SURFACE);
+        assertTrue(power.contains(LEAF_REFUSAL), "the power surface's own leafOnly refusal changed: " + power);
+        assertTrue(power.contains(CYCLE_REFUSAL), "the power surface's own cycle refusal changed: " + power);
+
+        for (String template : SELF_SERVICE_SURFACES) {
+            String rendered = render(template);
+
+            assertTrue(rendered.contains(LEAF_REFUSAL), template + " must refuse a non-leaf leafOnly reference: " + rendered);
+            assertTrue(rendered.contains(CYCLE_REFUSAL), template + " must refuse a hierarchy cycle: " + rendered);
+        }
+    }
+
+    /**
+     * The walk up the tree is bounded - a hierarchy already broken by an older write must refuse the
+     * request, not spin.
+     */
+    @Test
+    void theCycleWalkIsBoundedOnTheSelfServiceSurfacesToo() throws Exception {
+        for (String template : SELF_SERVICE_SURFACES) {
+            String rendered = render(template);
+
+            assertTrue(rendered.contains("The Booking hierarchy is implausibly deep - aborting"),
+                    template + " must bound the parent walk: " + rendered);
+        }
+    }
+
+    /**
+     * Called after the value validation, on the payload the server has finished deciding, and before
+     * the write - a refused reference must never reach the insert or the update.
+     */
+    @Test
+    void theReferenceChecksRunAfterTheValueChecksAndBeforeTheWrite() throws Exception {
+        for (String template : SELF_SERVICE_SURFACES) {
+            String rendered = render(template);
+
+            int validate = rendered.indexOf("        validate(entity);");
+            int references = rendered.indexOf("        validateReferences(entity);");
+            int save = rendered.indexOf("repository.save(entity)");
+            assertTrue(validate >= 0 && references > validate, template + " must check references after the values: " + rendered);
+            assertTrue(save > references, template + " must check references before the insert: " + rendered);
+
+            int update = rendered.indexOf("repository.update(entity)");
+            assertTrue(rendered.lastIndexOf("        validateReferences(entity);") < update,
+                    template + " must check references before the update too: " + rendered);
+        }
+    }
+
+    /** An entity with neither rule carries no dead validator and no call to one. */
+    @Test
+    void anEntityWithoutHierarchyRulesGetsNeitherTheMethodNorTheCall() throws Exception {
+        Map<String, Object> parameters = context();
+        parameters.remove("hasReferenceValidations");
+        parameters.remove("hierarchyProperty");
+        parameters.put("properties", List.of(primaryKey(), employee()));
+
+        for (String template : SELF_SERVICE_SURFACES) {
+            String rendered = render(template, parameters);
+
+            assertTrue(!rendered.contains("validateReferences"), template + " must not emit an unused validator: " + rendered);
+        }
+    }
+
+    /** A see-only personal surface refuses every write already: it carries no validator to call. */
+    @Test
+    void aSeeOnlyPersonalSurfaceCarriesNoValidatorAtAll() throws Exception {
+        Map<String, Object> parameters = context();
+        parameters.put("personalReadOnly", Boolean.TRUE);
+
+        String rendered = render("EntityMyController.java.template", parameters);
+
+        assertTrue(!rendered.contains("validateReferences"), "a read-only personal surface must not emit a validator: " + rendered);
+    }
+
+    private String render(String templateName) throws Exception {
+        return render(templateName, context());
+    }
+
+    private String render(String templateName, Map<String, Object> parameters) throws Exception {
+        String location = REST_BASE + templateName;
+        String template;
+        try (InputStream in = getClass().getResourceAsStream(location)) {
+            assertNotNull(in, "template resource not found on classpath: " + location);
+            template = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        byte[] out = velocityGenerationEngine.generate(parameters, location, template.getBytes(StandardCharsets.UTF_8));
+        return new String(out, StandardCharsets.UTF_8);
+    }
+
+    /** A personally owned document that is itself a tree AND points at a leafOnly relation. */
+    private static Map<String, Object> context() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("name", "Booking");
+        parameters.put("projectName", "bookings");
+        parameters.put("perspectiveName", "Booking");
+        parameters.put("javaGenFolderName", "bookings");
+        parameters.put("javaPerspectiveName", "booking");
+        parameters.put("tablePrefix", "BOOKINGS_");
+        parameters.put("dataName", "BOOKING");
+        parameters.put("pkPropertyName", "Id");
+        parameters.put("properties", List.of(primaryKey(), employee(), account(), parent()));
+        parameters.put("sensitiveProperties", List.of());
+        parameters.put("hierarchyProperty", "Parent");
+        parameters.put("hasReferenceValidations", Boolean.TRUE);
+        parameters.put("personalProperty", "Employee");
+        parameters.put("personalFkJavaClass", "Integer");
+        parameters.put("personalIdentityProperty", "Email");
+        parameters.put("personalIdentityLabel", "Name");
+        parameters.put("personalIdentityRepositoryClass", "gen.bookings.data.booking.EmployeeRepository");
+        parameters.put("partnerProperty", "Employee");
+        parameters.put("partnerFkJavaClass", "Integer");
+        parameters.put("partnerIdentityProperty", "Email");
+        parameters.put("partnerIdentityLabel", "Name");
+        parameters.put("partnerIdentityRepositoryClass", "gen.bookings.data.booking.EmployeeRepository");
+        return parameters;
+    }
+
+    private static Map<String, Object> primaryKey() {
+        Map<String, Object> property = new LinkedHashMap<>();
+        property.put("name", "Id");
+        property.put("dataName", "BOOKING_ID");
+        property.put("dataType", "INTEGER");
+        property.put("dataTypeJavaClass", "Integer");
+        property.put("dataPrimaryKey", Boolean.TRUE);
+        property.put("dataNotNull", Boolean.TRUE);
+        return property;
+    }
+
+    /** The identity relation the personal / partner surfaces scope every row by. */
+    private static Map<String, Object> employee() {
+        Map<String, Object> property = new LinkedHashMap<>();
+        property.put("name", "Employee");
+        property.put("dataName", "BOOKING_EMPLOYEE");
+        property.put("dataType", "INTEGER");
+        property.put("dataTypeJavaClass", "Integer");
+        property.put("dataPrimaryKey", Boolean.FALSE);
+        property.put("relationshipEntityName", "Employee");
+        return property;
+    }
+
+    /** intent `leafOnly: true` on a relation into a hierarchical Account. */
+    private static Map<String, Object> account() {
+        Map<String, Object> property = new LinkedHashMap<>();
+        property.put("name", "Account");
+        property.put("dataName", "BOOKING_ACCOUNT");
+        property.put("dataType", "INTEGER");
+        property.put("dataTypeJavaClass", "Integer");
+        property.put("dataPrimaryKey", Boolean.FALSE);
+        property.put("relationshipEntityName", "Account");
+        property.put("widgetLeafOnly", "true");
+        property.put("widgetHierarchyProperty", "Parent");
+        property.put("leafOnlyRepositoryClass", "gen.bookings.data.booking.AccountRepository");
+        return property;
+    }
+
+    /** intent `hierarchy: Parent` - the entity's own tree edge. */
+    private static Map<String, Object> parent() {
+        Map<String, Object> property = new LinkedHashMap<>();
+        property.put("name", "Parent");
+        property.put("dataName", "BOOKING_PARENT");
+        property.put("dataType", "INTEGER");
+        property.put("dataTypeJavaClass", "Integer");
+        property.put("dataPrimaryKey", Boolean.FALSE);
+        property.put("relationshipEntityName", "Booking");
+        return property;
+    }
+}


### PR DESCRIPTION
`validateReferences` — a `leafOnly:` relation must point at a leaf, a `hierarchy:` parent must not close a cycle — existed only in `EntityController.java.template`. The personal (`My`) and partner controllers, which #7110 aligned on value validation, had no occurrence: a self-service POST/PUT pointing a leafOnly relation at a node with children, or making a record its own ancestor, committed silently. Referential integrity is deliberately business-layer-only here, so nothing downstream refused the row either — the tree was simply broken, and the next reader of it paid.

## What changes

- `EntityMyController.java.template` and `EntityPartnerController.java.template` emit the power surface's `validateReferences` and call it on create and update, **after** `validate(entity)` (on the payload the server has finished deciding — owner forced, sensitive and role-scoped fields settled) and **before** the write, so a refused reference never reaches the insert or the update.
- The refusals are the power surface's verbatim: one rule reads the same whichever door the caller used.
- A see-only personal surface (`personalReadOnly`), which refuses every write already, gets neither the method nor a call to it.

The flags this reads — entity-level `hasReferenceValidations` / `hierarchyProperty` and the per-property `leafOnlyRepositoryClass`, all set in `ModelParameterProcessor` — were already in the model context of all three templates, so this is a template-only change; no generator change was needed.

## Verification

`SelfServiceReferenceValidationTemplateIT` renders the three controllers through the platform's `VelocityGenerationEngine` off an entity that is itself a tree AND points at a leafOnly relation, and pins:

- the leafOnly and cycle refusals on both self-service surfaces, byte-for-byte with the power surface's,
- the bounded parent walk,
- the order (references after values, before both `save` and `update`),
- the two variants that must stay clean of it: an entity with neither rule, and a read-only personal surface.

`SelfServiceReferenceValidationTemplateIT` and the neighbouring `PersonalSurfaceCreateValidationTemplateIT` are green (10/10, then 5/5 after the last test was added).

Fixes #7153

🤖 Generated with [Claude Code](https://claude.com/claude-code)