### PR TITLE
ui: the Inbox auto-refresh keeps the subject cache warm, and the record cache is bounded (#7157)

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/inboxPage.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/inboxPage.js
@@ -37,12 +37,16 @@ document.addEventListener('alpine:init', () => {
     actAs: { acting: null, hiddenTasks: 0 },
 
     init() {
-      // The store self-loads at startup; refresh on entry so the list is current.
-      this.refresh();
+      // The store self-loads at startup; re-read the list on entry so it is current — warm, since nothing
+      // has changed under us just by navigating here.
+      this.reload();
       this._onMessage = (e) => {
         if (e && e.data && e.data.type === 'harmonia.form.close') {
+          // The form wrote the record the selected task is about — that one subject re-reads, the rest of
+          // the list keeps its cache.
+          Alpine.store('processTasks').invalidate({ id: this.selectedId });
           this.selectedId = null;
-          this.refresh();
+          this.reload();
         }
       };
       window.addEventListener('message', this._onMessage);
@@ -100,7 +104,8 @@ document.addEventListener('alpine:init', () => {
       this.busy = true;
       try {
         await App.services.api.post('/services/inbox/tasks/' + task.id, { action: 'CLAIM' }, { baseUrl: '' });
-        await this.refresh();
+        // A claim changes who owns the task, not the record it is about; the subjects stay valid.
+        await this.reload();
         this.selectedId = task.id; // keep the selection after the list re-fetches
       } catch (e) {
         console.error('inbox: unable to claim task', e);
@@ -125,9 +130,24 @@ document.addEventListener('alpine:init', () => {
       if (res.ok) window.location.reload();
     },
 
-    async refresh() {
+    // The Refresh button: authoritative, so it drops the subject cache and re-reads every record the
+    // subject lines are built from.
+    refresh() {
+      return this._load(true);
+    },
+
+    // Everything automatic — page entry, the auto-refresh tick, a claim, a completed form — re-reads the
+    // task LIST and keeps the subject cache warm. Clearing it on a 15s timer meant every record and every
+    // relation target was re-fetched each cycle and the subject lines blanked out and repopulated (#7157);
+    // what a cycle can genuinely invalidate is one task, and that is invalidated where it happens.
+    reload() {
+      return this._load(false);
+    },
+
+    async _load(authoritative) {
       await this.loadActAs();
-      await Alpine.store('processTasks').refresh();
+      const store = Alpine.store('processTasks');
+      await (authoritative ? store.refresh() : store.load());
       this.lastUpdated = new Date();
       // A completed task drops out of the list — clear a stale selection.
       if (this.selectedId && !this.tasks.some(t => t.id === this.selectedId)) this.selectedId = null;
@@ -142,7 +162,7 @@ document.addEventListener('alpine:init', () => {
           if (!this.$root || !this.$root.isConnected) return this.stopAuto();
           // Server gone — processTasks already stopped its own poll; stop auto-refresh too (refresh to resume).
           if (Alpine.store('processTasks').serverUnavailable) return this.stopAuto();
-          this.refresh();
+          this.reload();
         }, 15000);
       } else {
         this.stopAuto();

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/processTasks.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/processTasks.js
@@ -25,17 +25,45 @@
 document.addEventListener('alpine:init', () => {
   // Records already fetched while building subject lines, keyed by '<controller url>/<id>'. Deliberately
   // outside the store: it is a request cache, not view state, and several tasks of the same document (or
-  // several documents of the same customer) must share one fetch rather than one each. Cleared by an
-  // explicit refresh(), which is what makes a manual Refresh authoritative while the 30s poll stays cheap.
+  // several documents of the same customer) must share one fetch rather than one each.
+  //
+  // It is BOUNDED in both directions, because a shell stays open for a working day: an entry older than
+  // the TTL is re-fetched (so a record edited elsewhere stops answering with the value it had this
+  // morning), and the map never holds more than MAX entries (least recently used dropped first), so the
+  // memory a long session holds is a function of the cap, not of how many documents were ever inspected.
+  const RECORD_CACHE_TTL_MS = 60000;
+  const RECORD_CACHE_MAX = 200;
   const recordCache = new Map();
 
+  const cacheKey = (url, id) => url + '/' + id;
+
   const fetchRecord = (url, id) => {
-    const key = url + '/' + id;
-    if (!recordCache.has(key)) {
-      recordCache.set(key, App.services.api.get(url + '/' + encodeURIComponent(id), { baseUrl: '' })
-        .catch(() => null));   // unreachable or not permitted: the subject simply omits what it cannot read
+    const key = cacheKey(url, id);
+    const cached = recordCache.get(key);
+    if (cached && (Date.now() - cached.at) < RECORD_CACHE_TTL_MS) {
+      // A Map iterates in insertion order, so re-inserting a hit makes it the most recently used and the
+      // eviction below always drops the coldest entry.
+      recordCache.delete(key);
+      recordCache.set(key, cached);
+      return cached.promise;
     }
-    return recordCache.get(key);
+    const promise = App.services.api.get(url + '/' + encodeURIComponent(id), { baseUrl: '' })
+      .catch(() => null);   // unreachable or not permitted: the subject simply omits what it cannot read
+    recordCache.delete(key);
+    recordCache.set(key, { at: Date.now(), promise });
+    while (recordCache.size > RECORD_CACHE_MAX) recordCache.delete(recordCache.keys().next().value);
+    return promise;
+  };
+
+  // The cache keys each task's subject line was built from — the record itself plus every relation target
+  // a label was read from — keyed by task id, since the task objects themselves are replaced on every
+  // load. Dropping exactly those keys is what lets a task whose record just changed re-read it while
+  // every other task keeps its warm entry.
+  const subjectKeys = new Map();
+
+  const forgetTask = (taskId) => {
+    (subjectKeys.get(taskId) || []).forEach((key) => recordCache.delete(key));
+    subjectKeys.delete(taskId);
   };
 
   Alpine.store('processTasks', {
@@ -46,6 +74,7 @@ document.addEventListener('alpine:init', () => {
     formUrl: '',
     formTitle: '',
     formTitleKey: '',   // the open task's translation key; '' for a process that declares no catalog
+    formTaskId: '',     // the open task, so closing the form re-reads exactly the record it wrote
     subjects: {},       // taskId -> the resolved business-identity line; '' while unresolved or when there is none
     serverUnavailable: false,   // set once the backend is unreachable; stops the poll until a reload
     _poll: null,
@@ -120,13 +149,24 @@ document.addEventListener('alpine:init', () => {
       }
     },
 
-    // An explicit refresh re-reads the records the subject lines are built from; the periodic poll only
-    // resolves the tasks it has not seen yet, so a shell sitting open does not re-fetch every document
-    // every 30 seconds.
+    // An explicit refresh — the Inbox's Refresh button — re-reads the records the subject lines are built
+    // from, which is what makes it authoritative. Everything automatic (the 30s poll, the Inbox's 15s
+    // auto-refresh) goes through load() instead and only resolves the tasks it has not seen yet, so a
+    // shell sitting open does not re-fetch every document, and the subject lines do not blank out and
+    // repopulate on every cycle (#7157).
     refresh() {
       recordCache.clear();
+      subjectKeys.clear();
       this.subjects = {};
       return this.load();
+    },
+
+    // The targeted counterpart: the record behind ONE task has just been written (its form completed), so
+    // that task alone re-resolves and every other subject stays warm.
+    invalidate(task) {
+      if (!task) return;
+      forgetTask(task.id);
+      delete this.subjects[task.id];
     },
 
     /**
@@ -146,7 +186,11 @@ document.addEventListener('alpine:init', () => {
 
     async resolveSubjects(tasks) {
       const current = new Set(tasks.map((t) => t.id));
-      Object.keys(this.subjects).forEach((id) => { if (!current.has(id)) delete this.subjects[id]; });
+      Object.keys(this.subjects).forEach((id) => {
+        if (current.has(id)) return;
+        delete this.subjects[id];
+        subjectKeys.delete(id);   // the records stay cached (another task may share them); they age out on TTL
+      });
       const pending = tasks.filter((t) => t.subject && this.subjects[t.id] === undefined);
       if (!pending.length) return;
       await Promise.all(pending.map((t) => this.resolveSubject(t)));
@@ -159,11 +203,13 @@ document.addEventListener('alpine:init', () => {
       this.subjects[task.id] = '';   // claim it, so a concurrent load does not resolve the same task twice
       try {
         const declared = task.subject;
+        const keys = [cacheKey(declared.url, declared.id)];
         const record = await fetchRecord(declared.url, declared.id);
+        subjectKeys.set(task.id, keys);
         if (!record) return;
         const parts = [];
         for (const field of declared.fields) {
-          const value = await this.subjectPart(field, record[field.property]);
+          const value = await this.subjectPart(field, record[field.property], keys);
           if (value) parts.push(value);
         }
         this.subjects[task.id] = parts.join(' · ');
@@ -173,9 +219,10 @@ document.addEventListener('alpine:init', () => {
     },
 
     // One property of a subject line, rendered the way the record's own application renders it.
-    async subjectPart(field, value) {
+    async subjectPart(field, value, keys) {
       if (value === null || value === undefined || value === '') return '';
       if (field.kind === 'relation') {
+        if (keys) keys.push(cacheKey(field.url, value));
         const related = await fetchRecord(field.url, value);
         const label = related && related[field.label];
         return label === null || label === undefined || label === '' ? '' : String(label);
@@ -254,16 +301,21 @@ document.addEventListener('alpine:init', () => {
       // (and the catalogs, which may still be loading) rather than being resolved once here.
       this.formTitle = task.name || 'Task';
       this.formTitleKey = task.nameKey || '';
+      this.formTaskId = task.id;
       this.formOpen = true;
     },
 
     // Called when the task-form dialog closes; the generated task form completes the task itself,
     // so a re-fetch drops the finished task from the originating view's badge.
     closeForm() {
+      // The form just wrote the record this task is about, so that one subject is re-read; the rest of
+      // the inbox is untouched and keeps its cache.
+      this.invalidate({ id: this.formTaskId });
       this.formOpen = false;
       this.formUrl = '';
       this.formTitleKey = '';
-      this.refresh();
+      this.formTaskId = '';
+      this.load();
     },
   });
 }, { once: true });


### PR DESCRIPTION
## What

Two cache behaviours in the #7077 subject derivation.

**The auto-refresh dropped the cache.** `inboxPage.refresh()` clears the record cache and every resolved subject — and it was also the body of the Inbox's own 15-second auto-refresh interval and of its `harmonia.form.close` handler. With auto-refresh on, every record plus every relation target was re-fetched each cycle and the subject lines blanked out and repopulated in front of the person reading them.

The page now separates the two:

- `refresh()` is the Refresh button and stays authoritative — caches dropped, every record re-read.
- `reload()` is everything automatic (page entry, the 15s tick, a claim, a completed form) and re-reads the task **list** only. The store's `resolveSubjects` already resolves just the tasks it has not seen, so a warm cycle costs one request.
- What a cycle can genuinely invalidate is ONE task, and that is invalidated where it happens: closing a task form — in the Inbox and in the app-wide dialog — calls a new `invalidate(task)` on the store, which drops exactly the record and the relation targets that task's subject was built from. A claim changes who owns the task, not the record it is about, so it invalidates nothing.

**The record cache grew without bound.** A module-level `Map` with no cap and no TTL, in a shell that stays open for a working day. It is now bounded in both directions: an entry older than 60s is re-fetched (so a record edited elsewhere stops answering with the value it had this morning), and the map holds at most 200 entries, least recently used dropped first (a `Map` iterates in insertion order, so a hit is re-inserted to become the newest).

The keys behind each subject line are tracked per **task id** — the task objects are replaced on every load — which is what makes the per-task invalidation exact rather than a prefix sweep over the relation's controller.

## Verification

The shell JS has no test harness, so the store was exercised directly under `node` (stubbed `Alpine` / `App.services.api`, faked clock):

- first resolve of two tasks over one shared customer → 3 requests, not 4;
- a warm reload of the same list → **0** requests (was: every record, every cycle);
- `invalidate(t1)` then reload → only `t1`'s record and its relation target re-fetched, `t2` untouched;
- a task leaving the list → its subject and key index pruned;
- 260 distinct records then re-reading the oldest → re-fetched, i.e. evicted by the cap;
- a hit past 60s → re-fetched; within 60s → served from cache.

Fixes #7157

🤖 Generated with [Claude Code](https://claude.com/claude-code)