### PR TITLE
postings: a header assignment written before #7163 falls back to what it used to emit (#7195)

### DIFF
--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/GlueGenerator.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/GlueGenerator.java
@@ -789,7 +789,7 @@ class GlueGenerator {
         copy(context, item, "name", "className", "isCreate", "sourcePerspective", "sourceEntity", "sourceKeyField", "guardProperty",
                 "guardValue", "targetEntity", "targetPk", "itemsEntity", "itemsFk", "backRefProperty", "stornoProperty",
                 "stornoFilterProperty", "hasRule", "ruleEntity", "ruleMatchProperty", "ruleMatchValueJava", "usedRuleColumns",
-                "conditionalRuleGuards", "headerAssignments", "itemRows");
+                "conditionalRuleGuards", "itemRows");
         // The bound axis (issue #6929): the channel the handler subscribes to, and the sentence its
         // header comment describes it in. Both are absent from a .glue written before the enrichment
         // phase existed, and a bare reference would render as its own literal - so each falls back to
@@ -817,6 +817,44 @@ class GlueGenerator {
         // before the amendment half carries neither key and needs neither helper.
         context.put("comparesAgainstDefaults", truthy(item, "comparesAgainstDefaults"));
         context.put("comparesUnlessDerivedIsEmpty", truthy(item, "comparesUnlessDerivedIsEmpty"));
+        List<Map<String, Object>> headerAssignments = headerAssignments(item.get("headerAssignments"));
+        context.put("headerAssignments", headerAssignments);
+        context.put("hoistsHeaderValues", headerAssignments.stream()
+                                                           .anyMatch(assignment -> truthy(assignment, "hoisted")));
+    }
+
+    /**
+     * Normalises the header assignments of a posting. The keys the hoisting half of the amend
+     * comparison reads (#7131) live <em>inside</em> each entry rather than on the descriptor, so the
+     * fallbacks the descriptor's own keys carry do not reach them: an entry written before that change
+     * carries {@code targetProp} and {@code expr} alone, and the bare references would render as their
+     * own literal text - {@code var $a.local = source.Date;}, which does not compile.
+     *
+     * <p>
+     * Each entry therefore falls back to exactly what its shape used to emit: the expression read
+     * inline at both the comparison and the assignment, no hoisted local, and no default-aware
+     * comparison. {@code value} is what both sites read, so the template needs no branch of its own.
+     *
+     * @param raw the declared assignments
+     * @return the normalised assignments
+     */
+    private static List<Map<String, Object>> headerAssignments(Object raw) {
+        List<Map<String, Object>> assignments = new ArrayList<>();
+        for (Map<String, Object> declared : asMaps(raw)) {
+            String local = strOr(declared, "local", "");
+            String expr = strOr(declared, "expr", "");
+            Map<String, Object> assignment = new LinkedHashMap<>();
+            assignment.put("targetProp", declared.get("targetProp"));
+            assignment.put("expr", expr);
+            assignment.put("hoisted", !local.isEmpty());
+            assignment.put("local", local);
+            assignment.put("value", local.isEmpty() ? expr : local);
+            assignment.put("derivedDefault", strOr(declared, "derivedDefault", ""));
+            assignment.put("compareOnlyWhenDerived", truthy(declared, "compareOnlyWhenDerived"));
+            assignment.put("overwrittenOnSave", truthy(declared, "overwrittenOnSave"));
+            assignments.add(assignment);
+        }
+        return assignments;
     }
 
     /**

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Posting.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Posting.java.template
@@ -160,7 +160,7 @@ public class ${className}Posting implements MessageHandler {
         java.util.List<gen.${javaGenFolderName}.data.${targetJavaPerspective}.${targetEntity}Entity> existingTargets =
                 relatedTargets;
 #end
-#if($headerAssignments.size() > 0)
+#if($hoistsHeaderValues)
         // The header values, evaluated ONCE. The comparison below and the assignment further down must
         // see the SAME value: an expression read twice - anything reading the clock - would differ
         // between the two reads and make every redelivery look like an amendment (#7131). Evaluated
@@ -169,7 +169,9 @@ public class ${className}Posting implements MessageHandler {
         // an expression with a cost or a side effect must not run for those (#7177).
 #end
 #foreach($a in $headerAssignments)
+#if($a.hoisted)
         var ${a.local} = ${a.expr};
+#end
 #end
         gen.${javaGenFolderName}.data.${targetJavaPerspective}.${targetEntity}Entity target;
         boolean refresh = !existingTargets.isEmpty();
@@ -184,11 +186,11 @@ public class ${className}Posting implements MessageHandler {
 #if($a.overwrittenOnSave)
             // ${a.targetProp} is not compared: the write computes it itself (#7177).
 #elseif($a.compareOnlyWhenDerived)
-            unchanged = unchanged && sameUnlessDerivedIsEmpty(target.${a.targetProp}, ${a.local});
+            unchanged = unchanged && sameUnlessDerivedIsEmpty(target.${a.targetProp}, ${a.value});
 #elseif($a.derivedDefault != "")
-            unchanged = unchanged && same(target.${a.targetProp}, ${a.local}, ${a.derivedDefault});
+            unchanged = unchanged && same(target.${a.targetProp}, ${a.value}, ${a.derivedDefault});
 #else
-            unchanged = unchanged && same(target.${a.targetProp}, ${a.local});
+            unchanged = unchanged && same(target.${a.targetProp}, ${a.value});
 #end
 #end
             // Row order is not guaranteed by the query, so each derived row is matched against an
@@ -229,7 +231,7 @@ public class ${className}Posting implements MessageHandler {
             currentItems = java.util.List.of();
         }
 #foreach($a in $headerAssignments)
-        target.${a.targetProp} = ${a.local};
+        target.${a.targetProp} = ${a.value};
 #end
         // ONE transaction for the whole post: the stale rows a rewrite replaces, the header and every
         // derived line either all become durable or none of them does. Written as separate

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/template/ModelGenerationIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/template/ModelGenerationIT.java
@@ -171,6 +171,11 @@ class ModelGenerationIT extends IntegrationTest {
             // keeping its own MANAGE layout - the partitions no other fixture exercises, because none
             // of them declares a view.
             new Case("views.model", TEMPLATE_APPLICATION, false), //
+            // The glue fixture's posting is deliberately written in the shape a .glue committed before
+            // #7163 holds - a header assignment carrying its expression alone, none of the keys the
+            // hoisted-local comparison reads. Velocity renders an undefined reference as its own
+            // literal, so a binder that stops normalising those entries emits `var $a.local = ...`
+            // and the unresolved-reference check below catches it (#7195).
             new Case("orders.glue", TEMPLATE_GLUE, false), //
             new Case("leave-request.form", TEMPLATE_FORM, false), //
             new Case("revenue.report", TEMPLATE_REPORT, false), //

--- a/tests/tests-integrations/src/main/resources/ModelGenerationIT/orders.glue
+++ b/tests/tests-integrations/src/main/resources/ModelGenerationIT/orders.glue
@@ -629,5 +629,54 @@
             "notifyOutcomeKeyProperty": "Id",
             "notifyOutcomeLength": "64"
         }
+    ],
+    "postings": [
+        {
+            "name": "PostOrderToLedger",
+            "className": "PostOrderToLedger",
+            "isCreate": "false",
+            "sourceEntity": "SalesOrder",
+            "sourcePerspective": "Sales Orders",
+            "sourceKeyField": "Id",
+            "guardProperty": "Status",
+            "guardValue": "2",
+            "targetEntity": "JournalEntry",
+            "targetPerspective": "Journal",
+            "targetPk": "Id",
+            "itemsEntity": "JournalEntryLine",
+            "itemsPerspective": "Journal",
+            "itemsFk": "JournalEntry",
+            "backRefProperty": "SalesOrder",
+            "stornoProperty": "",
+            "stornoFilterProperty": "",
+            "hasRule": "false",
+            "ruleEntity": "",
+            "rulePerspective": "",
+            "ruleMatchProperty": "",
+            "ruleMatchValueJava": "",
+            "usedRuleColumns": [],
+            "conditionalRuleGuards": [],
+            "headerAssignments": [
+                {
+                    "targetProp": "Date",
+                    "expr": "source.Date"
+                },
+                {
+                    "targetProp": "Description",
+                    "expr": "\"Sales order \" + source.Number"
+                }
+            ],
+            "itemRows": [
+                {
+                    "guard": "",
+                    "assigns": [
+                        {
+                            "targetProp": "Debit",
+                            "expr": "source.Total"
+                        }
+                    ]
+                }
+            ]
+        }
     ]
 }


### PR DESCRIPTION
`GlueGenerator.bindPosting` keeps an explicit fallback for every descriptor key added since a `.glue` was first written - the moment axis of #6929, the amend keys of #7071, the two comparison-helper flags of #7177 - because Velocity renders an undefined reference as its own literal text, so a key the binder does not put in the context becomes a syntax error rather than a missing value.

`headerAssignments` is copied wholesale, and #7163 added its keys **inside each entry**, where those fallbacks do not reach. An entry written before it carries `targetProp` and `expr` alone, so the generated handler read

```java
        var $a.local = source.Date;
```

which does not compile, and the comparison line took whichever branch `$a.derivedDefault != ""` evaluates to over a null left-hand side, neither of which is right. The blast radius is a project whose `.glue` is regenerated later than its code, or not at all: the intent Generate writes a fresh descriptor and runs the recipes in one pass, so it is unaffected, but "Generate from model" over a committed `.glue` is exactly the case those fallbacks exist for.

Each entry is now normalised on the way into the context the way the top-level keys are. `value` is what the comparison and the assignment both read - the hoisted local when the entry declares one, the expression itself otherwise - so an entry with no `local` emits exactly what that shape used to emit: the expression inline at both sites, no hoisted local, and no default-aware comparison. A current descriptor renders byte-identically.

## Verification

`ModelGenerationIT`'s glue fixture gains a posting written in the pre-#7163 shape, which the harness's own unresolved-reference check catches without a case-specific assertion: with the binder and template reverted the run reports eight `kept an unresolved template reference: ${a` problems on that fixture, and green with the fix in place.

- `ModelGenerationIT` + `IntentEmissionCoverageIT` green
- `ide-template` + `engine-intent` unit tests: 1186/1186
- `formatter:format` clean, javadoc clean under `-P release`

Fixes #7195

🤖 Generated with [Claude Code](https://claude.com/claude-code)