### PR TITLE
LeakedConnectionsDoctor retains every borrowed connection (unsynchronized HashSet + silently dying sweep task) -> OutOfMemoryError

### DIFF
--- a/components/data/data-sources/src/main/java/com/zaxxer/hikari/pool/LeakedConnectionsDoctor.java
+++ b/components/data/data-sources/src/main/java/com/zaxxer/hikari/pool/LeakedConnectionsDoctor.java
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Component;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -30,14 +30,16 @@ public class LeakedConnectionsDoctor {
     private static final Logger LOGGER = LoggerFactory.getLogger(LeakedConnectionsDoctor.class);
     private static final long MAX_IN_USE_MILLIS =
             TimeUnit.SECONDS.toMillis(DirigibleConfig.LEAKED_CONNECTIONS_MAX_IN_USE_SECONDS.getIntValue());
-    private static final Set<InUseConnectionEntry> IN_USE_CONNECTIONS = new HashSet<>();
+    // registered from every thread that borrows a connection while the check thread iterates - the
+    // weakly consistent iteration of a concurrent set never throws ConcurrentModificationException
+    private static final Set<InUseConnectionEntry> IN_USE_CONNECTIONS = ConcurrentHashMap.newKeySet();
 
     public static void init() {
         ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
 
         LOGGER.info("Scheduling check for leaked connection with initial delay of [{}] seconds and interval [{}] seconds.", INITIAL_DELAY,
                 DirigibleConfig.LEAKED_CONNECTIONS_CHECK_INTERVAL_SECONDS.getIntValue());
-        executor.scheduleAtFixedRate(LeakedConnectionsDoctor::closeLeakedConnections, INITIAL_DELAY,
+        executor.scheduleAtFixedRate(LeakedConnectionsDoctor::checkForLeakedConnections, INITIAL_DELAY,
                 DirigibleConfig.LEAKED_CONNECTIONS_CHECK_INTERVAL_SECONDS.getIntValue(), TimeUnit.SECONDS);
 
         Runtime.getRuntime()
@@ -55,18 +57,26 @@ public class LeakedConnectionsDoctor {
                }));
     }
 
-    private static void closeLeakedConnections() {
-        LOGGER.debug("Checking for leaked connections...");
-        long executionStartedAt = System.currentTimeMillis();
-        Set<InUseConnectionEntry> leftInUseConnections = new HashSet<>();
-        Set<InUseConnectionEntry> connectionsForRemove = new HashSet<>();
+    private static void checkForLeakedConnections() {
+        try {
+            closeLeakedConnections();
+        } catch (Throwable ex) {
+            // a scheduled task that throws is never executed again and the executor reports nothing,
+            // so every connection registered from then on would be retained until the heap is exhausted
+            LOGGER.error("Failed to check for leaked connections. Will retry on the next scheduled execution.", ex);
+        }
+    }
 
-        IN_USE_CONNECTIONS.forEach(entry -> {
+    static void closeLeakedConnections() {
+        LOGGER.debug("Checking [{}] registered connections for leaks...", IN_USE_CONNECTIONS.size());
+        long executionStartedAt = System.currentTimeMillis();
+
+        for (InUseConnectionEntry entry : IN_USE_CONNECTIONS) {
             if (isClosed(entry.getConnection())) {
                 LOGGER.debug("Connection [{}] borrowed at [{}] is closed. Will be removed from the list.", entry.getConnection(),
                         entry.getBorrowedAt());
-                connectionsForRemove.add(entry);
-                return;
+                IN_USE_CONNECTIONS.remove(entry);
+                continue;
             }
 
             if (entry.getConnection() instanceof HikariProxyConnection hikariProxyConnection
@@ -77,19 +87,16 @@ public class LeakedConnectionsDoctor {
                 boolean maxInUsePassed = executionStartedAt > (entry.getBorrowedAt() + MAX_IN_USE_MILLIS);
                 if (maxInUsePassed) {
                     closeLeakedEntry(entry, hikariProxyConnection);
-                    connectionsForRemove.add(entry);
+                    IN_USE_CONNECTIONS.remove(entry);
                 } else {
                     LOGGER.debug(
                             "Connection [{}] borrowed at [{}] didn't reached the configured max in use time of [{}] millis. Will check it on the next execution.",
                             entry.getConnection(), entry.getBorrowedAt(), MAX_IN_USE_MILLIS);
-                    leftInUseConnections.add(entry);
                 }
             } else {
-                connectionsForRemove.add(entry);
+                IN_USE_CONNECTIONS.remove(entry);
             }
-        });
-        IN_USE_CONNECTIONS.removeAll(connectionsForRemove);
-        IN_USE_CONNECTIONS.addAll(leftInUseConnections);
+        }
     }
 
     private static void closeLeakedEntry(InUseConnectionEntry entry, HikariProxyConnection hikariProxyConnection) {
@@ -131,5 +138,19 @@ public class LeakedConnectionsDoctor {
 
     public static void registerConnection(Connection connection) {
         IN_USE_CONNECTIONS.add(new InUseConnectionEntry(connection));
+    }
+
+    /**
+     * Forgets a connection that was returned to the pool, so that it is not retained until the next
+     * check.
+     *
+     * @param connection the connection registered by {@link #registerConnection(Connection)}
+     */
+    public static void unregisterConnection(Connection connection) {
+        IN_USE_CONNECTIONS.remove(new InUseConnectionEntry(connection));
+    }
+
+    static boolean isRegistered(Connection connection) {
+        return IN_USE_CONNECTIONS.contains(new InUseConnectionEntry(connection));
     }
 }

--- a/components/data/data-sources/src/main/java/org/eclipse/dirigible/components/data/sources/manager/DirigibleConnectionImpl.java
+++ b/components/data/data-sources/src/main/java/org/eclipse/dirigible/components/data/sources/manager/DirigibleConnectionImpl.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.dirigible.components.data.sources.manager;
 
+import com.zaxxer.hikari.pool.LeakedConnectionsDoctor;
 import org.eclipse.dirigible.components.database.DatabaseSystem;
 import org.eclipse.dirigible.components.database.DirigibleConnection;
 
@@ -72,6 +73,7 @@ class DirigibleConnectionImpl implements DirigibleConnection {
     @Override
     public void close() throws SQLException {
         connection.close();
+        LeakedConnectionsDoctor.unregisterConnection(connection);
     }
 
     @Override

--- a/components/data/data-sources/src/test/java/com/zaxxer/hikari/pool/LeakedConnectionsDoctorTest.java
+++ b/components/data/data-sources/src/test/java/com/zaxxer/hikari/pool/LeakedConnectionsDoctorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package com.zaxxer.hikari.pool;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LeakedConnectionsDoctorTest {
+
+    @Test
+    void checkSurvivesConnectionBorrowedOnAnotherThreadWhileItRuns() throws SQLException {
+        Connection borrowedDuringCheck = mock(Connection.class);
+        Answer<Boolean> borrowOnAnotherThread = invocation -> {
+            // a request thread borrows a connection while the check thread is iterating the registered ones
+            Thread borrower = new Thread(() -> LeakedConnectionsDoctor.registerConnection(borrowedDuringCheck));
+            borrower.start();
+            borrower.join();
+            return false;
+        };
+        // two registered connections, so that the iteration continues after the borrow
+        List<Connection> inspected = List.of(mock(Connection.class), mock(Connection.class));
+        for (Connection connection : inspected) {
+            when(connection.isClosed()).thenAnswer(borrowOnAnotherThread);
+            LeakedConnectionsDoctor.registerConnection(connection);
+        }
+
+        assertDoesNotThrow(LeakedConnectionsDoctor::closeLeakedConnections);
+
+        LeakedConnectionsDoctor.closeLeakedConnections();
+        for (Connection connection : inspected) {
+            assertFalse(LeakedConnectionsDoctor.isRegistered(connection));
+        }
+        assertFalse(LeakedConnectionsDoctor.isRegistered(borrowedDuringCheck));
+    }
+
+    @Test
+    void checkForgetsClosedConnection() throws SQLException {
+        Connection connection = mock(Connection.class);
+        when(connection.isClosed()).thenReturn(true);
+        LeakedConnectionsDoctor.registerConnection(connection);
+
+        LeakedConnectionsDoctor.closeLeakedConnections();
+
+        assertFalse(LeakedConnectionsDoctor.isRegistered(connection));
+    }
+
+    @Test
+    void unregisterForgetsConnectionWithoutWaitingForCheck() {
+        Connection connection = mock(Connection.class);
+        LeakedConnectionsDoctor.registerConnection(connection);
+        assertTrue(LeakedConnectionsDoctor.isRegistered(connection));
+
+        LeakedConnectionsDoctor.unregisterConnection(connection);
+
+        assertFalse(LeakedConnectionsDoctor.isRegistered(connection));
+    }
+}

--- a/components/data/data-sources/src/test/java/org/eclipse/dirigible/components/data/sources/manager/DirigibleConnectionImplTest.java
+++ b/components/data/data-sources/src/test/java/org/eclipse/dirigible/components/data/sources/manager/DirigibleConnectionImplTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.data.sources.manager;
+
+import com.zaxxer.hikari.pool.LeakedConnectionsDoctor;
+import org.eclipse.dirigible.components.database.DatabaseSystem;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+class DirigibleConnectionImplTest {
+
+    private final Connection connection = mock(Connection.class);
+    private final DirigibleConnectionImpl dirigibleConnection = new DirigibleConnectionImpl("TestDB", connection, DatabaseSystem.H2);
+
+    @Test
+    void closeUnregistersConnectionFromLeakedConnectionsDoctor() throws SQLException {
+        try (MockedStatic<LeakedConnectionsDoctor> doctor = mockStatic(LeakedConnectionsDoctor.class)) {
+            dirigibleConnection.close();
+
+            verify(connection).close();
+            doctor.verify(() -> LeakedConnectionsDoctor.unregisterConnection(connection));
+        }
+    }
+
+    @Test
+    void failedCloseLeavesConnectionRegisteredForLeakedConnectionsDoctor() throws SQLException {
+        doThrow(new SQLException("close failed")).when(connection)
+                                                 .close();
+
+        try (MockedStatic<LeakedConnectionsDoctor> doctor = mockStatic(LeakedConnectionsDoctor.class)) {
+            assertThrows(SQLException.class, dirigibleConnection::close);
+
+            doctor.verifyNoInteractions();
+        }
+    }
+}


### PR DESCRIPTION
## Overview

The leaked-connections check no longer dies on the first connection borrowed while it runs, and a connection returned to the pool is forgotten immediately instead of being retained until the next check. A long-running instance therefore stops accumulating closed connections until it runs out of heap.

Fixes: #7194.
