### PR TITLE
build: pin the webjars' open npm version ranges so resolution never needs remote metadata (#7284)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1019,6 +1019,89 @@
                 <artifactId>dom4j</artifactId>
                 <version>2.2.0</version>
             </dependency>
+            <!-- Several webjars declare their transitive dependencies with npm-style open version
+                 ranges. A range is resolved by fetching maven-metadata.xml from every remote on every
+                 build, so a transient metadata failure on any of them breaks dependency collection and
+                 fails the reactor before a single test runs; and because the range picks whatever is
+                 published at the time, the content of the shipped webjar is not a function of this
+                 repository. The entries below pin every such artifact reachable from the reactor to the
+                 version the ranges resolve to today, so the coordinates are fixed and come from the
+                 local repository. When bumping the webjar that drags them in, re-check the pins. -->
+            <!-- via ag-grid-community__all-modules (${ag-grid.version}) -->
+            <dependency>
+                <groupId>org.webjars.npm</groupId>
+                <artifactId>ag-grid-community__core</artifactId>
+                <version>27.1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.webjars.npm</groupId>
+                <artifactId>ag-grid-community__client-side-row-model</artifactId>
+                <version>27.1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.webjars.npm</groupId>
+                <artifactId>ag-grid-community__csv-export</artifactId>
+                <version>27.1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.webjars.npm</groupId>
+                <artifactId>ag-grid-community__infinite-row-model</artifactId>
+                <version>27.1.0</version>
+            </dependency>
+            <!-- via alpinejs (${alpinejs.version}) -->
+            <dependency>
+                <groupId>org.webjars.npm</groupId>
+                <artifactId>vue__reactivity</artifactId>
+                <version>3.2.0-beta.8</version>
+            </dependency>
+            <dependency>
+                <groupId>org.webjars.npm</groupId>
+                <artifactId>vue__shared</artifactId>
+                <version>3.2.0-beta.8</version>
+            </dependency>
+            <!-- via bpmn-visualization (${bpmn-visualization.version}); strnum through fast-xml-parser -->
+            <dependency>
+                <groupId>org.webjars.npm</groupId>
+                <artifactId>typed-mxgraph__typed-mxgraph</artifactId>
+                <version>1.0.8</version>
+            </dependency>
+            <dependency>
+                <groupId>org.webjars.npm</groupId>
+                <artifactId>es-toolkit</artifactId>
+                <version>1.39.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.webjars.npm</groupId>
+                <artifactId>strnum</artifactId>
+                <version>2.3.0</version>
+            </dependency>
+            <!-- via codbex__harmonia (${harmonia.version}) -->
+            <dependency>
+                <groupId>org.webjars.npm</groupId>
+                <artifactId>floating-ui__dom</artifactId>
+                <version>1.8.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.webjars.npm</groupId>
+                <artifactId>floating-ui__core</artifactId>
+                <version>1.8.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.webjars.npm</groupId>
+                <artifactId>floating-ui__utils</artifactId>
+                <version>0.2.12</version>
+            </dependency>
+            <!-- via i18next (${i18next.version}); regenerator-runtime through babel__runtime -->
+            <dependency>
+                <groupId>org.webjars.npm</groupId>
+                <artifactId>babel__runtime</artifactId>
+                <version>8.0.0-alpha.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.webjars.npm</groupId>
+                <artifactId>regenerator-runtime</artifactId>
+                <version>0.14.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Cause

Nightly run 34428729298, job `integration-tests-postgresql (slow)`, died after a minute of Maven with no test run:

```
[ERROR] No versions available for org.webjars.npm:typed-mxgraph__typed-mxgraph:jar:[1.0.8,1.1.0-0) within specified range
```

The seven sibling shards of the same run, restored from the same Maven cache key, resolved the same artifacts fine a minute earlier - a transient metadata fetch.

`org.webjars.npm:bpmn-visualization:0.47.0` (root `bpmn-visualization.version`, used by `perspective-processes` and `resources-monitoring`) declares two of its transitives as npm-style open ranges, and a third arrives one level deeper:

```xml
<artifactId>typed-mxgraph__typed-mxgraph</artifactId> <version>[1.0.8,1.1.0-0)</version>
<artifactId>es-toolkit</artifactId>                   <version>[1.39.3,1.40.0-0)</version>
<!-- fast-xml-parser 5.2.5 -->
<artifactId>strnum</artifactId>                       <version>[2.1.0,3.0.0-0)</version>
```

A range is resolved by fetching `maven-metadata.xml` from every remote on every build - CI and local - so a hiccup on any of them fails dependency collection and the reactor before a single test runs. It is also not reproducible: whichever version is published at the time changes the shipped webjar content with no change in this repository.

## Change

Pins in the root `dependencyManagement`, at the version the ranges resolve to today. Managed versions win over a transitively declared range at every depth, so the coordinates become fixed and are read from the local repository.

**The issue named three artifacts; this pins fourteen.** The same exposure is not particular to `bpmn-visualization` - `ag-grid`, `alpinejs`, `codbex__harmonia` and `i18next` drag in eleven more artifacts through ranges, and the next blip on any of them fails a shard identically. Pinning only the three would have left that in place, so every open range reachable from the reactor is pinned:

| via | pinned |
| --- | --- |
| `ag-grid-community__all-modules` (`${ag-grid.version}`) | `ag-grid-community__core`, `…__client-side-row-model`, `…__csv-export`, `…__infinite-row-model` 27.1.0 |
| `alpinejs` (`${alpinejs.version}`) | `vue__reactivity`, `vue__shared` 3.2.0-beta.8 |
| `bpmn-visualization` (`${bpmn-visualization.version}`) | `typed-mxgraph__typed-mxgraph` 1.0.8, `es-toolkit` 1.39.10, `strnum` 2.3.0 |
| `codbex__harmonia` (`${harmonia.version}`) | `floating-ui__dom`, `floating-ui__core` 1.8.0, `floating-ui__utils` 0.2.12 |
| `i18next` (`${i18next.version}`) | `babel__runtime` 8.0.0-alpha.6, `regenerator-runtime` 0.14.1 |

`com.h2database:h2` (`[2.3.232,)`, via jsqlparser) and `junit:junit` (via mchange-commons-java) are reached through ranges too, but both are already managed by the imported Spring Boot BOM at exactly the versions the tree resolves (2.4.240 / 4.13.2), so their ranges are never consulted and they are deliberately left alone.

Every pin is the version resolved today, so this changes no dependency - only how it is resolved.

## Verified

- **The dependency tree is unchanged.** Full-reactor `mvn dependency:tree` captured before and after the pins: identical, artifact for artifact (1217 artifacts).
- **Resolution no longer needs remote metadata.** Against a clone of `~/.m2/repository` with the cached `maven-metadata-*.xml` and `resolver-status.properties` of all fourteen artifacts deleted, `mvn -o dependency:tree` over the whole reactor is `BUILD SUCCESS` with the pins; reverting just the pom in the same repository reproduces the nightly's error verbatim (`No versions available for org.webjars.npm:typed-mxgraph__typed-mxgraph:jar:[1.0.8,1.1.0-0) within specified range`).
- `mvn -T 1C -P quick-build install -DskipTests` over the whole reactor: `BUILD SUCCESS`.
- `mvn -T 1C formatter:validate` with the formatter caches wiped: `BUILD SUCCESS`.

Not run: the integration suites - this is a pom-only change that provably leaves the resolved tree identical, so there is nothing for them to exercise beyond what CI will run on this PR anyway.

## Worth a maintainer's eye (not changed here)

Two of the ranges resolve to **pre-release** artifacts today, which the pins now make visible rather than hidden behind a range: `i18next` 25.3.0's `[7.27.6,8.0.0-0)` picks `babel__runtime` **8.0.0-alpha.6**, and `alpinejs` 3.15.11's `[3.1.1,3.2.0-0)` picks `vue__reactivity` **3.2.0-beta.8**. That is what ships today; moving either to a stable line is a behaviour change and belongs in its own issue.

Fixes #7284

🤖 Generated with [Claude Code](https://claude.com/claude-code)