### PR TITLE
templates: an authored default is escaped into the JSON string it is written into (#7206)

### DIFF
--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/JsonLiterals.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/JsonLiterals.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.ide.template.service.model;
+
+/**
+ * JSON literals for values a model carries as text.
+ *
+ * <p>
+ * The generated {@code .schema} is a JSON document assembled by a template, which interpolates a
+ * model value verbatim. A value holding a quote or a backslash therefore used to end the string it
+ * was being written into and leave the whole artefact unparseable - an authored
+ * {@code defaultValue: '6"'} rendered {@code "defaultValue": "6"",} and the synchronizer then
+ * created no table for ANY entity of the project (dirigible #7206). Escaping the value keeps the
+ * worst case at one mis-valued column DEFAULT.
+ *
+ * <p>
+ * The twin of {@link JavaLiterals} for the other literal syntax the same authored value reaches.
+ */
+final class JsonLiterals {
+
+    /**
+     * Not instantiable.
+     */
+    private JsonLiterals() {}
+
+    /**
+     * Escapes a value for placement inside a JSON string: the backslash and the double quote that would
+     * otherwise end the string, and the control characters JSON does not admit in one at all.
+     *
+     * @param value the raw value
+     * @return the escaped value, ready to be placed between two double quotes
+     */
+    static String escape(String value) {
+        StringBuilder escaped = new StringBuilder(value.length() + 8);
+        for (int index = 0; index < value.length(); index++) {
+            char character = value.charAt(index);
+            switch (character) {
+                case '\\' -> escaped.append("\\\\");
+                case '"' -> escaped.append("\\\"");
+                case '\n' -> escaped.append("\\n");
+                case '\r' -> escaped.append("\\r");
+                case '\t' -> escaped.append("\\t");
+                case '\b' -> escaped.append("\\b");
+                case '\f' -> escaped.append("\\f");
+                default -> {
+                    if (character < 0x20) {
+                        escaped.append(String.format("\\u%04x", (int) character));
+                    } else {
+                        escaped.append(character);
+                    }
+                }
+            }
+        }
+        return escaped.toString();
+    }
+
+    /**
+     * A value as a complete JSON string literal, quotes included.
+     *
+     * <p>
+     * The quotes belong to the literal rather than to the template around it, so that a template can
+     * read the key's presence as "there is a value here" and never has to write a quote of its own next
+     * to an interpolation.
+     *
+     * @param value the raw value
+     * @return the quoted, escaped literal
+     */
+    static String stringLiteral(String value) {
+        return "\"" + escape(value) + "\"";
+    }
+}

--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/ModelParameterProcessor.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/ModelParameterProcessor.java
@@ -352,7 +352,7 @@ final class ModelParameterProcessor {
             property.put("widgetIsMajor", Boolean.FALSE);
         }
 
-        resolveDefaultValueLiteral(property);
+        resolveDefaultValueLiterals(property);
 
         resolveWidgetLengths(property, entity, dataType);
         property.put("inputRule", strOr(property, "widgetPattern", ""));
@@ -363,27 +363,41 @@ final class ModelParameterProcessor {
     }
 
     /**
-     * Derives the authored default as a Java expression, for the properties whose default the generated
-     * repository can apply itself.
+     * Derives the authored default as the literals the generated artefacts write it into.
      *
      * <p>
-     * The default is also the column's DB DEFAULT, but the database supplies it at INSERT - which is
-     * after the create-time calculations have already run in Java and read a null (#7104), so the
-     * repository assigns it first. The expression is resolved here rather than assembled in the
-     * template, so an authored value carrying a quote or a backslash is escaped instead of ending the
-     * literal it is written into and failing the compile of the whole generated module (#7154).
+     * The value is a piece of authored text that ends up inside a Java string literal (the repository
+     * assigning the default) and inside a JSON string (the {@code .schema} declaring the column
+     * DEFAULT). Interpolated verbatim by a template, a value carrying a quote or a backslash ended the
+     * literal it was being written into and took the whole artefact with it - a failed compile of the
+     * generated module (#7154), an unparseable schema for which the synchronizer then created no table
+     * at all (#7206). Resolving the literals here keeps the worst case at one mis-valued field.
      *
      * <p>
-     * A key with no expression is left absent rather than null: a template reads the key's presence as
-     * "this property has a default to apply".
+     * The JSON literal is the value as authored, because the schema's DEFAULT reaches the DDL verbatim
+     * by design - a malformed default is the author's broken SQL, and only escaped so that it cannot
+     * break anything but its own column. The Java expression is of the property's own type and exists
+     * only where a literal can stand in for the default at all.
+     *
+     * <p>
+     * A key with no value is left absent rather than null: a template reads the key's presence as "this
+     * property has a default".
      *
      * @param property the property
      */
-    private static void resolveDefaultValueLiteral(Map<String, Object> property) {
+    private static void resolveDefaultValueLiterals(Map<String, Object> property) {
+        String defaultValue = str(property, "dataDefaultValue");
+        if (defaultValue == null || defaultValue.isEmpty()) {
+            return;
+        }
+        property.put("dataDefaultValueJsonLiteral", JsonLiterals.stringLiteral(defaultValue));
+
+        // The generated key is the database's to assign, so its default is never applied in Java - the
+        // schema, which only declares what was authored, keeps carrying it.
         if (Boolean.TRUE.equals(property.get("dataPrimaryKey")) || Boolean.TRUE.equals(property.get("dataAutoIncrement"))) {
             return;
         }
-        String expression = JavaLiterals.defaultValueExpression(str(property, "dataTypeJavaClass"), str(property, "dataDefaultValue"));
+        String expression = JavaLiterals.defaultValueExpression(str(property, "dataTypeJavaClass"), defaultValue);
         if (expression != null) {
             property.put("dataDefaultValueJavaLiteral", expression);
         }

--- a/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/JsonLiteralsTest.java
+++ b/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/JsonLiteralsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.ide.template.service.model;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonPrimitive;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests the JSON literals a model value is written into a generated artefact as.
+ */
+class JsonLiteralsTest {
+
+    private static final Gson GSON = new Gson();
+
+    @Test
+    void leavesAnOrdinaryValueAlone() {
+        assertEquals("\"DRAFT\"", JsonLiterals.stringLiteral("DRAFT"));
+        assertEquals("\"6 mm\"", JsonLiterals.stringLiteral("6 mm"));
+        assertEquals("\"Ц\"", JsonLiterals.stringLiteral("Ц"));
+        assertEquals("\"\"", JsonLiterals.stringLiteral(""));
+    }
+
+    /**
+     * The defect: the quote used to end the string it was being written into, so one authored inch mark
+     * left the whole schema artefact unparseable and every table of the project uncreated (#7206).
+     */
+    @Test
+    void escapesTheCharactersThatWouldEndTheString() {
+        assertEquals("\"6\\\"\"", JsonLiterals.stringLiteral("6\""));
+        assertEquals("\"C:\\\\tmp\"", JsonLiterals.stringLiteral("C:\\tmp"));
+        assertEquals("\"\\\\\\\"\"", JsonLiterals.stringLiteral("\\\""));
+    }
+
+    /**
+     * A raw control character is not admitted in a JSON string at all, whatever the quotes around it.
+     */
+    @Test
+    void escapesTheControlCharactersJsonDoesNotAdmit() {
+        assertEquals("\"a\\nb\"", JsonLiterals.stringLiteral("a\nb"));
+        assertEquals("\"a\\rb\"", JsonLiterals.stringLiteral("a\rb"));
+        assertEquals("\"a\\tb\"", JsonLiterals.stringLiteral("a\tb"));
+        assertEquals("\"a\\bb\"", JsonLiterals.stringLiteral("a\bb"));
+        assertEquals("\"a\\fb\"", JsonLiterals.stringLiteral("a\fb"));
+        assertEquals("\"a\\u0000b\"", JsonLiterals.stringLiteral("a\u0000b"));
+        assertEquals("\"a\\u001bb\"", JsonLiterals.stringLiteral("a\u001bb"));
+    }
+
+    /**
+     * The DEFAULT reaches the DDL from the parsed schema, so the literal has to read back as the value
+     * the author wrote - escaping it must not change the column's default, only keep it from taking the
+     * artefact with it.
+     */
+    @Test
+    void readsBackAsTheAuthoredValue() {
+        for (String value : new String[] {"DRAFT", "'DRAFT'", "6\"", "C:\\tmp", "a\nb", "a\u0000b", "\\\"", "Ц"}) {
+            assertEquals(value, GSON.fromJson(JsonLiterals.stringLiteral(value), JsonPrimitive.class)
+                                    .getAsString(),
+                    "the escaped literal must parse back to the authored value");
+        }
+    }
+}

--- a/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/ModelParameterProcessorTest.java
+++ b/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/ModelParameterProcessorTest.java
@@ -113,6 +113,38 @@ class ModelParameterProcessorTest {
         assertFalse(generatedKey.containsKey("dataDefaultValueJavaLiteral"));
     }
 
+    /**
+     * The .schema declares the same default as the column's DB DEFAULT, in a JSON string - so the
+     * parameter graph carries it escaped for one too, as authored (the value reaches the DDL verbatim
+     * by design) and quotes included. It used to be interpolated unescaped, and an authored quote left
+     * the whole schema artefact unparseable, so the synchronizer created no table for ANY entity of the
+     * project (#7206).
+     */
+    @Test
+    void carriesTheAuthoredDefaultAsAnEscapedJsonLiteralToo() {
+        Map<String, Object> quoted = property("Size", "VARCHAR");
+        quoted.put("dataDefaultValue", "6\" \\ wide");
+        Map<String, Object> status = property("Status", "VARCHAR");
+        status.put("dataDefaultValue", "'DRAFT'");
+        Map<String, Object> issued = property("Issued", "DATE");
+        issued.put("dataDefaultValue", "CURRENT_DATE");
+        // The database assigns the generated key, so it carries no Java literal - but the schema still
+        // declares whatever was authored on it.
+        Map<String, Object> generatedKey = property("Id", "INTEGER");
+        generatedKey.put("dataPrimaryKey", "true");
+        generatedKey.put("dataAutoIncrement", "true");
+        generatedKey.put("dataDefaultValue", "1");
+        Map<String, Object> none = property("Name", "VARCHAR");
+        ModelParameterProcessor.process(model(entity("Line", "Lines", quoted, status, issued, generatedKey, none)), parameters());
+
+        assertEquals("\"6\\\" \\\\ wide\"", quoted.get("dataDefaultValueJsonLiteral"));
+        assertEquals("\"'DRAFT'\"", status.get("dataDefaultValueJsonLiteral"),
+                "the SQL quotes are the DDL's, so the schema keeps the value as authored");
+        assertEquals("\"CURRENT_DATE\"", issued.get("dataDefaultValueJsonLiteral"));
+        assertEquals("\"1\"", generatedKey.get("dataDefaultValueJsonLiteral"));
+        assertFalse(none.containsKey("dataDefaultValueJsonLiteral"), "a property with no default must leave the key absent");
+    }
+
     @Test
     void defaultsTheWidgetLabelFromThePropertyName() {
         Map<String, Object> property = property("TaxEventDate", "DATE");

--- a/components/template/template-application-schema/src/main/resources/META-INF/dirigible/template-application-schema/data/application.schema.template
+++ b/components/template/template-application-schema/src/main/resources/META-INF/dirigible/template-application-schema/data/application.schema.template
@@ -143,8 +143,12 @@
 #if($property.dataScale)
                         "scale": "${property.dataScale}",
 #end
-#if($property.dataDefaultValue)
-                        "defaultValue": "${property.dataDefaultValue}",
+## The authored default reaches the DDL verbatim by design, so a malformed one is the author's broken
+## SQL - but it is escaped into this JSON string (as ${property.dataDefaultValueJsonLiteral}, quotes
+## included), so that at worst it mis-values its own column instead of leaving the whole schema
+## artefact unparseable and every table of the project uncreated (#7206).
+#if($property.dataDefaultValueJsonLiteral)
+                        "defaultValue": ${property.dataDefaultValueJsonLiteral},
 #end
 #if($property.dataNotNull)
 #else

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -18,10 +18,16 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
+import org.eclipse.dirigible.components.data.structures.domain.Table;
+import org.eclipse.dirigible.components.data.structures.domain.TableColumn;
+import org.eclipse.dirigible.components.data.structures.synchronizer.SchemasSynchronizer;
 import org.eclipse.dirigible.repository.api.IRepository;
 import org.eclipse.dirigible.repository.api.IRepositoryStructure;
 import org.eclipse.dirigible.repository.api.IResource;
@@ -32,6 +38,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
 /**
  * End-to-end test for the intent editor services: {@code POST /services/ide/intent/parse} (the
@@ -449,6 +458,12 @@ class IntentEngineIT extends IntegrationTest {
 
     @Autowired
     private RestAssuredExecutor restAssuredExecutor;
+
+    /**
+     * Reads a generated .schema back exactly as the runtime does, to assert what it creates from it.
+     */
+    @Autowired
+    private SchemasSynchronizer schemasSynchronizer;
 
     @Test
     void parse_returns_the_full_model() {
@@ -3921,6 +3936,47 @@ class IntentEngineIT extends IntegrationTest {
         // user deliberately cleared stays cleared through update().
         assertEquals(1, occurrencesOf(repository, "entity.VatRate = new java.math.BigDecimal(\"20\")"),
                 "the default must be applied on create only, never re-applied by update(): " + repository);
+    }
+
+    @Test
+    void an_authored_default_carrying_a_quote_keeps_the_schema_parseable() {
+        // #7206: the .schema wrote the authored default into a JSON string verbatim, so an authored inch
+        // mark ended that string and left the whole artefact unparseable - the synchronizer then created
+        // NO table for any entity of the project, not just the one column's. The sibling of #7154 in the
+        // other literal syntax the same value reaches.
+        writeIntent("""
+                name: sizing
+                entities:
+                  - name: Panel
+                    fields:
+                      - { name: id,    type: integer, primaryKey: true, generated: true }
+                      - { name: size,  type: string, length: 20, defaultValue: '6" \\ wide' }
+                      - { name: stage, type: string, length: 20, defaultValue: DRAFT }
+                """);
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .post(GENERATE_URL)
+                                                 .then()
+                                                 .statusCode(200));
+        generateFromModel("template-application-schema/template/template.js", "sizing.model");
+        String schema = contentOf("gen/sizing/schema/" + PROJECT + ".schema");
+
+        try {
+            assertNotNull(new Gson().fromJson(schema, JsonObject.class));
+        } catch (RuntimeException e) {
+            throw new AssertionError("the emitted schema must be valid JSON: " + schema, e);
+        }
+        // And the DEFAULT the synchronizer reads back is the value as authored - escaping it keeps the
+        // artefact parseable without changing what the column defaults to. A quote in it remains the
+        // author's broken SQL, on that one column.
+        Table table = schemasSynchronizer.parseSchema("/sizing-it/application.schema", schema)
+                                         .getTables()
+                                         .get(0);
+        Map<String, String> defaults = new LinkedHashMap<>();
+        for (TableColumn column : table.getColumns()) {
+            defaults.put(column.getName(), column.getDefaultValue());
+        }
+        assertTrue(defaults.containsValue("6\" \\ wide"), "the authored default must reach the schema intact: " + defaults);
+        assertTrue(defaults.containsValue("DRAFT"), "an ordinary default must be unchanged: " + defaults);
     }
 
     @Test


### PR DESCRIPTION
`template-application-schema`'s `application.schema.template` wrote the authored default into a JSON string verbatim:

```
"defaultValue": "${property.dataDefaultValue}",
```

so an authored `- { name: size, type: string, defaultValue: '6"' }` emitted `"defaultValue": "6"",` and the generated `.schema` was not JSON. The whole schema artefact failed to parse, and the synchronizer then created **no table for any entity of the project** - not just for that one column. A backslash or a control character did the same. The sibling of #7154, in the other literal syntax the same authored value reaches.

## The fix

The literal is resolved in Java - `JsonLiterals.stringLiteral`, carried by `ModelParameterProcessor` as `dataDefaultValueJsonLiteral`, the JSON twin of the `dataDefaultValueJavaLiteral` #7154 added in the same place - where the backslash, the double quote and the control characters JSON does not admit inside a string are escaped. Quotes are part of the literal, so the template no longer writes one next to an interpolation, and it reads the key's presence as "this property has a default".

The value is otherwise kept exactly as authored: the DEFAULT reaches the DDL verbatim by design, so a malformed one remains the author's broken SQL - the escaping only keeps it from taking the rest of the schema with it. A generated key still carries its authored default into the schema even though nothing applies it in Java.

Every default that generated before generates byte-identically, so regenerating an unchanged model produces an unchanged file. The worst case for a malformed default drops from a project with no tables at all to one mis-valued column DEFAULT.

## Verification

- `JsonLiteralsTest` - the escaping, and that every escaped literal parses back to the authored value (the DDL must be unchanged).
- `ModelParameterProcessorTest` - the key is carried for each authoring shape, present on a generated key, absent where there is no default.
- `IntentEngineIT#an_authored_default_carrying_a_quote_keeps_the_schema_parseable` - end to end from an intent authoring `defaultValue: '6" \ wide'`: the generated `.schema` parses, and the real `SchemasSynchronizer` reads the column DEFAULT back as authored.
- Green: `ide-template` unit suite (120), `IntentEngineIT` default tests, `SchemaTemplateUniqueConstraintIT`, `SchemaTemplateForeignKeyIT`, `ModelGenerationIT`.

Fixes #7206

🤖 Generated with [Claude Code](https://claude.com/claude-code)