### PR TITLE
templates: a wait or abort that does not correlate is logged, not swallowed

### DIFF
--- a/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/bpm/Process.java
+++ b/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/bpm/Process.java
@@ -102,6 +102,14 @@ public final class Process {
     /**
      * Delivers a message event with payload variables to all process instances waiting on a matching
      * intermediate-message catch event. The execution is resumed transactionally.
+     *
+     * @param processInstanceId the instance to correlate the message on
+     * @param messageName the message name declared by the catch event
+     * @param variables the variables to deliver with the message
+     * @throws IllegalArgumentException the expected miss - the instance has ended, is outside the
+     *         current tenant, or is not waiting on a message with this name. Any other runtime
+     *         exception is a real fault (a database or Flowable failure, a permission), so a caller
+     *         that treats the miss as a no-op must still report the rest.
      */
     public static void correlateMessageEvent(String processInstanceId, String messageName, Map<String, Object> variables) {
         BpmFacade.correlateMessageEvent(processInstanceId, messageName, variables);

--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/BpmProviderFlowable.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/BpmProviderFlowable.java
@@ -310,9 +310,16 @@ public class BpmProviderFlowable implements BpmProvider {
     /**
      * Correlates a message event to the process instance.
      *
+     * An instance that is not subscribed to the message is the expected miss for the fail-soft glue
+     * that drives waits and aborts - it is reported by its own type, like an instance that has already
+     * ended, so a caller can tell it apart from a real fault (a database or Flowable failure, the wrong
+     * tenant scope, a mis-generated message name) instead of meeting a NullPointerException.
+     *
      * @param processInstanceId the process instance id
      * @param messageName the name of the event
      * @param variables the variables to be passed with the event
+     * @throws IllegalArgumentException if the instance does not exist in the current tenant, or is not
+     *         waiting on a message with this name
      */
     public void correlateMessageEvent(String processInstanceId, String messageName, Map<String, Object> variables) {
         flowableArtefactsValidator.validateProcessInstanceId(processInstanceId);
@@ -324,6 +331,11 @@ public class BpmProviderFlowable implements BpmProvider {
                                             .processInstanceId(processInstanceId)
                                             .executionTenantId(getTenantId())
                                             .singleResult();
+
+        if (execution == null) {
+            throw new IllegalArgumentException("Process instance with id [" + processInstanceId
+                    + "] is not waiting on a message event with name [" + messageName + "]");
+        }
 
         runtimeService.messageEventReceived(messageName, execution.getId(), variables);
     }

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Abort.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Abort.java.template
@@ -22,7 +22,9 @@ import gen.${javaGenFolderName}.data.${javaPerspective}.${entity}Entity;
  * ProcessIds stamp the trigger listener writes back for THIS process - not the record's single
  * ProcessId, which holds whichever process started last and would abort a stranger's instance once a
  * record is the subject of several flows. Fail-soft: no stamp, no matching parked instance, or an
- * instance already past the abort scope is a no-op, never an error.
+ * instance already past the abort scope is a no-op, never an error - but an abort that fails for any
+ * other reason leaves an instance that should have been cancelled still running, so it is logged with
+ * its cause rather than swallowed (dirigible #7230).
  *
  * Self-describing MessageHandler (strong-interface style): the destination/kind come from the
  * interface, not an annotation; @Component makes it a managed bean.
@@ -63,9 +65,15 @@ public class ${process}Abort implements MessageHandler {
         }
         try {
             Process.correlateMessageEvent(instance, "${messageName}", java.util.Map.of());
-        } catch (RuntimeException notAborting) {
-            // The instance is not in the abort scope (already ended or never reached it) - a no-op by
-            // the fail-soft glue convention, never an error.
+        } catch (IllegalArgumentException notAborting) {
+            // The one expected miss: the instance is not in the abort scope (already ended, or never
+            // reached it), which the platform reports with exactly this type. A no-op by the fail-soft
+            // glue convention.
+            LOG.debug("${process} instance [{}] was not in the abort scope of \"${messageName}\"", instance, notAborting);
+        } catch (RuntimeException failed) {
+            // Anything else - the abort did not happen, so an instance that should have been cancelled
+            // keeps its pending user tasks, parked waits and armed timers. Fail-soft, but never silent.
+            LOG.warn("Could not abort ${process} instance [{}] - it keeps running with its pending tasks", instance, failed);
         }
     }
 

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Wait.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Wait.java.template
@@ -28,7 +28,9 @@ import gen.${javaGenFolderName}.data.${javaEventPerspective}.${eventEntity}Repos
  * holds whichever process started last: once a record can be the subject of several flows, correlating
  * on that one would resume a stranger's wait, or nothing at all.
  * Fail-soft by design: no stamp, no matching parked instance, or an instance already past the wait is
- * a no-op, never an error - the event is simply not for this wait.
+ * a no-op, never an error - the event is simply not for this wait. A correlation that fails for any
+ * other reason is a different matter: the instance stays parked on a wait nobody will resume, so it is
+ * logged with its cause rather than swallowed (dirigible #7230).
  *
  * Self-describing MessageHandler (strong-interface style): the destination/kind come from the
  * interface, not an annotation; @Component makes it a managed bean.
@@ -84,9 +86,15 @@ public class ${className}Wait implements MessageHandler {
         }
         try {
             Process.correlateMessageEvent(instance, "${messageName}", java.util.Map.of());
-        } catch (RuntimeException notParked) {
-            // The instance is not waiting on this message (already resumed, on another step, or
-            // ended) - a no-op by the fail-soft glue convention, never an error.
+        } catch (IllegalArgumentException notParked) {
+            // The one expected miss: the instance is not waiting on this message (already resumed, on
+            // another step, or ended), which the platform reports with exactly this type. A no-op by
+            // the fail-soft glue convention.
+            LOG.debug("${process} instance [{}] was not parked on \"${messageName}\"", instance, notParked);
+        } catch (RuntimeException failed) {
+            // Anything else - the correlation did not happen, so an instance that should have moved on
+            // stays parked on this wait until someone notices. Fail-soft, but never silent.
+            LOG.warn("Could not resume ${process} instance [{}] parked on \"${messageName}\" - it is still waiting", instance, failed);
         }
     }
 

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -2577,6 +2577,17 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 "the wait listener must correlate the message on its own process's stamped instance");
         assertTrue(waitHandler.contains("new RfqRepository().findById(entity.Rfq)"),
                 "the wait listener must resolve the parked record through the via back-reference");
+        // ...and a correlation that does NOT happen is never silent (#7230). Only the not-parked case -
+        // the platform's IllegalArgumentException - is the expected no-op; anything else leaves the
+        // instance waiting on a step nobody will resume, and is logged with its throwable.
+        assertTrue(
+                waitHandler.contains("catch (IllegalArgumentException notParked)") && waitHandler.contains("LOG.debug(")
+                        && waitHandler.contains("notParked);"),
+                "the not-parked miss must be caught by its own type and logged with the throwable");
+        assertTrue(waitHandler.contains("catch (RuntimeException failed)") && waitHandler.contains("LOG.warn(\"Could not resume")
+                && waitHandler.contains("failed);"), "any other correlation failure must be logged with the throwable");
+        assertFalse(waitHandler.contains("catch (RuntimeException notParked)"),
+                "the empty catch that treated every failure as not-parked must be gone");
         String timerLoader = contentOf("gen/events/emission/LoadRfqFlowReviewExpire.java");
         assertTrue(timerLoader.contains("execution.setVariable(\"__reviewExpireDate\", due)"),
                 "the expire date loader must publish the variable the boundary timer arms from");
@@ -2668,6 +2679,17 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                         && abortHandler.contains("ProcessStamps.idFor(entity.ProcessIds, \"ApprovalFlow\")")
                         && abortHandler.contains("Process.correlateMessageEvent(instance, \"ApprovalFlowAbort\""),
                 "the abort listener must match the status on -transitioned and abort ITS OWN instance, not whichever flow stamped last");
+        // ...and an abort that does NOT happen is never silent (#7230), on the same recipe: the
+        // not-in-scope miss by its own type at debug, every other failure at warn with its throwable -
+        // an instance that should have been cancelled otherwise keeps running with nothing in the log.
+        assertTrue(
+                abortHandler.contains("catch (IllegalArgumentException notAborting)") && abortHandler.contains("LOG.debug(")
+                        && abortHandler.contains("notAborting);"),
+                "the not-in-abort-scope miss must be caught by its own type and logged with the throwable");
+        assertTrue(abortHandler.contains("catch (RuntimeException failed)") && abortHandler.contains("LOG.warn(\"Could not abort")
+                && abortHandler.contains("failed);"), "any other abort failure must be logged with the throwable");
+        assertFalse(abortHandler.contains("catch (RuntimeException notAborting)"),
+                "the empty catch that treated every failure as not-aborting must be gone");
         // ...and the row's DELETE retires the flow too (#7074): a listener on -deleted for every
         // entity-triggered process, cancelling ITS OWN still-running instance, whether or not abortOn is
         // declared - an Inbox task over a row that is gone opens an empty form and can still be completed.


### PR DESCRIPTION
### What does this PR do?

#7184 typed the blanket `catch (RuntimeException)` around `Process.cancel` in `AbortOnDelete.java.template`, but the fix reached only that one template. Its two siblings still wrapped `Process.correlateMessageEvent` in an empty catch with no log line at all:

```java
} catch (RuntimeException notParked) {
    // The instance is not waiting on this message ... never an error.
}
```

A correlation that fails because the database is down, the tenant scope is wrong or the message name was mis-generated is indistinguishable there from "the instance is not waiting" - and a `wait` step that is never resumed is exactly the kind of incident an operator has to explain later with nothing in the log. The generated file also taught the pattern to every application developer who opened it, against the repo's own always-log-the-throwable rule.

**Confirming the expected type against `BpmProviderFlowable` found there wasn't one to catch.** `correlateMessageEvent` validates the instance - an ended or out-of-tenant one is an `IllegalArgumentException` from the platform's own validator - but then dereferences the execution query's `singleResult()` with no null check:

```java
Execution execution = runtimeService.createExecutionQuery()
        .messageEventSubscriptionName(messageName)
        .processInstanceId(processInstanceId)
        .executionTenantId(getTenantId())
        .singleResult();

runtimeService.messageEventReceived(messageName, execution.getId(), variables);
```

So the far more common miss - instance running, just not parked on this message - surfaced as a raw `NullPointerException`. Catching an NPE is no contract, and the JS `process.correlateMessageEvent` handed the same NPE to script callers. The provider now reports that miss the way it already reports the ended one, naming the instance and the message, and the SDK `Process` javadoc states the contract the generated code relies on.

Both listeners then follow the #7184 recipe: the miss caught by its own type and logged at debug with the throwable, anything else at warn with the throwable and what it costs - the instance stays parked on a wait nobody will resume (`Wait`), or keeps running when it should have been cancelled (`Abort`). Both stay fail-soft; throwing would only redeliver the message.

Files changed:

- `BpmProviderFlowable.correlateMessageEvent` - null check on the execution query, `IllegalArgumentException` naming the instance and the message
- `sdk/bpm/Process.correlateMessageEvent` - `@throws` documenting the typed contract
- `events/Abort.java.template`, `events/Wait.java.template` - typed catch at debug, everything else at warn with the throwable
- `IntentEmissionCoverageIT` - `contains` checks on both catch shapes, mirroring the `AbortOnDelete` block #7184 added

### What issues does this PR fix or reference?

Fixes #7230. Follow-up to #7184 (#7145), which fixed the same shape in `AbortOnDelete.java.template` only.

### How was this verified?

- `IntentEmissionCoverageIT` green (`Tests run: 1, Failures: 0, Errors: 0`). It publishes the emission app, so it does not merely grep the rendered source: the run's log shows `Compiled batch: [328] units, [341] class file(s), no failures` with `gen.events.emission.RfqFlowAwaitReplyWait` and `gen.events.emission.ApprovalFlowAbort` connected to their topics - the new catch blocks really compile and register.
- `mvn formatter:validate` clean on the three changed modules.
- `mvn -P release -Dgpg.skip=true -DskipTests -Dlicense.skip=true -Dformatter.skip=true install` clean on `engine-bpm-flowable` and `api-modules-java` (javadoc was added to both).

Not run: the rest of the IT suite, and no runtime test exercises the new `IllegalArgumentException` against a live Flowable engine - the miss is covered through the generated listeners' compile-and-register path only.

#### Release Notes
N/A - bug fix.

#### Documentation
N/A - no user-facing documentation change.
