### PR TITLE
fix(java): retry a client-Java listener subscription that failed at startup (#7217)

### DIFF
--- a/components/engine/engine-java/CLAUDE.md
+++ b/components/engine/engine-java/CLAUDE.md
@@ -147,6 +147,30 @@ instantiate client classes.
   `offlineDurableSubscriberTimeout` (7 days, set in `MessagingConfig`) — the consumer cannot
   unsubscribe on its own, because `onClassUnloaded` fires for a *replaced* class as well as a deleted
   one, and a class deleted while the server was down is never reported at all.
+- **A subscription (or a job registration) that could not be established is retried on a JVM-local
+  timer.** `JavaConsumersReconciler` calls `JavaClassConsumer.reconcile()` on every consumer every
+  `DIRIGIBLE_JAVA_RECONCILE_INTERVAL_SECONDS` (30), and `ListenerClassConsumer` /
+  `ScheduledClassConsumer` implement it by re-attempting what is still not open. Before that, a
+  subscription that lost the boot race against the embedded broker's `vm://localhost` transport was
+  never retried at all and the handler stayed silent for the life of the process — a topic discards
+  what it delivers to nobody, so an intent app's `onCreate` trigger wrote the row and started nothing
+  while every controller answered 200 (#7217). Neither of the two triggers the consumers relied on
+  ever arrives on a steady instance: a generation is rebuilt only on publish, and the
+  `TenantPostProvisioningStep` runs only when `TenantsProvisioner` actually provisioned a tenant
+  (`if (!tenants.isEmpty())` over `findByStatus(INITIAL)`). Three things about the shape:
+  **it is a timer of its own, not Quartz and not Spring's `@Scheduled`** — a `SystemJob` fires once
+  cluster-wide (`isClustered=true`) and this state is per-JVM, while Spring's scheduling pool is a
+  single thread shared with `AccessVerifier` and `TscWatcherService` that an unreachable `failover:`
+  broker would block indefinitely; **`subscribe` catches `RuntimeException` as well as `JMSException`**,
+  because `ActiveMQConnectionArtifactsFactory` reports a broker that is not accepting by wrapping the
+  `JMSException` in an `IllegalStateException` — uncaught, it escaped the per-tenant fan-out, skipped
+  every tenant behind the failing one and leaked whatever had already opened; and **a pass re-checks
+  registration identity** (`registrations.get(fqn) != registration`) before subscribing, because a
+  republish can swap the registration mid-pass and connections opened for the superseded one could
+  never be closed. Log volume is bounded on purpose: WARN on a subscription's first failure, DEBUG on
+  the repeats, plus one WARN summary per incomplete pass — a permanently refused subscription (every
+  node of a deployment derives the same durable id, so the second one to attach is turned away for
+  good) would otherwise emit a line per tenant per tick forever.
 - `WebsocketClassConsumer` + `JavaWebsocketRegistry` — websockets; `WebsocketProcessor`
   (`engine-websockets`) calls `JavaWebsocketRegistry.dispatch(...)` reflectively (keeps that module free
   of an `engine-java` dependency).
@@ -287,7 +311,10 @@ browser-IDE developer sees what's wrong without reading the server log.
   `ControllerClassConsumer*Test`,
   `ControllerInvoker*Test`, `ControllerRouterTest`, `JavaLoaderTest`; (`data-store-java`)
   `JavaEntityToHbmMapperTest`, `EntityBeanMapperTest`, `CriteriaTest`.
-- HTTP ITs (extend `IntegrationTest`, no Selenide): `JavaEngineIT` (handler lifecycle), `JavaComponentIT`
+- HTTP ITs (extend `IntegrationTest`, no Selenide): `JavaEngineIT` (handler lifecycle),
+  `JavaListenerSubscriptionRetryIT` (a refused subscription reaches its handler once the timer retries
+  it - the refusal injected as the `IllegalStateException` the connection factory really throws, scoped
+  to that one listener's durable id), `JavaComponentIT`
   (constructor + collection injection, and a `@Component` `JavaHandler`), `JavaDelegateInjectionIT`
   (both BPMN delegate paths injected, the unsatisfiable one failing the step and not the deployment,
   and a recompiled collaborator reaching the cached delegate), `JavaNoMixingIT` (the

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumer.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumer.java
@@ -13,10 +13,13 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.components.base.tenant.DefaultTenant;
@@ -87,6 +90,19 @@ import jakarta.jms.Topic;
  * tenant provisioned after the last client-Java rebuild is topped up without disturbing the
  * subscriptions already open. A tenant that goes away leaves its subscriptions behind until the
  * next rebuild — inert, because nothing publishes to a removed tenant's destinations.
+ *
+ * <p>
+ * <b>A subscription the broker refuses is retried, indefinitely.</b> The attempt races the embedded
+ * broker on every boot — the {@code vm://localhost} transport may not be accepting yet, and against
+ * a shared message store the broker may not hold the lease for much longer than that — and a topic
+ * discards whatever it delivers to nobody, so an unsubscribed handler loses every event silently.
+ * Neither of the two triggers this consumer used to rely on ever arrives on a steady-state
+ * instance: a generation is rebuilt only on publish, and {@link #execute()} runs only when a tenant
+ * was actually provisioned. So whatever could not be opened is remembered and re-attempted by
+ * {@link #reconcile()}, which the JVM-local {@code JavaConsumersReconciler} calls on a timer (issue
+ * #7217). Retrying is safe because a partial attempt is undone: a tenant is recorded only once all
+ * of its subscriptions are open, and what did open in a failed attempt is closed again, so a retry
+ * can never end up with two consumers competing on the same destination.
  */
 @Component
 @Order(500)
@@ -107,6 +123,17 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
 
     /** fqn → what the loaded class declared, and the connections open for it per tenant. */
     private final ConcurrentMap<String, Registration> registrations = new ConcurrentHashMap<>();
+
+    /** Set while anything this consumer declared is not subscribed; drives {@link #reconcile()}. */
+    private final AtomicBoolean subscriptionsIncomplete = new AtomicBoolean();
+
+    /**
+     * The {@code label|scope} pairs already reported as failing. A retry runs on a timer, so without
+     * this a permanently refused subscription would log one WARN per tenant per tick forever - and the
+     * refusal is not hypothetical: every node of a deployment derives the same durable subscription id,
+     * so the second one to attach is turned away for good.
+     */
+    private final Set<String> reportedFailures = ConcurrentHashMap.newKeySet();
 
     @Autowired
     public ListenerClassConsumer(ComponentContainer componentContainer, ActiveMQConnectionArtifactsFactory connectionFactory,
@@ -182,14 +209,30 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
     }
 
     /**
-     * Top up the tenants that have no subscription yet for the classes already loaded. Called once a
-     * tenant provisioning round completes: the client-Java generation is JVM-wide and is only rebuilt
-     * on publish, so a tenant created afterwards would otherwise stay unsubscribed until the next
-     * rebuild.
+     * Top up whatever the classes already loaded have not subscribed yet. Called once a tenant
+     * provisioning round completes: the client-Java generation is JVM-wide and is only rebuilt on
+     * publish, so a tenant created afterwards would otherwise stay unsubscribed until the next rebuild.
      */
     @Override
     public void execute() {
-        registrations.forEach(this::subscribeMissingTenants);
+        topUp();
+    }
+
+    /**
+     * Re-attempt whatever is still not subscribed, on the reconciliation timer. Gated on the flag so an
+     * instance whose subscriptions are all open pays nothing per tick - not even the tenant lookup the
+     * fan-out below performs.
+     *
+     * <p>
+     * The flag is cleared <b>before</b> the pass, never after: a failure the pass itself records has to
+     * survive it, or the very subscription that just failed would never be retried again.
+     */
+    @Override
+    public void reconcile() {
+        if (!subscriptionsIncomplete.compareAndSet(true, false)) {
+            return;
+        }
+        topUp();
     }
 
     /** Replace whatever this class had subscribed with the subscriptions it declares now. */
@@ -197,62 +240,137 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
         stopExisting(fqn);
         Registration registration = new Registration(subscriptions);
         registrations.put(fqn, registration);
-        subscribeGlobal(registration);
+        subscribeGlobal(fqn, registration);
         subscribeMissingTenants(fqn, registration);
+    }
+
+    /**
+     * One reconciliation pass over everything loaded: the global destinations first, then the tenant
+     * ones. The tenant fan-out happens <b>once for the pass</b> rather than once per class, because
+     * {@link TenantContext#executeForEachTenant} reads the provisioned tenants from the database and a
+     * per-class fan-out would turn one tick into one query per registered listener.
+     */
+    private void topUp() {
+        registrations.forEach(this::subscribeGlobal);
+        try {
+            tenantContext.executeForEachTenant(() -> {
+                String tenantId = tenantContext.getCurrentTenant()
+                                               .getId();
+                registrations.forEach((fqn, registration) -> subscribeTenant(fqn, registration, tenantId));
+                return null;
+            });
+        } catch (Exception e) {
+            markIncomplete();
+            LOGGER.error("Failed to top up the client-Java listener subscriptions of the provisioned tenants: {}", e.getMessage(), e);
+        }
+        reportIncomplete();
     }
 
     /**
      * Open this class's global subscriptions - once for the deployment, not once per tenant. Runs on
      * the loading thread, which has no tenant of its own, and needs none: a global destination resolves
      * to the same physical name everywhere.
+     *
+     * <p>
+     * All or nothing, and idempotent, for the same reason the per-tenant branch is: a retry must not be
+     * able to open a second consumer beside one that is already live.
      */
-    private void subscribeGlobal(Registration registration) {
+    private synchronized void subscribeGlobal(String fqn, Registration registration) {
+        if (isSuperseded(fqn, registration) || registration.isGlobalSubscribed()) {
+            return;
+        }
         List<Connection> opened = new ArrayList<>();
+        boolean complete = true;
         for (Subscription subscription : registration.globalSubscriptions()) {
             Connection connection = subscribe(subscription, "all tenants (global destination)");
-            if (connection != null) {
+            if (connection == null) {
+                complete = false;
+            } else {
                 opened.add(connection);
             }
         }
-        registration.globalSubscribed(opened);
+        if (complete) {
+            registration.globalSubscribed(opened);
+        } else {
+            // Leave the connections unrecorded before closing them, or a later teardown would close
+            // them a second time and openConnections() would report handles that are already gone.
+            closeAll(fqn, opened);
+            markIncomplete();
+        }
     }
 
     /**
-     * Open this class's subscriptions in every provisioned tenant that does not have them yet. Additive
-     * on purpose — an already-subscribed tenant is left alone, so topping up after a provisioning round
-     * never drops a message in flight.
+     * Open one class's subscriptions in every provisioned tenant that does not have them yet. Additive
+     * on purpose — an already-subscribed tenant is left alone, so topping up never drops a message in
+     * flight.
      */
-    private synchronized void subscribeMissingTenants(String fqn, Registration registration) {
+    private void subscribeMissingTenants(String fqn, Registration registration) {
         try {
             tenantContext.executeForEachTenant(() -> {
-                String tenantId = tenantContext.getCurrentTenant()
-                                               .getId();
-                if (registration.isSubscribed(tenantId)) {
-                    return null;
-                }
-                List<Connection> opened = new ArrayList<>();
-                boolean complete = true;
-                for (Subscription subscription : registration.tenantSubscriptions()) {
-                    Connection connection = subscribe(subscription, "tenant [" + tenantId + "]");
-                    if (connection == null) {
-                        complete = false;
-                    } else {
-                        opened.add(connection);
-                    }
-                }
-                if (complete) {
-                    registration.subscribed(tenantId, opened);
-                } else {
-                    // All or nothing per tenant: leave the tenant unrecorded so the next load or
-                    // provisioning round retries it cleanly, and close what did open so that retry
-                    // cannot end up with two consumers competing on the same destination.
-                    closeAll(fqn, opened);
-                }
+                subscribeTenant(fqn, registration, tenantContext.getCurrentTenant()
+                                                                .getId());
                 return null;
             });
         } catch (Exception e) {
+            markIncomplete();
             LOGGER.error("Failed to subscribe listener [{}] for the provisioned tenants: {}", fqn, e.getMessage(), e);
         }
+    }
+
+    /** Open one class's tenant-scoped subscriptions in the tenant whose context is currently active. */
+    private synchronized void subscribeTenant(String fqn, Registration registration, String tenantId) {
+        if (isSuperseded(fqn, registration) || registration.isSubscribed(tenantId)) {
+            return;
+        }
+        List<Connection> opened = new ArrayList<>();
+        boolean complete = true;
+        for (Subscription subscription : registration.tenantSubscriptions()) {
+            Connection connection = subscribe(subscription, "tenant [" + tenantId + "]");
+            if (connection == null) {
+                complete = false;
+            } else {
+                opened.add(connection);
+            }
+        }
+        if (complete) {
+            registration.subscribed(tenantId, opened);
+        } else {
+            // All or nothing per tenant: leave the tenant unrecorded so the reconciliation timer
+            // retries it cleanly, and close what did open so that retry cannot end up with two
+            // consumers competing on the same destination.
+            closeAll(fqn, opened);
+            markIncomplete();
+        }
+    }
+
+    /**
+     * Whether this registration has been replaced or unloaded since the caller picked it up. A pass
+     * iterates a weakly consistent map, so a republish can install a new registration for the same
+     * class in between - and subscribing the old one would open connections nothing holds a reference
+     * to, live on the destination its replacement is also consuming, and impossible to ever close.
+     */
+    private boolean isSuperseded(String fqn, Registration registration) {
+        return registrations.get(fqn) != registration;
+    }
+
+    private void markIncomplete() {
+        subscriptionsIncomplete.set(true);
+    }
+
+    /**
+     * One line per pass while anything is still down. The per-attempt log falls to DEBUG after the
+     * first failure, so this summary is what keeps a lasting outage visible instead of scrolling past
+     * once at boot - which is how an unsubscribed handler went unnoticed in the first place.
+     */
+    private void reportIncomplete() {
+        if (!subscriptionsIncomplete.get() || reportedFailures.isEmpty()) {
+            // An empty set means the fan-out itself failed, which the outer catch has already reported.
+            return;
+        }
+        LOGGER.warn(
+                "[{}] client-Java listener subscription(s) are still not open, so messages published to their destinations are"
+                        + " not handled: {}. Retrying on the next reconciliation pass.",
+                reportedFailures.size(), new LinkedHashSet<>(reportedFailures));
     }
 
     /**
@@ -266,13 +384,16 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
      */
     private Connection subscribe(Subscription subscription, String scope) {
         String label = subscription.label();
-        String destinationName = destinationNameManager.toTenantName(subscription.destination());
         // A queue holds its messages until something consumes them; a topic drops whatever it delivers
         // to nobody. So only a topic subscription needs to be durable - and a durable one needs the
         // connection to carry an id, which is how the broker recognises it across a reconnect.
         boolean topic = subscription.kind() == ListenerKind.TOPIC;
-        String subscriptionId = topic ? durableSubscriptionId(label, destinationName) : null;
+        // Resolving the physical name is inside the try with the attach it belongs to: anything thrown
+        // between here and the consumer must stay this subscription's problem, or it escapes the
+        // per-tenant fan-out and skips every tenant behind this one.
         try {
+            String destinationName = destinationNameManager.toTenantName(subscription.destination());
+            String subscriptionId = topic ? durableSubscriptionId(label, destinationName) : null;
             Connection connection = connectionFactory.createConnection(
                     ex -> LOGGER.error("[java-listener] JMS error for [{}]: {}", label, ex.getMessage(), ex), subscriptionId);
             Session session = connectionFactory.createSession(connection);
@@ -289,12 +410,37 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
             MessageConsumer consumer =
                     topic ? session.createDurableSubscriber((Topic) destination, subscriptionId) : session.createConsumer(destination);
             consumer.setMessageListener(msg -> dispatch(msg, subscription.dispatcher(), label));
+            reportedFailures.remove(failureKey(label, scope));
             LOGGER.info("Java @Listener [{}] connected to {} '{}' for {}.", label, subscription.kind(), destinationName, scope);
             return connection;
-        } catch (JMSException e) {
-            LOGGER.error("Failed to start listener for [{}] for {}: {}", label, scope, e.getMessage(), e);
+        } catch (JMSException | RuntimeException e) {
+            // RuntimeException is not defensive padding: the connection factory reports a broker that is
+            // not accepting yet by wrapping the JMSException in an IllegalStateException, which is
+            // exactly the failure this whole retry exists for. Left uncaught it escaped the per-tenant
+            // fan-out, skipping every remaining tenant and leaking the connections already opened.
+            reportFailure(label, scope, e);
             return null;
         }
+    }
+
+    /**
+     * Report a refused subscription once, then quietly. It is a WARN and not an ERROR because it is now
+     * transient by construction - the reconciliation timer retries it - and the repeats fall to DEBUG
+     * because that timer would otherwise emit one line per subscription per tenant, forever, for a
+     * destination that can never be opened.
+     */
+    private void reportFailure(String label, String scope, Exception cause) {
+        String consequence = "Failed to start listener [" + label + "] for " + scope
+                + " - messages published to its destination are not handled until it connects; retrying on the next pass.";
+        if (reportedFailures.add(failureKey(label, scope))) {
+            LOGGER.warn("{} {}", consequence, cause.getMessage(), cause);
+        } else {
+            LOGGER.debug("{} {}", consequence, cause.getMessage(), cause);
+        }
+    }
+
+    private static String failureKey(String label, String scope) {
+        return label + "|" + scope;
     }
 
     /**
@@ -320,6 +466,7 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
 
     private synchronized void stopExisting(String fqn) {
         Registration old = registrations.remove(fqn);
+        reportedFailures.removeIf(key -> key.startsWith(fqn + "|") || key.startsWith(fqn + "#"));
         if (old != null) {
             closeAll(fqn, old.openConnections());
         }
@@ -431,6 +578,9 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
         /** The JMS connections open for this class's global destinations. */
         private List<Connection> globalConnections = List.of();
 
+        /** Whether every global destination this class declares is subscribed. */
+        private boolean globalSubscribed;
+
         Registration(List<Subscription> subscriptions) {
             this.tenantSubscriptions = subscriptions.stream()
                                                     .filter(subscription -> !DestinationNameManager.isGlobal(subscription.destination()))
@@ -438,6 +588,8 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
             this.globalSubscriptions = subscriptions.stream()
                                                     .filter(subscription -> DestinationNameManager.isGlobal(subscription.destination()))
                                                     .toList();
+            // A class declaring no global destination has nothing outstanding on that side, ever.
+            this.globalSubscribed = this.globalSubscriptions.isEmpty();
         }
 
         List<Subscription> tenantSubscriptions() {
@@ -448,8 +600,13 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
             return globalSubscriptions;
         }
 
+        boolean isGlobalSubscribed() {
+            return globalSubscribed;
+        }
+
         void globalSubscribed(List<Connection> connections) {
             this.globalConnections = List.copyOf(connections);
+            this.globalSubscribed = true;
         }
 
         boolean isSubscribed(String tenantId) {

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/JavaConsumersReconciler.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/JavaConsumersReconciler.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.java.runtime;
+
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.engine.java.spi.JavaClassConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+/**
+ * The JVM-local watchdog that asks every {@link JavaClassConsumer} to
+ * {@link JavaClassConsumer#reconcile() reconcile} what it could not establish earlier - above all a
+ * JMS subscription the embedded broker refused while its {@code vm://localhost} transport was still
+ * coming up. Without it such a subscription is never retried and the handler stays silent for the
+ * life of the process (issue #7217): a client-Java generation is rebuilt only on publish, and the
+ * tenant post-provisioning steps run only when a tenant was actually provisioned, so neither of the
+ * two triggers the consumers were written against ever arrives on a steady-state instance.
+ *
+ * <p>
+ * <b>Why a timer of its own</b>, rather than the two schedulers already in the platform:
+ * <ul>
+ * <li>a Quartz {@code SystemJob} fires <b>once cluster-wide</b> (the shared JDBC job store is
+ * clustered), and the state being repaired here is per-JVM - the nodes that did not win the trigger
+ * would stay unsubscribed forever;</li>
+ * <li>Spring's shared {@code TaskScheduler} is a <b>single thread</b> also carrying the
+ * access-constraint refresh and the {@code tsc} liveness monitor, while an external broker
+ * addressed through a {@code failover:} URL can block {@code createConnection} indefinitely - one
+ * unreachable broker would freeze those too.</li>
+ * </ul>
+ */
+@Component
+class JavaConsumersReconciler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JavaConsumersReconciler.class);
+
+    private static final String THREAD_NAME = "dirigible-java-reconciler";
+
+    private final List<JavaClassConsumer> consumers;
+
+    private ScheduledExecutorService executor;
+
+    @Autowired
+    JavaConsumersReconciler(List<JavaClassConsumer> consumers) {
+        this.consumers = consumers;
+    }
+
+    /**
+     * Start the timer once the context is up. Deliberately not in the constructor: the consumers' unit
+     * tests build them directly, and a timer ticking underneath them would make their call counts
+     * non-deterministic.
+     */
+    @PostConstruct
+    void start() {
+        long intervalSeconds = DirigibleConfig.JAVA_RECONCILE_INTERVAL_SECONDS.getIntValue();
+        executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, THREAD_NAME);
+            thread.setDaemon(true);
+            return thread;
+        });
+        executor.scheduleWithFixedDelay(this::reconcileAll, intervalSeconds, intervalSeconds, TimeUnit.SECONDS);
+        LOGGER.info("Client-Java runtime reconciliation scheduled every [{}] second(s).", intervalSeconds);
+    }
+
+    @PreDestroy
+    void stop() {
+        if (null != executor) {
+            executor.shutdownNow();
+            executor = null;
+        }
+    }
+
+    /**
+     * One pass. Each consumer is isolated the same way {@code JavaLoader} isolates them, and the whole
+     * body catches {@link Throwable} on purpose: an exception escaping a task submitted to
+     * {@code scheduleWithFixedDelay} cancels that task <b>permanently</b> and without a word, which
+     * would silently turn the watchdog off for the rest of the process.
+     *
+     * <p>
+     * It takes no lock of its own. {@code JavaLoader.rebuild} is synchronized on the loader and every
+     * consumer guards its own state, so locking here could only deadlock against a concurrent rebuild.
+     */
+    void reconcileAll() {
+        try {
+            for (JavaClassConsumer consumer : consumers) {
+                try {
+                    consumer.reconcile();
+                } catch (Exception | LinkageError e) {
+                    LOGGER.error("Consumer [{}] threw while reconciling: {}", consumer.getClass()
+                                                                                      .getSimpleName(),
+                            e.getMessage(), e);
+                }
+            }
+        } catch (Throwable t) {
+            LOGGER.error("Client-Java runtime reconciliation pass failed: {}", t.getMessage(), t);
+        }
+    }
+
+}

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/scheduled/ScheduledClassConsumer.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/scheduled/ScheduledClassConsumer.java
@@ -13,8 +13,10 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.dirigible.components.base.tenant.TenantContext;
 import org.eclipse.dirigible.components.base.tenant.TenantPostProvisioningStep;
@@ -89,6 +91,14 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
     /** fqn -> the jobs it declared (a class may declare several @Scheduled methods). */
     private final ConcurrentMap<String, List<JobDeclaration>> registered = new ConcurrentHashMap<>();
 
+    /** Set while a declared job is not registered in every tenant; drives {@link #reconcile()}. */
+    private final AtomicBoolean registrationsIncomplete = new AtomicBoolean();
+
+    /**
+     * Job names already reported as failing, so a retry on a timer does not log the same line forever.
+     */
+    private final Set<String> reportedFailures = ConcurrentHashMap.newKeySet();
+
     @Autowired
     public ScheduledClassConsumer(ComponentContainer componentContainer, JobsManager jobsManager, JobService jobService,
             TenantContext tenantContext) {
@@ -150,14 +160,15 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
             LOGGER.warn("Scheduled job [{}] produced no schedule.", info.fqn());
             return;
         }
-        List<JobDeclaration> scheduled = new ArrayList<>();
+        // Track what the class DECLARES, not what happened to register: a registration that threw - the
+        // scheduler or the tenant's database briefly unavailable - must stay retryable, and comparing the
+        // previous names against the successful ones instead would make a transient failure DELETE the
+        // Job row a previous run created, along with the operator's enabled flag on it.
+        retainOnly(info.fqn(), declarations);
+        registered.put(info.fqn(), declarations);
         for (JobDeclaration declaration : declarations) {
-            if (register(declaration)) {
-                scheduled.add(declaration);
-            }
+            register(declaration);
         }
-        retainOnly(info.fqn(), scheduled);
-        registered.put(info.fqn(), scheduled);
     }
 
     @Override
@@ -181,8 +192,34 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
      */
     @Override
     public void execute() {
-        registered.values()
-                  .forEach(declarations -> declarations.forEach(this::register));
+        registerAll();
+    }
+
+    /**
+     * Re-attempt the registrations that did not land, on the reconciliation timer. Gated on the flag,
+     * so an instance whose jobs are all registered pays nothing per tick - and the flag is cleared
+     * before the pass, never after, or a failure the pass itself records would be lost.
+     */
+    @Override
+    public void reconcile() {
+        if (!registrationsIncomplete.compareAndSet(true, false)) {
+            return;
+        }
+        registerAll();
+    }
+
+    /**
+     * Re-register every job of every loaded class. Idempotent, so covering the healthy ones is free.
+     */
+    private void registerAll() {
+        registered.forEach((fqn, declarations) -> {
+            if (registered.get(fqn) != declarations) {
+                // Replaced or unloaded while this pass was running - re-registering it now would
+                // recreate rows the unload has just deleted.
+                return;
+            }
+            declarations.forEach(this::register);
+        });
     }
 
     @Override
@@ -191,6 +228,7 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
         // shutdown (other nodes keep running them; a restart re-registers idempotently). Just drop the
         // local tracking.
         registered.clear();
+        reportedFailures.clear();
     }
 
     /**
@@ -202,9 +240,8 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
      * thread and a rebuild registers from the synchronizer's, and the find-then-save below is exactly
      * the window in which two of them could insert the same job row twice.
      *
-     * @return true if the job is now registered in every tenant
      */
-    private synchronized boolean register(JobDeclaration declaration) {
+    private synchronized void register(JobDeclaration declaration) {
         String name = declaration.name();
         String handler = declaration.handler();
         String expression = declaration.expression();
@@ -246,19 +283,27 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
                 jobsManager.scheduleJob(job);
                 return null;
             });
+            reportedFailures.remove(name);
             LOGGER.info("Registered client-Java job [{}] (handler [{}]) with cron '{}' on the shared scheduler.", name, handler,
                     expression);
-            return true;
         } catch (Exception e) {
-            LOGGER.error("Failed to register client-Java job [{}] with cron '{}': {}", handler, expression, e.getMessage(), e);
-            return false;
+            registrationsIncomplete.set(true);
+            String message = "Failed to register client-Java job [" + handler + "] with cron '" + expression
+                    + "' - it does not fire until it is registered; retrying on the next reconciliation pass.";
+            // Once, then quietly: the retry runs on a timer, and a job that can never be registered would
+            // otherwise log the same line every tick for the life of the process.
+            if (reportedFailures.add(name)) {
+                LOGGER.warn("{} {}", message, e.getMessage(), e);
+            } else {
+                LOGGER.debug("{} {}", message, e.getMessage(), e);
+            }
         }
     }
 
     /**
      * Drop the jobs a class registered before but no longer declares - a {@code @Scheduled} method that
-     * was renamed or removed. The ones it still declares were just re-registered onto their existing
-     * rows, so they keep their operator state.
+     * was renamed or removed. The ones it still declares are re-registered onto their existing rows, so
+     * they keep their operator state.
      */
     private void retainOnly(String fqn, List<JobDeclaration> current) {
         List<JobDeclaration> previous = registered.get(fqn);
@@ -281,6 +326,7 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
         if (declarations == null) {
             return;
         }
+        declarations.forEach(declaration -> reportedFailures.remove(declaration.name()));
         remove(declarations.stream()
                            .map(JobDeclaration::name)
                            .toList());

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/spi/JavaClassConsumer.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/spi/JavaClassConsumer.java
@@ -50,4 +50,20 @@ public interface JavaClassConsumer {
      */
     void onClassUnloaded(LoadedClass info);
 
+    /**
+     * Re-attempt runtime state this consumer wanted but could not establish - a JMS subscription the
+     * broker refused while it was still starting, a job registration that threw. Called periodically by
+     * {@code JavaConsumersReconciler} on a JVM-local timer, deliberately independent of a rebuild and
+     * of a tenant provisioning round: a client-Java generation is only rebuilt on publish, and the
+     * post-provisioning steps run only when a tenant was actually provisioned, so a consumer that
+     * relies on either to retry never retries at all on a steady-state instance.
+     *
+     * <p>
+     * Implementations must be cheap and a no-op when nothing is outstanding, and must be safe to call
+     * concurrently with a rebuild.
+     */
+    default void reconcile() {
+        // Nothing outstanding by default.
+    }
+
 }

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumerRetryTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumerRetryTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.java.listener;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.dirigible.components.base.callable.CallableResultAndException;
+import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.eclipse.dirigible.components.configurations.tenant.TenantConfigurationService;
+import org.eclipse.dirigible.components.listeners.config.ActiveMQConnectionArtifactsFactory;
+import org.eclipse.dirigible.components.listeners.service.DestinationNameManager;
+import org.eclipse.dirigible.components.listeners.service.TenantPropertyManager;
+import org.eclipse.dirigible.engine.java.component.ComponentContainer;
+import org.eclipse.dirigible.engine.java.spi.LoadedClass;
+import org.eclipse.dirigible.sdk.messaging.MessageHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.jms.Connection;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.Queue;
+import jakarta.jms.Session;
+
+/**
+ * A subscription the broker refuses must be retried, and the retry must not depend on anything a
+ * steady-state instance never does. The client-Java generation is rebuilt only on publish and the
+ * post-provisioning step runs only when a tenant was actually provisioned, so a listener that lost
+ * the race against the broker's transport at boot stayed unsubscribed for the life of the process,
+ * and a topic discarded every message published to it without a word (issue #7217).
+ *
+ * <p>
+ * The refusal is reproduced the way it really arrives: {@code ActiveMQConnectionArtifactsFactory}
+ * wraps the broker's {@code JMSException} in an {@link IllegalStateException}, which the consumer
+ * used not to catch at all.
+ */
+class ListenerClassConsumerRetryTest {
+
+    /** A typed listener on a queue, so the assertions can read {@code createQueue} arguments. */
+    static class OrdersHandler implements MessageHandler {
+
+        @Override
+        public String destination() {
+            return "orders";
+        }
+
+        @Override
+        public void onMessage(String message) {
+            // The subscription, not the dispatch, is what this test is about.
+        }
+    }
+
+    /** A typed listener on a destination shared with another deployment. */
+    static class GlobalOrdersHandler implements MessageHandler {
+
+        @Override
+        public String destination() {
+            return DestinationNameManager.GLOBAL_MARKER + "codbex.orders";
+        }
+
+        @Override
+        public void onMessage(String message) {
+            // The subscription, not the dispatch, is what this test is about.
+        }
+    }
+
+    private static final String DEFAULT_TENANT_ID = "default-tenant";
+
+    private final Map<String, Tenant> provisionedTenants = new LinkedHashMap<>();
+
+    private final AtomicReference<String> currentTenantId = new AtomicReference<>();
+
+    /** While set, every attempt to attach to the broker fails the way a starting broker fails. */
+    private final AtomicBoolean brokerRefusing = new AtomicBoolean();
+
+    /** When set, only attempts made in that tenant's context fail. */
+    private final AtomicReference<String> brokerRefusingForTenant = new AtomicReference<>();
+
+    private Session session;
+    private TenantContext tenantContext;
+    private ListenerClassConsumer consumer;
+
+    @BeforeEach
+    @SuppressWarnings("rawtypes")
+    void setUp() throws Exception {
+        addTenant(DEFAULT_TENANT_ID);
+        addTenant("acme");
+
+        ComponentContainer componentContainer = mock(ComponentContainer.class);
+        when(componentContainer.instanceOf(OrdersHandler.class)).thenReturn(Optional.of(new OrdersHandler()));
+        when(componentContainer.instanceOf(GlobalOrdersHandler.class)).thenReturn(Optional.of(new GlobalOrdersHandler()));
+
+        ActiveMQConnectionArtifactsFactory connectionFactory = mock(ActiveMQConnectionArtifactsFactory.class);
+        Connection connection = mock(Connection.class);
+        session = mock(Session.class);
+        when(connectionFactory.createConnection(any(), any())).thenAnswer(invocation -> {
+            String refusingFor = brokerRefusingForTenant.get();
+            if (brokerRefusing.get() || (refusingFor != null && refusingFor.equals(currentTenantId.get()))) {
+                throw new IllegalStateException("Failed to create connection to ActiveMQ");
+            }
+            return connection;
+        });
+        when(connectionFactory.createSession(connection)).thenReturn(session);
+        when(session.createQueue(anyString())).thenReturn(mock(Queue.class));
+        when(session.createConsumer(any())).thenReturn(mock(MessageConsumer.class));
+
+        tenantContext = mock(TenantContext.class);
+        when(tenantContext.getCurrentTenant()).thenAnswer(invocation -> provisionedTenants.get(currentTenantId.get()));
+        when(tenantContext.executeForEachTenant(any())).thenAnswer(invocation -> {
+            for (String tenantId : new ArrayList<>(provisionedTenants.keySet())) {
+                currentTenantId.set(tenantId);
+                ((CallableResultAndException) invocation.getArgument(0)).call();
+            }
+            currentTenantId.set(null);
+            return List.of();
+        });
+
+        DestinationNameManager destinationNameManager = mock(DestinationNameManager.class);
+        when(destinationNameManager.toTenantName(anyString())).thenAnswer(invocation -> {
+            String logicalName = invocation.getArgument(0);
+            if (DestinationNameManager.isGlobal(logicalName)) {
+                return logicalName.substring(DestinationNameManager.GLOBAL_MARKER.length());
+            }
+            String tenantId = currentTenantId.get();
+            return DEFAULT_TENANT_ID.equals(tenantId) ? logicalName : tenantId + "###" + logicalName;
+        });
+
+        TenantConfigurationService tenantConfigurationService = mock(TenantConfigurationService.class);
+        when(tenantConfigurationService.resolveInjectableForCurrentTenant()).thenReturn(new HashMap<>());
+
+        consumer = new ListenerClassConsumer(componentContainer, connectionFactory, tenantContext, mock(TenantPropertyManager.class),
+                mock(Tenant.class), tenantConfigurationService, destinationNameManager);
+    }
+
+    @Test
+    void aSubscriptionRefusedAtLoadIsOpenedByTheNextReconciliationPass() throws Exception {
+        brokerRefusing.set(true);
+        loadListener();
+        verify(session, never()).createQueue(anyString());
+
+        brokerRefusing.set(false);
+        consumer.reconcile();
+
+        verify(session).createQueue("orders");
+        verify(session).createQueue("acme###orders");
+    }
+
+    /**
+     * The refusal arrives as an unchecked exception, and the consumer caught only {@code JMSException}.
+     * So the first tenant's failure escaped the fan-out and every tenant behind it was skipped without
+     * even an attempt - the failure was not merely un-retried, it was contagious.
+     */
+    @Test
+    void aRefusalInOneTenantDoesNotAbortTheFanOutOverTheOthers() throws Exception {
+        brokerRefusingForTenant.set(DEFAULT_TENANT_ID);
+
+        loadListener();
+
+        verify(session, never()).createQueue("orders");
+        verify(session).createQueue("acme###orders");
+    }
+
+    @Test
+    void theTenantARefusalSkippedIsSubscribedByTheNextReconciliationPass() throws Exception {
+        brokerRefusingForTenant.set(DEFAULT_TENANT_ID);
+        loadListener();
+
+        brokerRefusingForTenant.set(null);
+        consumer.reconcile();
+
+        verify(session).createQueue("orders");
+        verify(session, times(1)).createQueue("acme###orders");
+    }
+
+    @Test
+    void aRefusedSubscriptionIsNotRecordedSoTheRetryOpensItExactlyOnce() throws Exception {
+        brokerRefusing.set(true);
+        loadListener();
+
+        brokerRefusing.set(false);
+        consumer.reconcile();
+        consumer.reconcile();
+
+        // A second consumer on the same queue in the same tenant competes for its messages.
+        verify(session, times(1)).createQueue("orders");
+        verify(session, times(1)).createQueue("acme###orders");
+    }
+
+    /**
+     * A global destination is subscribed once for the deployment, outside any tenant, and that half had
+     * no retry at all: {@code subscribeGlobal} was reachable only from a class load.
+     */
+    @Test
+    void aRefusedGlobalSubscriptionIsOpenedByTheNextReconciliationPass() throws Exception {
+        brokerRefusing.set(true);
+        loadGlobalListener();
+        verify(session, never()).createQueue(anyString());
+
+        brokerRefusing.set(false);
+        consumer.reconcile();
+
+        verify(session, times(1)).createQueue("codbex.orders");
+    }
+
+    @Test
+    void aPassThatSucceededCostsTheNextTickNothing() throws Exception {
+        loadListener();
+        verify(tenantContext, times(1)).executeForEachTenant(any());
+
+        consumer.reconcile();
+
+        // Not even the tenant lookup: executeForEachTenant reads the provisioned tenants from the
+        // database, and this tick fires every 30 seconds for the life of the process.
+        verify(tenantContext, times(1)).executeForEachTenant(any());
+        verify(session, times(1)).createQueue("orders");
+    }
+
+    private void addTenant(String tenantId) {
+        Tenant tenant = mock(Tenant.class);
+        when(tenant.getId()).thenReturn(tenantId);
+        when(tenant.isDefault()).thenReturn(DEFAULT_TENANT_ID.equals(tenantId));
+        provisionedTenants.put(tenantId, tenant);
+    }
+
+    private void loadListener() {
+        consumer.onClassLoaded(
+                new LoadedClass("sample", OrdersHandler.class.getName(), OrdersHandler.class, OrdersHandler.class.getClassLoader()));
+    }
+
+    private void loadGlobalListener() {
+        consumer.onClassLoaded(new LoadedClass("sample", GlobalOrdersHandler.class.getName(), GlobalOrdersHandler.class,
+                GlobalOrdersHandler.class.getClassLoader()));
+    }
+}

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/runtime/JavaConsumersReconcilerTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/runtime/JavaConsumersReconcilerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.java.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.dirigible.engine.java.spi.JavaClassConsumer;
+import org.eclipse.dirigible.engine.java.spi.LoadedClass;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The reconciliation pass is the only thing that retries a subscription the broker refused, so it
+ * has to survive everything a consumer can do to it. One that throws must not stop the ones behind
+ * it, and nothing may escape the pass at all: it is submitted to {@code scheduleWithFixedDelay},
+ * which cancels a task that throws permanently and without a word - turning the watchdog off for
+ * the rest of the process, which is precisely the state issue #7217 is about.
+ */
+class JavaConsumersReconcilerTest {
+
+    /** Counts its reconciliations, and optionally fails them. */
+    private static final class CountingConsumer implements JavaClassConsumer {
+
+        private final AtomicInteger reconciliations = new AtomicInteger();
+        private final RuntimeException failure;
+
+        private CountingConsumer(RuntimeException failure) {
+            this.failure = failure;
+        }
+
+        @Override
+        public boolean accepts(Class<?> clazz) {
+            return false;
+        }
+
+        @Override
+        public void onClassLoaded(LoadedClass info) {
+            // Not part of this test.
+        }
+
+        @Override
+        public void onClassUnloaded(LoadedClass info) {
+            // Not part of this test.
+        }
+
+        @Override
+        public void reconcile() {
+            reconciliations.incrementAndGet();
+            if (failure != null) {
+                throw failure;
+            }
+        }
+    }
+
+    @Test
+    void everyConsumerIsReconciled() {
+        CountingConsumer first = new CountingConsumer(null);
+        CountingConsumer second = new CountingConsumer(null);
+
+        new JavaConsumersReconciler(List.of(first, second)).reconcileAll();
+
+        assertEquals(1, first.reconciliations.get());
+        assertEquals(1, second.reconciliations.get());
+    }
+
+    @Test
+    void aThrowingConsumerNeitherStopsTheOthersNorEscapesThePass() {
+        CountingConsumer throwing = new CountingConsumer(new IllegalStateException("boom"));
+        CountingConsumer behindIt = new CountingConsumer(null);
+        JavaConsumersReconciler reconciler = new JavaConsumersReconciler(List.of(throwing, behindIt));
+
+        assertDoesNotThrow(reconciler::reconcileAll);
+
+        assertEquals(1, behindIt.reconciliations.get(), "a consumer must not lose its retry because an earlier one failed");
+    }
+}

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/scheduled/ScheduledClassConsumerRetryTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/scheduled/ScheduledClassConsumerRetryTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.java.scheduled;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.dirigible.components.base.callable.CallableResultAndException;
+import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.eclipse.dirigible.components.jobs.domain.Job;
+import org.eclipse.dirigible.components.jobs.manager.JobsManager;
+import org.eclipse.dirigible.components.jobs.service.JobService;
+import org.eclipse.dirigible.engine.java.component.ComponentContainer;
+import org.eclipse.dirigible.engine.java.spi.LoadedClass;
+import org.eclipse.dirigible.sdk.job.Scheduled;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A registration that threw has to stay retryable. The consumer used to record only the
+ * declarations that registered successfully, which cost twice: the failed job was dropped from its
+ * tracking, so even the post-provisioning top-up could not bring it back, and the stale-name sweep
+ * then compared the PREVIOUS names against the successful ones - so a transient failure on reload
+ * deleted the {@code Job} row an earlier run had created, taking the operator's enabled flag with
+ * it.
+ *
+ * <p>
+ * The sibling of the listener defect in issue #7217, and repaired by the same reconciliation timer.
+ */
+class ScheduledClassConsumerRetryTest {
+
+    /** A method-level job, so the assertions also cover the {@code <fqn>#<method>} handler shape. */
+    static class ReportsJob {
+
+        @Scheduled(expression = "0 0 6 * * ?")
+        public void sendDaily() {
+            // The registration, not the run, is what this test is about.
+        }
+    }
+
+    private static final String DEFAULT_TENANT_ID = "default-tenant";
+    private static final String JOB_NAME = ReportsJob.class.getName() + ".sendDaily";
+
+    private final Map<String, Tenant> provisionedTenants = new LinkedHashMap<>();
+
+    private final AtomicReference<String> currentTenantId = new AtomicReference<>();
+
+    private final List<String> scheduledForTenants = new ArrayList<>();
+
+    private final Map<String, Map<String, Job>> rowsByTenant = new LinkedHashMap<>();
+
+    /** While set, scheduling fails the way an unavailable scheduler or tenant database fails. */
+    private final AtomicBoolean schedulerRefusing = new AtomicBoolean();
+
+    private JobsManager jobsManager;
+    private JobService jobService;
+    private ScheduledClassConsumer consumer;
+
+    @BeforeEach
+    @SuppressWarnings("rawtypes")
+    void setUp() throws Exception {
+        addTenant(DEFAULT_TENANT_ID);
+        addTenant("acme");
+
+        ComponentContainer componentContainer = mock(ComponentContainer.class);
+        when(componentContainer.instanceOf(ReportsJob.class)).thenReturn(Optional.of(new ReportsJob()));
+
+        jobsManager = mock(JobsManager.class);
+        doAnswer(invocation -> {
+            if (schedulerRefusing.get()) {
+                throw new IllegalStateException("The scheduler is not available");
+            }
+            scheduledForTenants.add(currentTenantId.get());
+            return null;
+        }).when(jobsManager)
+          .scheduleJob(any());
+
+        jobService = mock(JobService.class);
+        when(jobService.findByName(anyString())).thenAnswer(invocation -> {
+            String name = invocation.getArgument(0);
+            Job row = rows().get(name);
+            if (row == null) {
+                throw new IllegalArgumentException("Job with name does not exist: " + name);
+            }
+            return row;
+        });
+        when(jobService.save(any())).thenAnswer(invocation -> {
+            Job job = invocation.getArgument(0);
+            rows().put(job.getName(), job);
+            return job;
+        });
+
+        TenantContext tenantContext = mock(TenantContext.class);
+        when(tenantContext.executeForEachTenant(any())).thenAnswer(invocation -> {
+            for (String tenantId : new ArrayList<>(provisionedTenants.keySet())) {
+                currentTenantId.set(tenantId);
+                ((CallableResultAndException) invocation.getArgument(0)).call();
+            }
+            currentTenantId.set(null);
+            return List.of();
+        });
+
+        consumer = new ScheduledClassConsumer(componentContainer, jobsManager, jobService, tenantContext);
+    }
+
+    @Test
+    void aRegistrationThatFailedAtLoadIsRetriedByTheNextReconciliationPass() {
+        schedulerRefusing.set(true);
+        loadJob();
+        assertTrue(scheduledForTenants.isEmpty(), "nothing can be scheduled while the scheduler refuses");
+
+        schedulerRefusing.set(false);
+        consumer.reconcile();
+
+        assertEquals(List.of(DEFAULT_TENANT_ID, "acme"), scheduledForTenants);
+    }
+
+    @Test
+    void aPassThatSucceededIsNotRepeatedByTheNextTick() {
+        loadJob();
+        scheduledForTenants.clear();
+
+        consumer.reconcile();
+
+        assertTrue(scheduledForTenants.isEmpty(), "nothing was outstanding, so the tick must do no work at all");
+    }
+
+    /**
+     * The expensive half of the old behaviour: the row survives the failure. Deleting it would strand
+     * the operator's enable/disable choice and, on the next successful pass, silently switch the job
+     * back on.
+     */
+    @Test
+    void aTransientFailureOnReloadDoesNotDeleteTheRowAnEarlierRunRegistered() throws Exception {
+        loadJob();
+        row("acme").setEnabled(false);
+
+        schedulerRefusing.set(true);
+        loadJob();
+
+        verify(jobService, never()).delete(any());
+        verify(jobsManager, never()).unscheduleJob(anyString(), anyString());
+        assertFalse(row("acme").isEnabled(), "the operator's disable must survive a failed re-registration");
+    }
+
+    private Job row(String tenantId) {
+        Job job = rowsByTenant.getOrDefault(tenantId, Map.of())
+                              .get(JOB_NAME);
+        assertNotNull(job, "tenant [" + tenantId + "] has no row for the client-Java job [" + JOB_NAME + "]");
+        return job;
+    }
+
+    private Map<String, Job> rows() {
+        return rowsByTenant.computeIfAbsent(currentTenantId.get(), tenantId -> new LinkedHashMap<>());
+    }
+
+    private void addTenant(String tenantId) {
+        Tenant tenant = mock(Tenant.class);
+        when(tenant.getId()).thenReturn(tenantId);
+        when(tenant.isDefault()).thenReturn(DEFAULT_TENANT_ID.equals(tenantId));
+        provisionedTenants.put(tenantId, tenant);
+    }
+
+    private void loadJob() {
+        consumer.onClassLoaded(new LoadedClass("sample", ReportsJob.class.getName(), ReportsJob.class, ReportsJob.class.getClassLoader()));
+    }
+}

--- a/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
+++ b/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
@@ -253,6 +253,13 @@ public enum DirigibleConfig {
      */
     EVENT_OUTBOX_RELAY_GRACE_SECONDS("DIRIGIBLE_EVENT_OUTBOX_RELAY_GRACE_SECONDS", "60"),
 
+    /**
+     * Interval (seconds) between ticks of the watchdog that re-attempts client-Java runtime state a
+     * previous pass could not establish - a JMS subscription the broker refused, a job registration
+     * that threw.
+     */
+    JAVA_RECONCILE_INTERVAL_SECONDS("DIRIGIBLE_JAVA_RECONCILE_INTERVAL_SECONDS", "30"),
+
     /** Anthropic API key powering the Intent Editor's AI assistant; blank disables the assistant. */
     INTENT_AI_API_KEY("DIRIGIBLE_INTENT_AI_API_KEY", null),
 

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaListenerSubscriptionRetryIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaListenerSubscriptionRetryIT.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.components.api.messaging.MessagingFacade;
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.components.listeners.config.ActiveMQConnectionArtifactsFactory;
+import org.eclipse.dirigible.engine.java.listener.ListenerClassConsumer;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.logging.LogsAsserter;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import ch.qos.logback.classic.Level;
+
+/**
+ * A client-Java listener whose subscription the broker refuses must end up subscribed anyway.
+ *
+ * <p>
+ * On a restart the attempt races the embedded broker's {@code vm://localhost} transport, and when
+ * it lost that race nothing ever tried again: the generation is rebuilt only on publish, and the
+ * post-provisioning top-up runs only when a tenant was actually provisioned. A topic discards
+ * whatever it delivers to nobody, so the handler stayed silent for the life of the process while
+ * every generated controller answered 200 - which is how an intent application's {@code onCreate}
+ * process trigger came to write the row and start nothing (issue #7217).
+ *
+ * <p>
+ * The refusal is injected at the one place it really originates, and in its real shape: the
+ * connection factory turns the broker's {@code JMSException} into an {@link IllegalStateException}.
+ * It is scoped to this probe listener's own durable subscription id, so the platform's other
+ * messaging is untouched. The recovery is then asserted end to end - a message published to the
+ * topic has to reach the handler and come back on its queue - with nothing between the deploy and
+ * the round trip but the passage of time.
+ */
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class JavaListenerSubscriptionRetryIT extends IntegrationTest {
+
+    private static final String PROJECT = "java-listener-retry-it";
+    private static final String HANDLER_CLASS = "RetryProbeListener";
+    private static final String TOPIC = PROJECT + "-in";
+    private static final String QUEUE = PROJECT + "-out";
+
+    /**
+     * Short enough to keep the test quick, long enough to be a real timer rather than a direct call.
+     */
+    private static final String RECONCILE_INTERVAL_SECONDS = "2";
+
+    private static final int SUBSCRIPTION_FAILURE_TIMEOUT_SECONDS = 60;
+    private static final int ROUND_TRIP_TIMEOUT_SECONDS = 90;
+
+    /** Per attempt - short, because a failed attempt is retried with a fresh publish. */
+    private static final long RECEIVE_TIMEOUT_MILLIS = 2000;
+
+    private static String previousReconcileInterval;
+
+    /** While set, this probe's subscription attempts fail the way a starting broker fails them. */
+    private volatile boolean refuseProbeSubscription = true;
+
+    @MockitoSpyBean
+    private ActiveMQConnectionArtifactsFactory connectionArtifactsFactory;
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    private LogsAsserter consumerLogs;
+
+    /** Before the context exists, so the reconciler reads the shortened interval when it starts. */
+    @BeforeAll
+    static void shortenTheReconcileInterval() {
+        previousReconcileInterval = DirigibleConfig.JAVA_RECONCILE_INTERVAL_SECONDS.getStringValue();
+        DirigibleConfig.JAVA_RECONCILE_INTERVAL_SECONDS.setStringValue(RECONCILE_INTERVAL_SECONDS);
+    }
+
+    @AfterAll
+    static void restoreTheReconcileInterval() {
+        DirigibleConfig.JAVA_RECONCILE_INTERVAL_SECONDS.setStringValue(previousReconcileInterval);
+    }
+
+    /**
+     * One answer, installed once and steered by a flag. Re-stubbing a spy other threads are calling is
+     * how these tests turn flaky.
+     */
+    @BeforeEach
+    void armTheBrokerRefusal() {
+        // Attached here rather than in a field: Spring re-initializes logback while it starts the
+        // application context, which drops an appender attached any earlier.
+        consumerLogs = new LogsAsserter(ListenerClassConsumer.class, Level.WARN);
+
+        doAnswer(invocation -> {
+            String clientId = invocation.getArgument(1);
+            // A queue subscription passes no client id at all, and so does the platform's own shared
+            // connection - the one-arg overload delegates here with null, and a spy intercepts even that
+            // self-call. Everything but this probe's durable topic subscription must behave normally.
+            if (refuseProbeSubscription && clientId != null && clientId.contains(HANDLER_CLASS)) {
+                throw new IllegalStateException("Failed to create connection to ActiveMQ");
+            }
+            return invocation.callRealMethod();
+        }).when(connectionArtifactsFactory)
+          .createConnection(any(), any());
+    }
+
+    @Test
+    void aSubscriptionTheBrokerRefusedIsRetriedUntilItConnects() {
+        deployProbeListener();
+
+        // Without this the whole test would pass on a spy that never intercepted anything.
+        Awaitility.await()
+                  .pollInterval(1, TimeUnit.SECONDS)
+                  .atMost(SUBSCRIPTION_FAILURE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                  .until(() -> consumerLogs.containsMessage("Failed to start listener [demo." + HANDLER_CLASS + "]", Level.WARN));
+
+        refuseProbeSubscription = false;
+
+        // Nothing republishes and no tenant is provisioned from here on: only the reconciliation timer
+        // can open this subscription now.
+        assertRoundTrip();
+    }
+
+    /**
+     * Publish into the topic and draw the listener's echo back off its queue, retrying the whole
+     * exchange. A durable subscription retains only what is published once it exists, and the refused
+     * attempt never created it, so every message sent before the retry lands is simply gone.
+     */
+    private void assertRoundTrip() {
+        String message = "ping-" + System.currentTimeMillis();
+        String[] received = new String[1];
+
+        Awaitility.await()
+                  .pollInterval(1, TimeUnit.SECONDS)
+                  .atMost(ROUND_TRIP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                  .until(() -> {
+                      MessagingFacade.sendToTopic(TOPIC, message);
+                      try {
+                          received[0] = MessagingFacade.receiveFromQueue(QUEUE, RECEIVE_TIMEOUT_MILLIS);
+                          return true;
+                      } catch (RuntimeException notYet) {
+                          return false;
+                      }
+                  });
+
+        assertEquals("echo:" + message, received[0],
+                "the listener must handle what is published once the retry has opened its subscription");
+    }
+
+    /** Write a client listener source into the registry and reconcile it. */
+    private void deployProbeListener() {
+        String source = """
+                package demo;
+
+                import org.eclipse.dirigible.sdk.component.Component;
+                import org.eclipse.dirigible.sdk.messaging.ListenerKind;
+                import org.eclipse.dirigible.sdk.messaging.MessageHandler;
+                import org.eclipse.dirigible.sdk.messaging.Producer;
+
+                @Component
+                public class %s implements MessageHandler {
+
+                    @Override
+                    public String destination() {
+                        return "%s";
+                    }
+
+                    @Override
+                    public ListenerKind kind() {
+                        return ListenerKind.TOPIC;
+                    }
+
+                    @Override
+                    public void onMessage(String message) {
+                        Producer.sendToQueue("%s", "echo:" + message);
+                    }
+                }
+                """.formatted(HANDLER_CLASS, TOPIC, QUEUE);
+
+        String path = IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/demo/" + HANDLER_CLASS + ".java";
+        repository.createResource(path, source.getBytes(StandardCharsets.UTF_8), false, "text/x-java", true);
+        synchronizationProcessor.forceProcessSynchronizers();
+    }
+}


### PR DESCRIPTION
Fixes #7217.

## The defect

A client-Java `MessageHandler` / `@Listener` whose subscription fails while the embedded broker is still starting is **never retried**, so it stays unsubscribed for the life of the process. A topic discards whatever it delivers to nobody, so every message published to that destination afterwards is silently lost — which is why an intent application's `trigger: { onCreate: X }` writes the row, leaves `ProcessId` null, and looks perfectly healthy: every controller answers 200 and the only clue is one ERROR line at boot that says nothing about the consequence.

`subscribeMissingTenants` leaves a failed tenant unrecorded "so the next load or provisioning round retries it cleanly". On a steady-state instance neither trigger ever arrives: a generation is rebuilt only on publish, and `TenantsProvisioner` runs the post-provisioning steps only `if (!tenants.isEmpty())` over `findByStatus(INITIAL)`.

The window is also wider than the first second of boot. With a shared message store a standby node's broker may not take the lease for a long time, and `EmbeddedBrokerMessagingConfig`'s own javadoc already promises that "a send or a listener that runs before the broker is master fails **and is retried**". That promise is exactly what this consumer broke — hence an unbounded retry rather than a few attempts.

## The fix

`JavaConsumersReconciler` calls a new `JavaClassConsumer.reconcile()` on every consumer every `DIRIGIBLE_JAVA_RECONCILE_INTERVAL_SECONDS` (30), on **a JVM-local daemon timer of its own**. Neither of the two schedulers already in the platform would do:

- a Quartz `SystemJob` fires **once cluster-wide** (`org.quartz.jobStore.isClustered=true`), and JMS subscriptions are per-JVM state — the nodes that did not win the trigger would stay unsubscribed forever;
- Spring's `@Scheduled` pool is a **single thread** shared with `AccessVerifier` (5 s / 8 s) and `TscWatcherService` (30 s), and in external-broker mode a `failover:` URL makes `createConnection` block indefinitely — one unreachable broker would freeze those too.

Three defects had to go with it, or the retry would have had nothing to work on:

1. **`subscribe(...)` caught only `JMSException`.** `ActiveMQConnectionArtifactsFactory` reports a broker that is not accepting by wrapping it in an `IllegalStateException`, so the failure never took the intended `return null` path: it escaped the per-tenant fan-out — skipping every tenant behind the failing one and leaking the connections already opened — or, from `subscribeGlobal`, aborted `register()` before the tenants were reached at all.
2. **A failed *global* subscription was retried by nothing** — `subscribeGlobal` was reachable only from a class load. It is now idempotent, all-or-nothing, and part of the top-up (so `execute()` covers it too).
3. **`ScheduledClassConsumer` had the same shape of hole, with a worse consequence.** It recorded only the declarations that registered successfully, so a job whose registration threw was dropped from its tracking and could not be retried by anything — and because the stale-name sweep then compared the previous names against the *successful* ones, a transient failure on reload **deleted the `Job` row** an earlier run had created, taking the operator's enabled flag with it (the very thing #6626 went to the trouble of preserving).

Two smaller things the retry made necessary:

- **A pass re-checks registration identity** (`registrations.get(fqn) != registration`) before subscribing. A pass iterates a weakly consistent map and a republish can install a new registration mid-pass; subscribing the old one would open connections nothing holds a reference to — live on the destination its replacement is also consuming, and impossible to ever close.
- **The tenant fan-out happens once per pass, not once per class.** `executeForEachTenant` reads the provisioned tenants from the database; per-class was fine for a rare provisioning round, not for a 30 s tick.

**Log volume** is bounded on purpose: WARN with the throwable on a subscription's first failure, DEBUG on the repeats, plus one WARN summary per incomplete pass. A permanently refused subscription is not hypothetical — every node of a deployment derives the same durable subscription id, so the second one to attach is turned away for good — and it would otherwise emit a line per subscription per tenant per tick forever. WARN rather than ERROR because it now self-heals, and the repeating summary is the operator signal the single boot-time ERROR never was.

## Tests

- **`JavaListenerSubscriptionRetryIT`** (new, HTTP-level) is the end-to-end guard. The refusal is injected at the one place it originates and in its real shape — a `@MockitoSpyBean ActiveMQConnectionArtifactsFactory` throwing `IllegalStateException`, scoped to the probe listener's own durable subscription id so the platform's other messaging is untouched. It then deploys the listener, asserts the refusal actually happened (a green no-op otherwise), disarms, and asserts a real round trip: a message published to the topic reaches the handler and comes back on its queue, with nothing between the deploy and the round trip but the passage of time. **Verified to time out on the pre-fix behaviour.**
- **`ListenerClassConsumerRetryTest`** (6), **`ScheduledClassConsumerRetryTest`** (3), **`JavaConsumersReconcilerTest`** (2) — new unit tests in the module's existing style. The listener ones fail loudly if the `RuntimeException` catch is removed.
- `ListenerClassConsumerTenantSubscriptionTest.aTenantProvisionedLaterDoesNotAddASecondGlobalSubscription` used to pass trivially (`execute()` never touched globals); it is now the real idempotence guard for `globalSubscribed`. All 128 `engine-java` unit tests and `JavaEngineIT` / `JavaListenerTenantIT` pass.

## Deliberately not in this PR

- **Broker readiness as a real precondition** (the issue's "second, smaller question"). Worth noting *why* the `@DependsOn("ActiveMQBroker")` looks insufficient: the listener path does not go through the `@Lazy` `ActiveMQConnection` bean at all — it builds its own connections straight off `ActiveMQConnectionFactory`. A fix would therefore mean a blocking wait inside the shared `ActiveMQConnectionArtifactsFactory`, which is the delicate area of #7002's rolling-deploy startup deadlock. The retry removes the consequence.
- **The `.listener` artefact path has the same gap.** `ListenerSynchronizer`'s START phase retries once within the first pass and then registers `FATAL`, after which `parseDefinitions()` strips the artefact and nothing retries until the file's bytes change. Same root cause, different module — filed separately as #7248 so this fix does not *look* like it covered it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

