### PR TITLE
tests: a deep link after login keeps its route, and the form wait is a budget (#7282)

### DIFF
--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/ide/IDE.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/ide/IDE.java
@@ -14,6 +14,7 @@ import org.eclipse.dirigible.tests.framework.browser.HtmlAttribute;
 import org.eclipse.dirigible.tests.framework.browser.HtmlElementType;
 import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
 import org.eclipse.dirigible.tests.framework.tenant.DirigibleTestTenant;
+import org.eclipse.dirigible.tests.framework.util.SleepUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Component;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @Lazy
 @Component
@@ -35,6 +37,8 @@ public class IDE {
     private static final String PASSWORD_FIELD_ID = "password";
     private static final String SUBMIT_TYPE = "submit";
     private static final String SIGN_IN_BUTTON_TEXT = "Sign in";
+    private static final long LOGIN_COMPLETION_TIMEOUT_MILLIS = 30_000;
+    private static final long LOGIN_COMPLETION_POLL_MILLIS = 500;
 
     private final Browser browser;
     private final String username;
@@ -120,6 +124,27 @@ public class IDE {
         browser.enterTextInElementByAttributePattern(HtmlElementType.INPUT, HtmlAttribute.ID, USERNAME_FIELD_ID, username);
         browser.enterTextInElementByAttributePattern(HtmlElementType.INPUT, HtmlAttribute.ID, PASSWORD_FIELD_ID, password);
         browser.clickOnElementByAttributePatternAndText(HtmlElementType.BUTTON, HtmlAttribute.TYPE, SUBMIT_TYPE, SIGN_IN_BUTTON_TEXT);
+        awaitLoginCompleted();
+    }
+
+    /**
+     * Waits for the sign-in form to be replaced by the page the login redirects to. Clicking Sign in
+     * only SUBMITS the form, so a caller that navigates straight afterwards raced the login: the app
+     * URL was requested before the session existed, Spring saved it and answered with the login
+     * redirect, and the request it saves never carries the fragment the browser did not send - so a
+     * deep link into a generated SPA silently lost its route and the shell rendered its default page
+     * instead (issue #7282).
+     */
+    private void awaitLoginCompleted() {
+        long deadline = System.currentTimeMillis() + LOGIN_COMPLETION_TIMEOUT_MILLIS;
+        do {
+            if (!isLoginPageOpened()) {
+                LOGGER.info("Logged in");
+                return;
+            }
+            SleepUtil.sleepMillis(LOGIN_COMPLETION_POLL_MILLIS);
+        } while (System.currentTimeMillis() < deadline);
+        fail("The sign-in page is still open after " + LOGIN_COMPLETION_TIMEOUT_MILLIS / 1000 + "s - the login did not complete");
     }
 
     private boolean isLoginPageOpened() {

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/ContextLockedParentHarmoniaIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/ContextLockedParentHarmoniaIT.java
@@ -45,6 +45,15 @@ import com.codeborne.selenide.Selenide;
  */
 class ContextLockedParentHarmoniaIT extends UserInterfaceIntegrationTest {
 
+    /**
+     * The budget every poll in this class gets, replacing a fixed 40 x 250 ms = 10 s. 60 s is the cap
+     * the framework's own cross-frame element search uses, and it is a budget rather than a fixed
+     * attempt count so a loaded runner cannot shorten the wait (issue #7282).
+     */
+    private static final long POLL_TIMEOUT_MILLIS = 60_000;
+
+    private static final long POLL_INTERVAL_MILLIS = 250;
+
     private static final String PROJECT = "context-locked-it";
     private static final String WORKSPACE = "workspace";
     private static final String PROJECT_PATH = IRepositoryStructure.PATH_USERS + "/admin/" + WORKSPACE + "/" + PROJECT;
@@ -82,9 +91,27 @@ class ContextLockedParentHarmoniaIT extends UserInterfaceIntegrationTest {
             """;
 
     /**
+     * The child form's readiness, independent of which parent-control branch renders. The field row's
+     * label is emitted by both branches and is the anchor; its parent is the row's {@code x-h-field}
+     * wrapper, which Harmonia stamps with {@code data-slot="field"} as it processes it. That stamp is
+     * therefore proof that Alpine has walked the injected fragment - so by the time it is there, the
+     * two {@code x-if} branches inside the same row have been decided too. Polled before the control is
+     * classified, so a page that has not painted the form can no longer be reported as a form that
+     * painted without the control (issue #7282 - the flake was the shell rendering its DEFAULT route,
+     * and the old script classified that as {@code missing} exactly like the defect).
+     */
+    private static final String FORM_READY_STATE = """
+            var label = document.querySelector('label[for="f_SalesInvoice"]');
+            var field = label ? label.parentElement : null;
+            return field && field.getAttribute('data-slot') === 'field' ? 'ready' : 'not-rendered';
+            """;
+
+    /**
      * Classifies the parent control as the page rendered it: {@code locked:<label>} for the read-only
      * display, {@code free} for the combobox (its trigger is a button the select directive appends next
-     * to the bound input), {@code missing} when neither branch rendered.
+     * to the bound input), {@code missing} when the form rendered but neither branch produced a control
+     * - which is the defect this test guards, and is only ever reported once {@link #FORM_READY_STATE}
+     * has settled.
      */
     private static final String PARENT_CONTROL_STATE = """
             var e = document.getElementById('f_SalesInvoice');
@@ -138,20 +165,28 @@ class ContextLockedParentHarmoniaIT extends UserInterfaceIntegrationTest {
                 "the detail panel must name the master FK in the child form's URL, got: " + dialogSources);
     }
 
-    /** The parent control's state, polled until it settles on the expected one (or times out). */
+    /**
+     * The parent control's state, polled until it settles on the expected one (or times out) - after
+     * the form itself is confirmed rendered, so the two failure modes stay apart: a form that never
+     * painted fails here, naming the wait, and only a form that painted without a control reaches the
+     * caller's assertion as {@code missing}.
+     */
     private String parentControlState(String expected) {
+        assertEquals("ready", poll(FORM_READY_STATE, "ready"::equals), "the child form did not render within " + POLL_TIMEOUT_MILLIS / 1000
+                + "s - the page never reached this route, not the parent control this test classifies");
         return poll(PARENT_CONTROL_STATE, expected::equals);
     }
 
     private String poll(String script, Predicate<String> settled) {
+        long deadline = System.currentTimeMillis() + POLL_TIMEOUT_MILLIS;
         String value = "";
-        for (int attempt = 0; attempt < 40; attempt++) {
+        do {
             value = Selenide.executeJavaScript(script);
             if (value != null && settled.test(value)) {
                 return value;
             }
-            Selenide.sleep(250);
-        }
+            Selenide.sleep(POLL_INTERVAL_MILLIS);
+        } while (System.currentTimeMillis() < deadline);
         return value;
     }
 


### PR DESCRIPTION
## Cause

`ContextLockedParentHarmoniaIT` failed on `integration-tests-postgresql (ui)` and passed on the retry. The issue read it as a cold SPA load outrunning the 10 s poll; it is not.

`IDE.login` only **submits** the sign-in form - it clicks Sign in and returns. The test then calls `browser.openPath(APP + "#/SalesInvoiceNote/create?SalesInvoice=1")` immediately, which races the login's redirect chain: the app URL is requested before the session exists, Spring saves it and answers with the login redirect, and **a saved request never carries the fragment the browser does not send**. The redirect back therefore lands on `.../index.html` with no hash, the shell renders its DEFAULT route, and `document.getElementById('f_SalesInvoice')` is null - which the old script classified as `missing`, exactly like the defect the test guards.

Reproduced locally in **2 of 6 runs**. At the timeout, a diagnostic dump showed `window.location.hash` empty and the loaded-resource list containing `_dashboard.html` (the shell's home page), not the child form - with Alpine, Harmonia, the router and every page module loaded within 90 ms of the navigation, so nothing was slow.

## Change

- **`IDE.login` waits for the sign-in page to be replaced** before returning, polling on the **calling thread** - Selenide's WebDriver is thread-local, so an `AwaitilityExecutor` poll runs on a thread with no driver bound and only ever throws `No webdriver is bound to current thread`. This is the root fix and it is at the right altitude: `GeneratesPromptHarmoniaIT`, `MultiselectHarmoniaIT` and `IntentDiagramGlueIT` all navigate straight after `openHomePage()` and carry the same exposure.
- **The IT waits for the form to be RENDERED before classifying the control.** The field row's `x-h-field` wrapper carries Harmonia's `data-slot="field"` stamp only after Alpine has walked the injected fragment, and the row's `<label for="f_SalesInvoice">` is emitted by both `x-if` branches, so it is the branch-independent anchor. A page that never painted the form now fails naming the wait, and `missing` means "the form rendered without a control" and nothing else - the distinction the issue asks for.
- **The poll is a 60 s budget** (the cap the framework's own cross-frame element search uses) instead of a fixed `40 x 250 ms` = 10 s, so a loaded runner cannot shorten the wait. All four assertions in the class share it.

## Verification

- `ContextLockedParentHarmoniaIT`: **12 consecutive green runs** after the change, against 4 of 6 before it - and the test now finishes in ~27 s instead of 41-100 s, because it no longer spends the wait on a page it will never read.
- Green with the shared framework change: `DirigibleHomepageIT`, `HomepageRedirectIT`, `MultiselectHarmoniaIT`, `GeneratesPromptHarmoniaIT`, `IntentDiagramGlueIT`, `MultitenancyHarmoniaIT` (which exercises the `forceLogin` path) and `CreateNewProjectIT`.
- `mvn formatter:validate` with the formatter cache wiped; `mvn -P release` builds `tests-framework` with no javadoc `error:`.
- Not run: the rest of the UI suite (CI covers it).

Fixes #7282

🤖 Generated with [Claude Code](https://claude.com/claude-code)
