### PR TITLE
intent: a posts: set: constant renders as a Java string literal (#7246)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -1945,39 +1945,16 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
 
     /**
      * Render a {@code posts:} {@code set:} value to a Java expression over the {@code source} entity
-     * and the per-item {@code item} entity. Supported forms (the inventory ledger's needs):
-     * {@code item.<Field>} (item copy), {@code -item.<Field>} (negated item copy, null-safe),
-     * {@code source.<Field>} (source copy), an integer literal (a constant FK/int), a quoted string,
-     * else pass-through (best effort). Fuller {@code Calc} expressions are a follow-up.
+     * and the per-item {@code item} entity. The vocabulary lives in {@link PostSetSupport}, shared with
+     * the parse-time refusal so the two cannot drift: a plain constant renders as an escaped string
+     * literal, and a value that reads as an expression this renderer cannot compile never reaches here
+     * - the parser refuses it.
+     *
+     * @param raw the authored value
+     * @return the Java expression
      */
     private static String postSetExpr(String raw) {
-        if (raw == null) {
-            return "null";
-        }
-        String v = raw.trim();
-        java.util.regex.Matcher neg = java.util.regex.Pattern.compile("^-\\s*item\\.(\\w+)$")
-                                                             .matcher(v);
-        if (neg.matches()) {
-            String f = "item." + IntentNaming.pascalCase(neg.group(1));
-            return f + " == null ? null : " + f + ".negate()";
-        }
-        java.util.regex.Matcher item = java.util.regex.Pattern.compile("^item\\.(\\w+)$")
-                                                              .matcher(v);
-        if (item.matches()) {
-            return "item." + IntentNaming.pascalCase(item.group(1));
-        }
-        java.util.regex.Matcher src = java.util.regex.Pattern.compile("^source\\.(\\w+)$")
-                                                             .matcher(v);
-        if (src.matches()) {
-            return "source." + IntentNaming.pascalCase(src.group(1));
-        }
-        if (v.matches("-?\\d+")) {
-            return v; // integer constant (e.g. a Direction FK id)
-        }
-        if (v.matches("\"[^\"]*\"")) {
-            return v; // already-quoted string literal
-        }
-        return v; // pass-through (best effort); fuller Calc rendering is a follow-up
+        return PostSetSupport.expression(raw);
     }
 
     /** Test hook: build the {@code posts} glue collection without a repository. */

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/PostSetSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/PostSetSupport.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The value vocabulary of a {@code posts:} {@code set:} entry - the forms the parser accepts and
+ * the Java the generator renders, in one place so the two cannot drift.
+ *
+ * <p>
+ * The vocabulary is closed on purpose. A value the renderer did not recognise used to be passed
+ * through verbatim into the generated assignment, so an authored {@code Note: issued} - YAML having
+ * stripped the quotes long before the renderer saw it - emitted {@code row.Note = issued;} and the
+ * whole generated module stopped compiling (dirigible #7246). A plain constant is therefore
+ * rendered as an escaped Java string literal, and a value that reads as an EXPRESSION the renderer
+ * cannot compile is refused at parse time rather than turned into a string that would silently be
+ * the wrong value.
+ */
+public final class PostSetSupport {
+
+    /** A negated per-item copy: {@code -item.<Field>}. */
+    private static final Pattern NEGATED_ITEM = Pattern.compile("^-\\s*item\\.(\\w+)$");
+
+    /** A per-item copy: {@code item.<Field>}. */
+    private static final Pattern ITEM = Pattern.compile("^item\\.(\\w+)$");
+
+    /** A copy off the source record: {@code source.<Field>}. */
+    private static final Pattern SOURCE = Pattern.compile("^source\\.(\\w+)$");
+
+    /** A number - an integer (an FK id, a direction) or a decimal. */
+    private static final Pattern NUMBER = Pattern.compile("^-?\\d+(\\.\\d+)?$");
+
+    /** A value the author quoted explicitly, to force the string reading of an expression-like text. */
+    private static final Pattern QUOTED = Pattern.compile("^\"[^\"]*\"$");
+
+    /**
+     * Not instantiable.
+     */
+    private PostSetSupport() {}
+
+    /**
+     * Whether a value reads as an expression this renderer cannot compile - a dotted path off anything
+     * but {@code item} / {@code source}, or a negation of anything but a per-item copy.
+     *
+     * <p>
+     * Such a value is refused rather than rendered: the author meant a value read from somewhere, so
+     * emitting the text as a string constant would put a wrong value in the ledger silently, which is
+     * the one outcome worse than a refusal.
+     *
+     * @param raw the authored value
+     * @return true when the value must be refused
+     */
+    public static boolean isUnsupportedExpression(String raw) {
+        if (raw == null) {
+            return false;
+        }
+        String value = raw.trim();
+        if (NEGATED_ITEM.matcher(value)
+                        .matches()
+                || ITEM.matcher(value)
+                       .matches()
+                || SOURCE.matcher(value)
+                         .matches()
+                || NUMBER.matcher(value)
+                         .matches()
+                || QUOTED.matcher(value)
+                         .matches()) {
+            return false;
+        }
+        return value.indexOf('.') >= 0 || value.startsWith("-");
+    }
+
+    /**
+     * The Java expression a {@code set:} value renders to, over the {@code source} record and - in a
+     * {@code forEach} rule - the {@code item} row.
+     *
+     * <p>
+     * The recognised forms are {@code item.<Field>}, {@code -item.<Field>} (null-safe),
+     * {@code source.<Field>}, a number, {@code true} / {@code false} / {@code null}, and a value the
+     * author quoted explicitly. Everything else is a plain constant and renders as an escaped Java
+     * string literal - never as a bare identifier, which cannot compile.
+     *
+     * @param raw the authored value
+     * @return the Java expression
+     */
+    public static String expression(String raw) {
+        if (raw == null) {
+            return "null";
+        }
+        String value = raw.trim();
+        Matcher negated = NEGATED_ITEM.matcher(value);
+        if (negated.matches()) {
+            String access = "item." + IntentNaming.pascalCase(negated.group(1));
+            return access + " == null ? null : " + access + ".negate()";
+        }
+        Matcher item = ITEM.matcher(value);
+        if (item.matches()) {
+            return "item." + IntentNaming.pascalCase(item.group(1));
+        }
+        Matcher source = SOURCE.matcher(value);
+        if (source.matches()) {
+            return "source." + IntentNaming.pascalCase(source.group(1));
+        }
+        if (NUMBER.matcher(value)
+                  .matches()) {
+            return value;
+        }
+        if ("true".equals(value) || "false".equals(value) || "null".equals(value)) {
+            return value;
+        }
+        if (QUOTED.matcher(value)
+                  .matches()) {
+            return value;
+        }
+        return '"' + escape(value) + '"';
+    }
+
+    /**
+     * Escapes a constant for placement inside a Java string literal: the backslash and the double quote
+     * that would otherwise end the literal, and the control characters that would end the line.
+     *
+     * @param value the raw constant
+     * @return the escaped constant, ready to be placed between two double quotes
+     */
+    private static String escape(String value) {
+        StringBuilder escaped = new StringBuilder(value.length() + 8);
+        for (int index = 0; index < value.length(); index++) {
+            char character = value.charAt(index);
+            switch (character) {
+                case '\\' -> escaped.append("\\\\");
+                case '"' -> escaped.append("\\\"");
+                case '\n' -> escaped.append("\\n");
+                case '\r' -> escaped.append("\\r");
+                case '\t' -> escaped.append("\\t");
+                case '\b' -> escaped.append("\\b");
+                case '\f' -> escaped.append("\\f");
+                default -> {
+                    if (character < 0x20 || character == 0x7f) {
+                        escaped.append(String.format("\\u%04x", (int) character));
+                    } else {
+                        escaped.append(character);
+                    }
+                }
+            }
+        }
+        return escaped.toString();
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/PostIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/PostIntent.java
@@ -32,10 +32,14 @@ import java.util.Map;
  *     guard: negativeStock     # optional precondition; a violation aborts the event
  *     set:
  *       Product:  item.Product     # item.&lt;field&gt;
- *       Store:    Receipt.Store     # &lt;Master&gt;.&lt;field&gt;
- *       Quantity: item.Quantity     # or a Calc expression (e.g. -item.Quantity)
- *       GoodsReceipt: Receipt.Id    # the back-reference (matches idempotentBy)
+ *       Store:    source.Store     # source.&lt;field&gt; - a field of the master record
+ *       Quantity: -item.Quantity   # the null-safe negation of a per-item copy
+ *       Note:     issued           # a plain constant, rendered as a string literal
  * </pre>
+ *
+ * <p>
+ * The back-reference named by {@code idempotentBy} is written by the generated handler itself and
+ * is not authored here.
  */
 public class PostIntent {
 
@@ -71,8 +75,10 @@ public class PostIntent {
     private String guard;
 
     /**
-     * Field map for each emitted row: target field -> value (a constant, {@code Master.field},
-     * {@code item.field}, or a Calc expression).
+     * Field map for each emitted row: target field to value. The vocabulary is closed -
+     * {@code item.<Field>}, {@code -item.<Field>}, {@code source.<Field>}, a number, a boolean,
+     * {@code null}, or a plain constant (rendered as a string literal) - and anything else that reads
+     * as an expression is refused at parse time rather than rendered into code that cannot compile.
      */
     private Map<String, String> set = new LinkedHashMap<>();
 

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -30,6 +30,7 @@ import org.eclipse.dirigible.components.intent.generator.FileNameSupport;
 import org.eclipse.dirigible.components.intent.generator.NotificationSupport;
 import org.eclipse.dirigible.components.intent.generator.NotifySupport;
 import org.eclipse.dirigible.components.intent.generator.PayloadSupport;
+import org.eclipse.dirigible.components.intent.generator.PostSetSupport;
 import org.eclipse.dirigible.components.intent.generator.ProcessAssigneeSupport;
 import org.eclipse.dirigible.components.intent.generator.ProcessParallelSupport;
 import org.eclipse.dirigible.components.intent.generator.ProcessResilienceSupport;
@@ -410,6 +411,7 @@ public final class IntentParser {
         validateExpansions(model, issues);
         validateSettlements(model, issues);
         validateResolves(model, entityNames, issues);
+        validatePostSets(model, issues);
         validateIdempotencyGuardOwnership(model, issues);
         validatePermissions(model, issues);
         if (!issues.isEmpty()) {
@@ -7172,6 +7174,36 @@ public final class IntentParser {
                             }
                         }
                     }
+                }
+            }
+        }
+    }
+
+    /**
+     * The value vocabulary of a {@code posts:} {@code set:} entry: a per-item or source copy, a number,
+     * a boolean, {@code null}, or a plain constant. A value that reads as an expression the renderer
+     * cannot compile - a dotted path off anything but {@code item} / {@code source}, or a negation of
+     * anything but a per-item copy - is refused here.
+     *
+     * <p>
+     * It is refused rather than rendered because both other outcomes are silent: passing the text
+     * through emits a bare Java identifier and breaks the compile of the whole generated module
+     * (dirigible #7246), and rendering it as a string constant would put the text of the path into the
+     * ledger cell instead of the value it names. An author who really means the text quotes it.
+     *
+     * @param model the model
+     * @param issues the collected issues
+     */
+    private static void validatePostSets(IntentModel model, List<String> issues) {
+        for (PostIntent post : model.getPosts()) {
+            String subject = "posts [" + post.getName() + "]";
+            for (Map.Entry<String, String> assignment : post.getSet()
+                                                            .entrySet()) {
+                if (PostSetSupport.isUnsupportedExpression(assignment.getValue())) {
+                    issues.add(subject + " set [" + assignment.getKey() + "]: value [" + assignment.getValue()
+                            + "] is not a value this rule can render - write item.<Field>, source.<Field>,"
+                            + " -item.<Field>, a number, or a plain constant; quote it (\"" + assignment.getValue()
+                            + "\") to mean that text.");
                 }
             }
         }

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GluePostsTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GluePostsTest.java
@@ -10,12 +10,15 @@
 package org.eclipse.dirigible.components.intent.generator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
 
 import org.eclipse.dirigible.components.intent.model.IntentModel;
 import org.eclipse.dirigible.components.intent.parser.IntentParser;
+import org.eclipse.dirigible.components.intent.parser.IntentValidationException;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -71,6 +74,7 @@ class GluePostsTest {
                   Quantity: "-item.Quantity"
                   Direction: 2
                   Store: source.Store
+                  Note: issued
             """;
 
     @SuppressWarnings("unchecked")
@@ -98,11 +102,44 @@ class GluePostsTest {
         assertEquals("GoodsIssue", p.get("backRef"));
 
         List<Map<String, String>> assigns = (List<Map<String, String>>) p.get("assigns");
-        assertEquals(4, assigns.size());
+        assertEquals(5, assigns.size());
         // item copy, null-safe negation, integer constant, source copy - rendered to Java expressions.
         assertEquals(Map.of("field", "Product", "expr", "item.Product"), assigns.get(0));
         assertEquals(Map.of("field", "Quantity", "expr", "item.Quantity == null ? null : item.Quantity.negate()"), assigns.get(1));
         assertEquals(Map.of("field", "Direction", "expr", "2"), assigns.get(2));
         assertEquals(Map.of("field", "Store", "expr", "source.Store"), assigns.get(3));
+        // a plain constant: a Java string literal, never the bare identifier that would not compile.
+        assertEquals(Map.of("field", "Note", "expr", "\"issued\""), assigns.get(4));
+    }
+
+    /** A constant carrying a quote or a backslash cannot end the literal it is written into. */
+    @Test
+    void escapesAConstantThatWouldCloseTheLiteral() {
+        assertEquals("\"6\\\" pipe\"", PostSetSupport.expression("6\" pipe"));
+        assertEquals("\"back\\\\slash\"", PostSetSupport.expression("back\\slash"));
+    }
+
+    /** The forms that are values rather than text: numbers, booleans, an explicitly quoted constant. */
+    @Test
+    void rendersTheNonTextForms() {
+        assertEquals("2", PostSetSupport.expression("2"));
+        assertEquals("-3.5", PostSetSupport.expression("-3.5"));
+        assertEquals("true", PostSetSupport.expression("true"));
+        assertEquals("null", PostSetSupport.expression("null"));
+        assertEquals("\"source.Store\"", PostSetSupport.expression("\"source.Store\""));
+    }
+
+    /**
+     * A value that reads as an expression the renderer cannot compile is refused at parse time, naming
+     * the rule and the field - never rendered, since both other outcomes are silent.
+     */
+    @Test
+    void refusesAnExpressionItCannotRender() {
+        String yaml = YAML.replace("Store: source.Store", "Store: Receipt.Store");
+        IntentValidationException failure = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+        assertTrue(failure.getIssues()
+                          .stream()
+                          .anyMatch(issue -> issue.contains("posts [goodsIssueLedger] set [Store]") && issue.contains("[Receipt.Store]")),
+                "expected the refusal to name the rule and the field, got " + failure.getIssues());
     }
 }


### PR DESCRIPTION
Fixes #7246

### The defect

`GlueIntentGenerator.postSetExpr` tested a `set:` value against `"[^"]*"` for its string branch - it only fired while the value *still carried* its double quotes, which YAML strips long before the renderer sees it. An authored

```yaml
set:
  Note: issued
```

reached the renderer as `issued`, missed every branch and fell through the final pass-through, so the template emitted

```java
row.Note = issued;
```

and the whole generated module stopped compiling. `PostIntent`'s own javadoc documented "a quoted string" as a supported form, and `GluePostsTest` asserted the item / negation / integer / source forms only, so nothing caught it.

### The change

The value vocabulary moves into one place, `PostSetSupport`, shared by the renderer and a new parse-time refusal so the two cannot drift:

- a **plain constant** renders as an **escaped** Java string literal - the #7154 / #7241 family, so a value carrying a quote or a backslash cannot end the literal it is written into;
- a **number**, `true` / `false` / `null`, and a value the author **quoted explicitly** keep their non-text reading (the quoting is also the escape hatch for a constant that reads like an expression);
- a value that reads as an **expression the renderer cannot compile** - a dotted path off anything but `item` / `source`, or a negation of anything but a per-item copy - is **refused at parse time**, naming the rule and the field.

The refusal is the point of the third case. Rendering `Receipt.Store` as the string `"Receipt.Store"` would put the text of the path into the ledger cell instead of the value it names - silent in exactly the way passing it through was, and worse than a compile error. Refusing before anything is written is the honest outcome, and an author who really means that text quotes it.

The `PostIntent` example is corrected with it: it showed `Store: Receipt.Store` and `GoodsReceipt: Receipt.Id`, neither of which the renderer ever supported (the back-reference named by `idempotentBy` is written by the generated handler, not authored).

### Tests

`GluePostsTest` gains the constant to the existing descriptor assertion (`Note: issued` -> `"issued"`), plus the escaping of a quote / backslash, the non-text forms, and the parse-time refusal naming the rule and the field. Full `engine-intent` suite green (1190 tests); `formatter:validate` and the release-profile javadoc clean on the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)