### PR TITLE
templates: the personal and partner line dialogs name the refused field too (#7152)

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-page.js.template
@@ -56,6 +56,12 @@ document.addEventListener('alpine:init', () => {
     itemsEnabled: false,   // items only after the header exists
     itemsError: null,
     itemDialog: false,
+    // The line dialog's own error surface. A rejected save that NAMES a column marks that column
+    // (itemFieldError -> aria-invalid) and repeats the server's reason in the field's own label;
+    // anything else keeps the generic banner. It is separate from itemsError because that one
+    // renders in the items pane, BEHIND the open dialog, where nobody reads it.
+    itemError: null,
+    itemFieldError: null,
     itemMode: 'create',
     draft: {},
     itemOptions: {},
@@ -360,7 +366,28 @@ document.addEventListener('alpine:init', () => {
         Object.keys(preset)
               .forEach((key) => { this.draft[key] = preset[key]; });
       }
+      this.itemError = null;
+      this.itemFieldError = null;
       this.itemDialog = true;
+    },
+
+    // A line the server refuses is refused for ONE reason it states in prose, naming the property:
+    // "The 'TaxRate' property is required". Read that name out of the message and the dialog can do
+    // what the raw developer-facing text never could - point at the field that is wrong and repeat
+    // the reason in the dialog's own labels. A message naming no editable column keeps the generic
+    // banner. The same mapping the power document dialog runs (#7062).
+    applyItemError(e, fallback) {
+      const columns = this.itemColumns();
+      const named = App.services.apiErrors.namedProperty(e, columns.map((c) => c.name));
+      if (named) {
+        const labels = {};
+        for (const col of columns) labels[col.name] = window.T ? window.T(col.tkey, col.label) : col.label;
+        this.itemFieldError = named;
+        this.itemError = App.services.apiErrors.messageWithLabels(e, labels);
+        return;
+      }
+      this.itemFieldError = null;
+      this.itemError = App.services.apiErrors.messageFor(e, fallback);
     },
 
     async ensureItemOptions() {
@@ -402,7 +429,7 @@ document.addEventListener('alpine:init', () => {
         await this.loadItems();
         await this.reloadHeaderTotals();
       } catch (e) {
-        this.itemsError = (e && e.message) || 'Could not save the line item.';
+        this.applyItemError(e, 'Could not save the line item.');
       }
     },
 
@@ -431,7 +458,8 @@ document.addEventListener('alpine:init', () => {
       const dateCol = this.fillDateColumn();
       const month = String((dateCol && this.draft[dateCol.name]) || '').slice(0, 7);
       if (!/^\d{4}-\d{2}$/.test(month)) {
-        this.itemsError = 'Pick a month to fill.';
+        this.itemError = 'Pick a month to fill.';
+        this.itemFieldError = null;
         return;
       }
       const taken = new Set((this.items || []).map((r) => this.itemDayOf(r[dateCol.name])).filter(Boolean));
@@ -448,7 +476,7 @@ document.addEventListener('alpine:init', () => {
         await this.loadItems();
         await this.reloadHeaderTotals();
       } catch (e) {
-        this.itemsError = (e && e.message) || 'Could not fill the month.';
+        this.applyItemError(e, 'Could not fill the month.');
         await this.loadItems();
         await this.reloadHeaderTotals();
       }

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
@@ -372,17 +372,21 @@
         <button type="button" x-h-dialog-close @click="itemDialog = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
       </div>
       <div x-h-dialog-content>
+        <div x-show="itemError" x-h-alert data-variant="negative" role="alert"><div x-h-alert-description x-text="itemError"></div></div>
         <p x-h-text.muted x-show="itemMode === 'fill'" x-text="T('$projectName:${tprefix}.messages.fillMonthHint', 'One line is created for every working day (Mon-Fri) of the picked month; days that already have a line are skipped.')"></p>
         <div class="grid grid-cols-2 gap-4">
           <template x-for="col in itemColumns()" :key="col.name">
-            <div x-h-field :class="col.kind === 'text' ? 'col-span-2' : ''">
+            <!-- A rejected save names ONE column (itemFieldError): its control carries aria-invalid,
+                 which is what Harmonia colours the label and the border from - the same marking the
+                 header form's fields use. -->
+            <div x-h-field :class="col.kind === 'text' ? 'col-span-2' : ''" :data-invalid="itemFieldError === col.name">
               <!-- A required line column carries the same marker as the header form: the dialog is
                    where the value is entered, so hiding which ones are mandatory only defers the
                    rejection to the server. -->
               <label x-h-label><span x-text="T(col.tkey, col.label)"></span><span x-show="col.required &amp;&amp; !col.readonly" class="text-negative"> *</span></label>
               <template x-if="!col.readonly && col.lookup">
                 <div x-h-select data-filter="contains">
-                  <input x-h-select-input x-model="draft[col.name]" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select {{name}}...', { name: T(col.tkey, col.label) })" />
+                  <input x-h-select-input x-model="draft[col.name]" :aria-invalid="itemFieldError === col.name" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select {{name}}...', { name: T(col.tkey, col.label) })" />
                   <div x-h-select-content>
                     <div x-h-select-search></div>
                     <div x-h-select-list>
@@ -394,20 +398,20 @@
                 </div>
               </template>
               <template x-if="!col.readonly && !col.lookup && col.number">
-                <div x-h-input-number><input type="number" step="any" x-model.number="draft[col.name]" /></div>
+                <div x-h-input-number><input type="number" step="any" x-model.number="draft[col.name]" :aria-invalid="itemFieldError === col.name" /></div>
               </template>
               <template x-if="!col.readonly && !col.lookup && col.widget === 'CHECKBOX'">
-                <div class="hbox items-center"><span x-h-checkbox><input type="checkbox" x-model="draft[col.name]" /></span></div>
+                <div class="hbox items-center"><span x-h-checkbox><input type="checkbox" x-model="draft[col.name]" :aria-invalid="itemFieldError === col.name" /></span></div>
               </template>
               <template x-if="!col.readonly && !col.lookup && col.date && !(itemMode === 'fill' && col.name === fillDateName())">
-                <div x-h-date-picker><input type="text" :placeholder="HarmoniaFormat.dateHint()" /><button x-h-date-picker-trigger aria-label="Choose date"></button><div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="draft[col.name]"></div></div>
+                <div x-h-date-picker><input type="text" :placeholder="HarmoniaFormat.dateHint()" :aria-invalid="itemFieldError === col.name" /><button x-h-date-picker-trigger aria-label="Choose date"></button><div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="draft[col.name]"></div></div>
               </template>
               <!-- Fill Month: the fill-target date column picks the MONTH - every working day gets a line. -->
               <template x-if="!col.readonly && !col.lookup && col.date && itemMode === 'fill' && col.name === fillDateName()">
-                <div x-h-month-picker><input type="text" /><button x-h-month-picker-trigger aria-label="Choose month"></button><div x-h-month-picker-popup x-model="draft[col.name]"></div></div>
+                <div x-h-month-picker><input type="text" :aria-invalid="itemFieldError === col.name" /><button x-h-month-picker-trigger aria-label="Choose month"></button><div x-h-month-picker-popup x-model="draft[col.name]"></div></div>
               </template>
               <template x-if="!col.readonly && !col.lookup && !col.date && !col.number && col.widget !== 'CHECKBOX'">
-                <input x-h-input type="text" x-model="draft[col.name]" :pattern="col.pattern" />
+                <input x-h-input type="text" x-model="draft[col.name]" :pattern="col.pattern" :aria-invalid="itemFieldError === col.name" />
               </template>
               <!-- A read-only column (calculated / intent readOnly) is a VALUE, not a control: the
                    server recomputes it on save, so rendering an input only faked editability. -->

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-page.js.template
@@ -56,6 +56,12 @@ document.addEventListener('alpine:init', () => {
     itemsEnabled: false,   // items only after the header exists
     itemsError: null,
     itemDialog: false,
+    // The line dialog's own error surface. A rejected save that NAMES a column marks that column
+    // (itemFieldError -> aria-invalid) and repeats the server's reason in the field's own label;
+    // anything else keeps the generic banner. It is separate from itemsError because that one
+    // renders in the items pane, BEHIND the open dialog, where nobody reads it.
+    itemError: null,
+    itemFieldError: null,
     itemMode: 'create',
     draft: {},
     itemOptions: {},
@@ -358,7 +364,28 @@ document.addEventListener('alpine:init', () => {
         Object.keys(preset)
               .forEach((key) => { this.draft[key] = preset[key]; });
       }
+      this.itemError = null;
+      this.itemFieldError = null;
       this.itemDialog = true;
+    },
+
+    // A line the server refuses is refused for ONE reason it states in prose, naming the property:
+    // "The 'TaxRate' property is required". Read that name out of the message and the dialog can do
+    // what the raw developer-facing text never could - point at the field that is wrong and repeat
+    // the reason in the dialog's own labels. A message naming no editable column keeps the generic
+    // banner. The same mapping the power document dialog runs (#7062).
+    applyItemError(e, fallback) {
+      const columns = this.itemColumns();
+      const named = App.services.apiErrors.namedProperty(e, columns.map((c) => c.name));
+      if (named) {
+        const labels = {};
+        for (const col of columns) labels[col.name] = window.T ? window.T(col.tkey, col.label) : col.label;
+        this.itemFieldError = named;
+        this.itemError = App.services.apiErrors.messageWithLabels(e, labels);
+        return;
+      }
+      this.itemFieldError = null;
+      this.itemError = App.services.apiErrors.messageFor(e, fallback);
     },
 
     async ensureItemOptions() {
@@ -399,7 +426,7 @@ document.addEventListener('alpine:init', () => {
         await this.loadItems();
         await this.reloadHeaderTotals();
       } catch (e) {
-        this.itemsError = (e && e.message) || 'Could not save the line item.';
+        this.applyItemError(e, 'Could not save the line item.');
       }
     },
 

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
@@ -235,16 +235,20 @@
         <button type="button" x-h-dialog-close @click="itemDialog = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
       </div>
       <div x-h-dialog-content>
+        <div x-show="itemError" x-h-alert data-variant="negative" role="alert"><div x-h-alert-description x-text="itemError"></div></div>
         <div class="grid grid-cols-2 gap-4">
           <template x-for="col in itemColumns()" :key="col.name">
-            <div x-h-field :class="col.kind === 'text' ? 'col-span-2' : ''">
+            <!-- A rejected save names ONE column (itemFieldError): its control carries aria-invalid,
+                 which is what Harmonia colours the label and the border from - the same marking the
+                 header form's fields use. -->
+            <div x-h-field :class="col.kind === 'text' ? 'col-span-2' : ''" :data-invalid="itemFieldError === col.name">
               <!-- A required line column carries the same marker as the header form: the dialog is
                    where the value is entered, so hiding which ones are mandatory only defers the
                    rejection to the server. -->
               <label x-h-label><span x-text="T(col.tkey, col.label)"></span><span x-show="col.required &amp;&amp; !col.readonly" class="text-negative"> *</span></label>
               <template x-if="!col.readonly && col.lookup">
                 <div x-h-select data-filter="contains">
-                  <input x-h-select-input x-model="draft[col.name]" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select {{name}}...', { name: T(col.tkey, col.label) })" />
+                  <input x-h-select-input x-model="draft[col.name]" :aria-invalid="itemFieldError === col.name" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select {{name}}...', { name: T(col.tkey, col.label) })" />
                   <div x-h-select-content>
                     <div x-h-select-search></div>
                     <div x-h-select-list>
@@ -256,16 +260,16 @@
                 </div>
               </template>
               <template x-if="!col.readonly && !col.lookup && col.number">
-                <div x-h-input-number><input type="number" step="any" x-model.number="draft[col.name]" /></div>
+                <div x-h-input-number><input type="number" step="any" x-model.number="draft[col.name]" :aria-invalid="itemFieldError === col.name" /></div>
               </template>
               <template x-if="!col.readonly && !col.lookup && col.widget === 'CHECKBOX'">
-                <div class="hbox items-center"><span x-h-checkbox><input type="checkbox" x-model="draft[col.name]" /></span></div>
+                <div class="hbox items-center"><span x-h-checkbox><input type="checkbox" x-model="draft[col.name]" :aria-invalid="itemFieldError === col.name" /></span></div>
               </template>
               <template x-if="!col.readonly && !col.lookup && col.date">
-                <div x-h-date-picker><input type="text" :placeholder="HarmoniaFormat.dateHint()" /><button x-h-date-picker-trigger aria-label="Choose date"></button><div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="draft[col.name]"></div></div>
+                <div x-h-date-picker><input type="text" :placeholder="HarmoniaFormat.dateHint()" :aria-invalid="itemFieldError === col.name" /><button x-h-date-picker-trigger aria-label="Choose date"></button><div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="draft[col.name]"></div></div>
               </template>
               <template x-if="!col.readonly && !col.lookup && !col.date && !col.number && col.widget !== 'CHECKBOX'">
-                <input x-h-input type="text" x-model="draft[col.name]" :pattern="col.pattern" />
+                <input x-h-input type="text" x-model="draft[col.name]" :pattern="col.pattern" :aria-invalid="itemFieldError === col.name" />
               </template>
               <!-- A read-only column (calculated / intent readOnly) is a VALUE, not a control: the
                    server recomputes it on save, so rendering an input only faked editability. -->

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -2875,6 +2875,17 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertTrue(rosterPage.contains("applyDraftError") && rosterPage.contains("namedProperty"),
                 "a rejected line must be mapped onto the property the server named, not onto a generic banner");
 
+        // #7152: the same mapping on the PERSONAL line dialog. It got the required marker with #7062
+        // but kept printing the raw developer-facing message and marked no field, so the one surface
+        // where the owner actually enters lines was the one that named nothing. (The partner document
+        // is the mechanical mirror of this page; PartnerTicket carries no items child to emit one.)
+        assertTrue(myRosterDoc.contains(":aria-invalid=\"itemFieldError === col.name\""),
+                "the personal line dialog's refused column must carry aria-invalid too");
+        assertTrue(myRosterDoc.contains("x-text=\"itemError\""),
+                "the personal line dialog must show its error INSIDE the dialog - the items-pane banner sits behind it");
+        assertTrue(myRosterPage.contains("applyItemError") && myRosterPage.contains("namedProperty"),
+                "a refused personal line must be mapped onto the property the server named, not printed raw");
+
         // The app-test manifest carries the personal UI-parity metadata the runner's my flow
         // drives (wave 2): the /my route, the layout family the personal page belongs to, and
         // the relation columns that must resolve to labels on the personal list.


### PR DESCRIPTION
#7062 taught the power document dialog to read the property a rejected save NAMES ("The 'TaxRate' property is required"), mark that field `aria-invalid` and repeat the reason with the field's own label. The personal and partner document pages got only half of it: the required `*` marker landed, but their save path stayed `this.itemsError = (e && e.message) || '...'` — the raw developer-facing message, printed into the items-pane banner that sits BEHIND the open dialog, with no field marked at all. The two surfaces where the owner and the external partner actually enter lines were the two that named nothing.

## What changed

- `my-document-page.js.template` / `partner-document-page.js.template`: new `applyItemError(e, fallback)` — the same `namedProperty` + `messageWithLabels` mapping the power dialog runs. The named property goes to `itemFieldError`, the message is rewritten with the field's display label, and a message naming no editable column falls back to the catalog line via `messageFor`.
- `my-document-view.html.template` / `partner-document-view.html.template`: `:data-invalid` on the field and `:aria-invalid` on every control (select, number, checkbox, date, month, text) — what Harmonia colours the label and border from — plus the error banner moved INSIDE the dialog, where it is actually readable.
- The dialog's error state is cleared whenever it opens. The personal Fill Month path answers in the dialog too: "Pick a month to fill." was being written to the same hidden banner.

## Verification

`IntentEmissionCoverageIT` gains three assertions on the emitted personal document surface (the partner document is the mechanical mirror; the fixture's `PartnerTicket` carries no items child, so no partner document is emitted to assert on).

The IT run is green on this branch **except** for one failure that also reproduces on the unmodified base commit (`de5827b0a8`) and is untouched here: line 1999, `"a master being deleted must suspend the per-line totals write-back"` (#7143) — the emitted `EntryRepository` carries no `recalculate` at all, i.e. `annotateDocumentModels` did not set `$documentMaster` for `Entry` in that run. Master's own CI is green on all four IT shards, so this looks local to my environment rather than an upstream break; either way it is upstream of the three new assertions and unrelated to this change. With that one assertion skipped locally, the full IT including the three new assertions passes (whole reactor freshly installed from this worktree).

Fixes #7152
