### PR TITLE
templates: an authored default is escaped into the JavaScript seed it is written into (#7207)

### DIFF
--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/AuthoredDefaults.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/AuthoredDefaults.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.ide.template.service.model;
+
+/**
+ * The shapes an authored {@code defaultValue:} arrives in.
+ *
+ * <p>
+ * One authored default is written into several generated languages - the repository's Java literal
+ * ({@link JavaLiterals}) and the item dialog's JavaScript seed ({@link JsLiterals}) - and every one
+ * of them has to read the authored text the same way, or the value the column holds and the value
+ * the form offers stop agreeing.
+ */
+final class AuthoredDefaults {
+
+    /**
+     * Not instantiable.
+     */
+    private AuthoredDefaults() {}
+
+    /**
+     * Whether an authored boolean default reads as true.
+     *
+     * @param defaultValue the authored default
+     * @return true when it does
+     */
+    static boolean readsAsTrue(String defaultValue) {
+        return "true".equals(defaultValue) || "TRUE".equals(defaultValue) || "1".equals(defaultValue);
+    }
+
+    /**
+     * Strips the SQL single quotes an authored string default may carry, leaving the string the column
+     * would hold.
+     *
+     * <p>
+     * Both authoring shapes are accepted - bare ({@code DRAFT}, what the item dialog seeds) and
+     * SQL-quoted ({@code 'DRAFT'}, what a working DB DEFAULT needs, since the value reaches the DDL
+     * verbatim).
+     *
+     * @param defaultValue the authored default
+     * @return the value without its surrounding quotes
+     */
+    static String unquote(String defaultValue) {
+        if (defaultValue.length() > 1 && defaultValue.startsWith("'") && defaultValue.endsWith("'")) {
+            return defaultValue.substring(1, defaultValue.length() - 1);
+        }
+        return defaultValue;
+    }
+}

--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/JavaLiterals.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/JavaLiterals.java
@@ -64,11 +64,10 @@ final class JavaLiterals {
      * <p>
      * A numeric default is parsed from its authored text rather than inlined as a numeric literal, so
      * an author's {@code "8.0"} on an integer column fails that one create instead of failing the whole
-     * generated build. A string default is accepted in either authoring shape - bare ({@code DRAFT},
-     * what the item dialog seeds) or SQL-quoted ({@code 'DRAFT'}, what a working DB DEFAULT needs,
-     * since the value reaches the DDL verbatim) - and both yield the string the column would hold. A
-     * date/time or binary column has no literal: its DEFAULT is emitted verbatim into the DDL and is
-     * typically a SQL expression ({@code CURRENT_DATE}, {@code now()}).
+     * generated build. A string default is read in either authoring shape ({@link AuthoredDefaults}),
+     * and both yield the string the column would hold. A date/time or binary column has no literal: its
+     * DEFAULT is emitted verbatim into the DDL and is typically a SQL expression ({@code CURRENT_DATE},
+     * {@code now()}).
      *
      * @param javaClass the property's Java class, as the parameter graph resolved it
      * @param defaultValue the authored default, as the model carries it
@@ -85,33 +84,9 @@ final class JavaLiterals {
             case "Long" -> "Long.valueOf(\"" + escape(defaultValue) + "\")";
             case "Integer" -> "Integer.valueOf(\"" + escape(defaultValue) + "\")";
             case "Short" -> "Short.valueOf(\"" + escape(defaultValue) + "\")";
-            case "Boolean" -> isTrueLiteral(defaultValue) ? "Boolean.TRUE" : "Boolean.FALSE";
-            case "String" -> "\"" + escape(unquote(defaultValue)) + "\"";
+            case "Boolean" -> AuthoredDefaults.readsAsTrue(defaultValue) ? "Boolean.TRUE" : "Boolean.FALSE";
+            case "String" -> "\"" + escape(AuthoredDefaults.unquote(defaultValue)) + "\"";
             default -> null;
         };
-    }
-
-    /**
-     * Whether an authored boolean default reads as true.
-     *
-     * @param defaultValue the authored default
-     * @return true when it does
-     */
-    private static boolean isTrueLiteral(String defaultValue) {
-        return "true".equals(defaultValue) || "TRUE".equals(defaultValue) || "1".equals(defaultValue);
-    }
-
-    /**
-     * Strips the SQL single quotes an authored string default may carry, leaving the string the column
-     * would hold.
-     *
-     * @param defaultValue the authored default
-     * @return the value without its surrounding quotes
-     */
-    private static String unquote(String defaultValue) {
-        if (defaultValue.length() > 1 && defaultValue.startsWith("'") && defaultValue.endsWith("'")) {
-            return defaultValue.substring(1, defaultValue.length() - 1);
-        }
-        return defaultValue;
     }
 }

--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/JsLiterals.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/JsLiterals.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.ide.template.service.model;
+
+import java.util.regex.Pattern;
+
+/**
+ * JavaScript literals for values a model carries as text.
+ *
+ * <p>
+ * The Java twin of this ({@link JavaLiterals}) exists for the same reason, one language over: a
+ * model value reaches a generated source through a template, which interpolates it verbatim, so a
+ * value holding the quote that delimits the literal used to end it and break the whole generated
+ * file. An authored {@code defaultValue: "Owner's copy"} rendered {@code def: 'Owner's copy'} and
+ * made the register a syntax error, so the page failed to load entirely rather than one field
+ * mis-seeding (dirigible #7207).
+ */
+final class JsLiterals {
+
+    /**
+     * The authored texts that may stand unquoted where a number is expected. Deliberately narrower than
+     * JavaScript's numeric grammar - anything else falls back to a string literal, which mis-seeds one
+     * field instead of ending the literal.
+     */
+    private static final Pattern NUMBER = Pattern.compile("[+-]?(\\d+(\\.\\d*)?|\\.\\d+)([eE][+-]?\\d+)?");
+
+    /**
+     * Not instantiable.
+     */
+    private JsLiterals() {}
+
+    /**
+     * Escapes a value for placement inside a single-quoted JavaScript string literal: the backslash and
+     * the apostrophe that would otherwise end the literal, and the control characters that would end
+     * the line.
+     *
+     * @param value the raw value
+     * @return the escaped value, ready to be placed between two apostrophes
+     */
+    static String escape(String value) {
+        StringBuilder escaped = new StringBuilder(value.length() + 8);
+        for (int index = 0; index < value.length(); index++) {
+            char character = value.charAt(index);
+            switch (character) {
+                case '\\' -> escaped.append("\\\\");
+                case '\'' -> escaped.append("\\'");
+                case '\n' -> escaped.append("\\n");
+                case '\r' -> escaped.append("\\r");
+                case '\t' -> escaped.append("\\t");
+                case '\b' -> escaped.append("\\b");
+                case '\f' -> escaped.append("\\f");
+                default -> {
+                    if (character < 0x20 || character == 0x7f) {
+                        escaped.append(String.format("\\u%04x", (int) character));
+                    } else {
+                        escaped.append(character);
+                    }
+                }
+            }
+        }
+        return escaped.toString();
+    }
+
+    /**
+     * The authored default of a property as the JavaScript value the item dialog seeds a new line with,
+     * or null when the property has no default to seed.
+     *
+     * <p>
+     * The value is emitted in the shape the draft holds: a checkbox takes a real boolean, a numeric
+     * column a real number, and everything else a string - including a dropdown's foreign key, which
+     * the draft keeps stringified so it matches an option's data-value. A numeric default that is not a
+     * number falls back to a string, so an author's typo mis-seeds that one field instead of making the
+     * whole register a syntax error.
+     *
+     * @param widgetType the property's widget type
+     * @param numeric whether the property renders as a number
+     * @param defaultValue the authored default, as the model carries it
+     * @return the JavaScript expression, or null when there is none
+     */
+    static String defaultValueExpression(String widgetType, boolean numeric, String defaultValue) {
+        if (defaultValue == null || defaultValue.isEmpty()) {
+            return null;
+        }
+        if ("CHECKBOX".equals(widgetType)) {
+            return AuthoredDefaults.readsAsTrue(defaultValue) ? "true" : "false";
+        }
+        String value = AuthoredDefaults.unquote(defaultValue);
+        if (numeric && !"DROPDOWN".equals(widgetType) && NUMBER.matcher(value)
+                                                               .matches()) {
+            return value;
+        }
+        return "'" + escape(value) + "'";
+    }
+}

--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/ModelParameterProcessor.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/ModelParameterProcessor.java
@@ -355,6 +355,9 @@ final class ModelParameterProcessor {
         resolveDefaultValueLiterals(property);
 
         resolveWidgetLengths(property, entity, dataType);
+        // After the widget flags: the seed is emitted in the shape the draft holds, and a numeric
+        // column is what decides between a real number and a string.
+        resolveDefaultValueJsLiteral(property);
         property.put("inputRule", strOr(property, "widgetPattern", ""));
         collectMasterProperties(property, entity);
         collectReferencedProjections(property, entity, entities);
@@ -400,6 +403,30 @@ final class ModelParameterProcessor {
         String expression = JavaLiterals.defaultValueExpression(str(property, "dataTypeJavaClass"), defaultValue);
         if (expression != null) {
             property.put("dataDefaultValueJavaLiteral", expression);
+        }
+    }
+
+    /**
+     * Derives the authored default as the JavaScript value the item dialog seeds a new line with.
+     *
+     * <p>
+     * The column already carries this value as a DB DEFAULT and the repository applies it on create
+     * (#7104); seeding the dialog is what makes it visible and editable before the row is posted. The
+     * seed is resolved here rather than assembled in the template, so an authored value carrying an
+     * apostrophe or a backslash is escaped instead of ending the literal it is written into and making
+     * the whole generated register a syntax error - which fails the page, not the one field (#7207).
+     *
+     * <p>
+     * A key with no expression is left absent rather than null: a template reads the key's presence as
+     * "this property has a default to seed".
+     *
+     * @param property the property
+     */
+    private static void resolveDefaultValueJsLiteral(Map<String, Object> property) {
+        String expression = JsLiterals.defaultValueExpression(str(property, "widgetType"),
+                Boolean.TRUE.equals(property.get("isNumberType")), str(property, "dataDefaultValue"));
+        if (expression != null) {
+            property.put("dataDefaultValueJsLiteral", expression);
         }
     }
 

--- a/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/JsLiteralsTest.java
+++ b/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/JsLiteralsTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.ide.template.service.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests the JavaScript literals a model value is written into a generated source as.
+ */
+class JsLiteralsTest {
+
+    @Test
+    void leavesAnOrdinaryValueAlone() {
+        assertEquals("DRAFT", JsLiterals.escape("DRAFT"));
+        assertEquals("6\" wide", JsLiterals.escape("6\" wide"));
+        assertEquals("Ц", JsLiterals.escape("Ц"));
+    }
+
+    /**
+     * The defect: the apostrophe used to end the literal it was being written into, so one authored
+     * possessive made the whole register a syntax error and the page failed to load (#7207).
+     */
+    @Test
+    void escapesTheCharactersThatWouldEndTheLiteral() {
+        assertEquals("Owner\\'s copy", JsLiterals.escape("Owner's copy"));
+        assertEquals("C:\\\\tmp", JsLiterals.escape("C:\\tmp"));
+        assertEquals("\\\\\\'", JsLiterals.escape("\\'"));
+    }
+
+    @Test
+    void escapesTheControlCharactersThatWouldEndTheLine() {
+        assertEquals("a\\nb", JsLiterals.escape("a\nb"));
+        assertEquals("a\\rb", JsLiterals.escape("a\rb"));
+        assertEquals("a\\tb", JsLiterals.escape("a\tb"));
+        assertEquals("a\\bb", JsLiterals.escape("a\bb"));
+        assertEquals("a\\fb", JsLiterals.escape("a\fb"));
+        assertEquals("a\\u0000b", JsLiterals.escape("a\u0000b"));
+        assertEquals("a\\u001bb", JsLiterals.escape("a\u001bb"));
+        assertEquals("a\\u007fb", JsLiterals.escape("a\u007fb"));
+    }
+
+    /**
+     * The seed is emitted in the shape the draft holds, so the dialog's value has the type the widget
+     * binds to.
+     */
+    @Test
+    void seedsEachWidgetInTheShapeTheDraftHolds() {
+        assertEquals("true", JsLiterals.defaultValueExpression("CHECKBOX", false, "true"));
+        assertEquals("true", JsLiterals.defaultValueExpression("CHECKBOX", false, "TRUE"));
+        assertEquals("true", JsLiterals.defaultValueExpression("CHECKBOX", false, "1"));
+        assertEquals("false", JsLiterals.defaultValueExpression("CHECKBOX", false, "false"));
+        assertEquals("20.00", JsLiterals.defaultValueExpression("TEXTBOX", true, "20.00"));
+        assertEquals("'DRAFT'", JsLiterals.defaultValueExpression("TEXTBOX", false, "DRAFT"));
+        // A dropdown's FK stays a string even though it reads as a number, so it matches an option's
+        // data-value.
+        assertEquals("'7'", JsLiterals.defaultValueExpression("DROPDOWN", true, "7"));
+    }
+
+    /**
+     * Both authoring shapes of a string default - bare, and SQL-quoted the way a working DB DEFAULT
+     * needs - seed the string the column would hold, so the dialog offers what the repository applies.
+     */
+    @Test
+    void readsADefaultInEitherAuthoringShape() {
+        assertEquals("'DRAFT'", JsLiterals.defaultValueExpression("TEXTBOX", false, "'DRAFT'"));
+        assertEquals("20", JsLiterals.defaultValueExpression("TEXTBOX", true, "'20'"));
+    }
+
+    /**
+     * A numeric column's seed is written unquoted, so a default that is not a number has to fall back
+     * to a string rather than being emitted as a bare identifier the register would choke on.
+     */
+    @Test
+    void fallsBackToAStringWhereANumericDefaultIsNotANumber() {
+        assertEquals("'N/A'", JsLiterals.defaultValueExpression("TEXTBOX", true, "N/A"));
+        assertEquals("'1 or 2'", JsLiterals.defaultValueExpression("TEXTBOX", true, "1 or 2"));
+        assertEquals("-1.5", JsLiterals.defaultValueExpression("TEXTBOX", true, "-1.5"));
+        assertEquals("1e3", JsLiterals.defaultValueExpression("TEXTBOX", true, "1e3"));
+    }
+
+    @Test
+    void escapesAValueThatWouldEndTheLiteral() {
+        assertEquals("'Owner\\'s copy'", JsLiterals.defaultValueExpression("TEXTBOX", false, "Owner's copy"));
+        assertEquals("'Owner\\'s copy'", JsLiterals.defaultValueExpression("DROPDOWN", false, "Owner's copy"));
+        assertEquals("'C:\\\\tmp'", JsLiterals.defaultValueExpression("TEXTBOX", false, "C:\\tmp"));
+        assertEquals("'a\\nb'", JsLiterals.defaultValueExpression("TEXTBOX", false, "a\nb"));
+    }
+
+    @Test
+    void hasNoExpressionWithoutADefault() {
+        assertNull(JsLiterals.defaultValueExpression("TEXTBOX", false, null));
+        assertNull(JsLiterals.defaultValueExpression("TEXTBOX", false, ""));
+        assertNull(JsLiterals.defaultValueExpression("CHECKBOX", false, null));
+    }
+}

--- a/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/ModelParameterProcessorTest.java
+++ b/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/ModelParameterProcessorTest.java
@@ -145,6 +145,40 @@ class ModelParameterProcessorTest {
         assertFalse(none.containsKey("dataDefaultValueJsonLiteral"), "a property with no default must leave the key absent");
     }
 
+    /**
+     * The item dialog seeds a new line with the authored default, in the shape the draft holds - and
+     * the seed is resolved here rather than assembled in the template, which used to interpolate the
+     * value unescaped and make the whole generated register a syntax error on an authored apostrophe
+     * (#7207).
+     */
+    @Test
+    void carriesTheAuthoredDefaultAsAnEscapedJavaScriptSeed() {
+        Map<String, Object> possessive = property("Copy", "VARCHAR");
+        possessive.put("dataDefaultValue", "Owner's copy");
+        Map<String, Object> billable = property("Billable", "BOOLEAN");
+        billable.put("widgetType", "CHECKBOX");
+        billable.put("dataDefaultValue", "true");
+        Map<String, Object> rate = property("VatRate", "DECIMAL");
+        rate.put("dataDefaultValue", "20");
+        ModelParameterProcessor.process(model(entity("Line", "Lines", possessive, billable, rate)), parameters());
+
+        assertEquals("'Owner\\'s copy'", possessive.get("dataDefaultValueJsLiteral"));
+        assertEquals("true", billable.get("dataDefaultValueJsLiteral"));
+        assertEquals("20", rate.get("dataDefaultValueJsLiteral"));
+    }
+
+    /**
+     * The key's presence is what the template reads as "this property has a default to seed", so a
+     * property with none must leave it absent rather than null.
+     */
+    @Test
+    void leavesTheJavaScriptSeedAbsentWhereThereIsNothingToSeed() {
+        Map<String, Object> none = property("Name", "VARCHAR");
+        ModelParameterProcessor.process(model(entity("Invoice", "Invoices", none)), parameters());
+
+        assertFalse(none.containsKey("dataDefaultValueJsLiteral"));
+    }
+
     @Test
     void defaultsTheWidgetLabelFromThePropertyName() {
         Map<String, Object> property = property("TaxEventDate", "DATE");

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/detail-register.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/detail-register.js.template
@@ -36,8 +36,11 @@
 ## one-click affordance (Fill Month) books the standard values without the user retyping them.
 ## Emitted in the shape the draft holds: a checkbox takes a real boolean, a numeric column a real
 ## number, and everything else a string - including a DROPDOWN's FK, which the draft keeps stringified
-## so it matches an option's data-value.
-#macro(defaultMeta $property)#if($property.dataDefaultValue && $property.dataDefaultValue != "")#if($property.widgetType == "CHECKBOX"), def: #if($property.dataDefaultValue == "true")true#{else}false#end#elseif($property.widgetType == "DROPDOWN"), def: '${property.dataDefaultValue}'#elseif($property.isNumberType), def: ${property.dataDefaultValue}#{else}, def: '${property.dataDefaultValue}'#end#end#end
+## so it matches an option's data-value. The value itself is resolved in Java (ModelParameterProcessor
+## / JsLiterals) and is present only on a property that has a default, so the shapes live in one place
+## - and an authored value carrying an apostrophe or a backslash is escaped rather than ending the
+## literal it is written into and making this whole register a syntax error (dirigible #7207).
+#macro(defaultMeta $property)#if($property.dataDefaultValueJsLiteral), def: ${property.dataDefaultValueJsLiteral}#end#end
 App.registerDetail('${masterEntity}', {
   entity: '${name}',
   label: '${menuLabel}',

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -3079,6 +3079,53 @@ class IntentEngineIT extends IntegrationTest {
     }
 
     @Test
+    void an_authored_default_is_escaped_into_the_item_dialog_seed() {
+        // #7207: the seed for a new line was interpolated into a JavaScript string literal verbatim,
+        // so an authored apostrophe ended the literal and the whole register was a syntax error - the
+        // page failed to load entirely, rather than one field mis-seeding. Sibling of #7154, which
+        // fixed the same interpolation one language over (the repository's Java literal).
+        writeIntent("""
+                name: registers
+                entities:
+                  - name: Ticket
+                    fields:
+                      - { name: id,     type: integer, primaryKey: true, generated: true }
+                      - { name: issued, type: date }
+                    relations:
+                      - { name: lines, kind: oneToMany, to: TicketLine }
+
+                  - name: TicketLine
+                    fields:
+                      - { name: id,       type: integer, primaryKey: true, generated: true }
+                      - { name: copy,     type: string,  length: 40, defaultValue: "Owner's copy" }
+                      - { name: path,     type: string,  length: 40, defaultValue: 'C:\\tmp' }
+                      - { name: quantity, type: integer, defaultValue: 1 }
+                      - { name: billable, type: boolean, defaultValue: true }
+                      - { name: stage,    type: string,  length: 20, defaultValue: DRAFT }
+                    relations:
+                      - { name: ticket, kind: manyToOne, to: Ticket, composition: true }
+                """);
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .post(GENERATE_URL)
+                                                 .then()
+                                                 .statusCode(200));
+        generateFromModel("template-application-ui-harmonia-java/template/template.js", "registers.model");
+        String detailRegister = contentOf("gen/registers/js/components/pages/Ticket/TicketLine.detail.js");
+
+        // The seed keeps the shape the draft holds - a checkbox a real boolean, a numeric column a
+        // real number, everything else a string...
+        assertTrue(detailRegister.contains(", def: true"), "a boolean default must seed a real boolean, got: " + detailRegister);
+        assertTrue(detailRegister.contains(", def: 1"), "a numeric default must seed a real number, got: " + detailRegister);
+        assertTrue(detailRegister.contains(", def: 'DRAFT'"), "a string default must seed a quoted string, got: " + detailRegister);
+        // ...and a value carrying the apostrophe that delimits it is escaped into the literal instead
+        // of ending it.
+        assertTrue(detailRegister.contains(", def: 'Owner\\'s copy'"),
+                "a default carrying the apostrophe that delimits the seed must be escaped into it, got: " + detailRegister);
+        assertTrue(detailRegister.contains(", def: 'C:\\\\tmp'"),
+                "a default carrying a backslash must be escaped into the seed, got: " + detailRegister);
+    }
+
+    @Test
     void report_widget_generates_the_kpi_block_and_replaces_entity_tiles() {
         writeIntent(INTENT_YAML);
         restAssuredExecutor.execute(() -> given().when()


### PR DESCRIPTION
`#defaultMeta` in `detail-register.js.template` interpolated a string default into the JavaScript string literal the item dialog seeds a new line from, so an authored `defaultValue: "Owner's copy"` rendered `def: 'Owner's copy'` and made the whole generated register a syntax error - the page failed to load entirely, rather than one field mis-seeding. A backslash and a newline did the same.

The seed is now resolved in Java (`JsLiterals.defaultValueExpression`, called from `ModelParameterProcessor` as `dataDefaultValueJsLiteral`), where the backslash, the apostrophe and the control characters that would end the literal are escaped - the JavaScript twin of the Java literal #7154 moved to the same place. Grepping the Harmonia templates confirms this macro is the only place a default is seeded into a JS literal.

The macro's three shapes are unchanged (a checkbox seeds a real boolean, a numeric column a real number, everything else a string - including a DROPDOWN's FK, which stays stringified), so every model that generated before generates byte-identically. Two authoring shapes that used to emit broken JavaScript now seed what the column holds and the repository applies: an SQL-quoted string default (`'DRAFT'`, which rendered `def: ''DRAFT''`), and a boolean written `TRUE` or `1`, which seeded false next to a DB DEFAULT of true. A numeric default that is not a number falls back to a string rather than a bare identifier the register would choke on.

`AuthoredDefaults` holds the two readings of the authored text (the SQL quotes, the boolean shapes) that both literal writers share.

Verified: `JsLiteralsTest` + `ModelParameterProcessorTest` (125 tests in `ide-template`, green) and `IntentEngineIT#an_authored_default_is_escaped_into_the_item_dialog_seed`, which generates the Harmonia UI for a composition child whose defaults carry an apostrophe and a backslash and asserts the emitted seeds - run alongside the two neighbouring default/harmonia ITs, 3/3 green.

Fixes #7207

🤖 Generated with [Claude Code](https://claude.com/claude-code)