### PR TITLE
ide-template: collapse ModelValues.bool into isTrue so every .edm flag obeys one rule (#7231)

### DIFF
--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/CompositionChildren.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/CompositionChildren.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.eclipse.dirigible.components.ide.template.service.model.ModelValues.asMaps;
-import static org.eclipse.dirigible.components.ide.template.service.model.ModelValues.bool;
+import static org.eclipse.dirigible.components.ide.template.service.model.ModelValues.isTrue;
 import static org.eclipse.dirigible.components.ide.template.service.model.ModelValues.str;
 import static org.eclipse.dirigible.components.ide.template.service.model.ModelValues.strOr;
 
@@ -86,7 +86,7 @@ final class CompositionChildren {
      */
     private static boolean refusesMasterDelete(Map<String, Object> child) {
         for (Map<String, Object> property : asMaps(child.get("properties"))) {
-            if ("COMPOSITION".equals(str(property, "relationshipType")) && bool(property, "relationshipMasterDeleteRefused")) {
+            if ("COMPOSITION".equals(str(property, "relationshipType")) && isTrue(property, "relationshipMasterDeleteRefused")) {
                 return true;
             }
         }

--- a/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/ModelValues.java
+++ b/components/ide/ide-template/src/main/java/org/eclipse/dirigible/components/ide/template/service/model/ModelValues.java
@@ -108,33 +108,21 @@ final class ModelValues {
     }
 
     /**
-     * Tests a key for the string {@code "true"} - the model persists its flags as strings, and the
-     * derivation pass coerces them.
-     *
-     * @param map the node
-     * @param key the key
-     * @return true when the value is the string or boolean true
-     */
-    static boolean isTrue(Map<String, Object> map, String key) {
-        Object value = map == null ? null : map.get(key);
-        return Boolean.TRUE.equals(value) || "true".equals(value);
-    }
-
-    /**
-     * Reads a key whose value is a boolean the model persists as a string. Unlike
-     * {@link #truthy(Map, String)} - which any non-empty string satisfies, so a written-out
-     * {@code "false"} would read as true - this parses the value: only {@code true} in any case is
-     * true, and everything else, including an absent key, is false.
+     * Reads a boolean flag the model persists as a string - the single reader for every {@code .edm}
+     * flag. Unlike {@link #truthy(Map, String)} - which any non-empty string satisfies, so a
+     * written-out {@code "false"} would read as true - this parses the value: only {@code true} in any
+     * case (trimmed) is true, and everything else, including an absent key, is false.
      *
      * <p>
-     * Use it for a flag a hand-authored or tool-produced {@code .edm} may spell out in full. The
-     * generators only ever emit the flag when it holds, so the two agree on what they write.
+     * Because it parses rather than presence-tests, a flag a hand-authored or tool-produced
+     * {@code .edm} spells out in full is read the same way the generators - which only ever emit the
+     * flag when it holds - write it.
      *
      * @param map the node
      * @param key the key
      * @return the value as a boolean
      */
-    static boolean bool(Map<String, Object> map, String key) {
+    static boolean isTrue(Map<String, Object> map, String key) {
         Object value = map == null ? null : map.get(key);
         if (value instanceof Boolean flag) {
             return flag;

--- a/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/ModelValuesTest.java
+++ b/components/ide/ide-template/src/test/java/org/eclipse/dirigible/components/ide/template/service/model/ModelValuesTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.ide.template.service.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers {@link ModelValues#isTrue(Map, String)} - the single reader for every {@code .edm} boolean
+ * flag (dirigible #7231): it parses the string the model persists rather than presence-testing it,
+ * in any case and trimmed, so every flag obeys one rule.
+ */
+class ModelValuesTest {
+
+    @Test
+    void lowercaseTrueHolds() {
+        assertThat(ModelValues.isTrue(flag("true"), "flag")).isTrue();
+    }
+
+    @Test
+    void aBooleanValueIsReadDirectly() {
+        assertThat(ModelValues.isTrue(flag(Boolean.TRUE), "flag")).isTrue();
+        assertThat(ModelValues.isTrue(flag(Boolean.FALSE), "flag")).isFalse();
+    }
+
+    @Test
+    void trueHoldsHoweverItIsCasedOrPadded() {
+        assertThat(ModelValues.isTrue(flag("TRUE"), "flag")).isTrue();
+        assertThat(ModelValues.isTrue(flag("True"), "flag")).isTrue();
+        assertThat(ModelValues.isTrue(flag(" true "), "flag")).isTrue();
+    }
+
+    @Test
+    void aWrittenOutFalseIsFalseInAnyCase() {
+        assertThat(ModelValues.isTrue(flag("false"), "flag")).isFalse();
+        assertThat(ModelValues.isTrue(flag("FALSE"), "flag")).isFalse();
+    }
+
+    @Test
+    void anAbsentKeyOrMapIsFalse() {
+        assertThat(ModelValues.isTrue(new LinkedHashMap<>(), "flag")).isFalse();
+        assertThat(ModelValues.isTrue(null, "flag")).isFalse();
+    }
+
+    private static Map<String, Object> flag(Object value) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("flag", value);
+        return map;
+    }
+}


### PR DESCRIPTION
## Cause

#7182 (#7144) fixed `CompositionChildren.refusesMasterDelete` misreading `relationshipMasterDeleteRefused="false"` as true by introducing a new helper, `ModelValues.bool`. But `ModelValues.isTrue` already existed for exactly this purpose - its javadoc says *"the model persists its flags as strings"* - and is what **every other** `.edm` flag is read through (`dataUnique`, `isRequiredProperty`, `widgetIsMajor`, `detailCalendar`, `dataPrimaryKey`, …). The result was two helpers for "is this string flag true", and `relationshipMasterDeleteRefused` became the one attribute in the whole model that honoured `"TRUE"` / `" true "` while `isRequiredProperty="TRUE"` stayed false. `bool` had exactly one caller.

## Change — one rule, one helper (the case-insensitive one)

Case-insensitive parsing is the behaviour that is *wanted* here: #7182 deliberately locked it with tests (`CompositionChildrenTest.aWrittenOutTrueIsTheRefusal` / `aWrittenOutFalseIsTheCascade`) because this flag guards a destructive cascade (`whenMasterDeleted: refuse`, #7100/#7143) - a hand-authored `"True"` must **refuse**, not silently delete the master's children. So rather than dropping to a lowercase/presence test, this promotes `isTrue` to the single robust reader:

- `ModelValues.isTrue` now parses the value (`Boolean.parseBoolean`, trimmed, any case) - the exact body `bool` had - so every `.edm` flag is read one way.
- `ModelValues.bool` is deleted; `CompositionChildren` routes through `isTrue`.
- New `ModelValuesTest` pins the single rule directly at the helper (lowercase/uppercase/padded `true`, written-out `false` in any case, absent key/map, a `Boolean` value).

The change is lenient-only for the other flags (the modeler always emits lowercase `"true"`/`"false"`), so **generated output is byte-identical**; every existing `CompositionChildrenTest` case passes unchanged.

## Verification

- `mvn formatter:validate` after wiping the formatter cache - BUILD SUCCESS.
- `ide-template` unit suite - green (125 tests, incl. the new `ModelValuesTest` and the unchanged `CompositionChildrenTest`).
- `ModelGenerationIT` (the model-generation regression harness) - green (1/1).

Not run: the full IT suite (pure refactor with byte-identical output; CI covers it).

Fixes #7231