### PR TITLE
docs: the "take this: <issue>" delivery workflow is checked in - worktree, isolation, verification, PR, cleanup (#7257)

### DIFF
--- a/.claude/commands/dirigible-pr.md
+++ b/.claude/commands/dirigible-pr.md
@@ -2,7 +2,10 @@
 description: Prepare the branch for a PR — format Java + validate javadoc on changed modules, fix issues
 ---
 
-Prepare the current branch for a pull request. Do NOT commit or push — leave that to the user.
+Prepare the current branch for a pull request. On its own this command does NOT commit or push —
+it leaves that to the user. When it runs as the verification step of `/dirigible-take` or of a
+"take this: <issue>" request, the chain in `.claude/docs/take-this-workflow.md` continues with
+commit, push and `gh pr create` without asking.
 
 Announce each step to the user as you go (e.g. "Scoping changed modules…", "Formatting modules X, Y…",
 "Running the javadoc check…", "Fixing javadoc errors in …", "Done — summary below") so it is always
@@ -27,4 +30,5 @@ clear what is happening at the moment.
 
 5. **Summarize.** Report: which modules were formatted, what javadoc issues were fixed (if any),
    the final pass/fail state, and a short summary of the diff suitable for a PR description.
-   Remind the user the changes are staged for them to review/commit/push.
+   When invoked standalone, remind the user the changes are staged for them to review/commit/push;
+   inside a take-this run, continue with the commit, push and PR.

--- a/.claude/commands/dirigible-take.md
+++ b/.claude/commands/dirigible-take.md
@@ -1,0 +1,62 @@
+---
+description: Take a GitHub issue end to end — worktree off origin/master, implement + verify, commit, push, open the PR
+---
+
+Take the issue named in the arguments all the way to an open pull request, following
+`.claude/docs/take-this-workflow.md` (imported into CLAUDE.md) exactly. This command IS the
+standing authorization for every step below: do not stop to ask whether to branch, commit, push or
+open the PR. Never merge.
+
+Arguments: `$ARGUMENTS` — an issue URL or number (`https://github.com/eclipse-dirigible/dirigible/issues/NNNN`
+or `#NNNN`). Refuse politely if it is neither.
+
+**Keep the user informed at every step.** Before each command post a one-line note saying what you are
+about to do; run each step as a separate, visible tool call; surface the key result lines.
+
+1. **Read the issue.** `gh issue view NNNN --repo eclipse-dirigible/dirigible --comments`. Restate
+   the defect and the acceptance criteria in two sentences. If the issue admits materially different
+   designs, pick the one the issue's own text points at and say so — do not stop to ask unless the
+   choices lead to different deliverables.
+
+2. **Check the shared checkout, then branch in a worktree.** `git status -sb` in the current checkout
+   (if it is dirty, leave it alone — that is someone else's work). Then
+   `git fetch origin && git worktree add ../wt-NNNN -b issue-NNNN-<slug> origin/master`, `cd` there,
+   and confirm with `git status -sb` that HEAD is the new branch. All further work happens in the
+   worktree.
+
+3. **Isolate the Maven repository if anything else may build concurrently** (`pgrep -fl maven`,
+   `git worktree list` showing other worktrees): clone `~/.m2/repository` to `~/.m2/repo-wt-NNNN` per
+   the workflow doc and pass `-Dmaven.repo.local=$HOME/.m2/repo-wt-NNNN` to every Maven command.
+
+4. **Implement.** Surgical changes traceable to the issue. For a template or generator change, grep
+   the sibling templates and the other branches of the same template for the same code shape and fix
+   them all. Write the test that reproduces the defect first when that is feasible.
+
+5. **Verify.** In this order, each as its own visible step:
+   - `mvn formatter:format` on the changed modules (`-pl <modules> -am`);
+   - `find . -name formatter-maven-cache.properties -path '*/target/*' -delete` then
+     `mvn -T 1C formatter:validate` — must be `BUILD SUCCESS`;
+   - the changed modules' unit suites: `mvn -pl <modules> -am test -Dlicense.skip=true`;
+   - the integration tests that cover the change, by name, after a
+     `mvn -T 1C -P quick-build install -DskipTests -Dmaven.gitcommitid.skip=true` in the worktree
+     (`rm -rf tests/tests-integrations/target/dirigible` first);
+   - if the change added or changed Javadoc on a public SDK type, the release-profile javadoc build
+     on the touched modules.
+   If any step is red for a cause in your change, fix it and re-run. If it is red for a cause outside
+   your change, say so with the output — that is a block, and the one legitimate reason to return
+   without a PR.
+
+6. **Stage explicitly and commit.** `git status --short`; if `modules/parsers/typescript/**` shows as
+   modified, `git checkout -- modules/parsers/typescript` — it is build churn, never your change.
+   `git add <the intended paths>`, then a plain `git commit` (identity from git config, never set by
+   hand, never `--no-verify`) with subject `<area>: <what changed> (#NNNN)` and a body that states
+   the cause, the change and what was verified.
+
+7. **Push and open the PR.** `gh pr list --head issue-NNNN-<slug> --state all` (must be empty),
+   `git push -u origin issue-NNNN-<slug>`, confirm `git rev-parse HEAD origin/issue-NNNN-<slug>`
+   match, then `gh pr create --base master --title "<commit subject>" --body "<cause / change /
+   verification> ... Fixes #NNNN"`.
+
+8. **Report.** The PR URL, the branch and worktree path, what was verified and what was not, and the
+   cleanup to run after the merge (`git worktree remove ../wt-NNNN`, `git branch -d`,
+   `rm -rf ~/.m2/repo-wt-NNNN`).

--- a/.claude/docs/take-this-workflow.md
+++ b/.claude/docs/take-this-workflow.md
@@ -1,0 +1,139 @@
+## "Take this issue" means ship the PR
+
+**Trigger.** Any of these, from anyone, is a standing authorization for the WHOLE chain below, end to
+end, without asking at any step: `take this: <issue url>`, `take this issue`, `take #NNNN`,
+`implement #NNNN`, `fix #NNNN`, `fix this`, `do it`, or the `/dirigible-take <issue url>` command.
+Never stop after implementing to ask whether to branch, commit, push or open the PR - the asking is the
+thing being complained about. The only reason to come back without a PR URL is a genuine block: tests
+red for a cause outside the change, or a design fork whose branches lead to materially different work.
+Then say what blocks, what you did instead, and where the branch is.
+
+**Never merge.** This repository is PR-only: the chain ends at the PR URL. Merging is a human decision.
+
+### The chain
+
+```
+1. read the issue          gh issue view NNNN --repo eclipse-dirigible/dirigible
+2. worktree off origin     git fetch origin && git worktree add ../wt-NNNN -b issue-NNNN-<slug> origin/master
+3. isolate .m2 (if shared) see "Maven repository isolation"
+4. implement + test        module unit suite green, the relevant ITs green (see "Verification bar")
+5. format                  mvn formatter:format (changed modules), then validate with the cache wiped
+6. commit                  plain `git commit` - identity from git config, never set by hand
+7. push                    git push -u origin issue-NNNN-<slug>
+8. PR                      gh pr create --fill-first --body "... Fixes #NNNN ..."
+9. report                  the PR URL, what was verified, what was not
+10. clean up               after the PR merges: git worktree remove, delete the .m2 clone
+```
+
+### Worktree, not branch switch
+
+The primary checkout may be shared by several concurrent sessions (several Claude sessions, or a
+colleague's IDE). Switching its branch, stashing in it, or `git add -A` in it silently destroys someone
+else's uncommitted work - this has happened. So:
+
+- **Always work in a dedicated worktree**: `git worktree add ../wt-NNNN -b issue-NNNN-<slug> origin/master`
+  from the primary checkout. Branch off **`origin/master`** after a `git fetch`, never off the local
+  `master`, which is routinely days stale.
+- **Never `git stash`, `git checkout <branch>`, `git reset` or `git add -A` in the primary checkout.**
+  If you already edited files there, create the worktree first, `cp` your changed files into it, then
+  `git checkout -- <file>` them in the primary. Check `git status` in the primary before touching
+  anything - if it is dirty, assume the dirt is someone else's.
+- Verify the branch right before every mutating step (`git status -sb`, `git rev-parse --abbrev-ref HEAD`):
+  `git checkout -b` has printed "Switched to a new branch" while HEAD stayed put, and a commit then
+  landed on master.
+- A second running Dirigible instance needs its own ports: `DIRIGIBLE_SERVER_PORT` alone is not enough,
+  SFTP and FTP both default to 8022 (`DIRIGIBLE_SFTP_PORT`, `DIRIGIBLE_FTP_PORT`). Start long-running
+  servers with `nohup ... & disown` in a normal shell call, kill by PID or `lsof -ti :<port>`, never
+  `pkill -f dirigible` (it kills the other sessions' instances too).
+
+### Maven repository isolation
+
+Worktrees share `~/.m2`, so an `install` from one worktree replaces the SNAPSHOT jars another
+worktree's integration tests are resolving - the classic symptoms are a `NoClassDefFoundError` for a
+class that exists only on another branch, an IT failing at an assertion CI does not fail at, or a
+generated file that "misses" your feature although `target/classes` has it. When more than one
+worktree or session may build at the same time, give each worktree a private repository:
+
+```
+# macOS APFS (copy-on-write, seconds):   cp -Rc ~/.m2/repository ~/.m2/repo-wt-NNNN
+# Linux (reflink where supported):         cp -r --reflink=auto ~/.m2/repository ~/.m2/repo-wt-NNNN
+# anywhere (hard links also work):         cp -Rl ~/.m2/repository ~/.m2/repo-wt-NNNN
+rm -rf ~/.m2/repo-wt-NNNN/org/eclipse/dirigible
+```
+
+then pass `-Dmaven.repo.local=$HOME/.m2/repo-wt-NNNN` to EVERY Maven command in that worktree (the
+path is the `repository`-shaped directory itself, not its parent). Third-party artifacts are immutable
+releases, so the clone stays valid; only the dirigible SNAPSHOTs are rebuilt. Alternative that installs
+nothing: run the IT through the reactor, `mvn -pl tests/tests-integrations -am -P integration-tests
+-Dit.test=<Name> ... verify`, which resolves sibling modules from the worktree's `target/`.
+
+Never `mvn install` while an IT run is in progress in any worktree (`pgrep -fl maven` first).
+
+### Building and testing in a worktree - the known traps
+
+- **The full reactor fails at `dirigible-application`** with `Could not get HEAD Ref` from the
+  git-commit-id plugin, which cannot follow a worktree's `.git` file. Environment noise, not your bug:
+  add `-Dmaven.gitcommitid.skip=true` to every worktree build. A warm `mvn -T 1C -P quick-build install
+  -DskipTests -Dmaven.gitcommitid.skip=true` of the whole reactor takes about a minute.
+- **A full build dirties the tree**: `modules/parsers/typescript/**` are committed ANTLR-generated
+  sources that the build regenerates unformatted (six files, tens of thousands of lines). They are never
+  your change. `git status --short` before staging, stage intended paths explicitly, and
+  `git checkout -- modules/parsers/typescript` if they show up. This has reached CI as a `code-style`
+  failure on an unrelated PR more than once.
+- **Stale H2 breaks IT runs after a killed JVM**: `rm -rf tests/tests-integrations/target/dirigible`
+  before re-running locally.
+- **Run one IT**: `mvn -o -P integration-tests -pl tests/tests-integrations verify -Dit.test=<Name>
+  -Dselenide.headless=true` (after an install), adding `-Dit.groups= -Dit.excludedGroups=` when the
+  class carries a `@Tag`. A local run may wedge in Spring context teardown AFTER the tests passed (a
+  macOS file-watcher deadlock) and never write a report; read the assertion results out of the log
+  before calling it a failure.
+- `mvn test` in a worktree may need `-Dlicense.skip=true`; the javadoc release check is
+  `mvn -P release -Dgpg.skip=true -DskipTests -Dlicense.skip=true -Dformatter.skip=true install -pl <modules> -am`.
+
+### Verification bar (what "green" means before pushing)
+
+1. `mvn formatter:format` on the changed modules, then **wipe the formatter cache and validate with
+   CI's exact command**: `find . -name formatter-maven-cache.properties -path '*/target/*' -delete`,
+   then `mvn -T 1C formatter:validate`. The cache can report success on files CI will reject.
+2. The changed modules' unit suites green (`mvn -pl <module> -am test`).
+3. The integration tests that cover the change green, by name - and for a template or generator change,
+   an IT that COMPILES and RUNS the generated output (`IntentEmissionCoverageIT`, `IntentEngineIT`, a
+   `*TemplateIT`), not only one that asserts rendered source text. A test that greps the template for
+   the sentence you just wrote proves nothing.
+4. Read exit codes correctly: `$?` after a pipe is the last command's, so grep the Maven output for
+   `BUILD SUCCESS|BUILD FAILURE` or capture `mvn ...; MVN_EXIT=$?` directly.
+5. For a template fix, grep the sibling templates and the other branch of the same Velocity template for
+   the same code shape (`EntityController` vs `EntityMyController` vs `EntityPartnerController`;
+   `Generate` vs `Job` vs `Posting`; the generate vs notify branch of `Job.java.template`; the power vs
+   my/partner/admin views). A fix that reaches one of them is not done.
+6. Say plainly in the PR what was verified and what was not. Never describe a check you did not run.
+
+### Commit, push, PR
+
+- **Identity comes from git config.** Commit with plain `git commit`. Never pass `-c user.email=...`,
+  never set `GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_EMAIL`, never take an address from a tool's session
+  context, a profile or a signature. Every contributor's commit email must be the one they signed the
+  Eclipse Contributor Agreement with; any other address fails the `eclipsefdn/eca` check on the PR and is
+  repaired only by rewriting history on every affected branch. Do not bypass the repository's git hooks
+  with `--no-verify` - if a hook refuses the commit, the identity is wrong, not the hook.
+- Commit subject in the repo's style: `<area>: <what changed, as a sentence> (#NNNN)`.
+- Before any push: `gh pr list --head <branch> --state all` (never push new work onto a branch whose PR
+  is merged), `git status -sb`, `git log --oneline -3`. After the push, `git rev-parse HEAD origin/<branch>`
+  must match.
+- `gh pr create` against `master` with a body that explains the cause, the change, how it was verified,
+  and ends with `Fixes #NNNN`. Report the PR URL.
+
+### Cleanup
+
+After the PR is merged (not before - CI may need a follow-up on the branch):
+
+```
+cd <primary checkout>
+git worktree remove ../wt-NNNN            # add --force only if you are sure nothing there is unpushed
+git branch -d issue-NNNN-<slug>
+rm -rf ~/.m2/repo-wt-NNNN                 # the clones are the big consumers: orphaned ones filled a disk once
+git fetch --prune
+```
+
+`git worktree list` and `ls ~/.m2 | grep repo-wt-` show what is left over; a worktree whose branch's PR is
+merged can go.

--- a/.claude/scripts/README.md
+++ b/.claude/scripts/README.md
@@ -38,6 +38,12 @@ front and the log tail runs as a background task.
 - **`/dirigible-pr`** → format + javadoc-validate the changed Maven modules (the `mvn formatter:format`
   and release-profile javadoc commands from the root CLAUDE.md), fix issues, summarize; does **not**
   commit/push.
+- **`/dirigible-take <issue>`** → the whole delivery chain for one GitHub issue, per
+  `.claude/docs/take-this-workflow.md` (imported into CLAUDE.md, so the plain phrase
+  `take this: <issue url>` triggers the same chain): worktree off `origin/master`, private Maven
+  repository when other builds may run, implement, the verification bar, plain `git commit`,
+  push, `gh pr create` with `Fixes #NNNN`. It is the one command that DOES commit and push; it
+  never merges. `/dirigible-pr` is its verification step when run standalone.
 
 ## `dirigible.mjs` subcommands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Provides behavioral guidelines to reduce common LLM coding mistakes and guidance
 The guidance is split by topic into `.claude/docs/` and imported below (each file carries its own headings). Edit the topic files, not this index; add a new topic as a new file plus an import line here.
 
 @.claude/docs/behavioral-guidelines.md
+@.claude/docs/take-this-workflow.md
 @.claude/docs/project-build-run.md
 @.claude/docs/repository-layout.md
 @.claude/docs/synchronizer-model.md

--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ type the command in a Claude Code session opened in this repo.
 | `/dirigible-stop`  | Stops the running instance.                                                                    |
 | `/dirigible-test`  | Runs the tests — all by default, or just the unit or just the integration tests.               |
 | `/dirigible-pr`    | Gets your branch ready for a pull request (formats the code and checks the docs build).        |
+| `/dirigible-take`  | Takes a GitHub issue end to end: worktree off `origin/master`, implement, verify, commit, push, open the PR. Saying `take this: <issue url>` in plain words does the same. |
 
 `/dirigible-start` accepts two optional keywords you can add in any combination:
 
@@ -456,6 +457,9 @@ type the command in a Claude Code session opened in this repo.
 /dirigible-test integration   # run only the integration tests
 
 /dirigible-pr                 # format + validate before you open a PR
+
+/dirigible-take https://github.com/eclipse-dirigible/dirigible/issues/1234
+                              # take an issue end to end: worktree, fix, verify, commit, push, PR
 ```
 
 > **Note:** the integration tests boot the whole application and drive a headless Chrome, so they


### PR DESCRIPTION
## Why

The end-to-end way an issue becomes a PR with Claude Code on this repo lived in one maintainer's private `~/.claude/CLAUDE.md` and session memory. The checked-in `/dirigible-pr` covers only format + javadoc and instructs the model **not** to commit or push, so a colleague saying "take this: <issue url>" got a branch and a question instead of a PR URL.

## What

- **`.claude/docs/take-this-workflow.md`**, imported from the root `CLAUDE.md`, so the plain phrase (`take this: <url>`, `implement #NNNN`, `fix this`, ...) is a standing authorization for the whole chain in every session opened in this repo. It holds the ten-step chain and everything that made it work in practice: worktree off `origin/master` and never a branch switch, stash or `add -A` in the shared checkout; the private Maven repository per worktree and when it is needed; the worktree build traps (git-commit-id plugin, the regenerated TypeScript parser sources that reach CI as `code-style` failures, stale H2, running one IT and reading a wedged run); the verification bar (formatter with the cache wiped and CI's exact validate command, unit suites, the ITs by name - for a template change one that compiles and runs the output - and the sibling-template sweep); the commit-identity rule stated generally (the address must be the contributor's ECA one, taken from git config, never from session context, never `--no-verify`); pre-push state checks; and the cleanup, including the `~/.m2/repo-wt-*` clones that filled a disk once.
- **`/dirigible-take <issue>`** as the explicit command running that chain step by step.
- **`/dirigible-pr`** reconciled: standalone it still leaves commit/push to the user; inside a take-this run the chain continues.
- README (table + example) and `.claude/scripts/README.md` list the command.

Nothing in `.claude/settings.json` changes: `git worktree`, `git commit`, `git push` and `gh pr create` keep prompting for permission per call.

## Verified

Documentation-only change: no Java, no templates. Rendered Markdown read back; `CLAUDE.md` import line placed right after `behavioral-guidelines.md` so the workflow is loaded before the domain topics. Not verified: no automated check exists for the `.claude/` content.

Fixes #7257

🤖 Generated with [Claude Code](https://claude.com/claude-code)
