### PR TITLE
templates: give the my/partner form and document header save an applyApiError (#7242)

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-page.js.template
@@ -22,6 +22,9 @@ document.addEventListener('alpine:init', () => {
     mode: 'create',
     id: null,
     error: null,
+    // The single header property a rejected save NAMED ("The 'Name' property is required"), else
+    // null - drives :aria-invalid on that one control (see applyApiError).
+    fieldError: null,
     saving: false,
     ownerName: '',
     deleteOpen: false,
@@ -145,7 +148,7 @@ document.addEventListener('alpine:init', () => {
           if (this.loadChildren) this.loadChildren();
           this.state = 'default';
         } catch (e) {
-          this.error = (e && e.message) || 'Could not load the document.';
+          this.error = App.services.apiErrors.refusalMessageFor(e, 'Could not load the document.');
           this.state = 'error';
         }
       } else {
@@ -208,9 +211,26 @@ document.addEventListener('alpine:init', () => {
       return payload;
     },
 
+    // A rejected header save that NAMES one of this form's properties ("The 'Name' property is
+    // required") marks that one control (fieldError -> aria-invalid) and repeats the server's own
+    // reason; anything else - a fault, a refusal naming nothing this form owns - keeps the generic
+    // banner. Mirrors baseFormPage.applyApiError / the line dialog's applyItemError (#7062/#7152);
+    // never the developer-facing e.message.
+    applyApiError(e, fallback) {
+      const named = App.services.apiErrors.namedProperty(e, Object.keys(this.form));
+      if (named) {
+        this.fieldError = named;
+        this.error = App.services.apiErrors.messageWithLabels(e, {});
+        return;
+      }
+      this.fieldError = null;
+      this.error = App.services.apiErrors.refusalMessageFor(e, fallback);
+    },
+
     async save() {
       this.saving = true;
       this.error = null;
+      this.fieldError = null;
       try {
         if (this.mode === 'edit') {
           await App.services.api.put(this.apiPath + '/' + this.id, this.toPayload());
@@ -230,7 +250,7 @@ document.addEventListener('alpine:init', () => {
           }
         }
       } catch (e) {
-        this.error = (e && e.message) || 'Could not save.';
+        this.applyApiError(e, 'Could not save.');
       } finally {
         this.saving = false;
       }
@@ -251,7 +271,7 @@ document.addEventListener('alpine:init', () => {
         const rows = await App.services.api.getAll(this.itemsApiPath + q);
         this.items = rows || [];
       } catch (e) {
-        this.itemsError = (e && e.message) || 'Could not load the line items.';
+        this.itemsError = App.services.apiErrors.refusalMessageFor(e, 'Could not load the line items.');
         this.items = [];
       }
 #if($documentItemsLayout == "calendar")
@@ -521,7 +541,7 @@ document.addEventListener('alpine:init', () => {
         await this.loadItems();
         await this.reloadHeaderTotals();
       } catch (e) {
-        this.itemsError = (e && e.message) || 'Could not delete the line item.';
+        this.itemsError = App.services.apiErrors.refusalMessageFor(e, 'Could not delete the line item.');
       }
     },
 #if($documentItemsLayout == "chat")
@@ -547,7 +567,7 @@ document.addEventListener('alpine:init', () => {
 #end
         await this.loadItems();
       } catch (e) {
-        this.itemsError = (e && e.message) || 'Could not send the message.';
+        this.itemsError = App.services.apiErrors.refusalMessageFor(e, 'Could not send the message.');
       } finally {
         this.chatSending = false;
       }
@@ -589,7 +609,7 @@ document.addEventListener('alpine:init', () => {
         this.deleteOpen = false;
         this.goBack();
       } catch (e) {
-        this.error = (e && e.message) || 'Could not delete.';
+        this.error = App.services.apiErrors.refusalMessageFor(e, 'Could not delete.');
         this.deleteOpen = false;
       } finally {
         this.deleteBusy = false;

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
@@ -47,7 +47,7 @@
     <div class="grid grid-cols-1 sm:grid-cols-12 gap-4" style="max-width: 900px">
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement && !$property.sensitiveProperty && $property.name != "ProcessId" && !$property.isHiddenProperty && (!$property.auditType || $property.auditType == "NONE") && $property.name != "Name" && $property.name != "$!{personalProperty}" && $property.isReadOnlyProperty != "true" && $property.widgetType != "DOCUMENT_STATUS" && !($property.widgetType == "DOCUMENT_NUMBER" && $property.numberSeries) && $property.aggregate != "true")
-      <div x-h-field class="#if($property.widgetType == "MULTISELECT")col-span-full#elseif($property.widgetSize && $property.widgetSize != "")sm:col-span-${property.widgetSize}#{else}sm:col-span-6#end"#visibleGate($property)>
+      <div x-h-field class="#if($property.widgetType == "MULTISELECT")col-span-full#elseif($property.widgetSize && $property.widgetSize != "")sm:col-span-${property.widgetSize}#{else}sm:col-span-6#end"#visibleGate($property) :data-invalid="fieldError === '${property.name}'">
 ## A CHECKBOX carries its label BESIDE it, inside the branch below - not above, as every
 ## other control does.
 #if($property.widgetType != "CHECKBOX")
@@ -57,7 +57,7 @@
 #end
 #if($property.widgetType == "DROPDOWN")
         <div x-h-select data-filter="contains">
-          <input x-h-select-input x-model="form.${property.name}" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select #if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end') })" />
+          <input x-h-select-input x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select #if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end') })" />
           <div x-h-select-content>
             <div x-h-select-search></div>
             <div x-h-select-list>
@@ -71,7 +71,7 @@
         <!-- Subset (intent `kind: subset`): the bound ARRAY model puts the select in
              multiple mode - the csv is split on load and joined back on save. -->
         <div x-h-select data-filter="contains">
-          <input x-h-select-input x-model="form.${property.name}" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select #if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end') })" />
+          <input x-h-select-input x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select #if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end') })" />
           <div x-h-select-content>
             <div x-h-select-search></div>
             <div x-h-select-list>
@@ -82,49 +82,49 @@
           </div>
         </div>
 #elseif($property.widgetType == "NUMBER")
-        <div x-h-input-number><input type="number" step="any" x-model.number="form.${property.name}" /></div>
+        <div x-h-input-number><input type="number" step="any" x-model.number="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" /></div>
 #elseif($property.widgetType == "CHECKBOX")
         <!-- The checkbox goes beside its label, inside a plain box: x-h-field stretches every
              direct child to full width, which turns the checkbox's own square into a full-width
              bordered rectangle - indistinguishable from an empty text input (#7103). The wrapper
              absorbs the stretch, and the layout is then the power form's. -->
         <div class="hbox items-center gap-3">
-          <span x-h-checkbox><input type="checkbox" id="f_${property.name}" x-model="form.${property.name}" /></span>
+          <span x-h-checkbox><input type="checkbox" id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" /></span>
           <label x-h-label for="f_${property.name}"><span x-text="T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end')"></span>#if($property.isRequiredProperty == "true") <span class="text-negative">*</span>#end</label>
         </div>
 #elseif($property.widgetType == "DATE")
         <div x-h-date-picker>
-          <input type="text" :placeholder="HarmoniaFormat.dateHint()" />
+          <input type="text" :placeholder="HarmoniaFormat.dateHint()" :aria-invalid="fieldError === '${property.name}'" />
           <button x-h-date-picker-trigger aria-label="Choose date"></button>
           <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "DATETIME-LOCAL")
         <div x-h-datetime-picker>
-          <input type="text" />
+          <input type="text" :aria-invalid="fieldError === '${property.name}'" />
           <button x-h-datetime-picker-trigger aria-label="Choose date and time"></button>
           <div x-h-datetime-picker-popup="HarmoniaFormat.pickerConfig('dateTime')" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "TIME")
         <div x-h-time-picker>
-          <input type="text" x-h-time-picker-input x-model="form.${property.name}" />
+          <input type="text" x-h-time-picker-input x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" />
           <div x-h-time-picker-popup></div>
         </div>
 #elseif($property.widgetType == "MONTH")
         <!-- Harmonia month picker: model is a YYYY-MM string, so form.${property.name} round-trips unchanged. -->
         <div x-h-month-picker>
-          <input type="text" />
+          <input type="text" :aria-invalid="fieldError === '${property.name}'" />
           <button x-h-month-picker-trigger aria-label="Choose month"></button>
           <div x-h-month-picker-popup x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "WEEK")
         <!-- Harmonia week picker: model is a YYYY-Www ISO-week string, so form.${property.name} round-trips unchanged. -->
         <div x-h-week-picker>
-          <input type="text" />
+          <input type="text" :aria-invalid="fieldError === '${property.name}'" />
           <button x-h-week-picker-trigger aria-label="Choose week"></button>
           <div x-h-week-picker-popup x-model="form.${property.name}"></div>
         </div>
 #else
-        <input x-h-input type="text" x-model="form.${property.name}"#if($property.widgetPattern) pattern="${property.widgetPattern}"#end />
+        <input x-h-input type="text" x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'"#if($property.widgetPattern) pattern="${property.widgetPattern}"#end />
 #end
       </div>
 #end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-page.js.template
@@ -28,6 +28,9 @@ document.addEventListener('alpine:init', () => {
     mode: 'create',
     id: null,
     error: null,
+    // The single property a rejected save NAMED ("The 'Name' property is required"), else null -
+    // drives :aria-invalid on that one control (see applyApiError).
+    fieldError: null,
     saving: false,
     deleteOpen: false,
     deleteBusy: false,
@@ -91,7 +94,7 @@ document.addEventListener('alpine:init', () => {
 #end
           this.state = 'default';
         } catch (e) {
-          this.error = (e && e.message) || 'Could not load the record.';
+          this.error = App.services.apiErrors.refusalMessageFor(e, 'Could not load the record.');
           this.state = 'error';
         }
 #if($myChildren && $myChildren.size() > 0)
@@ -168,9 +171,26 @@ document.addEventListener('alpine:init', () => {
       return payload;
     },
 
+    // A rejected save that NAMES one of this form's properties ("The 'Name' property is required")
+    // marks that one control (fieldError -> aria-invalid) and repeats the server's own reason;
+    // anything else - a fault, a refusal naming nothing this form owns - keeps the generic banner.
+    // Mirrors baseFormPage.applyApiError / the line dialog's applyItemError (#7062/#7152); never the
+    // developer-facing e.message.
+    applyApiError(e, fallback) {
+      const named = App.services.apiErrors.namedProperty(e, Object.keys(this.form));
+      if (named) {
+        this.fieldError = named;
+        this.error = App.services.apiErrors.messageWithLabels(e, {});
+        return;
+      }
+      this.fieldError = null;
+      this.error = App.services.apiErrors.refusalMessageFor(e, fallback);
+    },
+
     async save() {
       this.saving = true;
       this.error = null;
+      this.fieldError = null;
       try {
         if (this.mode === 'edit') {
           await App.services.api.put(this.apiPath + '/' + this.id, this.toPayload());
@@ -179,7 +199,7 @@ document.addEventListener('alpine:init', () => {
         }
         this.goBack();
       } catch (e) {
-        this.error = (e && e.message) || 'Could not save.';
+        this.applyApiError(e, 'Could not save.');
       } finally {
         this.saving = false;
       }
@@ -192,7 +212,7 @@ document.addEventListener('alpine:init', () => {
         this.deleteOpen = false;
         this.goBack();
       } catch (e) {
-        this.error = (e && e.message) || 'Could not delete.';
+        this.error = App.services.apiErrors.refusalMessageFor(e, 'Could not delete.');
         this.deleteOpen = false;
       } finally {
         this.deleteBusy = false;

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template
@@ -49,7 +49,7 @@
     <div class="grid grid-cols-1 sm:grid-cols-12 gap-4" style="max-width: 900px">
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement && !$property.sensitiveProperty && $property.name != "ProcessId" && !$property.isHiddenProperty && (!$property.auditType || $property.auditType == "NONE") && $property.name != "Name" && $property.name != $skipOwnerFk && $property.name != $skipParentFk && $property.isReadOnlyProperty != "true" && $property.widgetType != "DOCUMENT_STATUS")
-      <div x-h-field class="#if($property.widgetType == "MULTISELECT")col-span-full#elseif($property.widgetSize && $property.widgetSize != "")sm:col-span-${property.widgetSize}#{else}sm:col-span-6#end"#visibleGate($property)>
+      <div x-h-field class="#if($property.widgetType == "MULTISELECT")col-span-full#elseif($property.widgetSize && $property.widgetSize != "")sm:col-span-${property.widgetSize}#{else}sm:col-span-6#end"#visibleGate($property) :data-invalid="fieldError === '${property.name}'">
 ## A CHECKBOX carries its label BESIDE it, inside the branch below - not above, as every
 ## other control does.
 #if($property.widgetType != "CHECKBOX")
@@ -59,7 +59,7 @@
 #end
 #if($property.widgetType == "DROPDOWN")
         <div x-h-select data-filter="contains">
-          <input x-h-select-input x-model="form.${property.name}" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select #if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end') })" />
+          <input x-h-select-input x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select #if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end') })" />
           <div x-h-select-content>
             <div x-h-select-search></div>
             <div x-h-select-list>
@@ -73,7 +73,7 @@
         <!-- Subset (intent `kind: subset`): the bound ARRAY model puts the select in
              multiple mode - the csv is split on load and joined back on save. -->
         <div x-h-select data-filter="contains">
-          <input x-h-select-input x-model="form.${property.name}" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select #if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end') })" />
+          <input x-h-select-input x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select #if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end') })" />
           <div x-h-select-content>
             <div x-h-select-search></div>
             <div x-h-select-list>
@@ -84,51 +84,51 @@
           </div>
         </div>
 #elseif($property.widgetType == "NUMBER")
-        <div x-h-input-number><input type="number" step="any" x-model.number="form.${property.name}" /></div>
+        <div x-h-input-number><input type="number" step="any" x-model.number="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" /></div>
 #elseif($property.widgetType == "CHECKBOX")
         <!-- The checkbox goes beside its label, inside a plain box: x-h-field stretches every
              direct child to full width, which turns the checkbox's own square into a full-width
              bordered rectangle - indistinguishable from an empty text input (#7103). The wrapper
              absorbs the stretch, and the layout is then the power form's. -->
         <div class="hbox items-center gap-3">
-          <span x-h-checkbox><input type="checkbox" id="f_${property.name}" x-model="form.${property.name}" /></span>
+          <span x-h-checkbox><input type="checkbox" id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" /></span>
           <label x-h-label for="f_${property.name}"><span x-text="T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end')"></span>#if($property.isRequiredProperty == "true") <span class="text-negative">*</span>#end</label>
         </div>
 #elseif($property.widgetType == "DATE")
         <!-- Harmonia date picker: model is YYYY-MM-DD (same as the native date input it replaces),
              so form.${property.name} round-trips unchanged through toDateInput/toPayload. -->
         <div x-h-date-picker>
-          <input type="text" :placeholder="HarmoniaFormat.dateHint()" />
+          <input type="text" :placeholder="HarmoniaFormat.dateHint()" :aria-invalid="fieldError === '${property.name}'" />
           <button x-h-date-picker-trigger aria-label="Choose date"></button>
           <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "DATETIME-LOCAL")
         <div x-h-datetime-picker>
-          <input type="text" />
+          <input type="text" :aria-invalid="fieldError === '${property.name}'" />
           <button x-h-datetime-picker-trigger aria-label="Choose date and time"></button>
           <div x-h-datetime-picker-popup="HarmoniaFormat.pickerConfig('dateTime')" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "TIME")
         <div x-h-time-picker>
-          <input type="text" x-h-time-picker-input x-model="form.${property.name}" />
+          <input type="text" x-h-time-picker-input x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" />
           <div x-h-time-picker-popup></div>
         </div>
 #elseif($property.widgetType == "MONTH")
         <!-- Harmonia month picker: model is a YYYY-MM string, so form.${property.name} round-trips unchanged. -->
         <div x-h-month-picker>
-          <input type="text" />
+          <input type="text" :aria-invalid="fieldError === '${property.name}'" />
           <button x-h-month-picker-trigger aria-label="Choose month"></button>
           <div x-h-month-picker-popup x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "WEEK")
         <!-- Harmonia week picker: model is a YYYY-Www ISO-week string, so form.${property.name} round-trips unchanged. -->
         <div x-h-week-picker>
-          <input type="text" />
+          <input type="text" :aria-invalid="fieldError === '${property.name}'" />
           <button x-h-week-picker-trigger aria-label="Choose week"></button>
           <div x-h-week-picker-popup x-model="form.${property.name}"></div>
         </div>
 #else
-        <input x-h-input type="text" x-model="form.${property.name}"#if($property.widgetPattern) pattern="${property.widgetPattern}"#end />
+        <input x-h-input type="text" x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'"#if($property.widgetPattern) pattern="${property.widgetPattern}"#end />
 #end
       </div>
 #end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-page.js.template
@@ -22,6 +22,9 @@ document.addEventListener('alpine:init', () => {
     mode: 'create',
     id: null,
     error: null,
+    // The single header property a rejected save NAMED ("The 'Name' property is required"), else
+    // null - drives :aria-invalid on that one control (see applyApiError).
+    fieldError: null,
     saving: false,
     ownerName: '',
     deleteOpen: false,
@@ -135,7 +138,7 @@ document.addEventListener('alpine:init', () => {
           await this.loadItems();
           this.state = 'default';
         } catch (e) {
-          this.error = (e && e.message) || 'Could not load the document.';
+          this.error = App.services.apiErrors.refusalMessageFor(e, 'Could not load the document.');
           this.state = 'error';
         }
       } else {
@@ -198,9 +201,26 @@ document.addEventListener('alpine:init', () => {
       return payload;
     },
 
+    // A rejected header save that NAMES one of this form's properties ("The 'Name' property is
+    // required") marks that one control (fieldError -> aria-invalid) and repeats the server's own
+    // reason; anything else - a fault, a refusal naming nothing this form owns - keeps the generic
+    // banner. Mirrors baseFormPage.applyApiError / the line dialog's applyItemError (#7062/#7152);
+    // never the developer-facing e.message.
+    applyApiError(e, fallback) {
+      const named = App.services.apiErrors.namedProperty(e, Object.keys(this.form));
+      if (named) {
+        this.fieldError = named;
+        this.error = App.services.apiErrors.messageWithLabels(e, {});
+        return;
+      }
+      this.fieldError = null;
+      this.error = App.services.apiErrors.refusalMessageFor(e, fallback);
+    },
+
     async save() {
       this.saving = true;
       this.error = null;
+      this.fieldError = null;
       try {
         if (this.mode === 'edit') {
           await App.services.api.put(this.apiPath + '/' + this.id, this.toPayload());
@@ -220,7 +240,7 @@ document.addEventListener('alpine:init', () => {
           }
         }
       } catch (e) {
-        this.error = (e && e.message) || 'Could not save.';
+        this.applyApiError(e, 'Could not save.');
       } finally {
         this.saving = false;
       }
@@ -241,7 +261,7 @@ document.addEventListener('alpine:init', () => {
         const rows = await App.services.api.getAll(this.itemsApiPath + q);
         this.items = rows || [];
       } catch (e) {
-        this.itemsError = (e && e.message) || 'Could not load the line items.';
+        this.itemsError = App.services.apiErrors.refusalMessageFor(e, 'Could not load the line items.');
         this.items = [];
       }
 #if($documentItemsLayout == "calendar")
@@ -436,7 +456,7 @@ document.addEventListener('alpine:init', () => {
         await this.loadItems();
         await this.reloadHeaderTotals();
       } catch (e) {
-        this.itemsError = (e && e.message) || 'Could not delete the line item.';
+        this.itemsError = App.services.apiErrors.refusalMessageFor(e, 'Could not delete the line item.');
       }
     },
 
@@ -475,7 +495,7 @@ document.addEventListener('alpine:init', () => {
         this.deleteOpen = false;
         this.goBack();
       } catch (e) {
-        this.error = (e && e.message) || 'Could not delete.';
+        this.error = App.services.apiErrors.refusalMessageFor(e, 'Could not delete.');
         this.deleteOpen = false;
       } finally {
         this.deleteBusy = false;

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
@@ -47,7 +47,7 @@
     <div class="grid grid-cols-1 sm:grid-cols-12 gap-4" style="max-width: 900px">
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement && !$property.sensitiveProperty && $property.name != "ProcessId" && !$property.isHiddenProperty && (!$property.auditType || $property.auditType == "NONE") && $property.name != "Name" && $property.name != "$!{partnerProperty}" && $property.isReadOnlyProperty != "true" && $property.widgetType != "DOCUMENT_STATUS" && !($property.widgetType == "DOCUMENT_NUMBER" && $property.numberSeries) && $property.aggregate != "true")
-      <div x-h-field class="#if($property.widgetType == "MULTISELECT")col-span-full#elseif($property.widgetSize && $property.widgetSize != "")sm:col-span-${property.widgetSize}#{else}sm:col-span-6#end"#visibleGate($property)>
+      <div x-h-field class="#if($property.widgetType == "MULTISELECT")col-span-full#elseif($property.widgetSize && $property.widgetSize != "")sm:col-span-${property.widgetSize}#{else}sm:col-span-6#end"#visibleGate($property) :data-invalid="fieldError === '${property.name}'">
 ## A CHECKBOX carries its label BESIDE it, inside the branch below - not above, as every
 ## other control does.
 #if($property.widgetType != "CHECKBOX")
@@ -57,7 +57,7 @@
 #end
 #if($property.widgetType == "DROPDOWN")
         <div x-h-select data-filter="contains">
-          <input x-h-select-input x-model="form.${property.name}" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select #if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end') })" />
+          <input x-h-select-input x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select #if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end') })" />
           <div x-h-select-content>
             <div x-h-select-search></div>
             <div x-h-select-list>
@@ -71,7 +71,7 @@
         <!-- Subset (intent `kind: subset`): the bound ARRAY model puts the select in
              multiple mode - the csv is split on load and joined back on save. -->
         <div x-h-select data-filter="contains">
-          <input x-h-select-input x-model="form.${property.name}" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select #if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end') })" />
+          <input x-h-select-input x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select #if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end') })" />
           <div x-h-select-content>
             <div x-h-select-search></div>
             <div x-h-select-list>
@@ -82,49 +82,49 @@
           </div>
         </div>
 #elseif($property.widgetType == "NUMBER")
-        <div x-h-input-number><input type="number" step="any" x-model.number="form.${property.name}" /></div>
+        <div x-h-input-number><input type="number" step="any" x-model.number="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" /></div>
 #elseif($property.widgetType == "CHECKBOX")
         <!-- The checkbox goes beside its label, inside a plain box: x-h-field stretches every
              direct child to full width, which turns the checkbox's own square into a full-width
              bordered rectangle - indistinguishable from an empty text input (#7103). The wrapper
              absorbs the stretch, and the layout is then the power form's. -->
         <div class="hbox items-center gap-3">
-          <span x-h-checkbox><input type="checkbox" id="f_${property.name}" x-model="form.${property.name}" /></span>
+          <span x-h-checkbox><input type="checkbox" id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" /></span>
           <label x-h-label for="f_${property.name}"><span x-text="T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end')"></span>#if($property.isRequiredProperty == "true") <span class="text-negative">*</span>#end</label>
         </div>
 #elseif($property.widgetType == "DATE")
         <div x-h-date-picker>
-          <input type="text" :placeholder="HarmoniaFormat.dateHint()" />
+          <input type="text" :placeholder="HarmoniaFormat.dateHint()" :aria-invalid="fieldError === '${property.name}'" />
           <button x-h-date-picker-trigger aria-label="Choose date"></button>
           <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "DATETIME-LOCAL")
         <div x-h-datetime-picker>
-          <input type="text" />
+          <input type="text" :aria-invalid="fieldError === '${property.name}'" />
           <button x-h-datetime-picker-trigger aria-label="Choose date and time"></button>
           <div x-h-datetime-picker-popup="HarmoniaFormat.pickerConfig('dateTime')" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "TIME")
         <div x-h-time-picker>
-          <input type="text" x-h-time-picker-input x-model="form.${property.name}" />
+          <input type="text" x-h-time-picker-input x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" />
           <div x-h-time-picker-popup></div>
         </div>
 #elseif($property.widgetType == "MONTH")
         <!-- Harmonia month picker: model is a YYYY-MM string, so form.${property.name} round-trips unchanged. -->
         <div x-h-month-picker>
-          <input type="text" />
+          <input type="text" :aria-invalid="fieldError === '${property.name}'" />
           <button x-h-month-picker-trigger aria-label="Choose month"></button>
           <div x-h-month-picker-popup x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "WEEK")
         <!-- Harmonia week picker: model is a YYYY-Www ISO-week string, so form.${property.name} round-trips unchanged. -->
         <div x-h-week-picker>
-          <input type="text" />
+          <input type="text" :aria-invalid="fieldError === '${property.name}'" />
           <button x-h-week-picker-trigger aria-label="Choose week"></button>
           <div x-h-week-picker-popup x-model="form.${property.name}"></div>
         </div>
 #else
-        <input x-h-input type="text" x-model="form.${property.name}"#if($property.widgetPattern) pattern="${property.widgetPattern}"#end />
+        <input x-h-input type="text" x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'"#if($property.widgetPattern) pattern="${property.widgetPattern}"#end />
 #end
       </div>
 #end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-form-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-form-page.js.template
@@ -28,6 +28,9 @@ document.addEventListener('alpine:init', () => {
     mode: 'create',
     id: null,
     error: null,
+    // The single property a rejected save NAMED ("The 'Name' property is required"), else null -
+    // drives :aria-invalid on that one control (see applyApiError).
+    fieldError: null,
     saving: false,
     deleteOpen: false,
     deleteBusy: false,
@@ -91,7 +94,7 @@ document.addEventListener('alpine:init', () => {
 #end
           this.state = 'default';
         } catch (e) {
-          this.error = (e && e.message) || 'Could not load the record.';
+          this.error = App.services.apiErrors.refusalMessageFor(e, 'Could not load the record.');
           this.state = 'error';
         }
 #if($partnerChildren && $partnerChildren.size() > 0)
@@ -168,9 +171,26 @@ document.addEventListener('alpine:init', () => {
       return payload;
     },
 
+    // A rejected save that NAMES one of this form's properties ("The 'Name' property is required")
+    // marks that one control (fieldError -> aria-invalid) and repeats the server's own reason;
+    // anything else - a fault, a refusal naming nothing this form owns - keeps the generic banner.
+    // Mirrors baseFormPage.applyApiError / the line dialog's applyItemError (#7062/#7152); never the
+    // developer-facing e.message.
+    applyApiError(e, fallback) {
+      const named = App.services.apiErrors.namedProperty(e, Object.keys(this.form));
+      if (named) {
+        this.fieldError = named;
+        this.error = App.services.apiErrors.messageWithLabels(e, {});
+        return;
+      }
+      this.fieldError = null;
+      this.error = App.services.apiErrors.refusalMessageFor(e, fallback);
+    },
+
     async save() {
       this.saving = true;
       this.error = null;
+      this.fieldError = null;
       try {
         if (this.mode === 'edit') {
           await App.services.api.put(this.apiPath + '/' + this.id, this.toPayload());
@@ -179,7 +199,7 @@ document.addEventListener('alpine:init', () => {
         }
         this.goBack();
       } catch (e) {
-        this.error = (e && e.message) || 'Could not save.';
+        this.applyApiError(e, 'Could not save.');
       } finally {
         this.saving = false;
       }
@@ -192,7 +212,7 @@ document.addEventListener('alpine:init', () => {
         this.deleteOpen = false;
         this.goBack();
       } catch (e) {
-        this.error = (e && e.message) || 'Could not delete.';
+        this.error = App.services.apiErrors.refusalMessageFor(e, 'Could not delete.');
         this.deleteOpen = false;
       } finally {
         this.deleteBusy = false;

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-form-view.html.template
@@ -49,7 +49,7 @@
     <div class="grid grid-cols-1 sm:grid-cols-12 gap-4" style="max-width: 900px">
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement && !$property.sensitiveProperty && $property.name != "ProcessId" && !$property.isHiddenProperty && (!$property.auditType || $property.auditType == "NONE") && $property.name != "Name" && $property.name != $skipOwnerFk && $property.name != $skipParentFk && $property.isReadOnlyProperty != "true" && $property.widgetType != "DOCUMENT_STATUS")
-      <div x-h-field class="#if($property.widgetType == "MULTISELECT")col-span-full#elseif($property.widgetSize && $property.widgetSize != "")sm:col-span-${property.widgetSize}#{else}sm:col-span-6#end"#visibleGate($property)>
+      <div x-h-field class="#if($property.widgetType == "MULTISELECT")col-span-full#elseif($property.widgetSize && $property.widgetSize != "")sm:col-span-${property.widgetSize}#{else}sm:col-span-6#end"#visibleGate($property) :data-invalid="fieldError === '${property.name}'">
 ## A CHECKBOX carries its label BESIDE it, inside the branch below - not above, as every
 ## other control does.
 #if($property.widgetType != "CHECKBOX")
@@ -59,7 +59,7 @@
 #end
 #if($property.widgetType == "DROPDOWN")
         <div x-h-select data-filter="contains">
-          <input x-h-select-input x-model="form.${property.name}" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select #if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end') })" />
+          <input x-h-select-input x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select #if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end') })" />
           <div x-h-select-content>
             <div x-h-select-search></div>
             <div x-h-select-list>
@@ -73,7 +73,7 @@
         <!-- Subset (intent `kind: subset`): the bound ARRAY model puts the select in
              multiple mode - the csv is split on load and joined back on save. -->
         <div x-h-select data-filter="contains">
-          <input x-h-select-input x-model="form.${property.name}" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select #if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end') })" />
+          <input x-h-select-input x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" :placeholder="T('$projectName:${tprefix}.messages.inputSelect', 'Select #if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end...', { name: T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end') })" />
           <div x-h-select-content>
             <div x-h-select-search></div>
             <div x-h-select-list>
@@ -84,51 +84,51 @@
           </div>
         </div>
 #elseif($property.widgetType == "NUMBER")
-        <div x-h-input-number><input type="number" step="any" x-model.number="form.${property.name}" /></div>
+        <div x-h-input-number><input type="number" step="any" x-model.number="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" /></div>
 #elseif($property.widgetType == "CHECKBOX")
         <!-- The checkbox goes beside its label, inside a plain box: x-h-field stretches every
              direct child to full width, which turns the checkbox's own square into a full-width
              bordered rectangle - indistinguishable from an empty text input (#7103). The wrapper
              absorbs the stretch, and the layout is then the power form's. -->
         <div class="hbox items-center gap-3">
-          <span x-h-checkbox><input type="checkbox" id="f_${property.name}" x-model="form.${property.name}" /></span>
+          <span x-h-checkbox><input type="checkbox" id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" /></span>
           <label x-h-label for="f_${property.name}"><span x-text="T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end')"></span>#if($property.isRequiredProperty == "true") <span class="text-negative">*</span>#end</label>
         </div>
 #elseif($property.widgetType == "DATE")
         <!-- Harmonia date picker: model is YYYY-MM-DD (same as the native date input it replaces),
              so form.${property.name} round-trips unchanged through toDateInput/toPayload. -->
         <div x-h-date-picker>
-          <input type="text" :placeholder="HarmoniaFormat.dateHint()" />
+          <input type="text" :placeholder="HarmoniaFormat.dateHint()" :aria-invalid="fieldError === '${property.name}'" />
           <button x-h-date-picker-trigger aria-label="Choose date"></button>
           <div x-h-date-picker-popup="HarmoniaFormat.pickerConfig()" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "DATETIME-LOCAL")
         <div x-h-datetime-picker>
-          <input type="text" />
+          <input type="text" :aria-invalid="fieldError === '${property.name}'" />
           <button x-h-datetime-picker-trigger aria-label="Choose date and time"></button>
           <div x-h-datetime-picker-popup="HarmoniaFormat.pickerConfig('dateTime')" x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "TIME")
         <div x-h-time-picker>
-          <input type="text" x-h-time-picker-input x-model="form.${property.name}" />
+          <input type="text" x-h-time-picker-input x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'" />
           <div x-h-time-picker-popup></div>
         </div>
 #elseif($property.widgetType == "MONTH")
         <!-- Harmonia month picker: model is a YYYY-MM string, so form.${property.name} round-trips unchanged. -->
         <div x-h-month-picker>
-          <input type="text" />
+          <input type="text" :aria-invalid="fieldError === '${property.name}'" />
           <button x-h-month-picker-trigger aria-label="Choose month"></button>
           <div x-h-month-picker-popup x-model="form.${property.name}"></div>
         </div>
 #elseif($property.widgetType == "WEEK")
         <!-- Harmonia week picker: model is a YYYY-Www ISO-week string, so form.${property.name} round-trips unchanged. -->
         <div x-h-week-picker>
-          <input type="text" />
+          <input type="text" :aria-invalid="fieldError === '${property.name}'" />
           <button x-h-week-picker-trigger aria-label="Choose week"></button>
           <div x-h-week-picker-popup x-model="form.${property.name}"></div>
         </div>
 #else
-        <input x-h-input type="text" x-model="form.${property.name}"#if($property.widgetPattern) pattern="${property.widgetPattern}"#end />
+        <input x-h-input type="text" x-model="form.${property.name}" :aria-invalid="fieldError === '${property.name}'"#if($property.widgetPattern) pattern="${property.widgetPattern}"#end />
 #end
       </div>
 #end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -735,7 +735,7 @@
               <!-- Fill Month: the fill-target date column picks the MONTH - every working day gets a line. -->
               <template x-if="!col.readonly && col.widget === 'DATE' && draftMode === 'fill' && col.name === fillDateName()">
                 <div x-h-month-picker>
-                  <input type="text" />
+                  <input type="text" :aria-invalid="draftFieldError === col.name" />
                   <button x-h-month-picker-trigger aria-label="Choose month"></button>
                   <div x-h-month-picker-popup x-model="draft[col.name]"></div>
                 </div>

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -2901,6 +2901,39 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertTrue(myRosterPage.contains("applyItemError") && myRosterPage.contains("namedProperty"),
                 "a refused personal line must be mapped onto the property the server named, not printed raw");
 
+        // #7242: #7151/#7152 reached the shared apiErrors helper and the line dialogs only - the
+        // personal/partner form save and the document HEADER save still printed the raw developer-
+        // facing e.message and marked no field. Mirror baseFormPage.applyApiError on both surfaces:
+        // namedProperty -> fieldError, messageWithLabels, else the refusal text, else the neutral
+        // fallback - and route the load/delete paths through the same safe refusalMessageFor helper.
+        assertTrue(myFormPage.contains("applyApiError") && myFormPage.contains("namedProperty"),
+                "the personal form save must map a named rejection onto its property, not print e.message");
+        assertTrue(myFormPage.contains("refusalMessageFor"),
+                "the personal form's load/delete paths must go through the safe refusal helper, not e.message");
+        assertFalse(myFormPage.contains("(e && e.message)"), "the personal form must never surface the developer-facing e.message");
+        assertTrue(myForm.contains(":aria-invalid=\"fieldError === "),
+                "the personal form's header controls must mark the field a rejection named");
+
+        String partnerForm = contentOf("gen/emission/views/partner/PartnerTicket-form.html");
+        String partnerFormPage = contentOf("gen/emission/js/components/pages/partner/PartnerTicketPartnerFormPage.js");
+        assertTrue(partnerFormPage.contains("applyApiError") && partnerFormPage.contains("namedProperty"),
+                "the partner form save must map a named rejection onto its property, not print e.message");
+        assertTrue(partnerFormPage.contains("refusalMessageFor"),
+                "the partner form's load/delete paths must go through the safe refusal helper, not e.message");
+        assertFalse(partnerFormPage.contains("(e && e.message)"), "the partner form must never surface the developer-facing e.message");
+        assertTrue(partnerForm.contains(":aria-invalid=\"fieldError === "),
+                "the partner form's header controls must mark the field a rejection named");
+
+        // The document HEADER save gets the identical treatment - the my-document class is the one
+        // #7242 was filed reviewing (the line dialog got it in #7152, the header did not).
+        assertTrue(myRosterPage.contains("applyApiError") && myRosterPage.contains("namedProperty"),
+                "the personal document's header save must map a named rejection onto its property");
+        assertTrue(myRosterPage.contains("refusalMessageFor"),
+                "the personal document's load/delete/items paths must go through the safe refusal helper");
+        assertFalse(myRosterPage.contains("(e && e.message)"), "the personal document must never surface the developer-facing e.message");
+        assertTrue(myRosterDoc.contains(":aria-invalid=\"fieldError === "),
+                "the personal document's header controls must mark the field a rejection named");
+
         // The app-test manifest carries the personal UI-parity metadata the runner's my flow
         // drives (wave 2): the /my route, the layout family the personal page belongs to, and
         // the relation columns that must resolve to labels on the personal list.


### PR DESCRIPTION
## Summary
- `#7151`/`#7062` made the shared `apiErrors` helper safe (`namedProperty`/`messageWithLabels`/`refusalMessageFor`) and wired it into the power form/dialog; `#7152` reached the personal/partner **line dialogs**. The personal/partner **form and document header** save paths were left out: they still assigned the raw developer-facing `e.message` to the banner, and their header controls carried no `aria-invalid`, so a rejection naming a field pointed at nothing.
- Give the my/partner form and document pages an `applyApiError` mirroring `baseFormPage`'s: a rejection that NAMES one of the form's properties marks that one control (`fieldError` -> `aria-invalid`) and repeats the server's own reason; anything else falls back to the safe `refusalMessageFor`.
- Route every remaining load/delete/items path (header load, header delete, items load, item delete, chat send) through `refusalMessageFor` too, replacing every `(e && e.message) || '...'` fallback.
- Adjacent nit: the power document dialog's Fill-Month input was missing the `:aria-invalid` its DATE/DATETIME-LOCAL siblings carry.

## Test plan
- [x] `mvn formatter:validate` (repo-wide) — `BUILD SUCCESS`
- [x] Added `#7242` coverage to `IntentEmissionCoverageIT` (personal form/document `Claim`/`Roster` + partner form `PartnerTicket`) asserting `applyApiError`/`namedProperty`/`refusalMessageFor` are used and the raw `(e && e.message)` fallback is gone
- [x] `mvn -pl tests/tests-integrations -am -P integration-tests -Dit.test=IntentEmissionCoverageIT -D selenide.headless=true install` — green

Fixes #7242

🤖 Generated with [Claude Code](https://claude.com/claude-code)