### PR TITLE
java: the '@Component JavaDelegate' rule is a publish-time Problems entry, not a per-execution WARN

### DIFF
--- a/components/engine/engine-java/CLAUDE.md
+++ b/components/engine/engine-java/CLAUDE.md
@@ -114,6 +114,19 @@ One Spring-singleton container, rebuilt per `ClientClassLoader` generation.
   Ambiguity **refuses** rather than guessing, which is stricter than `Beans.get(SomeInterface.class)`
   (that answers empty and falls through to the platform context, surfacing as "no such bean").
   Unit coverage: `ComponentContainerUnmanagedTest`; end-to-end: `JavaDelegateInjectionIT`.
+- **"A `JavaDelegate` must NOT be a `@Component`" is checked at publish, not per execution** (#7291).
+  `rebuild` flags a bean that implements `org.flowable.engine.delegate.JavaDelegate` — matched by
+  interface **name**, since `engine-java` cannot see the Flowable type — as a `wiringWarnings()` entry,
+  which `JavaSynchronizer` projects onto the Problems view while leaving the artefact `CREATED` (the
+  bean works; the annotation is the mistake). `createUnmanaged` still WARNs, because a delegate can
+  reach it from an AOT module the synchronizer never saw, but **once per class per generation and then
+  at DEBUG**: the `${JavaTask}` path wires a fresh delegate for every execution, so an unconditional
+  WARN restated the same fact on every tick of a step that runs all day. The suppression set is cleared
+  by `rebuild`, so a republish says it again. Its message says "instantiated outside the container"
+  rather than "is a JavaDelegate", because the check there is `isBean` on whatever class the caller
+  asked to wire — it must not claim more than it looked at. Coverage:
+  `ComponentContainerDelegateRuleTest` (with a name-only `org.flowable.engine.delegate.JavaDelegate`
+  stand-in under `src/test/java`, which is how the by-name match is testable without the dependency).
 
 ## Behaviour consumers (`JavaClassConsumer` SPI)
 
@@ -248,6 +261,9 @@ through `ClientBeanFactory.createUnmanaged` (see the container section):
   new generation.
 - **`${JavaTask}` + a `handler` field** — `DirigibleJavaCallDelegate`, fresh per execution.
 
+A delegate annotated `@Component` is reported at **publish** as a Problems entry on its source
+(`ComponentContainer.wiringWarnings()`), not as a WARN per step execution — see the container section.
+
 Three properties worth keeping: a delegate stays **lazy** (nothing is built at publish, so an
 unsatisfiable dependency is a *step* failure routed by the step's `retry:` / `onError:`, never a
 publish-time wiring error); a class declaring **no injection point is built exactly as before**; and
@@ -305,6 +321,13 @@ construction cycle, duplicate bean name, throwing constructor) are projected ont
 view and mark the `JavaFile` artefact `FAILED` (see `JavaSynchronizer.recordCompilationProblems` and
 `ComponentContainer.wiringErrors()` carried on `RebuildResult`). Don't regress this — it's how a
 browser-IDE developer sees what's wrong without reading the server log.
+
+**Bean-wiring warnings** (`ComponentContainer.wiringWarnings()`, also on `RebuildResult`) take the same
+route to the Problems view but leave the artefact `CREATED`: the class compiled and wired, it just
+breaks a container rule. Today there is one — a bean that is also a `JavaDelegate` (#7291). Reach for a
+warning rather than an error whenever the code still runs correctly enough that failing the artefact
+would be a lie; reach for the Problems view rather than a log line whenever the audience is the
+developer who wrote the line, not the operator who happened to run the process.
 
 ## Conventions / gotchas
 

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/component/ComponentContainer.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/component/ComponentContainer.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.dirigible.engine.java.runtime.ClientBeanFactory;
 import org.eclipse.dirigible.engine.java.runtime.ClientBeansHolder;
@@ -62,6 +63,9 @@ public class ComponentContainer implements ClientBeanFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ComponentContainer.class);
 
+    /** Flowable's delegate interface, referenced by name — see {@link #isJavaDelegate(Class)}. */
+    private static final String FLOWABLE_JAVA_DELEGATE = "org.flowable.engine.delegate.JavaDelegate";
+
     /** Definitions of the live generation, in registration order. */
     private volatile List<BeanDefinition> definitions = List.of();
 
@@ -73,6 +77,16 @@ public class ComponentContainer implements ClientBeanFactory {
 
     /** client class FQN → wiring error from the last rebuild (so the synchronizer can surface it). */
     private volatile Map<String, String> wiringErrors = Map.of();
+
+    /** client class FQN → wiring warning from the last rebuild (surfaced, but not a failure). */
+    private volatile Map<String, String> wiringWarnings = Map.of();
+
+    /**
+     * Classes already warned about on the {@link #createUnmanaged(Class)} path in this generation, so
+     * the same fact is stated once and then only at DEBUG. Cleared by {@link #rebuild(Collection)}: a
+     * republish is a new generation, and the developer who just changed the class should hear it again.
+     */
+    private final Set<String> reportedUnmanagedBeans = ConcurrentHashMap.newKeySet();
 
     public ComponentContainer(ClientBeansHolder holder) {
         holder.swap(this);
@@ -91,6 +105,19 @@ public class ComponentContainer implements ClientBeanFactory {
     }
 
     /**
+     * Wiring <em>warnings</em> from the last {@link #rebuild(Collection)} keyed by client class FQN —
+     * today exactly one: a bean that is also a Flowable {@code JavaDelegate}. The class still works, so
+     * this is deliberately not a {@link #wiringErrors() wiring error} (the artefact stays healthy); it
+     * is surfaced on the Problems view at publish because that is where the developer who annotated the
+     * class looks, whereas the execution-time WARN only reaches whoever happens to run the process.
+     *
+     * @return an immutable FQN → message map (empty if the last rebuild had nothing to warn about)
+     */
+    public Map<String, String> wiringWarnings() {
+        return wiringWarnings;
+    }
+
+    /**
      * Re-create the whole client bean set for a new generation. Builds and instantiates the new beans
      * first, publishes them atomically, then tears down the previous generation (so reads transition
      * cleanly old → new). Per-bean failures are logged and skipped — one bad bean never aborts the
@@ -105,6 +132,7 @@ public class ComponentContainer implements ClientBeanFactory {
         Map<String, BeanDefinition> byName = new LinkedHashMap<>();
         List<BeanDefinition> ordered = new ArrayList<>();
         Map<String, String> errors = new LinkedHashMap<>();
+        Map<String, String> warnings = new LinkedHashMap<>();
         ClassLoader loader = null;
         for (LoadedClass info : loaded) {
             if (info == null) {
@@ -115,6 +143,14 @@ public class ComponentContainer implements ClientBeanFactory {
                 continue;
             }
             loader = info.loader();
+            if (isJavaDelegate(type)) {
+                // The bean is still registered - the annotation is the mistake, not the class - so this
+                // rebuild behaves exactly as it did before the check existed, and the only new effect is
+                // the Problems entry the synchronizer projects from wiringWarnings().
+                String message = componentOnDelegateMessage(type.getName());
+                LOGGER.warn(message);
+                warnings.put(type.getName(), message);
+            }
             try {
                 String name = beanName(type);
                 BeanDefinition existing = byName.get(name);
@@ -173,6 +209,8 @@ public class ComponentContainer implements ClientBeanFactory {
         this.singletons = java.util.Collections.unmodifiableMap(snapshot);
         this.instancesByType = java.util.Collections.unmodifiableMap(byType);
         this.wiringErrors = Map.copyOf(errors);
+        this.wiringWarnings = Map.copyOf(warnings);
+        reportedUnmanagedBeans.clear();
 
         destroy(previousDefinitions, previousSingletons);
         LOGGER.info("Client bean container rebuilt: {} bean(s).", snapshot.size());
@@ -436,9 +474,17 @@ public class ComponentContainer implements ClientBeanFactory {
     @Override
     public <T> Optional<T> createUnmanaged(Class<T> type) {
         if (isBean(type)) {
-            LOGGER.warn(
-                    "[{}] is a JavaDelegate annotated @Component. A JavaDelegate must NOT be a @Component: Flowable instantiates the delegate itself, so the annotation additionally builds a container-managed singleton the engine never runs — a stray candidate for every List<JavaDelegate> injection. Remove @Component from the delegate.",
-                    type.getName());
+            // Once per class per generation, then DEBUG: on the ${JavaTask} path a fresh delegate is
+            // wired for every execution, so an unconditional WARN would restate the same fact on every
+            // tick of a step that runs all day. The publish-time entry in wiringWarnings() is the one a
+            // developer is meant to read; this line only serves whoever is already reading the log.
+            if (reportedUnmanagedBeans.add(type.getName())) {
+                LOGGER.warn(componentOnUnmanagedMessage(type.getName()));
+            } else if (LOGGER.isDebugEnabled()) {
+                // Guarded because this runs per step execution: with DEBUG off, the suppressed repeat
+                // must not even build its message.
+                LOGGER.debug(componentOnUnmanagedMessage(type.getName()));
+            }
         }
         BeanDefinition definition = new BeanDefinition(type.getName(), type);
         if (!declaresInjectionPoint(definition)) {
@@ -470,6 +516,44 @@ public class ComponentContainer implements ClientBeanFactory {
 
     private static boolean isBean(Class<?> type) {
         return AnnotatedElementUtils.hasAnnotation(type, Component.class);
+    }
+
+    /**
+     * Whether {@code type} is a Flowable {@code JavaDelegate}, matched by interface <em>name</em>:
+     * {@code engine-java} cannot see the Flowable type ({@code engine-bpm-flowable} depends on this
+     * module, not the other way round), which is also why the {@link #createUnmanaged(Class)} check is
+     * the broader {@code isBean}.
+     */
+    private static boolean isJavaDelegate(Class<?> type) {
+        for (Class<?> current = type; current != null && current != Object.class; current = current.getSuperclass()) {
+            for (Class<?> implemented : current.getInterfaces()) {
+                if (FLOWABLE_JAVA_DELEGATE.equals(implemented.getName()) || isJavaDelegate(implemented)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /** The publish-time wording: the rebuild knows the bean is a delegate, so it says so. */
+    private static String componentOnDelegateMessage(String className) {
+        return "[" + className + "] implements " + FLOWABLE_JAVA_DELEGATE + " and is annotated @Component. A JavaDelegate"
+                + " must NOT be a @Component: Flowable instantiates the delegate itself, so the annotation additionally builds"
+                + " a container-managed singleton the engine never runs — a stray candidate for every List<JavaDelegate>"
+                + " injection. Remove @Component from the delegate.";
+    }
+
+    /**
+     * The execution-time wording. It says {@code instantiated outside the container} rather than
+     * {@code JavaDelegate}, because the detection here is {@code isBean} on whatever class the caller
+     * asked to wire unmanaged - true of a delegate today, but the message must not claim more than it
+     * actually checked.
+     */
+    private static String componentOnUnmanagedMessage(String className) {
+        return "[" + className + "] is annotated @Component but is instantiated outside the container (which is what a"
+                + " JavaDelegate is: Flowable instantiates it itself). Such a class must NOT be a @Component: the annotation"
+                + " additionally builds a container-managed singleton nothing ever runs — a stray candidate for every"
+                + " collection injection point of its type. Remove @Component from it.";
     }
 
     private static String beanName(Class<?> type) {

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/JavaLoader.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/JavaLoader.java
@@ -184,7 +184,8 @@ public class JavaLoader {
         currentBytecode.putAll(effectiveBytecode);
 
         RebuildResult result = new RebuildResult(Collections.unmodifiableSet(succeeded), Collections.unmodifiableMap(failures),
-                Collections.unmodifiableSet(removed), Collections.unmodifiableMap(batch.diagnostics()), componentContainer.wiringErrors());
+                Collections.unmodifiableSet(removed), Collections.unmodifiableMap(batch.diagnostics()), componentContainer.wiringErrors(),
+                componentContainer.wiringWarnings());
 
         // Writes this cycle's fresh bytecode and deletes only source-removed FQNs. Carried-over
         // (failed-to-recompile) classes keep their existing .class files untouched.
@@ -392,9 +393,12 @@ public class JavaLoader {
      * @param wiringErrors per FQN → a bean-container wiring error (unsatisfied/ambiguous dependency,
      *        construction cycle, duplicate bean name, throwing constructor) for classes that compiled
      *        but could not be wired
+     * @param wiringWarnings per FQN → a bean-container wiring warning for classes that compiled and
+     *        wired fine but break a rule (today: a bean that is also a Flowable {@code JavaDelegate}).
+     *        Surfaced on the Problems view like an error, but it does not fail the artefact
      */
     public record RebuildResult(Set<String> succeededFqns, Map<String, String> failures, Set<String> unloadedFqns,
-            Map<String, List<CompileDiagnostic>> diagnostics, Map<String, String> wiringErrors) {
+            Map<String, List<CompileDiagnostic>> diagnostics, Map<String, String> wiringErrors, Map<String, String> wiringWarnings) {
     }
 
 }

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/synchronizer/JavaSynchronizer.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/synchronizer/JavaSynchronizer.java
@@ -292,17 +292,28 @@ public class JavaSynchronizer extends BaseSynchronizer<JavaFile, Long> {
                 file.setLifecycle(ArtefactLifecycle.CREATED);
                 file.setError(null);
                 javaFileService.save(file);
-                clearCompilationProblems(file.getLocation());
+                String warning = result.wiringWarnings()
+                                       .get(fqn);
+                if (warning != null) {
+                    // Compiled and wired, but breaks a container rule (today: a bean that is also a
+                    // JavaDelegate). The artefact stays CREATED - it works - yet the entry lands in the
+                    // Problems view at publish, in front of the developer who wrote the annotation,
+                    // rather than only in a WARN whoever runs the process later may or may not read.
+                    recordCompilationProblems(file.getLocation(), List.of(), warning);
+                } else {
+                    clearCompilationProblems(file.getLocation());
+                }
             }
         }
         return true;
     }
 
     /**
-     * Project a file's compile failure onto the Problems view: replace its previous compilation
-     * problems (so resolved errors disappear), then add one entry per structured diagnostic at its
-     * line/column - or a single entry with the formatted message when no positioned diagnostic is
-     * available (e.g. a read failure or a class that compiled but failed to load).
+     * Project a file's compile failure - or a wiring error/warning - onto the Problems view: replace
+     * its previous compilation problems (so resolved ones disappear), then add one entry per structured
+     * diagnostic at its line/column - or a single entry with the formatted message when no positioned
+     * diagnostic is available (e.g. a read failure, a class that compiled but failed to load, or a bean
+     * that broke a container rule).
      */
     private void recordCompilationProblems(String location, List<CompileDiagnostic> diagnostics, String message) {
         try {

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/component/ComponentContainerDelegateRuleTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/component/ComponentContainerDelegateRuleTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.java.component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.dirigible.engine.java.runtime.ClientBeansHolder;
+import org.eclipse.dirigible.engine.java.spi.LoadedClass;
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.component.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+/**
+ * "A {@code JavaDelegate} must NOT be a {@code @Component}" — where and how often the container
+ * states that rule. It belongs on the Problems view at publish, in front of the developer who wrote
+ * the annotation; the execution-time WARN is a fallback that must not restate the same fact on
+ * every step execution.
+ */
+class ComponentContainerDelegateRuleTest {
+
+    private Logger logger;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void captureContainerLog() {
+        logger = (Logger) LoggerFactory.getLogger(ComponentContainer.class);
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        // The suppressed repeats are DEBUG, so the assertions can only see them with DEBUG enabled.
+        logger.setLevel(Level.DEBUG);
+    }
+
+    @AfterEach
+    void releaseContainerLog() {
+        logger.detachAppender(appender);
+        logger.setLevel(null);
+    }
+
+    @Test
+    void a_bean_that_is_also_a_delegate_is_a_wiring_warning_of_the_generation() {
+        ComponentContainer container = TestComponentContainers.of(RateProvider.class, ComponentDelegate.class);
+
+        String warning = container.wiringWarnings()
+                                  .get(ComponentDelegate.class.getName());
+
+        assertEquals(List.of(ComponentDelegate.class.getName()), List.copyOf(container.wiringWarnings()
+                                                                                      .keySet()));
+        assertTrue(warning.contains(ComponentDelegate.class.getName()), warning);
+        assertTrue(warning.contains("must NOT be a @Component"), warning);
+        assertTrue(warning.contains("org.flowable.engine.delegate.JavaDelegate"), warning);
+    }
+
+    @Test
+    void the_warning_does_not_fail_the_bean_it_is_about() {
+        // It is a warning and not a wiring error on purpose: the bean is built and usable, so the
+        // artefact must not go FAILED - only the Problems entry appears.
+        ComponentContainer container = TestComponentContainers.of(RateProvider.class, ComponentDelegate.class);
+
+        assertTrue(container.instanceOf(ComponentDelegate.class)
+                            .isPresent());
+        assertTrue(container.wiringErrors()
+                            .isEmpty());
+    }
+
+    @Test
+    void a_delegate_inherited_through_a_super_interface_is_still_found() {
+        ComponentContainer container = TestComponentContainers.of(IndirectComponentDelegate.class);
+
+        assertTrue(container.wiringWarnings()
+                            .containsKey(IndirectComponentDelegate.class.getName()));
+    }
+
+    @Test
+    void a_bean_that_is_not_a_delegate_is_not_warned_about() {
+        ComponentContainer container = TestComponentContainers.of(RateProvider.class);
+
+        assertTrue(container.wiringWarnings()
+                            .isEmpty());
+    }
+
+    @Test
+    void a_removed_annotation_clears_the_warning_of_the_previous_generation() {
+        ComponentContainer container = new ComponentContainer(new ClientBeansHolder());
+        container.rebuild(generation(RateProvider.class, ComponentDelegate.class));
+
+        container.rebuild(generation(RateProvider.class));
+
+        assertTrue(container.wiringWarnings()
+                            .isEmpty());
+    }
+
+    @Test
+    void the_execution_time_warning_is_logged_once_per_class_per_generation() {
+        ComponentContainer container = TestComponentContainers.of(RateProvider.class, ComponentDelegate.class);
+        appender.list.clear(); // the rebuild's own publish-time WARN is asserted separately
+
+        container.createUnmanaged(ComponentDelegate.class);
+        container.createUnmanaged(ComponentDelegate.class);
+        container.createUnmanaged(ComponentDelegate.class);
+
+        // On the ${JavaTask} path this runs for every execution of the step, forever.
+        assertEquals(1, ruleLines(Level.WARN).size(), () -> "expected exactly one WARN, got: " + appender.list);
+        assertEquals(2, ruleLines(Level.DEBUG).size(), () -> "expected the repeats at DEBUG, got: " + appender.list);
+    }
+
+    @Test
+    void the_execution_time_warning_names_the_class_and_the_rule() {
+        ComponentContainer container = TestComponentContainers.of(RateProvider.class, ComponentDelegate.class);
+        appender.list.clear();
+
+        container.createUnmanaged(ComponentDelegate.class);
+
+        String message = ruleLines(Level.WARN).get(0);
+        assertTrue(message.contains(ComponentDelegate.class.getName()), message);
+        assertTrue(message.contains("must NOT be a @Component"), message);
+        // It checked @Component on a class being wired unmanaged, not the JavaDelegate interface, so
+        // it must not claim the class is a delegate.
+        assertFalse(message.contains("is a JavaDelegate annotated"), message);
+    }
+
+    @Test
+    void a_republish_says_it_again_because_the_developer_just_changed_the_class() {
+        ComponentContainer container = new ComponentContainer(new ClientBeansHolder());
+        container.rebuild(generation(RateProvider.class, ComponentDelegate.class));
+        container.createUnmanaged(ComponentDelegate.class);
+
+        container.rebuild(generation(RateProvider.class, ComponentDelegate.class));
+        appender.list.clear();
+        container.createUnmanaged(ComponentDelegate.class);
+
+        assertEquals(1, ruleLines(Level.WARN).size(), () -> "expected the new generation to warn again, got: " + appender.list);
+    }
+
+    /**
+     * The captured messages of {@code level} that state the rule (not e.g. the rebuilt-container INFO).
+     */
+    private List<String> ruleLines(Level level) {
+        return appender.list.stream()
+                            .filter(event -> event.getLevel() == level)
+                            .map(ILoggingEvent::getFormattedMessage)
+                            .filter(message -> message.contains("must NOT be a @Component"))
+                            .toList();
+    }
+
+    private static List<LoadedClass> generation(Class<?>... classes) {
+        return Arrays.stream(classes)
+                     .map(type -> new LoadedClass("p", type.getName(), type, type.getClassLoader()))
+                     .toList();
+    }
+
+    // --- fixtures --------------------------------------------------------------------------------
+
+    @Component
+    static class RateProvider {
+    }
+
+    /** The mistake the rule forbids: a delegate annotated {@code @Component}. */
+    @Component
+    static class ComponentDelegate implements org.flowable.engine.delegate.JavaDelegate {
+
+        @Inject
+        RateProvider rates;
+    }
+
+    interface AuditedDelegate extends org.flowable.engine.delegate.JavaDelegate {
+    }
+
+    /** Same mistake, one interface further away — the search has to walk the hierarchy. */
+    @Component
+    static class IndirectComponentDelegate implements AuditedDelegate {
+    }
+}

--- a/components/engine/engine-java/src/test/java/org/flowable/engine/delegate/JavaDelegate.java
+++ b/components/engine/engine-java/src/test/java/org/flowable/engine/delegate/JavaDelegate.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.flowable.engine.delegate;
+
+/**
+ * A test-only stand-in for Flowable's delegate interface, under Flowable's own package so its
+ * {@linkplain Class#getName() binary name} is the real one.
+ *
+ * <p>
+ * {@code engine-java} has no Flowable dependency (the dependency runs the other way:
+ * {@code engine-bpm-flowable} depends on this module), which is why
+ * {@code ComponentContainer.isJavaDelegate} matches the interface by <em>name</em>. This fixture is
+ * what lets that match be tested at all — and it deliberately declares no {@code execute} method,
+ * because the name is the whole of what the container checks.
+ */
+public interface JavaDelegate {
+}


### PR DESCRIPTION
### What does this PR do?

Moves the rule *"a `JavaDelegate` must NOT be a `@Component`"* from a per-execution log line to a **publish-time Problems-view entry**, and makes the log line that remains state itself once instead of forever.

Since #7272 the rule was observable only as a WARN in `ComponentContainer.createUnmanaged`. Two problems with that placement:

1. **It fired on every execution, forever.** On the `${JavaTask}` + `handler` path, `DirigibleJavaCallDelegate.instantiate` calls `createUnmanaged` for each `execute` — the delegate is fresh per execution by design. An annotated handler on a step that runs a thousand times a day logged a thousand identical WARNs.
2. **It never reached the developer who wrote the annotation.** A delegate nobody has executed yet warned nothing, and an operator reading a WARN in the Logs view is not the person who added `@Component`.

**Changes:**

- **Publish-time check.** `ComponentContainer.rebuild` now flags a bean implementing Flowable's `JavaDelegate` as a `wiringWarnings()` entry, naming the class and the rule. The interface is matched by **name** (`org.flowable.engine.delegate.JavaDelegate`), walking superclasses and super-interfaces, because `engine-java` cannot see the Flowable type — the dependency runs the other way, which is also why the execution-time check is the broader `isBean`.
- **It is a *warning*, not a wiring error.** `wiringWarnings()` is a new map beside `wiringErrors()`, carried on `RebuildResult` and projected by `JavaSynchronizer` through the same `recordCompilationProblems` path. The artefact stays `CREATED`: the bean is built and usable, so only the Problems entry appears. Routing it through `wiringErrors()` would have marked the file `FAILED`, which would be a lie about a class that works.
- **Once-then-DEBUG at execution time.** The WARN is kept — a delegate can arrive from an AOT-compiled module the synchronizer never saw — but is logged once per class per generation and then at DEBUG, the shape #7220/#7267 established for exactly this class of "the same fact, every tick" logging. The suppression set is cleared by `rebuild`, so a republish states it again for the developer who just changed the class. The DEBUG branch is `isDebugEnabled`-guarded so a suppressed repeat does not even build its message on a per-execution path.
- **The message no longer over-claims.** It said the class "is a JavaDelegate annotated @Component" while the check was `isBean` on whatever class was handed to `createUnmanaged`; it now says "is annotated `@Component` but is instantiated outside the container".

### What issues does this PR fix or reference?

Fixes #7291. Follow-up to #7223 / #7272; reuses the once-then-DEBUG pattern from #7220 and #7267.

#### Notes for reviewers

- **`RebuildResult` gained a component.** Its only construction site is `JavaLoader.rebuild`, and every consumer of the record lives inside `engine-java`, so no downstream module is affected.
- **The `wiringWarnings` branch sits inside the `succeededFqns` arm** of `JavaSynchronizer.rebuildAll`, so it records the Problems entry where the code previously cleared them — a class that failed to compile or failed to wire still reports that stronger failure instead.
- **Test fixture in `org.flowable.*`.** `src/test/java/org/flowable/engine/delegate/JavaDelegate.java` is a name-only stand-in (no `execute` method — the name is the whole of what the container checks). It is what makes the by-name match testable at all, given `engine-java` has no Flowable dependency.
- **Coverage:** new `ComponentContainerDelegateRuleTest` (8 tests) — the warning's content, that it does not fail the bean it is about, a delegate found through a super-interface, a non-delegate bean warning nothing, the previous generation's warning being cleared, exactly one WARN and two DEBUGs across three executions, the reworded execution-time message, and re-warning after a republish. Full module suite: **145 tests, 0 failures**.
- `license-maven-plugin:check` cannot run from a git worktree at all (`Bare Repository has neither a working tree, nor an index`), so local verification used `-Dlicense.skip=true`; every new file carries the standard EPL header, and the formatter validates clean.
- `engine-java/CLAUDE.md` is updated with where the rule is checked, why a warning rather than an error, and the guidance behind that choice.

#### Release Notes

N/A — bug fix.

#### Documentation

N/A — no user-facing documentation change; the developer-facing note lives in `components/engine/engine-java/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
