### PR TITLE
tests: the totals-suspension assertion belongs to the fixture's document master (#7183)

### DIFF
--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -1997,10 +1997,15 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         // sweeping N lines away with their master issued N reads, N targeted updates and N SYSTEM
         // "totals changed" history rows against a row that is gone microseconds later. The master marks
         // its own id for the duration of the cascade, and recalculate honours the mark (#7143).
+        // Asserted on Bill, the fixture's DOCUMENT master: the suspension exists only where a totals
+        // write-back does. Entry declares no aggregate of its lines and neither of its two composition
+        // children is the document's items, so its repository carries no recalculate to suspend - the
+        // guard could never be emitted there.
+        String documentMasterRepository = contentOf("gen/emission/data/bill/BillRepository.java");
         assertTrue(
-                entryRepository.contains("DELETING_IDS.get().add(deletingMaster)")
-                        && entryRepository.contains("if (DELETING_IDS.get().contains(String.valueOf(id)))"),
-                "a master being deleted must suspend the per-line totals write-back, got: " + entryRepository);
+                documentMasterRepository.contains("DELETING_IDS.get().add(deletingMaster)")
+                        && documentMasterRepository.contains("if (DELETING_IDS.get().contains(String.valueOf(id)))"),
+                "a master being deleted must suspend the per-line totals write-back, got: " + documentMasterRepository);
         // The children's own repositories own nothing: neither may cascade into its master.
         assertFalse(contentOf("gen/emission/data/entry/EntryLineRepository.java").contains("deleteOwnedChildren"),
                 "a childless composition child must emit no cascade at all");


### PR DESCRIPTION
The single failure of the restored integration suite - #7216's `smoke-tests` run was `Tests run: 404, Failures: 1`.

### What was wrong

`IntentEmissionCoverageIT` asserted the #7143 delete-cascade guard - `DELETING_IDS`, which suspends the per-line totals write-back while a master's lines are being cascaded away - against **`EntryRepository`**. `Entry` is not a document master, so that repository has no totals write-back to suspend and the guard can never be emitted in it:

- the guard sits under `#if($documentMaster)` in `Repository.java.template`;
- `ModelGenerator.annotateDocumentModels` sets `documentMaster` only for a `MANAGE_DOCUMENT` master whose `aggregate: true` fields are **also carried by its resolved items child**;
- `EdmIntentGenerator.documentMasters` makes a master a document only through a `function: DocumentItem` / `*Item`-named child, or `function: Document` with a **sole** composition child.

`Entry` matches none of those: no `function: Document`, and two composition children (`EntryLine`, `EntryCopy`), neither flagged nor `*Item`-named. The fixture's document master is **`Bill`** (`function: Document`, `aggregate: amount`, `BillLine` as its `function: DocumentItem` child) - whose repository this same test already reads a few assertions later to check the totals recompute. The assertion now reads it too.

Its sibling in the same block - the `whenMasterDeleted` refusal ordering - **is** correctly about `Entry` (`EntryCopy` carries `whenMasterDeleted: refuse`) and is untouched.

### Why it was never caught

The assertion was added on 2026-09-08 in 6f803fc534 (#7143 / #7183), inside the window in which no integration test executed on CI at all (#7215). It first ran when #7216 restored the suite, and was that run's only failure.

### Verification

Against a freshly installed build (`mvn -T 1C clean install -P quick-build`), one variable at a time:

```
without this change → Failures: 1
  IntentEmissionCoverageIT...:1786->assertEmission:2000
  a master being deleted must suspend the per-line totals write-back
with this change    → Tests run: 1, Failures: 0   (144.9 s, full run)
```

A note for anyone reproducing locally: a **stale** `~/.m2` copy of `dirigible-components-template-application-dao-java` (anything built before #7143 merged) generates the pre-#7143 cascade and makes the *sibling* refusal-ordering assertion fail instead, which looks like a product bug in `deleteOwnedChildren` and is not one. Install the module (or the reactor) before trusting a local run of this IT.

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
