### PR TITLE
fix(bpm): report the step an instance is parked on while an async retry is pending (#7193)

### DIFF
--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/BpmProviderFlowable.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/BpmProviderFlowable.java
@@ -12,12 +12,16 @@ package org.eclipse.dirigible.components.engine.bpm.flowable.config;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.dirigible.commons.api.helpers.GsonHelper;
@@ -32,6 +36,7 @@ import org.eclipse.dirigible.repository.api.IRepositoryStructure;
 import org.eclipse.dirigible.repository.api.IResource;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.Process;
+import org.flowable.engine.ManagementService;
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.RepositoryService;
@@ -432,7 +437,6 @@ public class BpmProviderFlowable implements BpmProvider {
         RepositoryService repositoryService = processEngine.getRepositoryService();
 
         ProcessEngineConfiguration processEngineConfiguration = processEngine.getProcessEngineConfiguration();
-        RuntimeService runtimeService = processEngine.getRuntimeService();
 
         ProcessInstance processInstance = getProcessInstance(processInstanceId);
 
@@ -444,11 +448,10 @@ public class BpmProviderFlowable implements BpmProvider {
         if (processDefinition != null && processDefinition.hasGraphicalNotation()) {
             BpmnModel bpmnModel = repositoryService.getBpmnModel(processDefinition.getId());
             ProcessDiagramGenerator diagramGenerator = processEngineConfiguration.getProcessDiagramGenerator();
-            InputStream resource = diagramGenerator.generateDiagram(bpmnModel, "png",
-                    runtimeService.getActiveActivityIds(processInstance.getId()), Collections.emptyList(),
-                    processEngineConfiguration.getActivityFontName(), processEngineConfiguration.getLabelFontName(),
-                    processEngineConfiguration.getAnnotationFontName(), processEngineConfiguration.getClassLoader(), 1.0,
-                    processEngineConfiguration.isDrawSequenceFlowNameWithNoLabelDI());
+            InputStream resource = diagramGenerator.generateDiagram(bpmnModel, "png", getProcessInstanceActivityIds(processInstance),
+                    Collections.emptyList(), processEngineConfiguration.getActivityFontName(),
+                    processEngineConfiguration.getLabelFontName(), processEngineConfiguration.getAnnotationFontName(),
+                    processEngineConfiguration.getClassLoader(), 1.0, processEngineConfiguration.isDrawSequenceFlowNameWithNoLabelDI());
 
             try {
                 byte[] byteArray = IOUtils.toByteArray(resource);
@@ -609,46 +612,119 @@ public class BpmProviderFlowable implements BpmProvider {
         }
     }
 
+    /**
+     * Reports where a running process instance currently sits, per activity.
+     *
+     * <p>
+     * An active execution is only half the evidence. Flowable deactivates an execution as soon as an
+     * asynchronous attempt fails - its {@code JobRetryCmd} moves the job to the timer-job table and
+     * clears the active flag - and {@code RuntimeService#getActiveActivityIds} reports active
+     * executions only, so a step waiting between retry attempts is invisible there and only its own
+     * pending job still names it. Executable and timer jobs therefore count towards {@code positive}
+     * alongside the active executions, by the higher of the two counts rather than by their sum: a
+     * token that has not failed yet is active <em>and</em> job-bearing, so adding the two would report
+     * every pending asynchronous step twice. Dead-lettered jobs stay {@code negative}.
+     *
+     * <p>
+     * A retrying step is deliberately counted as {@code positive} - it is the step the instance is on,
+     * and its failure is already visible as the job's exception message and as {@code negative} once
+     * the retries are exhausted.
+     *
+     * @param processInstanceId the process instance id
+     * @return the counters per activity id, empty when no such instance runs in the current tenant
+     */
     public Map<String, ActivityStatusData> getProcessInstanceActiveActivityIds(String processInstanceId) {
         ProcessInstance processInstance = getProcessInstance(processInstanceId);
         if (null == processInstance) {
             return Collections.emptyMap();
         }
-        RuntimeService runtimeService = processEngine.getRuntimeService();
-        List<String> positiveActiveActivityIds = runtimeService.getActiveActivityIds(processInstance.getId());
 
-        List<Job> jobs = processEngine.getManagementService()
-                                      .createDeadLetterJobQuery()
-                                      .processInstanceId(processInstanceId)
-                                      .list();
-
-        List<String> negativeActiveActivityIds = jobs.stream()
-                                                     .map(Job::getElementId)
-                                                     .collect(Collectors.toList());
+        Map<String, Integer> activeExecutions = countByValue(processEngine.getRuntimeService()
+                                                                          .getActiveActivityIds(processInstance.getId()));
+        // Merged by the higher count, never added, because the two sources overlap on every token that
+        // has not failed yet. That undercounts only an element hosting both a waiting token and a
+        // retrying one - an asynchronous task behind a loop or a fan-in - which would take a further
+        // per-activity execution query to tell apart.
+        Map<String, Integer> pendingJobs = countByElementId(getPendingJobs(processInstanceId));
+        Map<String, Integer> deadLetterJobs = countByElementId(processEngine.getManagementService()
+                                                                            .createDeadLetterJobQuery()
+                                                                            .processInstanceId(processInstanceId)
+                                                                            .list());
 
         Map<String, ActivityStatusData> statuses = new HashMap<>();
-        for (String positive : positiveActiveActivityIds) {
-            ActivityStatusData data = statuses.get(positive);
-            if (data == null) {
-                data = new ActivityStatusData();
-                data.positive = 1;
-                statuses.put(positive, data);
-                continue;
-            }
-            data.positive += 1;
-        }
-        for (String negative : negativeActiveActivityIds) {
-            ActivityStatusData data = statuses.get(negative);
-            if (data == null) {
-                data = new ActivityStatusData();
-                data.negative = 1;
-                statuses.put(negative, data);
-                continue;
-            }
-            data.negative += 1;
-        }
+        activeExecutions.forEach((activityId, tokens) -> statusOf(statuses, activityId).positive = tokens);
+        pendingJobs.forEach((activityId, jobs) -> {
+            ActivityStatusData status = statusOf(statuses, activityId);
+            status.positive = Math.max(status.positive, jobs);
+        });
+        deadLetterJobs.forEach((activityId, jobs) -> statusOf(statuses, activityId).negative = jobs);
 
         return statuses;
+    }
+
+    /**
+     * The activity ids a running process instance occupies: its active executions plus the elements of
+     * its pending jobs, which are the only evidence left for a step parked between retry attempts.
+     *
+     * @param processInstance the already resolved process instance
+     * @return the occupied activity ids without duplicates, active executions first
+     */
+    public List<String> getProcessInstanceActivityIds(ProcessInstance processInstance) {
+        Set<String> activityIds = new LinkedHashSet<>(processEngine.getRuntimeService()
+                                                                   .getActiveActivityIds(processInstance.getId()));
+        activityIds.addAll(elementIds(getPendingJobs(processInstance.getId())));
+
+        return List.copyOf(activityIds);
+    }
+
+    /**
+     * The jobs a process instance is waiting on: the executable ones, including a job an executor
+     * currently holds, and the timer ones, where a failed job with retries left is parked between
+     * attempts.
+     *
+     * @param processInstanceId the process instance id
+     * @return the pending jobs
+     */
+    private List<Job> getPendingJobs(String processInstanceId) {
+        ManagementService managementService = processEngine.getManagementService();
+
+        List<Job> pendingJobs = new ArrayList<>(managementService.createJobQuery()
+                                                                 .processInstanceId(processInstanceId)
+                                                                 .list());
+        pendingJobs.addAll(managementService.createTimerJobQuery()
+                                            .processInstanceId(processInstanceId)
+                                            .list());
+
+        return pendingJobs;
+    }
+
+    private static ActivityStatusData statusOf(Map<String, ActivityStatusData> statuses, String activityId) {
+        return statuses.computeIfAbsent(activityId, id -> new ActivityStatusData());
+    }
+
+    private static Map<String, Integer> countByElementId(List<? extends Job> jobs) {
+        return countByValue(elementIds(jobs));
+    }
+
+    /**
+     * The flow elements the given jobs belong to. A job bound to no element - an asynchronous variable
+     * write, a process-instance migration - contributes nothing.
+     *
+     * @param jobs the jobs
+     * @return the element ids, duplicates kept
+     */
+    private static List<String> elementIds(List<? extends Job> jobs) {
+        return jobs.stream()
+                   .map(Job::getElementId)
+                   .filter(Objects::nonNull)
+                   .toList();
+    }
+
+    private static Map<String, Integer> countByValue(List<String> values) {
+        Map<String, Integer> counts = new HashMap<>();
+        values.forEach(value -> counts.merge(value, 1, Integer::sum));
+
+        return counts;
     }
 
     public Map<String, ActivityStatusData> getProcessDefinitionActiveActivityIds(String processDefinitionId) {

--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/service/BpmService.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/service/BpmService.java
@@ -272,6 +272,13 @@ public class BpmService {
     /**
      * Map process instance.
      *
+     * <p>
+     * The activity id is resolved rather than read off the instance: Flowable leaves it unset on a root
+     * process-instance execution, which is what every running instance is, so the field was always
+     * null. Resolving it costs a few indexed lookups per instance - hence the already resolved instance
+     * handed to the provider - and stays null while an instance is forked across several activities,
+     * the field being singular; {@code getProcessInstanceActiveActivityIds} answers for a fan-out.
+     *
      * @param processInstance the process instance
      * @return the process instance data
      */
@@ -291,8 +298,20 @@ public class BpmService {
         processInstanceData.setStartTime(processInstance.getStartTime());
         processInstanceData.setReferenceId(processInstance.getReferenceId());
         processInstanceData.setCallbackId(processInstance.getCallbackId());
-        processInstanceData.setActivityId(processInstance.getActivityId());
+        processInstanceData.setActivityId(resolveActivityId(processInstance));
         return processInstanceData;
+    }
+
+    /**
+     * The single activity a process instance sits on, or null when it sits on none or on several.
+     *
+     * @param processInstance the process instance
+     * @return the activity id, or null
+     */
+    private String resolveActivityId(ProcessInstance processInstance) {
+        List<String> activityIds = bpmProviderFlowable.getProcessInstanceActivityIds(processInstance);
+
+        return activityIds.size() == 1 ? activityIds.get(0) : null;
     }
 
     /**

--- a/components/engine/engine-bpm-flowable/src/test/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/BpmProviderFlowableActiveActivitiesTest.java
+++ b/components/engine/engine-bpm-flowable/src/test/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/BpmProviderFlowableActiveActivitiesTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.bpm.flowable.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.eclipse.dirigible.components.engine.bpm.flowable.dto.ActivityStatusData;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.delegate.JavaDelegate;
+import org.flowable.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.job.api.Job;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Where a process instance sits, against a REAL Flowable engine (in-memory), for every state an
+ * asynchronous step passes through.
+ *
+ * <p>
+ * Flowable deactivates an execution the moment an asynchronous attempt fails, so from the first
+ * failure on, a step parked between retry attempts is reported by nothing the engine calls "active"
+ * - which is why an intent-generated process, whose every step is {@code flowable:async}, used to
+ * answer "no step is running" for its whole life
+ * (<a href="https://github.com/eclipse-dirigible/dirigible/issues/7193">#7193</a>).
+ *
+ * <p>
+ * The async executor is deliberately OFF: {@code ManagementService#executeJob} runs the attempt on
+ * the calling thread and Flowable's own failed-job listener then applies the retry decision in its
+ * own transaction, so every state below is reached synchronously, with no sleeps and no polling.
+ */
+class BpmProviderFlowableActiveActivitiesTest {
+
+    private static final String TENANT_ID = "active-activities-tenant";
+
+    private static final String DOOMED_PROCESS = "parked-step";
+    private static final String DOOMED_STEP = "doomedStep";
+    private static final String WAITING_PROCESS = "waiting-step";
+    private static final String WAITING_STEP = "approve";
+
+    /**
+     * Two total attempts, an hour apart: the first failure parks the job in the timer-job table and
+     * nothing re-acquires it, the second exhausts the cycle and dead-letters.
+     */
+    private static final String RETRY_CYCLE = "R2/PT1H";
+
+    private static final String DOOMED_PROCESS_XML =
+            """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:flowable="http://flowable.org/bpmn" targetNamespace="http://www.flowable.org/processdef">
+                      <process id="%s" name="Parked Step" isExecutable="true">
+                        <startEvent id="start"></startEvent>
+                        <serviceTask id="%s" name="Doomed Step" flowable:async="true" flowable:class="%s">
+                          <extensionElements>
+                            <flowable:failedJobRetryTimeCycle>%s</flowable:failedJobRetryTimeCycle>
+                          </extensionElements>
+                        </serviceTask>
+                        <endEvent id="end"></endEvent>
+                        <sequenceFlow id="flow_start_step" sourceRef="start" targetRef="%s"></sequenceFlow>
+                        <sequenceFlow id="flow_step_end" sourceRef="%s" targetRef="end"></sequenceFlow>
+                      </process>
+                    </definitions>
+                    """;
+
+    private static final String WAITING_PROCESS_XML =
+            """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:flowable="http://flowable.org/bpmn" targetNamespace="http://www.flowable.org/processdef">
+                      <process id="%s" name="Waiting Step" isExecutable="true">
+                        <startEvent id="start"></startEvent>
+                        <userTask id="%s" name="Approve"></userTask>
+                        <endEvent id="end"></endEvent>
+                        <sequenceFlow id="flow_start_task" sourceRef="start" targetRef="%s"></sequenceFlow>
+                        <sequenceFlow id="flow_task_end" sourceRef="%s" targetRef="end"></sequenceFlow>
+                      </process>
+                    </definitions>
+                    """;
+
+    private static ProcessEngine engine;
+    private static BpmProviderFlowable bpmProvider;
+
+    /** Always fails, so the step never leaves its retry cycle. */
+    public static class DoomedDelegate implements JavaDelegate {
+
+        @Override
+        public void execute(DelegateExecution execution) {
+            throw new IllegalStateException("refused");
+        }
+    }
+
+    @BeforeAll
+    static void startEngine() {
+        StandaloneInMemProcessEngineConfiguration configuration = new StandaloneInMemProcessEngineConfiguration();
+        // A database of this test's own: another engine test in the same surefire JVM keeps its
+        // in-memory one alive past the class that built it.
+        configuration.setJdbcUrl("jdbc:h2:mem:active-activities-test;DB_CLOSE_DELAY=1000");
+        engine = configuration.buildProcessEngine();
+
+        deploy(DOOMED_PROCESS, DOOMED_PROCESS_XML.formatted(DOOMED_PROCESS, DOOMED_STEP, DoomedDelegate.class.getName(), RETRY_CYCLE,
+                DOOMED_STEP, DOOMED_STEP));
+        deploy(WAITING_PROCESS, WAITING_PROCESS_XML.formatted(WAITING_PROCESS, WAITING_STEP, WAITING_STEP, WAITING_STEP));
+
+        bpmProvider = new BpmProviderFlowable(mock(IRepository.class), tenantContext(), mock(FlowableArtefactsValidator.class), engine);
+    }
+
+    @AfterAll
+    static void stopEngine() {
+        if (engine != null) {
+            engine.close();
+        }
+    }
+
+    @Test
+    void aPendingAsynchronousStepIsReportedOnce() {
+        ProcessInstance instance = start(DOOMED_PROCESS);
+
+        // The execution is still active AND the async job exists, so the two sources of evidence
+        // overlap - the step must not be counted twice.
+        assertEquals(List.of(DOOMED_STEP), activeActivityIds(instance), "the untried step is active in the engine's own view");
+        assertStatus(instance, DOOMED_STEP, 1, 0);
+    }
+
+    @Test
+    void aStepParkedBetweenRetryAttemptsIsReported() {
+        ProcessInstance instance = start(DOOMED_PROCESS);
+        failNextAttempt(instance);
+
+        assertEquals(List.of(), activeActivityIds(instance),
+                "Flowable deactivates the execution while a retry is pending - the reason the answer used to be empty");
+        assertEquals(1, timerJobs(instance), "the failed job must be parked in the timer-job table");
+        assertStatus(instance, DOOMED_STEP, 1, 0);
+        assertEquals(List.of(DOOMED_STEP), bpmProvider.getProcessInstanceActivityIds(instance),
+                "the parked step is what the instance diagram must highlight");
+    }
+
+    @Test
+    void aDeadLetteredStepStaysNegative() {
+        ProcessInstance instance = deadLetter(start(DOOMED_PROCESS));
+
+        assertStatus(instance, DOOMED_STEP, 0, 1);
+    }
+
+    @Test
+    void aRetriedDeadLetterJobIsReportedAgain() {
+        ProcessInstance instance = deadLetter(start(DOOMED_PROCESS));
+
+        // What the Monitoring shell's Retry action does. It hands the job back to the executor
+        // without reactivating the execution, so the job is again the only evidence of the position.
+        engine.getManagementService()
+              .moveDeadLetterJobToExecutableJob(deadLetterJob(instance).getId(), 1);
+
+        assertEquals(List.of(), activeActivityIds(instance), "a retried job does not reactivate the execution by itself");
+        assertStatus(instance, DOOMED_STEP, 1, 0);
+    }
+
+    @Test
+    void aWaitStateIsReportedAsBefore() {
+        ProcessInstance instance = start(WAITING_PROCESS);
+
+        assertStatus(instance, WAITING_STEP, 1, 0);
+    }
+
+    private static void assertStatus(ProcessInstance instance, String activityId, int positive, int negative) {
+        Map<String, ActivityStatusData> statuses = bpmProvider.getProcessInstanceActiveActivityIds(instance.getId());
+
+        assertEquals(Set.of(activityId), statuses.keySet(), "exactly the occupied activity must be reported");
+        assertEquals(positive, statuses.get(activityId).positive, "positive count of [" + activityId + "]");
+        assertEquals(negative, statuses.get(activityId).negative, "negative count of [" + activityId + "]");
+    }
+
+    /** Runs the pending attempt on this thread; it fails, and Flowable applies the retry decision. */
+    private static void failNextAttempt(ProcessInstance instance) {
+        Job job = engine.getManagementService()
+                        .createJobQuery()
+                        .processInstanceId(instance.getId())
+                        .singleResult();
+
+        assertThrows(RuntimeException.class, () -> engine.getManagementService()
+                                                         .executeJob(job.getId()),
+                "the doomed delegate must fail the attempt");
+    }
+
+    /** Exhausts the retry cycle: the first attempt parks the job, the second dead-letters it. */
+    private static ProcessInstance deadLetter(ProcessInstance instance) {
+        failNextAttempt(instance);
+        engine.getManagementService()
+              .moveTimerToExecutableJob(engine.getManagementService()
+                                              .createTimerJobQuery()
+                                              .processInstanceId(instance.getId())
+                                              .singleResult()
+                                              .getId());
+        failNextAttempt(instance);
+
+        return instance;
+    }
+
+    private static Job deadLetterJob(ProcessInstance instance) {
+        return engine.getManagementService()
+                     .createDeadLetterJobQuery()
+                     .processInstanceId(instance.getId())
+                     .singleResult();
+    }
+
+    private static long timerJobs(ProcessInstance instance) {
+        return engine.getManagementService()
+                     .createTimerJobQuery()
+                     .processInstanceId(instance.getId())
+                     .count();
+    }
+
+    private static List<String> activeActivityIds(ProcessInstance instance) {
+        return engine.getRuntimeService()
+                     .getActiveActivityIds(instance.getId());
+    }
+
+    private static ProcessInstance start(String processKey) {
+        return engine.getRuntimeService()
+                     .startProcessInstanceByKeyAndTenantId(processKey, null, Map.of(), TENANT_ID);
+    }
+
+    private static void deploy(String processKey, String xml) {
+        engine.getRepositoryService()
+              .createDeployment()
+              .addString(processKey + ".bpmn20.xml", xml)
+              .tenantId(TENANT_ID)
+              .deploy();
+    }
+
+    /** The provider resolves its tenant per call; it must match the one the instances run in. */
+    private static TenantContext tenantContext() {
+        Tenant tenant = mock(Tenant.class);
+        when(tenant.getId()).thenReturn(TENANT_ID);
+
+        TenantContext tenantContext = mock(TenantContext.class);
+        when(tenantContext.getCurrentTenant()).thenReturn(tenant);
+
+        return tenantContext;
+    }
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/BpmActiveActivitiesIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/BpmActiveActivitiesIT.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.flowable.engine.ProcessEngine;
+import org.flowable.job.api.Job;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
+import io.restassured.http.ContentType;
+
+/**
+ * End-to-end test for the "which step is this instance on" answer of a process parked on an
+ * asynchronous step, i.e. every step of an intent-generated process
+ * (<a href="https://github.com/eclipse-dirigible/dirigible/issues/7193">#7193</a>).
+ *
+ * <p>
+ * Drops a {@code .java} delegate that always fails and a {@code .bpmn} whose single service task is
+ * {@code flowable:async} with a retry cycle into the registry, starts the process through the
+ * public BPM REST endpoint, and asserts that once the first attempt has failed - the state a
+ * retrying process spends its whole retry interval in, and the one Flowable's own
+ * {@code getActiveActivityIds} reports nothing for - both
+ * {@code /bpm-processes/instance/{id}/active} and the instance listing name that step.
+ */
+// One Dirigible boot for the whole class: the test cleans up after itself, so the per-method
+// context reset inherited from IntegrationTest would only add boot time.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class BpmActiveActivitiesIT extends IntegrationTest {
+
+    private static final String PROJECT = "bpm-active-activities-it";
+    private static final String PROCESS_KEY = "bpm-active-activities-it-process";
+    private static final String BUSINESS_KEY = "bpm-active-activities-it-key";
+
+    /** No hyphen: the id is read as a GPath property of the answered map. */
+    private static final String STEP_ID = "doomedStep";
+
+    private static final String DELEGATE_FQN = "com.acme.DoomedTask";
+    private static final String FAILURE_MESSAGE = "doomed step refused the attempt";
+
+    /**
+     * Five attempts an hour apart. The cycle is load-bearing: without one, a failed job is parked for
+     * the default failed-job wait time (10 s) and the executor dead-letters it within half a minute, so
+     * the state under test would expire mid-test. An hour makes it hold.
+     */
+    private static final String RETRY_CYCLE = "R5/PT1H";
+
+    private static final String DELEGATE_REGISTRY_PATH =
+            IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/" + DELEGATE_FQN.replace('.', '/') + ".java";
+    private static final String BPMN_REGISTRY_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/process.bpmn";
+
+    private static final Duration PARKING_TIMEOUT = Duration.ofSeconds(90);
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @Autowired
+    private ProcessEngine processEngine;
+
+    @Test
+    void aStepParkedBetweenRetryAttemptsIsReportedAsTheCurrentActivity() {
+        write(DELEGATE_REGISTRY_PATH, delegateSource(), "text/x-java");
+        write(BPMN_REGISTRY_PATH, bpmnSource(), "application/xml");
+        synchronizationProcessor.forceProcessSynchronizers();
+
+        String processInstanceId = startProcess();
+        Job parkedJob = awaitParkedJob(processInstanceId);
+
+        // The delegate's own message proves the attempt really ran the compiled client class and
+        // failed in it - without this the test would also pass on a job that never resolved it.
+        assertThat(parkedJob.getExceptionMessage()).contains(FAILURE_MESSAGE);
+        assertThat(processEngine.getRuntimeService()
+                                .getActiveActivityIds(processInstanceId)).describedAs(
+                                        "Flowable reports no active activity while a retry is pending - the reason the endpoint used to answer {}")
+                                                                         .isEmpty();
+
+        assertReportsCurrentStep(processInstanceId);
+        assertListingReportsCurrentStep(processInstanceId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        boolean removed = false;
+        for (String path : new String[] {BPMN_REGISTRY_PATH, DELEGATE_REGISTRY_PATH}) {
+            if (repository.hasResource(path)) {
+                repository.removeResource(path);
+                removed = true;
+            }
+        }
+        if (removed) {
+            // Undeploying the process cascades, dropping the parked instance and its timer job.
+            synchronizationProcessor.forceProcessSynchronizers();
+        }
+    }
+
+    private void assertReportsCurrentStep(String processInstanceId) {
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get("/services/bpm/bpm-processes/instance/" + processInstanceId + "/active")
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body("size()", equalTo(1))
+                                                 .body(STEP_ID + ".positive", equalTo(1))
+                                                 .body(STEP_ID + ".negative", equalTo(0)));
+    }
+
+    private void assertListingReportsCurrentStep(String processInstanceId) {
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get("/services/bpm/bpm-processes/instances?key=" + PROCESS_KEY)
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body("find { it.id == '" + processInstanceId + "' }.activityId", equalTo(STEP_ID)));
+    }
+
+    /**
+     * Waits for the instance to be parked between attempts - the compile pass plus the first
+     * asynchronous acquisition take seconds - and answers the job holding it there.
+     *
+     * @param processInstanceId the process instance id
+     * @return the parked timer job
+     */
+    private Job awaitParkedJob(String processInstanceId) {
+        await().atMost(PARKING_TIMEOUT)
+               .pollInterval(Duration.ofMillis(500))
+               .until(() -> parkedJob(processInstanceId) != null);
+
+        return parkedJob(processInstanceId);
+    }
+
+    private Job parkedJob(String processInstanceId) {
+        return processEngine.getManagementService()
+                            .createTimerJobQuery()
+                            .processInstanceId(processInstanceId)
+                            .singleResult();
+    }
+
+    private void write(String path, String content, String contentType) {
+        repository.createResource(path, content.getBytes(StandardCharsets.UTF_8), false, contentType, true);
+    }
+
+    private String startProcess() {
+        String body = "{\"processDefinitionKey\":\"" + PROCESS_KEY + "\",\"businessKey\":\"" + BUSINESS_KEY + "\",\"parameters\":\"{}\"}";
+        return restAssuredExecutor.executeWithResult(() -> given().contentType(ContentType.JSON)
+                                                                  .body(body)
+                                                                  .when()
+                                                                  .post("/services/bpm/bpm-processes/instance")
+                                                                  .then()
+                                                                  .statusCode(200)
+                                                                  .extract()
+                                                                  .asString());
+    }
+
+    private static String delegateSource() {
+        return """
+                package com.acme;
+                import org.flowable.engine.delegate.DelegateExecution;
+                import org.flowable.engine.delegate.JavaDelegate;
+                public class DoomedTask implements JavaDelegate {
+                    @Override
+                    public void execute(DelegateExecution execution) {
+                        throw new IllegalStateException("%s");
+                    }
+                }
+                """.formatted(FAILURE_MESSAGE);
+    }
+
+    private static String bpmnSource() {
+        return """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                             xmlns:flowable="http://flowable.org/bpmn"
+                             targetNamespace="http://www.flowable.org/processdef">
+                  <process id="%s" name="BPM Active Activities IT" isExecutable="true">
+                    <startEvent id="start"/>
+                    <sequenceFlow id="f1" sourceRef="start" targetRef="%s"/>
+                    <serviceTask id="%s" name="Doomed Step" flowable:async="true" flowable:class="%s">
+                      <extensionElements>
+                        <flowable:failedJobRetryTimeCycle>%s</flowable:failedJobRetryTimeCycle>
+                      </extensionElements>
+                    </serviceTask>
+                    <sequenceFlow id="f2" sourceRef="%s" targetRef="end"/>
+                    <endEvent id="end"/>
+                  </process>
+                </definitions>
+                """.formatted(PROCESS_KEY, STEP_ID, STEP_ID, DELEGATE_FQN, RETRY_CYCLE, STEP_ID);
+    }
+
+}


### PR DESCRIPTION
Fixes #7193.

### Root cause

Flowable's `JobRetryCmd` calls `executionEntity.setActive(false)` when it moves a failed asynchronous job to the timer-job table, and `FindActiveActivityIdsCmd` collects only activity ids of executions whose `isActive()` is true. So from the **first** failed attempt on, the execution is inactive and the pending job is the only remaining evidence of where the instance sits - while `getProcessInstanceActiveActivityIds` queried nothing but *dead-letter* jobs, which it maps to `negative`.

Because `BpmnIntentGenerator` emits its steps `flowable:async`, an intent-generated process therefore answered "no step is running" for its whole life: nothing for the Processes viewer or the Monitoring diagram to overlay, and no way for an application to tell its own users which step a record's process is on.

### The change

Executable and timer jobs now count towards `positive` alongside the active executions, merged by the **higher** of the two counts rather than by their sum. That matters: `ContinueProcessOperation` marks the execution active *before* it creates the async job, and a boundary event's own child execution stays active beside its timer job - so summing would render every pending asynchronous step, and every boundary timer, as a "2" badge on both diagram overlays. Dead-letter jobs stay `negative`, exactly as before, and a job bound to no flow element (an asynchronous variable write, a process-instance migration) no longer becomes a literal `"null"` key in the answer.

Two sites sharing the same root cause come with it:

- **`getProcessInstanceImage`** highlighted from the same `getActiveActivityIds` call, so `GET /bpm-processes/diagram/instance/{id}` had nothing to mark either.
- **The Monitoring shell's Retry action** - `moveDeadLetterJobToExecutableJob` hands the job back to the executor without reactivating the execution, so a click made *both* badges disappear and the step looked finished.

And `ProcessInstanceData.activityId` (the issue's second symptom, `"activityId": null` on `GET /bpm-processes/instances`) is resolved the same way instead of read off the root process-instance execution, where Flowable always leaves it unset. The field is singular, so it carries the sole occupied activity and stays null for a fan-out, where `/active` is the answer.

Deliberately out of scope: `createSuspendedJobQuery()` (suspension moves both job tables, but the platform exposes no suspend/activate path, so no instance is ever in that state) and `getProcessDefinitionActiveActivityIds`, which queries executions without the `isActive` filter and therefore already reports parked steps.

One knowing limitation, noted in a code comment rather than passed over: `max` undercounts if a single element ever hosts both a waiting token and a parked one - an asynchronous task behind a loop or a fan-in. Counting exactly would take a per-activity execution query on an endpoint both UIs poll.

### Tests

**`BpmProviderFlowableActiveActivitiesTest`** drives a real in-memory Flowable engine with the async executor **off**, so there are no threads and no sleeps: `ManagementService#executeJob` runs the attempt on the calling thread and Flowable's own failed-job listener then applies the retry decision in its own transaction. Five states: a pending job (guarding the double count), parked between retry attempts, dead-lettered, retried out of the dead letter, and a plain wait state.

**`BpmActiveActivitiesIT`** publishes a throwing client delegate on a `flowable:async` step with an `R5/PT1H` cycle (load-bearing - without a cycle the executor dead-letters the job within half a minute and the state under test would expire mid-test), waits for the parked timer job, and asserts that job's exception message carries the delegate's own text, so the test cannot pass on a job that never resolved the compiled class. It then asserts both HTTP answers. Untagged, so it runs in the per-PR smoke gate; ~21 s.

Both suites were confirmed to **fail without the production change** and pass with it. Also green locally: the module's full unit suite, and `JavaBpmnIT` / `BpmTaskLabelKeyIT` / `JavaDelegateInjectionIT` / `BpmnModelApiIT` (the integration tests exercising the changed instance mapping). `formatter:validate` is clean and the `-P release` javadoc build reports no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
