### PR TITLE
tests: the redelivery step reads the line rows' identity, and the cascade roll-back has a witness it cannot miss (#7298)

### DIFF
--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentCompositionCascadeIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentCompositionCascadeIT.java
@@ -65,6 +65,7 @@ class IntentCompositionCascadeIT extends IntegrationTest {
     private static final String API = "/services/java/" + PROJECT + "/gen/" + PROJECT + "/api";
     private static final String TRIPS = API + "/trip/TripController";
     private static final String LEGS = API + "/trip/TripLegController";
+    private static final String TAGS = API + "/trip/TripTagController";
     private static final String COPIES = API + "/trip/TripCopyController";
     private static final String NOTES = API + "/trip/TripLegNoteController";
     private static final String FLEETS = API + "/fleet/FleetController";
@@ -92,6 +93,17 @@ class IntentCompositionCascadeIT extends IntegrationTest {
                 fields:
                   - { name: id,   type: integer, primaryKey: true, generated: true }
                   - { name: note, type: string, length: 200 }
+
+              # A second cascading child, declared BEFORE TripLeg. The generated cascade visits the
+              # child TYPES in model order, so this one's rows are already deleted by the time the
+              # chain below refuses - which is what makes the roll-back claim a proof rather than a
+              # bet on which leg the leg query happens to visit first (#7298).
+              - name: TripTag
+                fields:
+                  - { name: id,   type: integer, primaryKey: true, generated: true }
+                  - { name: text, type: string, length: 100 }
+                relations:
+                  - { name: Trip, kind: manyToOne, to: Trip, composition: true, required: true }
 
               # The cascading child: it goes with its trip, and its own delete event is what
               # gives the fleet its count back.
@@ -147,8 +159,10 @@ class IntentCompositionCascadeIT extends IntegrationTest {
         create(LEGS, "{\"Trip\":" + cascading + ",\"Distance\":10,\"Fleet\":" + fleet + "}");
         create(LEGS, "{\"Trip\":" + cascading + ",\"Distance\":20,\"Fleet\":" + fleet + "}");
 
-        // A second one whose second leg carries a note - the chain that refuses one level down.
+        // A second one whose second leg carries a note - the chain that refuses one level down. Its tag
+        // is the row the cascade deletes BEFORE it ever reaches the legs.
         int chained = create(TRIPS, "{\"Note\":\"chained\"}");
+        create(TAGS, "{\"Trip\":" + chained + ",\"Text\":\"tagged\"}");
         create(LEGS, "{\"Trip\":" + chained + ",\"Distance\":30,\"Fleet\":" + fleet + "}");
         int notedLeg = create(LEGS, "{\"Trip\":" + chained + ",\"Distance\":40,\"Fleet\":" + fleet + "}");
         create(NOTES, "{\"TripLeg\":" + notedLeg + ",\"Text\":\"keep me\"}");
@@ -165,7 +179,9 @@ class IntentCompositionCascadeIT extends IntegrationTest {
         assertFleetCount(fleet, 2);
 
         // (3) The chain refuses at its second level, and the whole delete rolls back with it: the trip
-        // is still there, and so is the leg the cascade had ALREADY deleted when the note stopped it.
+        // is still there, and so is everything the cascade had ALREADY deleted when the note stopped
+        // it - the tag for certain (its child type is swept before the legs are looked at) and the
+        // unnoted leg as well.
         restAssuredExecutor.execute(() -> given().when()
                                                  .delete(TRIPS + "/" + chained)
                                                  .then()
@@ -175,6 +191,7 @@ class IntentCompositionCascadeIT extends IntegrationTest {
                                                  .get(TRIPS + "/" + chained)
                                                  .then()
                                                  .statusCode(200));
+        assertTagsOfTrip(chained, 1);
         assertLegsOfTrip(chained, 2);
         // Nothing was counted away either - the rolled-back deletes recorded no events to act on.
         assertFleetCount(fleet, 2);
@@ -221,6 +238,19 @@ class IntentCompositionCascadeIT extends IntegrationTest {
     private void assertLegsOfTrip(int trip, int expected) {
         restAssuredExecutor.execute(() -> given().when()
                                                  .get(LEGS + "?Trip=" + trip)
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body("", hasSize(expected)));
+    }
+
+    /**
+     * The tag rows of a trip. TripTag is the cascade's FIRST child type (model order), so it is the row
+     * a refusal further down the chain has to bring back - unlike a leg, whose deletion depends on
+     * which row the leg query visits first, which no ORDER BY pins (#7298).
+     */
+    private void assertTagsOfTrip(int trip, int expected) {
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get(TAGS + "?Trip=" + trip)
                                                  .then()
                                                  .statusCode(200)
                                                  .body("", hasSize(expected)));

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentPostingAmendIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentPostingAmendIT.java
@@ -57,7 +57,8 @@ import ch.qos.logback.classic.Level;
  * <li>an amended source REWRITES its post in place - the same entry, the new amounts, never a
  * second entry;
  * <li>a redelivery of the same content is a no-op, so the loop is not simply "rewrite on every
- * event";
+ * event" - read off the line rows' IDENTITY, the only thing that tells a no-op from a rewrite that
+ * re-derives the same content;
  * <li>the rewrite stops once the created document has left the status the posting created it in -
  * somebody has acted on it, so the divergence is reported and left to a correcting entry.
  * </ol>
@@ -185,12 +186,25 @@ class IntentPostingAmendIT extends IntegrationTest {
         // ...and it is still the only one: an amend is not a second posting.
         assertEquals(entry, onlyEntryOf(doc), "an amended source must rewrite ITS post, never open a second one");
 
-        // A redelivery - the same loop with nothing edited - changes nothing at all. Without this the
-        // rewrite above would also pass on a handler that simply re-posted on every event.
+        // A redelivery - the same loop with nothing edited - changes nothing at all. Neither the line
+        // count nor the amounts can tell that apart from a rewrite: the rewrite keeps the SAME header
+        // and re-derives the very same two lines, so both readings are already true before the handler
+        // has looked at the event and stay true whichever branch it takes. The claim is therefore made
+        // on the line IDS, the one thing the rewrite path cannot keep - it deletes the rows it replaces
+        // and inserts the derived ones (#7298).
+        List<Integer> lines = lineIdsOf(entry);
         transition("RejectDoc", doc);
         transition("IssueDoc", doc);
+        // Read once the handler has demonstrably got PAST that event: a second document issued
+        // afterwards travels the same topic to the same durable subscriber, so its own post existing
+        // means the redelivery was consumed before it. Without that fence the assertion would run
+        // while the event was still in flight and pass on a rewrite-on-every-event handler too.
+        int fence = create(DOCS, "{\"Date\":\"2026-02-04\",\"Amount\":10}");
+        transition("IssueDoc", fence);
+        awaitLines(onlyEntryOf(fence), 10.0f);
         assertEquals(entry, onlyEntryOf(doc));
         awaitLines(entry, 1260.0f);
+        assertEquals(lines, lineIdsOf(entry), "a redelivery must leave the post it already wrote alone, its rows included");
 
         // Past the created document's own lifecycle the rewrite stops: the accountant posts the entry,
         // and from there a divergence is reported rather than silently overwritten - unwinding a
@@ -209,18 +223,52 @@ class IntentPostingAmendIT extends IntegrationTest {
         awaitLines(entry, 1260.0f);
     }
 
-    /** The single entry the source carries, asserting there is exactly one. */
+    /**
+     * The single entry the source carries, asserting there is exactly one.
+     *
+     * <p>
+     * The rows are picked out here rather than by a query parameter: the generated list endpoint
+     * filters by a COMPOSITION foreign key, and the back-reference to the source is a plain
+     * association, so {@code ?Doc=} is simply ignored and the whole table comes back.
+     */
     private int onlyEntryOf(int doc) {
+        String ofDoc = "findAll { it.Doc == " + doc + " }";
         AtomicInteger entry = new AtomicInteger();
         restAssuredExecutor.execute(() -> entry.set(given().when()
-                                                           .get(ENTRIES + "?Doc=" + doc)
+                                                           .get(ENTRIES)
                                                            .then()
                                                            .statusCode(200)
-                                                           .body("", hasSize(1))
+                                                           .body(ofDoc, hasSize(1))
                                                            .extract()
-                                                           .path("[0].Id")),
+                                                           .jsonPath()
+                                                           .getInt(ofDoc + "[0].Id")),
                 POSTING_TIMEOUT_SECONDS);
         return entry.get();
+    }
+
+    /**
+     * The ids of the entry's line rows, ascending - the identity only a genuine no-op keeps.
+     *
+     * <p>
+     * The rewrite path keeps the header ({@code targetRepository.update(target)}) and replaces the
+     * lines, so a redelivery that rewrote instead of returning early leaves the entry id, the line
+     * count and both amounts exactly as they were, and is visible only in these ids (#7298).
+     */
+    private List<Integer> lineIdsOf(int entry) {
+        AtomicReference<List<Integer>> ids = new AtomicReference<>();
+        restAssuredExecutor.execute(() -> ids.set(given().when()
+                                                         .get(LINES + "?Entry=" + entry)
+                                                         .then()
+                                                         .statusCode(200)
+                                                         .body("", hasSize(2))
+                                                         .extract()
+                                                         .jsonPath()
+                                                         .getList("Id", Integer.class)),
+                POSTING_TIMEOUT_SECONDS);
+        return ids.get()
+                  .stream()
+                  .sorted()
+                  .toList();
     }
 
     /** The balanced pair the posting derives: one debit line and one credit line, both the amount. */


### PR DESCRIPTION
Fixes #7298.

## The cause

**`IntentPostingAmendIT`.** The redelivery step (`RejectDoc` -> `IssueDoc` with no edit in between) asserted the entry id, the line count and both amounts. The rewrite path keeps the **same header** (`targetRepository.update(target)`) and re-derives the **same two lines**, so all three readings are true before the async handler has looked at the event and stay true whichever branch it takes. A `Posting.java.template` that rewrote on every event - the semantics #7071 deliberately bounded - passed the step unchanged.

**`IntentCompositionCascadeIT`.** The "the leg the cascade had ALREADY deleted comes back" narrative depended on the cascade's read visiting leg 30 before leg 40. Nothing pins that order (no `ORDER BY` in the generated `deleteOwnedChildren`), and on a database visiting 40 first the refusal fires before any row is deleted - the final `assertLegsOfTrip(chained, 2)` then holds without the roll-back having been exercised at all.

## The change

Tests only; no product code is touched.

**Posting.** The step captures the two line ids after the first amendment and asserts the redelivery leaves **those rows** in place. The rewrite deletes the rows it replaces and inserts the derived ones, so the ids are the one reading that separates a no-op from a rewrite.

The assertion is **fenced**: a second document is issued after the redelivery and its own post awaited. Both travel the same topic to the same durable subscriber (`ListenerClassConsumer` registers one `createDurableSubscriber` + one `setMessageListener`, so delivery is serial and ordered), so the fence's post existing means the redelivery was consumed before it. Without the fence the identity assertion would run while the event was still in flight and pass on a rewriting handler too.

One thing surfaced while adding the fence: `onlyEntryOf` queried `EntryController?Doc=<id>`, but the generated list endpoint filters by a **composition** foreign key, and the posting's back-reference is a plain association - `?Doc=` was ignored and the whole table came back. The assertion held only because the table had exactly one row. The entries of one source are now picked out in the test.

**Cascade.** The chained trip also carries a `TripTag`, declared **before** `TripLeg` in the fixture. `CompositionChildren` indexes the children in model order and the template emits one cascade loop per child type in that order, so the tag row is deleted before the legs are looked at, whatever order the leg rows come back in - and it is the row the refusal has to bring back. Asserted before the leg count. The alternative the issue names, an `ORDER BY` in the generated cascade read, would have changed emitted code for every application to pin a test; the fixture carries it instead.

## Verification

Both ITs run locally on H2 (`mvn -o -P integration-tests -pl tests/tests-integrations verify -Dit.test="IntentCompositionCascadeIT,IntentPostingAmendIT" -Dit.groups= -Dit.excludedGroups=`) - green, 2 tests.

Each new assertion was then checked against the regression it exists for:

- `Posting.java.template` with the `if (unchanged) return;` early exit disabled: the run fails on **the new assertion only** - `a redelivery must leave the post it already wrote alone, its rows included ==> expected: <[3, 4]> but was: <[5, 6]>`. The old entry-id / count / amount assertions all still passed, which is the defect this fixes.
- `Repository.java.template` with the cascade's `UnitOfWork.run(...)` removed: the run fails on `assertTagsOfTrip` (`Expected: a collection with size <1>, Actual: <[]>`). In the same broken build the leg assertion happened to catch it too - because the rows happened to come back in the favourable order - which is exactly the coin flip being removed.

Both templates were restored and re-installed, and the final green run above is against the restored ones. The generated `TripRepository.deleteOwnedChildren` was read off a live run to confirm `TripTag` is swept before `TripLeg`.

`mvn formatter:format` on the module, then `formatter:validate` over the whole reactor with the formatter caches deleted - clean.

Not verified: the PostgreSQL leg (both ITs are H2-only locally) and the rest of the IT suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)