### PR TITLE
tests-framework: the schedulers are stopped before the SystemDB schema is dropped (#7285)

### DIFF
--- a/tests/tests-framework/pom.xml
+++ b/tests/tests-framework/pom.xml
@@ -45,6 +45,20 @@
             <artifactId>dirigible-commons-resources</artifactId>
         </dependency>
 
+        <!-- The scheduler APIs whose beans PlatformSchedulersStopper destroys before the cleaner drops
+             the SystemDB schema they run on (#7285). Provided: the application under test brings them. -->
+        <dependency>
+            <groupId>org.quartz-scheduler</groupId>
+            <artifactId>quartz</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flowable</groupId>
+            <artifactId>flowable-engine</artifactId>
+            <version>${flowable.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/base/DirigibleCleanupBean.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/base/DirigibleCleanupBean.java
@@ -20,14 +20,18 @@ class DirigibleCleanupBean {
     private static final Logger LOGGER = LoggerFactory.getLogger(DirigibleCleanupBean.class);
 
     private final DirigibleCleaner dirigibleCleaner;
+    private final PlatformSchedulersStopper platformSchedulersStopper;
 
-    DirigibleCleanupBean(DirigibleCleaner dirigibleCleaner) {
+    DirigibleCleanupBean(DirigibleCleaner dirigibleCleaner, PlatformSchedulersStopper platformSchedulersStopper) {
         this.dirigibleCleaner = dirigibleCleaner;
+        this.platformSchedulersStopper = platformSchedulersStopper;
     }
 
     @PreDestroy
     public void destroy() {
         LOGGER.info("Destroying [{}]. Calling cleaner...", this.getClass());
+        // the schedulers run on the schema the cleaner is about to drop - see PlatformSchedulersStopper
+        platformSchedulersStopper.stopSchedulers();
         dirigibleCleaner.cleanup();
     }
 }

--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/base/PlatformSchedulersStopper.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/base/PlatformSchedulersStopper.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.tests.base;
+
+import java.util.List;
+import org.flowable.engine.ProcessEngine;
+import org.quartz.Scheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.DefaultSingletonBeanRegistry;
+import org.springframework.stereotype.Component;
+
+/**
+ * Destroys the platform's schedulers before {@link DirigibleCleaner} drops the SystemDB schema they
+ * run on.
+ * <p>
+ * Both of them keep polling that schema in the background - Quartz's cluster manager checks in on
+ * {@code qrtz_scheduler_state}, Flowable's async executor acquires from {@code act_ru_job} - and
+ * both issue a last round of statements when they are closed. The cleaner runs from a
+ * {@code @PreDestroy}, i.e. while every other bean is still alive, so on PostgreSQL - where the
+ * schema really is dropped instead of being discarded with the JVM, as the file-backed H2 SystemDB
+ * is - each of those threads then logged an ERROR with a stack trace per poll: hundreds per CI
+ * shard behind a green run, which is what made a PostgreSQL job log unreadable (#7285).
+ * <p>
+ * The beans are destroyed through the bean factory rather than shut down through their own APIs:
+ * that runs Spring's own destruction for them exactly once, at a moment when their tables still
+ * exist, and de-registers them, so the context close that follows does not close them a second time
+ * against the dropped schema. Their dependents are destroyed with them, as during any context
+ * close.
+ */
+@Component
+class PlatformSchedulersStopper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformSchedulersStopper.class);
+
+    /**
+     * The process engine goes first - closing it unlocks the jobs its async executor holds, which is
+     * work for the very scheduler that is stopped next.
+     */
+    private static final List<Class<?>> SYSTEM_DB_SCHEDULER_TYPES = List.of(ProcessEngine.class, Scheduler.class);
+
+    private final ConfigurableListableBeanFactory beanFactory;
+
+    PlatformSchedulersStopper(ConfigurableListableBeanFactory beanFactory) {
+        this.beanFactory = beanFactory;
+    }
+
+    void stopSchedulers() {
+        if (!(beanFactory instanceof DefaultSingletonBeanRegistry singletonRegistry)) {
+            LOGGER.warn("Bean factory [{}] cannot destroy a single bean - the schedulers are left to the context close", beanFactory);
+            return;
+        }
+        SYSTEM_DB_SCHEDULER_TYPES.forEach(type -> stopSchedulersOfType(type, singletonRegistry));
+    }
+
+    private void stopSchedulersOfType(Class<?> schedulerType, DefaultSingletonBeanRegistry singletonRegistry) {
+        // singletons only, and without initialising anything that has not been created yet
+        for (String beanName : beanFactory.getBeanNamesForType(schedulerType, false, false)) {
+            LOGGER.info("Destroying [{}] of type [{}] before the schema it runs on is dropped...", beanName, schedulerType.getName());
+            try {
+                singletonRegistry.destroySingleton(beanName);
+            } catch (RuntimeException ex) {
+                LOGGER.warn("Failed to destroy [{}] of type [{}]", beanName, schedulerType.getName(), ex);
+            }
+        }
+    }
+}

--- a/tests/tests-framework/src/test/java/org/eclipse/dirigible/tests/base/PlatformSchedulersStopperTest.java
+++ b/tests/tests-framework/src/test/java/org/eclipse/dirigible/tests/base/PlatformSchedulersStopperTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.tests.base;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.function.Supplier;
+import org.flowable.engine.ProcessEngine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.quartz.Scheduler;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+
+/**
+ * The stopper exists so that the Quartz scheduler and the Flowable process engine are torn down
+ * while the SystemDB schema they run on still exists - and torn down exactly once, so the context
+ * close that follows the schema drop does not talk to the dropped schema again (#7285).
+ */
+class PlatformSchedulersStopperTest {
+
+    private static final String SCHEDULER_BEAN = "scheduler";
+    private static final String PROCESS_ENGINE_BEAN = "getProcessEngine";
+    private static final String UNRELATED_BEAN = "unrelated";
+
+    private DefaultListableBeanFactory beanFactory;
+    private PlatformSchedulersStopper stopper;
+
+    private Scheduler scheduler;
+    private ProcessEngine processEngine;
+    private AutoCloseable unrelated;
+
+    @BeforeEach
+    void setUp() {
+        beanFactory = new DefaultListableBeanFactory();
+        stopper = new PlatformSchedulersStopper(beanFactory);
+
+        scheduler = registerSingleton(SCHEDULER_BEAN, Scheduler.class, "shutdown");
+        processEngine = registerSingleton(PROCESS_ENGINE_BEAN, ProcessEngine.class, "close");
+        unrelated = registerSingleton(UNRELATED_BEAN, AutoCloseable.class, "close");
+    }
+
+    @Test
+    void shouldDestroyTheSchedulersWithoutTouchingTheRestOfTheContext() throws Exception {
+        stopper.stopSchedulers();
+
+        verify(scheduler).shutdown();
+        verify(processEngine).close();
+        verifyNoInteractions(unrelated);
+    }
+
+    @Test
+    void shouldNotLeaveTheSchedulersToBeDestroyedAgainByTheContextClose() throws Exception {
+        stopper.stopSchedulers();
+
+        beanFactory.destroySingletons();
+
+        verify(scheduler, times(1)).shutdown();
+        verify(processEngine, times(1)).close();
+        verify(unrelated).close();
+    }
+
+    @Test
+    void shouldBeSilentWhenTheSchedulersWereNeverCreated() {
+        DefaultListableBeanFactory emptyBeanFactory = new DefaultListableBeanFactory();
+
+        new PlatformSchedulersStopper(emptyBeanFactory).stopSchedulers();
+    }
+
+    private <T> T registerSingleton(String beanName, Class<T> beanType, String destroyMethodName) {
+        T bean = mock(beanType);
+        Supplier<T> instanceSupplier = () -> bean;
+
+        AbstractBeanDefinition beanDefinition = new RootBeanDefinition(beanType);
+        beanDefinition.setInstanceSupplier(instanceSupplier);
+        beanDefinition.setDestroyMethodName(destroyMethodName);
+        beanFactory.registerBeanDefinition(beanName, beanDefinition);
+
+        // create it, so that it is a singleton the context close would destroy
+        beanFactory.getBean(beanName, beanType);
+
+        return bean;
+    }
+}


### PR DESCRIPTION
## Cause

`DirigibleCleaner` runs from a `@PreDestroy`, i.e. while every other bean is still alive, so it dropped and recreated the SystemDB schema under a **running** Quartz scheduler and Flowable process engine.

Both keep polling that schema in the background - the cluster manager checks in on `QRTZ_SCHEDULER_STATE` every 2s (`clusterCheckinInterval=2000`), the async executor acquires from `ACT_RU_JOB` - and both issue a last round of statements when they are closed. On PostgreSQL that then happened against a schema that no longer had their tables, leaving hundreds of ERROR stack traces per CI shard behind a green run (234 x `act_ru_job`, 45 x `qrtz_scheduler_state` on the `slow` shard of run 34447508315). The cost is a PostgreSQL job log nobody can read: the one real failure in it is a single ERROR line among ~300, and an assertion on "no ERROR in the log" is impossible on that leg.

It only looked like a PostgreSQL problem because the file-backed H2 SystemDB is discarded with the JVM rather than really dropped. On H2 the same race produces the same errors, just fewer of them - which the verification below reproduces.

## Change

`PlatformSchedulersStopper` destroys those two beans before the cleaner touches the schema, called from `DirigibleCleanupBean.destroy()` ahead of `dirigibleCleaner.cleanup()`.

They are destroyed **through the bean factory** rather than shut down through their own APIs. That runs Spring's own destruction for them exactly once, at a moment when their tables still exist, and de-registers them, so the context close that follows does not close them a second time against the dropped schema. Closing the process engine by hand would not have been enough: Spring's inferred `close()` on the `getProcessEngine` bean would still run afterwards, and its close runnable talks to `ACT_RU_JOB` - reproducing the very error being removed. The unit test pins exactly that (it fails with `TooManyActualInvocations` against the naive teardown).

The two scheduler APIs are new `provided` dependencies of the module; the application under test brings them.

## Verification

Locally against PostgreSQL 16 with the CI datasource configuration, and against H2, on the ITs whose teardown exercises both engines:

| run | before | after |
| --- | --- | --- |
| `RestErrorMessageIT`, PostgreSQL | 1 `[ERROR]`, 5 `act_ru_job` mentions, 1 `DisposableBeanAdapter ... propagated an exception` WARN | **0 / 0 / 0** |
| `BpmTaskLabelKeyIT` + `JavaUnitOfWorkIT`, H2 (5 contexts, per-method `@DirtiesContext`) | 11 `[ERROR]` | **5 `[ERROR]`** |

On PostgreSQL, nothing at all - no WARN, no ERROR - now follows `Will drop schema`; the log shows the intended order:

```
DirigibleCleanupBean      - Destroying [...DirigibleCleanupBean]. Calling cleaner...
PlatformSchedulersStopper - Destroying [getProcessEngine] of type [org.flowable.engine.ProcessEngine] before the schema it runs on is dropped...
PlatformSchedulersStopper - Destroying [scheduler] of type [org.quartz.Scheduler] before the schema it runs on is dropped...
QuartzScheduler           - Scheduler EclipseDirigibleScheduler_$_... shutting down.
PlatformSchedulersStopper - Destroying [schedulerFactoryBean] of type [org.quartz.Scheduler] before the schema it runs on is dropped...
DirigibleCleaner          - Will drop schema [public] from data source [...SystemDB...]
```

On H2 the 11 -> 5 delta is exactly the teardown noise: the 5 Flowable `Error while closing command context` and the 1 Quartz `ClusterManager: Error managing cluster ... Table QRTZ_SCHEDULER_STATE not found` are gone. What remains are the two errors `JavaUnitOfWorkIT` asserts on purpose and three pre-existing `peer (vm://localhost) stopped` JMS lines - all present on master too, so nothing new was introduced.

Also green:

- `JavaBpmnIT`, `JavaJobTenantIT`, `ArtefactStatusEndpointIT`, `RestErrorMessageIT` on H2 - 8 tests, zero `[ERROR]` lines, the stopper invoked in all 4 teardowns.
- `mvn -T 1C formatter:validate` with every `formatter-maven-cache.properties` deleted first.
- `mvn -pl tests/tests-framework -am test` - 30 tests, incl. the 3 new ones.
- The release-profile javadoc build on the module - 0 javadoc errors, no warning on the new file.

Not verified: the full suite on either database, and the CI shard counts themselves - the numbers above come from single-IT runs.

Fixes #7285

🤖 Generated with [Claude Code](https://claude.com/claude-code)
