### PR TITLE
intent: compile-test the run: period guard and unify its date with the parser (#7229)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -4668,31 +4668,27 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
      * current period exists. That is what makes a re-run on the 14th find what the 1st created, and it
      * is why no hidden period column and no run ledger were introduced.
      *
-     * @param entry the {@code { run: <period> }} entry, with an optional {@code of:} naming the date
+     * @param entry the {@code { run: <period> }} entry, its {@code of:} carrying the date the parser
+     *        resolved and pinned (issue #7229) - authored, or the single {@code date} default it chose
      * @param byProperty the rendered assignment expression per target property
-     * @return the term, or null when the date it would range over is absent or ambiguous (the parser
-     *         reports both; a generation reached by another route drops the schedule rather than
-     *         emitting a guard over the wrong column)
+     * @return the term, or null when {@code of:} is unpinned (an unvalidated model reached by another
+     *         route) or names a property this generate does not assign - either way the schedule is
+     *         dropped rather than a guard emitted over the wrong column
      */
     private static Map<String, Object> runTerm(UniqueKeyIntent entry, Map<String, String> byProperty) {
-        String property = null;
-        if (entry.getOf() != null && !entry.getOf()
-                                           .isBlank()) {
-            String named = IntentNaming.pascalCase(entry.getOf());
-            property = TODAY.equals(byProperty.get(named)) ? named : null;
-        } else {
-            // The date the run writes is the assignment that renders as today - a `month` / `week`
-            // field's `now` renders as its own string shape and is keyed on as an ordinary property.
-            for (Map.Entry<String, String> assignment : byProperty.entrySet()) {
-                if (TODAY.equals(assignment.getValue())) {
-                    if (property != null) {
-                        return null;
-                    }
-                    property = assignment.getKey();
-                }
-            }
+        // The date the run writes is the property the parser PINNED onto `of` (issue #7229): the single
+        // `date` field this block assigns from `now`, chosen by a type check. Reusing that one resolution
+        // is what keeps the two layers from each defining "the date assigned from now" - this method sees
+        // only rendered expressions, and `now` on a timestamp field renders as the same LocalDate.now() a
+        // `date` field does, so the string scan this replaced counted a field the parser's check excludes.
+        // An `of` that is blank means an unvalidated model reached here by another route; drop the guard
+        // rather than range it over a guessed column.
+        if (entry.getOf() == null || entry.getOf()
+                                          .isBlank()) {
+            return null;
         }
-        if (property == null) {
+        String property = IntentNaming.pascalCase(entry.getOf());
+        if (byProperty.get(property) == null) {
             return null;
         }
         String period = entry.getRun()

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/UniqueKeyIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/UniqueKeyIntent.java
@@ -49,10 +49,12 @@ public class UniqueKeyIntent {
     private String run;
 
     /**
-     * The target date property a {@link #run} term ranges over. Optional: it defaults to the single
-     * {@code date} property this block assigns from {@code now}, and is only needed when the block
-     * assigns more than one - naming it then is what keeps the guard's period and the document's own
-     * date the same period.
+     * The target date property a {@link #run} term ranges over. Optional to AUTHOR: it defaults to the
+     * single {@code date} property this block assigns from {@code now}, and is only written when the
+     * block assigns more than one - naming it then is what keeps the guard's period and the document's
+     * own date the same period. The parser resolves and PINS that single default here during validation
+     * (issue #7229), so a validated model always carries the resolved property and the generator ranges
+     * over exactly the field the parser's type check chose rather than re-deriving it.
      */
     private String of;
 

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -1254,7 +1254,14 @@ public final class IntentParser {
         if (candidates.size() > 1) {
             issues.add("schedule [" + name + "] generate unique declares run [" + period + "] and this generate assigns more than one date"
                     + " from now (" + String.join(", ", candidates) + ") - name the one the period ranges over with of:");
+            return;
         }
+        // Pin the single resolved date onto `of` so the generator ranges the run period over exactly the
+        // property this type check chose. Parser and generator must not each define "the date assigned
+        // from now" (issue #7229): the generator sees only rendered expressions, and `now` on a
+        // timestamp field renders as the same LocalDate.now() a `date` field does, so a string scan there
+        // counted a field this check excludes and refused a valid generate with a misleading message.
+        entry.setOf(candidates.get(0));
     }
 
     /**

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueSchedulesTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueSchedulesTest.java
@@ -344,6 +344,55 @@ class GlueSchedulesTest {
 
     @SuppressWarnings("unchecked")
     @Test
+    void theRunPeriodRangesOverTheDateFieldNotAnotherNowAssignment() {
+        // Issue #7229: parser and generator must not each decide "the date this run writes". The parser
+        // pins the single `date`-typed default it chose; the generator ranges over exactly that. Here a
+        // second default assigns `now` to a `timestamp` field, which renders as the same LocalDate.now()
+        // the `date` field does - so a generator that re-derived the run date by string-matching that
+        // expression counted two candidates and dropped a schedule the parser had accepted.
+        String yaml = """
+                name: purchases
+                entities:
+                  - name: BillTemplate
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                    relations:
+                      - { name: Supplier, kind: manyToOne, to: Supplier }
+                  - name: Supplier
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: PurchaseInvoice
+                    fields:
+                      - { name: id,        type: integer,   primaryKey: true, generated: true }
+                      - { name: date,      type: date }
+                      - { name: createdAt, type: timestamp }
+                    relations:
+                      - { name: Supplier, kind: manyToOne, to: Supplier }
+                schedules:
+                  - name: monthly-recurring-bills
+                    cron: "0 0 5 1 * ?"
+                    entity: BillTemplate
+                    generate:
+                      to: PurchaseInvoice
+                      unique: [Supplier, { run: month }]
+                      map:
+                        Supplier: Supplier
+                      defaults:
+                        date: now
+                        createdAt: now
+                """;
+        Map<String, Object> s = GlueIntentGenerator.buildSchedulesForTest(IntentParser.parse(yaml))
+                                                   .get(0);
+
+        assertEquals(true, s.get("hasGenUnique"));
+        List<Map<String, Object>> unique = (List<Map<String, Object>>) s.get("genUnique");
+        assertEquals(Map.of("property", "Supplier", "expr", "entity.Supplier"), unique.get(0));
+        assertEquals(Map.of("kind", "range", "property", "Date", "lower", "java.time.LocalDate.now().withDayOfMonth(1)", "upper",
+                "java.time.LocalDate.now().withDayOfMonth(1).plusMonths(1).minusDays(1)"), unique.get(1));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     void aQuarterlyRunPeriodRangesOverTheIsoQuarter() {
         String yaml = """
                 name: purchases

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -458,6 +458,12 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                   # a boolean: a real checkbox on the power form AND on the personal one (#7103)
                   - { name: urgent, type: boolean }
                   - { name: period, type: month }
+                  # a plain date the monthly schedule stamps with `now` - the property its
+                  # `unique: [Person, { run: month }]` key ranges the guard over (#7229/#7106).
+                  # Deliberately alongside `period` (a month field, `now` -> YYYY-MM string): the
+                  # run key must pick THIS field, not the string one, and the guard it compiles into
+                  # is what the publish step below actually javac's.
+                  - { name: filed, type: date }
                   - { name: rate, type: decimal, sensitive: true }
                   - { name: totalCost, type: decimal }
                   # visibleTo: role-scoped on EVERY surface - stripped from the responses and
@@ -1024,8 +1030,13 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 entity: Person
                 generate:
                   to: Claim
+                  # run: month natural key (#7106) - a re-run in the same month finds the Claim the
+                  # first tick filed instead of minting a duplicate. The guard ranges over `filed`
+                  # (the sole date-typed `now` default), NOT the month-typed `Period` (#7229); the
+                  # emitted .between(...) over a LocalDate column is compiled by the publish below.
+                  unique: [Person, { run: month }]
                   map: { Person: id }
-                  defaults: { note: monthly, Period: now }
+                  defaults: { note: monthly, Period: now, filed: now }
                   children:
                     - to: ClaimLine
                       parent: Claim
@@ -2730,6 +2741,12 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         // render the YYYY-MM string - the untyped LocalDate.now() would not even compile.
         assertTrue(job.contains(".Period = java.time.YearMonth.now().toString()"),
                 "a month field's `now` default must render the YYYY-MM string, not LocalDate");
+        // run: month natural key (#7106/#7229): the guard ranges over the month of `filed` - the date
+        // this run stamps - so a re-run in the same month finds the first tick's Claim. The key must
+        // pick the date-typed field, not the month-typed Period, and the .between over a LocalDate
+        // column has to COMPILE, which the publish + client-Java javac below is the first to prove.
+        assertTrue(job.contains(".between(\"Filed\", java.time.LocalDate.now().withDayOfMonth(1),"),
+                "the run: month key must compile a month range over the date the run writes: " + job);
 
         // month widget: the YYYY-MM field renders the Harmonia month picker on BOTH writable
         // surfaces - the power form and the personal form (my-shell parity).


### PR DESCRIPTION
## Cause

The `unique: [..., { run: month }]` natural key (#7106/#7117) had two gaps, found reviewing #7117.

1. **Nothing compiled or executed the range guard.** The only coverage was a unit assertion that the generated source CONTAINS `.between("Date", ...` plus the absence of a `_period` token nothing ever emitted (so it could not fail). No IT that compiles generated client Java carried a `run:` schedule, so whether the emitted `Criteria.between` over a `LocalDate` column and the Job template guard after #7166/#7168/#7186 even compile had never been observed - on the feature whose whole point is a runtime behaviour.

2. **Parser and generator each defined "the date this run writes".** The parser's `datesAssignedNow` counts a `now` default only when the target field's type is `date`; the generator's `runTerm` counted every assignment whose rendered expression equalled `java.time.LocalDate.now()` - which `now` on a **timestamp** field also renders as. So `defaults: { date: now, createdAt: now }` (createdAt a timestamp) parsed, then was refused at generation with "assigns more than once" - a message describing a condition the author never wrote. Two definitions of one rule is how the next regression hides.

## Change

- **Parser** (`IntentParser.validateScheduleGenerateUniqueRun`): pins the single resolved `date` default onto the entry's `of`, so a validated model always carries the property the type check chose.
- **Generator** (`GlueIntentGenerator.runTerm`): ranges the run period over that pinned `of` instead of re-deriving the date by string-matching the rendered expression. The two layers now share one definition; a blank `of` (an unvalidated model reached by another route) drops the guard rather than guessing.
- **`IntentEmissionCoverageIT`** (gap 1): the `monthly-claims` schedule now declares `unique: [Person, { run: month }]` and a `filed` date default, so the `.between("Filed", ...)` guard is generated, published, and run through the client-Java `javac` in CI - alongside a month-typed `Period: now` it must NOT pick. The IT asserts the guard shape.
- **`GlueSchedulesTest`** (gap 2): a `date: now` + `createdAt: now` (timestamp) schedule that the old `runTerm` dropped now emits the range over `Date`.

## Verification

- `mvn formatter:validate` - BUILD SUCCESS (cache wiped first)
- Full engine-intent unit suite - 1188 tests green
- `IntentEmissionCoverageIT` - green (the `.between` guard compiles and the published app enforces the rest)
- Release-profile javadoc on engine-intent - green

Not run: the full IT suite and the PostgreSQL leg.

Fixes #7229