### PR TITLE
bpm: a process-instance listing resolves every activity in three queries

### DIFF
--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/BpmProviderFlowable.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/BpmProviderFlowable.java
@@ -41,6 +41,7 @@ import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.RepositoryService;
 import org.flowable.engine.RuntimeService;
+import org.flowable.engine.delegate.DelegateExecution;
 import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.history.HistoricProcessInstanceQuery;
 import org.flowable.engine.repository.Deployment;
@@ -675,6 +676,96 @@ public class BpmProviderFlowable implements BpmProvider {
         activityIds.addAll(elementIds(getPendingJobs(processInstance.getId())));
 
         return List.copyOf(activityIds);
+    }
+
+    /**
+     * Where each of the given process instances sits, in a fixed number of statements rather than three
+     * per instance.
+     *
+     * <p>
+     * The evidence is the same as for a single instance - active executions plus the elements of the
+     * pending jobs - gathered in three queries and grouped in memory: one execution query over all the
+     * given ids, and the two job queries over the current tenant, whose rows are only the jobs waiting
+     * to run and are then matched against the ids asked for. Flowable's job queries take a single
+     * process-instance id, so the tenant is the narrowest batch filter available; a listing of a few
+     * hundred instances is what this is for, and it is what the Monitoring shell polls every 30 s
+     * (<a href="https://github.com/eclipse-dirigible/dirigible/issues/7250">#7250</a>).
+     *
+     * <p>
+     * An execution counts only while it is active, matching {@code RuntimeService#getActiveActivityIds}
+     * - the query itself cannot filter on the flag, so an inactive scope execution, the parent of a
+     * subprocess or of a multi-instance body, is dropped here instead of being reported as a second
+     * activity of the instance.
+     *
+     * @param processInstances the already resolved process instances
+     * @return the occupied activity ids per process instance id, active executions first; an instance
+     *         occupying none is absent
+     */
+    public Map<String, List<String>> getProcessInstanceActivityIds(List<ProcessInstance> processInstances) {
+        Set<String> processInstanceIds = processInstances.stream()
+                                                         .map(ProcessInstance::getId)
+                                                         .collect(Collectors.toCollection(LinkedHashSet::new));
+        if (processInstanceIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, Set<String>> activityIds = new HashMap<>();
+        activeExecutions(processInstanceIds).forEach(
+                execution -> record(activityIds, processInstanceIds, execution.getProcessInstanceId(), execution.getActivityId()));
+        pendingJobs().forEach(job -> record(activityIds, processInstanceIds, job.getProcessInstanceId(), job.getElementId()));
+
+        return activityIds.entrySet()
+                          .stream()
+                          .collect(Collectors.toMap(Map.Entry::getKey, entry -> List.copyOf(entry.getValue())));
+    }
+
+    private static void record(Map<String, Set<String>> activityIds, Set<String> processInstanceIds, String processInstanceId,
+            String activityId) {
+        if (null == activityId || !processInstanceIds.contains(processInstanceId)) {
+            return;
+        }
+        activityIds.computeIfAbsent(processInstanceId, id -> new LinkedHashSet<>())
+                   .add(activityId);
+    }
+
+    /**
+     * The active child executions of the given process instances. The active flag is not a query
+     * criterion in Flowable, so it is read off the returned rows, which are execution entities; an
+     * implementation that does not expose the flag is taken at face value rather than dropped.
+     *
+     * @param processInstanceIds the process instance ids
+     * @return the active child executions
+     */
+    private List<Execution> activeExecutions(Set<String> processInstanceIds) {
+        List<Execution> executions = processEngine.getRuntimeService()
+                                                  .createExecutionQuery()
+                                                  .processInstanceIds(processInstanceIds)
+                                                  .onlyChildExecutions()
+                                                  .executionTenantId(getTenantId())
+                                                  .list();
+
+        return executions.stream()
+                         .filter(execution -> !(execution instanceof DelegateExecution delegate) || delegate.isActive())
+                         .toList();
+    }
+
+    /**
+     * The jobs the current tenant is waiting on, executable and timer alike - the batch counterpart of
+     * {@link #getPendingJobs(String)}.
+     *
+     * @return the pending jobs
+     */
+    private List<Job> pendingJobs() {
+        ManagementService managementService = processEngine.getManagementService();
+
+        List<Job> pendingJobs = new ArrayList<>(managementService.createJobQuery()
+                                                                 .jobTenantId(getTenantId())
+                                                                 .list());
+        pendingJobs.addAll(managementService.createTimerJobQuery()
+                                            .jobTenantId(getTenantId())
+                                            .list());
+
+        return pendingJobs;
     }
 
     /**

--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/service/BpmService.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/service/BpmService.java
@@ -264,8 +264,13 @@ public class BpmService {
      */
     public List<ProcessInstanceData> getProcessInstances(Optional<String> key, Optional<String> businessKey) {
         List<ProcessInstance> processInstances = bpmProviderFlowable.getProcessInstances(key, businessKey);
+        // Resolved for the whole listing at once: per instance it is three statements, and the listing
+        // is unbounded - the Monitoring shell polls it every 30 s with no key (#7250).
+        Map<String, List<String>> activityIds = bpmProviderFlowable.getProcessInstanceActivityIds(processInstances);
+
         return processInstances.stream()
-                               .map(this::mapProcessInstance)
+                               .map(processInstance -> mapProcessInstance(processInstance,
+                                       activityIds.getOrDefault(processInstance.getId(), List.of())))
                                .toList();
     }
 
@@ -275,14 +280,14 @@ public class BpmService {
      * <p>
      * The activity id is resolved rather than read off the instance: Flowable leaves it unset on a root
      * process-instance execution, which is what every running instance is, so the field was always
-     * null. Resolving it costs a few indexed lookups per instance - hence the already resolved instance
-     * handed to the provider - and stays null while an instance is forked across several activities,
-     * the field being singular; {@code getProcessInstanceActiveActivityIds} answers for a fan-out.
+     * null. It stays null while an instance is forked across several activities, the field being
+     * singular; {@code getProcessInstanceActiveActivityIds} answers for a fan-out.
      *
      * @param processInstance the process instance
+     * @param activityIds the activity ids the instance occupies, already resolved
      * @return the process instance data
      */
-    private ProcessInstanceData mapProcessInstance(ProcessInstance processInstance) {
+    private ProcessInstanceData mapProcessInstance(ProcessInstance processInstance, List<String> activityIds) {
         ProcessInstanceData processInstanceData = new ProcessInstanceData();
         processInstanceData.setBusinessKey(processInstance.getBusinessKey());
         processInstanceData.setBusinessStatus(processInstance.getBusinessStatus());
@@ -298,19 +303,17 @@ public class BpmService {
         processInstanceData.setStartTime(processInstance.getStartTime());
         processInstanceData.setReferenceId(processInstance.getReferenceId());
         processInstanceData.setCallbackId(processInstance.getCallbackId());
-        processInstanceData.setActivityId(resolveActivityId(processInstance));
+        processInstanceData.setActivityId(singleActivityId(activityIds));
         return processInstanceData;
     }
 
     /**
      * The single activity a process instance sits on, or null when it sits on none or on several.
      *
-     * @param processInstance the process instance
+     * @param activityIds the activity ids the instance occupies
      * @return the activity id, or null
      */
-    private String resolveActivityId(ProcessInstance processInstance) {
-        List<String> activityIds = bpmProviderFlowable.getProcessInstanceActivityIds(processInstance);
-
+    private static String singleActivityId(List<String> activityIds) {
         return activityIds.size() == 1 ? activityIds.get(0) : null;
     }
 
@@ -338,7 +341,7 @@ public class BpmService {
      */
     public ProcessInstanceData getProcessInstanceById(String id) {
         ProcessInstance processInstance = bpmProviderFlowable.getProcessInstance(id);
-        return mapProcessInstance(processInstance);
+        return mapProcessInstance(processInstance, bpmProviderFlowable.getProcessInstanceActivityIds(processInstance));
     }
 
     /**

--- a/components/engine/engine-bpm-flowable/src/test/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/BpmProviderFlowableActiveActivitiesTest.java
+++ b/components/engine/engine-bpm-flowable/src/test/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/BpmProviderFlowableActiveActivitiesTest.java
@@ -14,9 +14,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.IntStream;
 
 import org.eclipse.dirigible.components.base.tenant.Tenant;
 import org.eclipse.dirigible.components.base.tenant.TenantContext;
@@ -51,6 +57,9 @@ import org.junit.jupiter.api.Test;
 class BpmProviderFlowableActiveActivitiesTest {
 
     private static final String TENANT_ID = "active-activities-tenant";
+
+    /** A database of this test's own; the statement count is read back over the same one. */
+    private static final String JDBC_URL = "jdbc:h2:mem:active-activities-test";
 
     private static final String DOOMED_PROCESS = "parked-step";
     private static final String DOOMED_STEP = "doomedStep";
@@ -112,7 +121,7 @@ class BpmProviderFlowableActiveActivitiesTest {
         StandaloneInMemProcessEngineConfiguration configuration = new StandaloneInMemProcessEngineConfiguration();
         // A database of this test's own: another engine test in the same surefire JVM keeps its
         // in-memory one alive past the class that built it.
-        configuration.setJdbcUrl("jdbc:h2:mem:active-activities-test;DB_CLOSE_DELAY=1000");
+        configuration.setJdbcUrl(JDBC_URL + ";DB_CLOSE_DELAY=-1");
         engine = configuration.buildProcessEngine();
 
         deploy(DOOMED_PROCESS, DOOMED_PROCESS_XML.formatted(DOOMED_PROCESS, DOOMED_STEP, DoomedDelegate.class.getName(), RETRY_CYCLE,
@@ -179,6 +188,79 @@ class BpmProviderFlowableActiveActivitiesTest {
         assertStatus(instance, WAITING_STEP, 1, 0);
     }
 
+    @Test
+    void aListingIsResolvedForEveryInstanceAtOnce() {
+        ProcessInstance parked = start(DOOMED_PROCESS);
+        failNextAttempt(parked);
+        ProcessInstance untried = start(DOOMED_PROCESS);
+        ProcessInstance waiting = start(WAITING_PROCESS);
+
+        Map<String, List<String>> activityIds = bpmProvider.getProcessInstanceActivityIds(List.of(parked, untried, waiting));
+
+        assertEquals(List.of(DOOMED_STEP), activityIds.get(parked.getId()), "a parked step is named by its timer job alone");
+        assertEquals(List.of(DOOMED_STEP), activityIds.get(untried.getId()), "an untried step is active and job-bearing - named once");
+        assertEquals(List.of(WAITING_STEP), activityIds.get(waiting.getId()), "a wait state is named by its active execution");
+    }
+
+    @Test
+    void anInstanceOutsideTheListingIsNotReported() {
+        ProcessInstance listed = start(WAITING_PROCESS);
+        // Job-bearing, and the batch reads the jobs of the whole tenant: the instance ids asked for
+        // are what narrows the answer.
+        start(DOOMED_PROCESS);
+
+        Map<String, List<String>> activityIds = bpmProvider.getProcessInstanceActivityIds(List.of(listed));
+
+        assertEquals(Set.of(listed.getId()), activityIds.keySet(), "only the listed instance may be answered for");
+    }
+
+    @Test
+    void anEmptyListingAsksTheEngineNothing() {
+        assertEquals(Map.of(), bpmProvider.getProcessInstanceActivityIds(List.of()));
+    }
+
+    /**
+     * The point of the batch. Resolved one by one this costs three queries per instance, and the
+     * Monitoring shell polls the listing unbounded every 30 s
+     * (<a href="https://github.com/eclipse-dirigible/dirigible/issues/7250">#7250</a>).
+     */
+    @Test
+    void theQueryCountDoesNotGrowWithTheListing() throws SQLException {
+        List<ProcessInstance> few = start(WAITING_PROCESS, 2);
+        List<ProcessInstance> many = start(WAITING_PROCESS, 8);
+
+        long forFew = queriesResolving(few);
+        long forMany = queriesResolving(many);
+
+        assertEquals(forFew, forMany, "resolving four times as many instances must not cost a query more");
+        assertEquals(3, forMany, "one execution query and the two job queries");
+    }
+
+    /**
+     * The queries H2 runs while the given instances are resolved; the commits around them are not what
+     * grows with the listing.
+     */
+    private static long queriesResolving(List<ProcessInstance> instances) throws SQLException {
+        try (Connection connection = DriverManager.getConnection(JDBC_URL, "sa", ""); Statement statement = connection.createStatement()) {
+            // Switching collection on discards whatever was collected before.
+            statement.execute("SET QUERY_STATISTICS TRUE");
+            try {
+                bpmProvider.getProcessInstanceActivityIds(instances);
+
+                return countQueries(statement);
+            } finally {
+                statement.execute("SET QUERY_STATISTICS FALSE");
+            }
+        }
+    }
+
+    private static long countQueries(Statement statement) throws SQLException {
+        try (ResultSet result = statement.executeQuery(
+                "SELECT SUM(EXECUTION_COUNT) FROM INFORMATION_SCHEMA.QUERY_STATISTICS WHERE SQL_STATEMENT LIKE 'SELECT%'")) {
+            return result.next() ? result.getLong(1) : 0;
+        }
+    }
+
     private static void assertStatus(ProcessInstance instance, String activityId, int positive, int negative) {
         Map<String, ActivityStatusData> statuses = bpmProvider.getProcessInstanceActiveActivityIds(instance.getId());
 
@@ -235,6 +317,12 @@ class BpmProviderFlowableActiveActivitiesTest {
     private static ProcessInstance start(String processKey) {
         return engine.getRuntimeService()
                      .startProcessInstanceByKeyAndTenantId(processKey, null, Map.of(), TENANT_ID);
+    }
+
+    private static List<ProcessInstance> start(String processKey, int count) {
+        return IntStream.range(0, count)
+                        .mapToObj(each -> start(processKey))
+                        .toList();
     }
 
     private static void deploy(String processKey, String xml) {

--- a/components/engine/engine-bpm-flowable/src/test/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/TaskListingProcessVariablesEngineTest.java
+++ b/components/engine/engine-bpm-flowable/src/test/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/TaskListingProcessVariablesEngineTest.java
@@ -52,7 +52,7 @@ class TaskListingProcessVariablesEngineTest {
     @BeforeAll
     static void startEngine() {
         StandaloneInMemProcessEngineConfiguration configuration = new StandaloneInMemProcessEngineConfiguration();
-        configuration.setJdbcUrl("jdbc:h2:mem:task-listing-variables-test;DB_CLOSE_DELAY=1000");
+        configuration.setJdbcUrl("jdbc:h2:mem:task-listing-variables-test;DB_CLOSE_DELAY=-1");
         engine = configuration.buildProcessEngine();
         engine.getRepositoryService()
               .createDeployment()


### PR DESCRIPTION
## What

`BpmService.getProcessInstances` resolved each instance's activity id one instance at a time - `getActiveActivityIds`, a `JobQuery` and a `TimerJobQuery`, three statements apiece (#7212). `GET /services/bpm/bpm-processes/instances` is unbounded, and the Monitoring shell's Overview polls it with no key every 30 s, so a tenant with a few hundred running instances paid 3N statements per poll.

The resolution now happens for the whole listing at once, in `BpmProviderFlowable.getProcessInstanceActivityIds(List<ProcessInstance>)`:

- one `ExecutionQuery` over all the listed ids (`processInstanceIds` + `onlyChildExecutions`, tenant-scoped), filtered to the active executions - the flag is not a query criterion, so it is read off the returned rows, which keeps a scope execution (a subprocess or multi-instance parent) from being reported as a second activity;
- the two job queries over the current tenant - Flowable's job queries take a single process-instance id, so the tenant is the narrowest batch filter available - matched against the listed ids in memory.

The evidence and the answer are unchanged, including a step parked between retry attempts that only its own timer job names (#7193). The single-instance path (`/instance/{id}`, the diagram) keeps its targeted queries.

## Tests

`BpmProviderFlowableActiveActivitiesTest`, against a real in-memory engine:

- the batch answers a parked step, an untried async step and a wait state in one call;
- an instance outside the listing is never answered for, though the job queries read the whole tenant;
- an empty listing asks the engine nothing;
- the query count does not grow with the listing - 2 instances and 8 instances both cost exactly 3 queries, read back from H2's `INFORMATION_SCHEMA.QUERY_STATISTICS`. That is the regression this fix is about.

`mvn -pl components/engine/engine-bpm-flowable test` - 35/35 green.

## Note

The nit from the issue is fixed too: both in-memory engine tests meant `DB_CLOSE_DELAY=-1`, not `1000`.

While here: the `limit: 100` the AngularJS Processes view sends is not a parameter the endpoint declares, so it is dropped on the floor - capping the call would not have helped, which is why this batches instead.

Fixes #7250

🤖 Generated with [Claude Code](https://claude.com/claude-code)