### PR TITLE
ui: a date filter applies only what the picker actually parsed (#7156)

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/basePage.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/basePage.js
@@ -106,6 +106,26 @@ function basePage() {
     },
 
     /**
+     * Whether a date picker's `change` event carries a value the picker actually PARSED.
+     *
+     * The picker listens on its own input, so its handler has already run by the time the event
+     * bubbles to a consumer's handler on the wrapper. When the typed text is not a date the picker
+     * logs it, marks the input with a custom validity message and returns WITHOUT touching the
+     * model - but the trusted `change` event still arrives here. A handler that acts unconditionally
+     * therefore acts on the PREVIOUS model value: a half-typed date silently re-applied the filter
+     * that was already in force, which reads as if the half-typed one had matched.
+     *
+     * A successful parse, a pick from the popup and an emptied input all clear that message, so the
+     * input's own validity is the discriminator - `false` here means "the picker did not take this,
+     * do nothing". The user is not left guessing: Harmonia paints a `user-invalid` picker input with
+     * the negative border, so the rejected text is visibly marked where it was typed.
+     */
+    datePickerAccepted(event) {
+      const input = event && event.target;
+      return !input || !input.validity || input.validity.valid;
+    },
+
+    /**
      * Format a floating-point value for display: decimals from the field's DecimalFormat pattern, the
      * grouping/decimal separators from the instance-wide Number setting (services/format.js).
      */

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
@@ -212,9 +212,11 @@
                          it print. A native <input type="date"> renders in the BROWSER's locale instead, which is
                          how one screen could offer dd.mm.yyyy while the form beside it read the same digits as
                          m/d/yyyy. The model stays the ISO the search expects; the picker's change event bubbles
-                         to the cell, covering both a typed value and a picked one. -->
+                         to the cell, covering both a typed value and a picked one - but only a value the picker
+                         PARSED is applied (datePickerAccepted): text it refused leaves the model on its previous
+                         date, and applying then would silently re-run the filter already in force. -->
                     <template x-if="col.type === 'date'">
-                      <div x-h-date-picker.table @change="applyServerFilter()">
+                      <div x-h-date-picker.table @change="if (datePickerAccepted($event)) applyServerFilter()">
                         <input type="text" :placeholder="HarmoniaFormat.dateHint()" />
                         <button x-h-date-picker-trigger :aria-label="T('$projectName:${tprefix}.defaults.filter', 'Filter…')"></button>
                         <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="columnFilters[col.name]"></div>


### PR DESCRIPTION
A date column filter in a generated list is a Harmonia picker, and the picker listens for `change` on its own input — so its handler has already run by the time the event bubbles to the filter cell's `@change="applyServerFilter()"`. When the typed text is not a date the picker logs it, marks the input with a custom validity message and returns **without touching the model**. The trusted change event still arrives at the cell, which then re-ran the search against the *previous* model value: with a filter already in force, half-typing over it (`05.09.20x6`) silently re-applied the old date, so the same rows came back and the row count never moved — it read as if the half-typed date had matched.

`basePage.datePickerAccepted(event)` answers whether the picker took the value, and the cell applies only then. The input's own validity is the discriminator: a successful parse, a pick from the popup and an emptied input all clear the custom validity message, and only text the picker refused leaves it set. An empty input therefore still applies — clearing a date filter must clear it.

Nothing is silent to the user either: Harmonia's picker input already carries `user-invalid:border-negative`, so the refused text keeps the negative border where it was typed, and the filter it did not apply is visibly the one the column still shows.

### Verification

Run in Chrome against harmonia 2.14.2 with the filter cell reproduced side by side, guarded and unguarded, over the real picker. With `2026-09-05` in force, typing `05.09.20x6` into both:

| | applied | input validity |
|---|---|---|
| unguarded (before) | `["2026-09-05", "2026-09-05"]` | invalid |
| guarded (after) | `["2026-09-05"]` | invalid |

Both inputs took the negative border. Clearing the refused text on the guarded cell then applied `""`, and a following `17.03.2027` applied as `2027-03-17` — neither recovery path is blocked by the guard.

Fixes #7156

🤖 Generated with [Claude Code](https://claude.com/claude-code)