### PR TITLE
java: a refused listener subscription closes the connection it started (#7264)

### DIFF
--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumer.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumer.java
@@ -391,10 +391,17 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
         // Resolving the physical name is inside the try with the attach it belongs to: anything thrown
         // between here and the consumer must stay this subscription's problem, or it escapes the
         // per-tenant fan-out and skips every tenant behind this one.
+        // The connection is held outside the try because the factory START()s it before returning: every
+        // step after that - the session, the destination, the redelivery policy, the consumer - can be
+        // refused by the broker with a live transport socket and its thread already in existence. A
+        // refusal that is permanent (a destination the broker's authorization refuses) is retried on
+        // every reconciliation pass, so an attempt that walked away from its connection would orphan one
+        // per subscription per tenant per tick until the process ran out of file descriptors.
+        Connection connection = null;
         try {
             String destinationName = destinationNameManager.toTenantName(subscription.destination());
             String subscriptionId = topic ? durableSubscriptionId(label, destinationName) : null;
-            Connection connection = connectionFactory.createConnection(
+            connection = connectionFactory.createConnection(
                     ex -> LOGGER.error("[java-listener] JMS error for [{}]: {}", label, ex.getMessage(), ex), subscriptionId);
             Session session = connectionFactory.createSession(connection);
             Destination destination = topic ? session.createTopic(destinationName) : session.createQueue(destinationName);
@@ -419,7 +426,24 @@ public class ListenerClassConsumer implements JavaClassConsumer, TenantPostProvi
             // exactly the failure this whole retry exists for. Left uncaught it escaped the per-tenant
             // fan-out, skipping every remaining tenant and leaking the connections already opened.
             reportFailure(label, scope, e);
+            closeQuietly(label, connection);
             return null;
+        }
+    }
+
+    /**
+     * Close a connection nothing will ever hold a reference to. The failure that brought us here is
+     * already reported, and a broker that just refused the subscription is likely to refuse the close
+     * too, so this one is DEBUG - it must not add a second line per tick to a lasting outage.
+     */
+    private static void closeQuietly(String label, Connection connection) {
+        if (connection == null) {
+            return;
+        }
+        try {
+            connection.close();
+        } catch (JMSException | RuntimeException e) {
+            LOGGER.debug("Failed to close the JMS connection of the refused subscription [{}]: {}", label, e.getMessage(), e);
         }
     }
 

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumerRetryTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/listener/ListenerClassConsumerRetryTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import jakarta.jms.Connection;
+import jakarta.jms.JMSSecurityException;
 import jakarta.jms.MessageConsumer;
 import jakarta.jms.Queue;
 import jakarta.jms.Session;
@@ -98,6 +99,13 @@ class ListenerClassConsumerRetryTest {
     /** When set, only attempts made in that tenant's context fail. */
     private final AtomicReference<String> brokerRefusingForTenant = new AtomicReference<>();
 
+    /**
+     * While set, the connection is handed out and only the step AFTER it - the session - is refused,
+     * which is where a broker's destination authorization really says no.
+     */
+    private final AtomicBoolean brokerRefusingTheSession = new AtomicBoolean();
+
+    private Connection connection;
     private Session session;
     private TenantContext tenantContext;
     private ListenerClassConsumer consumer;
@@ -113,7 +121,7 @@ class ListenerClassConsumerRetryTest {
         when(componentContainer.instanceOf(GlobalOrdersHandler.class)).thenReturn(Optional.of(new GlobalOrdersHandler()));
 
         ActiveMQConnectionArtifactsFactory connectionFactory = mock(ActiveMQConnectionArtifactsFactory.class);
-        Connection connection = mock(Connection.class);
+        connection = mock(Connection.class);
         session = mock(Session.class);
         when(connectionFactory.createConnection(any(), any())).thenAnswer(invocation -> {
             String refusingFor = brokerRefusingForTenant.get();
@@ -122,7 +130,12 @@ class ListenerClassConsumerRetryTest {
             }
             return connection;
         });
-        when(connectionFactory.createSession(connection)).thenReturn(session);
+        when(connectionFactory.createSession(connection)).thenAnswer(invocation -> {
+            if (brokerRefusingTheSession.get()) {
+                throw new JMSSecurityException("Destination authorization refused");
+            }
+            return session;
+        });
         when(session.createQueue(anyString())).thenReturn(mock(Queue.class));
         when(session.createConsumer(any())).thenReturn(mock(MessageConsumer.class));
 
@@ -235,6 +248,49 @@ class ListenerClassConsumerRetryTest {
         // database, and this tick fires every 30 seconds for the life of the process.
         verify(tenantContext, times(1)).executeForEachTenant(any());
         verify(session, times(1)).createQueue("orders");
+    }
+
+    /**
+     * The factory START()s the connection before returning it, so a refusal that arrives later - the
+     * session, the destination, the consumer - leaves a live transport socket and its thread behind. An
+     * attempt that walked away from that connection orphaned one per subscription per tenant, and once
+     * the reconciliation timer began retrying a permanently refused destination every 30 seconds, the
+     * retry itself became the outage it was added to prevent (issue #7264).
+     */
+    @Test
+    void aRefusalAfterTheConnectionWasStartedClosesIt() throws Exception {
+        brokerRefusingTheSession.set(true);
+
+        loadListener();
+
+        // Nothing was subscribed, and neither connection the two tenants opened is still around.
+        verify(session, never()).createQueue(anyString());
+        verify(connection, times(provisionedTenants.size())).close();
+    }
+
+    /** The retry must not accumulate what the attempt it repeats leaks. */
+    @Test
+    void everyRetryOfALastingRefusalClosesItsOwnConnection() throws Exception {
+        brokerRefusingTheSession.set(true);
+        loadListener();
+
+        consumer.reconcile();
+        consumer.reconcile();
+
+        verify(connection, times(3 * provisionedTenants.size())).close();
+    }
+
+    /** A closed attempt is not a recorded one: the subscription still opens once the broker accepts. */
+    @Test
+    void theSubscriptionStillOpensAfterAClosedAttempt() throws Exception {
+        brokerRefusingTheSession.set(true);
+        loadListener();
+
+        brokerRefusingTheSession.set(false);
+        consumer.reconcile();
+
+        verify(session, times(1)).createQueue("orders");
+        verify(session, times(1)).createQueue("acme###orders");
     }
 
     private void addTenant(String tenantId) {


### PR DESCRIPTION
Fixes #7264

`ActiveMQConnectionArtifactsFactory.createConnection` `start()`s the connection before returning it, so by the time `createSession` / `createTopic` / `configureRedeliveryPolicy` / `createDurableSubscriber` / `setMessageListener` can throw, a transport socket and its ActiveMQ thread exist. The `catch` in `ListenerClassConsumer.subscribe` reported the failure and returned `null` without closing them.

Before #7220 that ran once per rebuild, so the cost was one orphaned connection per refused subscription. Now `JavaConsumersReconciler` re-runs `subscribe` every 30 s for as long as the refusal lasts, and the realistic refusals at exactly this point are permanent: an external broker (`DIRIGIBLE_MESSAGING_BROKER_URL`) whose destination authorization refuses the consumer with a `JMSSecurityException`, or a destination name its policy rejects. One started connection per subscription per tenant per tick, at DEBUG after the first WARN — an outage the retry itself manufactures.

## Change

- `connection` is held in a local declared before the `try`, and the `catch` calls a new `closeQuietly(label, connection)`.
- The close failure is logged at **DEBUG with the throwable**: the refusal is already reported, and a broker that just refused the subscription is likely to refuse the close too, so it must not add a second line per tick to a lasting outage.

## Tests

Three cases in `ListenerClassConsumerRetryTest` — none of the existing ones makes anything after `createConnection` throw, so the path was untested. The mock factory now hands out the connection and refuses the **session** with a `JMSSecurityException`, which is where a broker's destination authorization really says no:

- `aRefusalAfterTheConnectionWasStartedClosesIt` — nothing subscribed, and both tenants' connections closed.
- `everyRetryOfALastingRefusalClosesItsOwnConnection` — three passes close three per tenant; the retry accumulates nothing.
- `theSubscriptionStillOpensAfterAClosedAttempt` — closing an attempt is not recording it; the subscription opens once on the first pass the broker accepts.

`mvn -pl components/engine/engine-java test -Dtest='ListenerClassConsumer*Test'` → 24 tests, all green. `formatter:validate` and the `release` javadoc profile pass on the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)