### PR TITLE
templates: an authored default is escaped into the Java literal it is written into (#7154)

### DIFF
--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/JavaLiterals.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/JavaLiterals.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.ide.template.service.model;
+
+/**
+ * Java literals for values a model carries as text.
+ *
+ * <p>
+ * A model value reaches a generated Java source through a template, which interpolates it verbatim.
+ * A value holding a quote or a backslash therefore used to end the literal it was being written
+ * into and break the compile of the whole generated module - an authored {@code defaultValue: '6"'}
+ * rendered {@code entity.Size = "6"";} (dirigible #7154). Escaping the value keeps the worst case
+ * at one mis-valued field.
+ */
+final class JavaLiterals {
+
+    /**
+     * Not instantiable.
+     */
+    private JavaLiterals() {}
+
+    /**
+     * Escapes a value for placement inside a Java string literal: the backslash and the double quote
+     * that would otherwise end the literal, and the control characters that would end the line.
+     *
+     * @param value the raw value
+     * @return the escaped value, ready to be placed between two double quotes
+     */
+    static String escape(String value) {
+        StringBuilder escaped = new StringBuilder(value.length() + 8);
+        for (int index = 0; index < value.length(); index++) {
+            char character = value.charAt(index);
+            switch (character) {
+                case '\\' -> escaped.append("\\\\");
+                case '"' -> escaped.append("\\\"");
+                case '\n' -> escaped.append("\\n");
+                case '\r' -> escaped.append("\\r");
+                case '\t' -> escaped.append("\\t");
+                case '\b' -> escaped.append("\\b");
+                case '\f' -> escaped.append("\\f");
+                default -> {
+                    if (character < 0x20 || character == 0x7f) {
+                        escaped.append(String.format("\\u%04x", (int) character));
+                    } else {
+                        escaped.append(character);
+                    }
+                }
+            }
+        }
+        return escaped.toString();
+    }
+
+    /**
+     * The authored default of a property as a Java expression of the property's own type, or null when
+     * the property has no default that a Java literal can stand in for.
+     *
+     * <p>
+     * A numeric default is parsed from its authored text rather than inlined as a numeric literal, so
+     * an author's {@code "8.0"} on an integer column fails that one create instead of failing the whole
+     * generated build. A string default is accepted in either authoring shape - bare ({@code DRAFT},
+     * what the item dialog seeds) or SQL-quoted ({@code 'DRAFT'}, what a working DB DEFAULT needs,
+     * since the value reaches the DDL verbatim) - and both yield the string the column would hold. A
+     * date/time or binary column has no literal: its DEFAULT is emitted verbatim into the DDL and is
+     * typically a SQL expression ({@code CURRENT_DATE}, {@code now()}).
+     *
+     * @param javaClass the property's Java class, as the parameter graph resolved it
+     * @param defaultValue the authored default, as the model carries it
+     * @return the Java expression, or null when there is none
+     */
+    static String defaultValueExpression(String javaClass, String defaultValue) {
+        if (javaClass == null || defaultValue == null || defaultValue.isEmpty()) {
+            return null;
+        }
+        return switch (javaClass) {
+            case "java.math.BigDecimal" -> "new java.math.BigDecimal(\"" + escape(defaultValue) + "\")";
+            case "Double" -> "Double.valueOf(\"" + escape(defaultValue) + "\")";
+            case "Float" -> "Float.valueOf(\"" + escape(defaultValue) + "\")";
+            case "Long" -> "Long.valueOf(\"" + escape(defaultValue) + "\")";
+            case "Integer" -> "Integer.valueOf(\"" + escape(defaultValue) + "\")";
+            case "Short" -> "Short.valueOf(\"" + escape(defaultValue) + "\")";
+            case "Boolean" -> isTrueLiteral(defaultValue) ? "Boolean.TRUE" : "Boolean.FALSE";
+            case "String" -> "\"" + escape(unquote(defaultValue)) + "\"";
+            default -> null;
+        };
+    }
+
+    /**
+     * Whether an authored boolean default reads as true.
+     *
+     * @param defaultValue the authored default
+     * @return true when it does
+     */
+    private static boolean isTrueLiteral(String defaultValue) {
+        return "true".equals(defaultValue) || "TRUE".equals(defaultValue) || "1".equals(defaultValue);
+    }
+
+    /**
+     * Strips the SQL single quotes an authored string default may carry, leaving the string the column
+     * would hold.
+     *
+     * @param defaultValue the authored default
+     * @return the value without its surrounding quotes
+     */
+    private static String unquote(String defaultValue) {
+        if (defaultValue.length() > 1 && defaultValue.startsWith("'") && defaultValue.endsWith("'")) {
+            return defaultValue.substring(1, defaultValue.length() - 1);
+        }
+        return defaultValue;
+    }
+}

--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/ModelParameterProcessor.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/ModelParameterProcessor.java
@@ -352,12 +352,41 @@ final class ModelParameterProcessor {
             property.put("widgetIsMajor", Boolean.FALSE);
         }
 
+        resolveDefaultValueLiteral(property);
+
         resolveWidgetLengths(property, entity, dataType);
         property.put("inputRule", strOr(property, "widgetPattern", ""));
         collectMasterProperties(property, entity);
         collectReferencedProjections(property, entity, entities);
         resolveDropdown(property, entity, parameters);
         resolveMultiselect(property, entity, entities, parameters);
+    }
+
+    /**
+     * Derives the authored default as a Java expression, for the properties whose default the generated
+     * repository can apply itself.
+     *
+     * <p>
+     * The default is also the column's DB DEFAULT, but the database supplies it at INSERT - which is
+     * after the create-time calculations have already run in Java and read a null (#7104), so the
+     * repository assigns it first. The expression is resolved here rather than assembled in the
+     * template, so an authored value carrying a quote or a backslash is escaped instead of ending the
+     * literal it is written into and failing the compile of the whole generated module (#7154).
+     *
+     * <p>
+     * A key with no expression is left absent rather than null: a template reads the key's presence as
+     * "this property has a default to apply".
+     *
+     * @param property the property
+     */
+    private static void resolveDefaultValueLiteral(Map<String, Object> property) {
+        if (Boolean.TRUE.equals(property.get("dataPrimaryKey")) || Boolean.TRUE.equals(property.get("dataAutoIncrement"))) {
+            return;
+        }
+        String expression = JavaLiterals.defaultValueExpression(str(property, "dataTypeJavaClass"), str(property, "dataDefaultValue"));
+        if (expression != null) {
+            property.put("dataDefaultValueJavaLiteral", expression);
+        }
     }
 
     /**

--- a/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/JavaLiteralsTest.java
+++ b/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/JavaLiteralsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.ide.template.service.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests the Java literals a model value is written into a generated source as.
+ */
+class JavaLiteralsTest {
+
+    @Test
+    void leavesAnOrdinaryValueAlone() {
+        assertEquals("DRAFT", JavaLiterals.escape("DRAFT"));
+        assertEquals("6 mm", JavaLiterals.escape("6 mm"));
+        assertEquals("Ц", JavaLiterals.escape("Ц"));
+    }
+
+    /**
+     * The defect: the quote used to end the literal it was being written into, so one authored inch
+     * mark failed the compile of the whole generated module (#7154).
+     */
+    @Test
+    void escapesTheCharactersThatWouldEndTheLiteral() {
+        assertEquals("6\\\"", JavaLiterals.escape("6\""));
+        assertEquals("C:\\\\tmp", JavaLiterals.escape("C:\\tmp"));
+        assertEquals("\\\\\\\"", JavaLiterals.escape("\\\""));
+    }
+
+    @Test
+    void escapesTheControlCharactersThatWouldEndTheLine() {
+        assertEquals("a\\nb", JavaLiterals.escape("a\nb"));
+        assertEquals("a\\rb", JavaLiterals.escape("a\rb"));
+        assertEquals("a\\tb", JavaLiterals.escape("a\tb"));
+        assertEquals("a\\bb", JavaLiterals.escape("a\bb"));
+        assertEquals("a\\fb", JavaLiterals.escape("a\fb"));
+        assertEquals("a\\u0000b", JavaLiterals.escape("a\u0000b"));
+        assertEquals("a\\u001bb", JavaLiterals.escape("a\u001bb"));
+        assertEquals("a\\u007fb", JavaLiterals.escape("a\u007fb"));
+    }
+
+    /**
+     * A numeric default is parsed from its authored text rather than inlined, so an author's "8.0" on
+     * an integer column fails that one create instead of failing the whole generated build.
+     */
+    @Test
+    void parsesANumericDefaultFromItsAuthoredText() {
+        assertEquals("new java.math.BigDecimal(\"20.00\")", JavaLiterals.defaultValueExpression("java.math.BigDecimal", "20.00"));
+        assertEquals("Double.valueOf(\"1.5\")", JavaLiterals.defaultValueExpression("Double", "1.5"));
+        assertEquals("Float.valueOf(\"1.5\")", JavaLiterals.defaultValueExpression("Float", "1.5"));
+        assertEquals("Long.valueOf(\"7\")", JavaLiterals.defaultValueExpression("Long", "7"));
+        assertEquals("Integer.valueOf(\"7\")", JavaLiterals.defaultValueExpression("Integer", "7"));
+        assertEquals("Short.valueOf(\"7\")", JavaLiterals.defaultValueExpression("Short", "7"));
+        assertEquals("Integer.valueOf(\"8.0\")", JavaLiterals.defaultValueExpression("Integer", "8.0"));
+    }
+
+    /**
+     * A numeric default is the one place a malformed value cannot even be escaped into something that
+     * parses - so it must still compile, and fail at that one create.
+     */
+    @Test
+    void escapesAMalformedNumericDefaultTooRatherThanBreakingTheCompile() {
+        assertEquals("Integer.valueOf(\"7\\\"\")", JavaLiterals.defaultValueExpression("Integer", "7\""));
+    }
+
+    @Test
+    void readsABooleanDefaultInEveryAuthoredShape() {
+        assertEquals("Boolean.TRUE", JavaLiterals.defaultValueExpression("Boolean", "true"));
+        assertEquals("Boolean.TRUE", JavaLiterals.defaultValueExpression("Boolean", "TRUE"));
+        assertEquals("Boolean.TRUE", JavaLiterals.defaultValueExpression("Boolean", "1"));
+        assertEquals("Boolean.FALSE", JavaLiterals.defaultValueExpression("Boolean", "false"));
+        assertEquals("Boolean.FALSE", JavaLiterals.defaultValueExpression("Boolean", "0"));
+    }
+
+    /**
+     * Both authoring shapes of a string default - bare, and SQL-quoted the way a working DB DEFAULT
+     * needs - yield the string the column would hold.
+     */
+    @Test
+    void readsAStringDefaultInEitherAuthoringShape() {
+        assertEquals("\"DRAFT\"", JavaLiterals.defaultValueExpression("String", "DRAFT"));
+        assertEquals("\"DRAFT\"", JavaLiterals.defaultValueExpression("String", "'DRAFT'"));
+        assertEquals("\"'\"", JavaLiterals.defaultValueExpression("String", "'"));
+        assertEquals("\"6\\\"\"", JavaLiterals.defaultValueExpression("String", "6\""));
+        assertEquals("\"6\\\"\"", JavaLiterals.defaultValueExpression("String", "'6\"'"));
+    }
+
+    @Test
+    void hasNoExpressionForATypeWhoseDefaultIsASqlExpression() {
+        assertNull(JavaLiterals.defaultValueExpression("java.time.LocalDate", "CURRENT_DATE"));
+        assertNull(JavaLiterals.defaultValueExpression("java.time.Instant", "now()"));
+        assertNull(JavaLiterals.defaultValueExpression("byte[]", "x"));
+    }
+
+    @Test
+    void hasNoExpressionWithoutADefault() {
+        assertNull(JavaLiterals.defaultValueExpression("String", null));
+        assertNull(JavaLiterals.defaultValueExpression("String", ""));
+        assertNull(JavaLiterals.defaultValueExpression(null, "DRAFT"));
+    }
+}

--- a/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/ModelParameterProcessorTest.java
+++ b/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/ModelParameterProcessorTest.java
@@ -72,6 +72,47 @@ class ModelParameterProcessorTest {
         assertEquals(Boolean.FALSE, plain.get("isHiddenProperty"));
     }
 
+    /**
+     * The generated repository applies the authored default itself, before the create-time calculations
+     * read the column (#7104), so the parameter graph carries it as a Java expression - resolved here
+     * rather than assembled in the template, which used to interpolate the value unescaped and fail the
+     * compile of the whole generated module on an authored quote (#7154).
+     */
+    @Test
+    void carriesTheAuthoredDefaultAsAnEscapedJavaExpression() {
+        Map<String, Object> quoted = property("Size", "VARCHAR");
+        quoted.put("dataDefaultValue", "6\"");
+        Map<String, Object> status = property("Status", "VARCHAR");
+        status.put("dataDefaultValue", "'DRAFT'");
+        Map<String, Object> rate = property("VatRate", "DECIMAL");
+        rate.put("dataDefaultValue", "20");
+        ModelParameterProcessor.process(model(entity("Line", "Lines", quoted, status, rate)), parameters());
+
+        assertEquals("\"6\\\"\"", quoted.get("dataDefaultValueJavaLiteral"));
+        assertEquals("\"DRAFT\"", status.get("dataDefaultValueJavaLiteral"));
+        assertEquals("new java.math.BigDecimal(\"20\")", rate.get("dataDefaultValueJavaLiteral"));
+    }
+
+    /**
+     * The key's presence is what the template reads as "this property has a default to apply", so a
+     * property with none must leave it absent rather than null.
+     */
+    @Test
+    void leavesTheDefaultExpressionAbsentWhereThereIsNothingToApply() {
+        Map<String, Object> none = property("Name", "VARCHAR");
+        Map<String, Object> sqlExpression = property("Issued", "DATE");
+        sqlExpression.put("dataDefaultValue", "CURRENT_DATE");
+        Map<String, Object> generatedKey = property("Id", "INTEGER");
+        generatedKey.put("dataPrimaryKey", "true");
+        generatedKey.put("dataAutoIncrement", "true");
+        generatedKey.put("dataDefaultValue", "1");
+        ModelParameterProcessor.process(model(entity("Invoice", "Invoices", none, sqlExpression, generatedKey)), parameters());
+
+        assertFalse(none.containsKey("dataDefaultValueJavaLiteral"));
+        assertFalse(sqlExpression.containsKey("dataDefaultValueJavaLiteral"));
+        assertFalse(generatedKey.containsKey("dataDefaultValueJavaLiteral"));
+    }
+
     @Test
     void defaultsTheWidgetLabelFromThePropertyName() {
         Map<String, Object> property = property("TaxEventDate", "DATE");

--- a/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
+++ b/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
@@ -141,25 +141,19 @@ package gen.${javaGenFolderName}.data.${javaPerspectiveName};
 ## cleared stays cleared.
 ## A date/time or binary column is excluded: its DEFAULT is emitted verbatim into the DDL and is
 ## typically a SQL expression (CURRENT_DATE, now()), which has no Java literal to stand in for it.
+## The literal itself is resolved in Java (ModelParameterProcessor / JavaLiterals) and is present only
+## on a property that has one, so the type list lives in one place - and an authored value carrying a
+## quote or a backslash is escaped rather than ending the literal it is written into and failing the
+## compile of the whole generated module (dirigible #7154).
 #macro(applyDefaults)
 #foreach($property in $properties)
-#if($property.dataDefaultValue && $property.dataDefaultValue != "" && !$property.dataPrimaryKey && !$property.dataAutoIncrement)
-#if($property.dataTypeJavaClass == "java.math.BigDecimal" || $property.dataTypeJavaClass == "Double" || $property.dataTypeJavaClass == "Float" || $property.dataTypeJavaClass == "Long" || $property.dataTypeJavaClass == "Integer" || $property.dataTypeJavaClass == "Short" || $property.dataTypeJavaClass == "Boolean" || $property.dataTypeJavaClass == "String")
+#if($property.dataDefaultValueJavaLiteral)
         if (entity.${property.name} == null) {
-            entity.${property.name} = #defaultLiteral($property);
+            entity.${property.name} = ${property.dataDefaultValueJavaLiteral};
         }
 #end
 #end
 #end
-#end
-## The authored default as a Java literal of the property's own type. A numeric default is parsed from
-## its authored text rather than inlined as a numeric literal, so an author's "8.0" on an integer column
-## fails that one create instead of failing the whole generated build. A string default is accepted in
-## either authoring shape - bare (`DRAFT`, what the item dialog seeds) or SQL-quoted (`'DRAFT'`, what a
-## working DB DEFAULT needs, since the value reaches the DDL verbatim) - and both yield the string the
-## column would hold.
-#macro(defaultLiteral $property)
-#if($property.dataTypeJavaClass == "java.math.BigDecimal")new java.math.BigDecimal("${property.dataDefaultValue}")#elseif($property.dataTypeJavaClass == "Double")Double.valueOf("${property.dataDefaultValue}")#elseif($property.dataTypeJavaClass == "Float")Float.valueOf("${property.dataDefaultValue}")#elseif($property.dataTypeJavaClass == "Long")Long.valueOf("${property.dataDefaultValue}")#elseif($property.dataTypeJavaClass == "Integer")Integer.valueOf("${property.dataDefaultValue}")#elseif($property.dataTypeJavaClass == "Short")Short.valueOf("${property.dataDefaultValue}")#elseif($property.dataTypeJavaClass == "Boolean")#if($property.dataDefaultValue == "true" || $property.dataDefaultValue == "TRUE" || $property.dataDefaultValue == "1")Boolean.TRUE#{else}Boolean.FALSE#end#{else}#if($property.dataDefaultValue.length() > 1 && $property.dataDefaultValue.startsWith("'") && $property.dataDefaultValue.endsWith("'"))#set($unquotedEnd = $property.dataDefaultValue.length() - 1)"${property.dataDefaultValue.substring(1, $unquotedEnd)}"#{else}"${property.dataDefaultValue}"#end#end#end
 ## Required values: refuse a write that leaves a NOT NULL column empty, naming the property, instead of
 ## letting the statement reach the database and come back as a driver-specific constraint violation - an
 ## HTTP 500 carrying a message about a physical column nobody outside the schema has heard of, from which

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -3887,6 +3887,7 @@ class IntentEngineIT extends IntegrationTest {
                               - { name: vat,      type: decimal, precision: 18, scale: 2, calculatedOnCreate: "Net * VatRate / 100", calculatedOnUpdate: "Net * VatRate / 100" }
                               - { name: billable, type: boolean, defaultValue: true }
                               - { name: stage,    type: string,  length: 20, defaultValue: DRAFT }
+                              - { name: size,     type: string,  length: 20, defaultValue: '6" \\ wide' }
                         """);
         restAssuredExecutor.execute(() -> given().when()
                                                  .post(GENERATE_URL)
@@ -3902,6 +3903,11 @@ class IntentEngineIT extends IntegrationTest {
                 "the decimal default must be assigned when the write left the column empty: " + repository);
         assertTrue(repository.contains("entity.Billable = Boolean.TRUE;"), "a boolean default must be a boolean literal");
         assertTrue(repository.contains("entity.Stage = \"DRAFT\";"), "a string default must be a quoted string literal");
+        // #7154: the literal used to be interpolated unescaped, so an authored inch mark ended it and
+        // failed javac on the whole generated module - the exact blast radius the numeric branch parses
+        // its text to avoid. A malformed default can at worst mis-value this one field.
+        assertTrue(repository.contains("entity.Size = \"6\\\" \\\\ wide\";"),
+                "a string default carrying a quote or a backslash must be escaped into the literal: " + repository);
 
         // ...and BEFORE the calculation that reads it, which is the whole point.
         assertTrue(


### PR DESCRIPTION
Fixes #7154

## The defect

`#defaultLiteral` (added by #7115 for #7104) interpolated a string default into a Java string literal verbatim - `"${property.dataDefaultValue}"`. An authored

```yaml
- { name: size, type: string, length: 20, defaultValue: 6" }
```

rendered `entity.Size = "6"";` and failed `javac` on the **whole generated module** - the exact blast radius the macro's numeric branch parses its text to avoid. A backslash did the same, and a newline or a control character ended the line.

## The fix

The literal is resolved in Java rather than assembled in the template: `JavaLiterals.defaultValueExpression(javaClass, defaultValue)`, called from `ModelParameterProcessor.processProperty` and carried on the property as `dataDefaultValueJavaLiteral`. It escapes `\`, `"`, and the control characters (`\n` `\r` `\t` `\b` `\f`, everything else below `0x20` and `0x7f` as `\uXXXX`). The worst case for a malformed default drops from a failed build to one mis-valued field.

Everything else is deliberately unchanged, so a model that generated before generates byte-identically:

- a numeric default is still **parsed** from its authored text (`Integer.valueOf("8.0")` fails that one create, not the build) - and is escaped too, since a malformed numeric is the one value escaping cannot make parse;
- a string default is still accepted in either authoring shape - bare `DRAFT` (what the item dialog seeds) or SQL-quoted `DRAFT` (what a working DB DEFAULT needs);
- a boolean reads `true` / `TRUE` / `1`;
- a date/time or binary column still has no literal (its DEFAULT is a SQL expression), and neither has a primary key or an auto-increment column.

The key is **present only** on a property that has a literal, so the type list lives in one place instead of being restated in the macro's `#if`, and `#defaultLiteral` is gone.

## Tests

- `JavaLiteralsTest` (new, 9 cases) - escaping, both string shapes, every numeric type, the boolean shapes, and the absent cases.
- `ModelParameterProcessorTest` - the key is derived on the graph for a quote-bearing, an SQL-quoted and a numeric default, and left **absent** (not null) where there is nothing to apply.
- `IntentEngineIT#an_authored_default_is_applied_before_the_create_time_calculations` - the #7104 test grows a `defaultValue: 6" \ wide` field and asserts the emitted `entity.Size = "6\" \\ wide";`. Run locally, green.

`mvn -pl components/ide/ide-template test` (113 tests) and `formatter:validate` on both modules are green; the release javadoc profile builds clean on `ide-template`.

## Siblings, deliberately out of scope

The same authored value breaks two other interpolations, in other literal syntaxes, with the same "one field breaks the whole artefact" shape - filed rather than folded in here:

- `template-application-schema/.../application.schema.template` writes `"defaultValue": "${property.dataDefaultValue}"` into JSON;
- the Harmonia templates seed the default into JS string literals (`detail-register.js.template`'s `defaultMeta`), where an apostrophe is the breaking character.

🤖 Generated with [Claude Code](https://claude.com/claude-code)