### PR TITLE
ide-workspace: a project descriptor without an actions section is not an error (#7286)

### DIFF
--- a/components/ide/ide-workspace/src/main/java/org/eclipse/dirigible/components/ide/workspace/service/ActionsService.java
+++ b/components/ide/ide-workspace/src/main/java/org/eclipse/dirigible/components/ide/workspace/service/ActionsService.java
@@ -68,7 +68,7 @@ public class ActionsService {
             ProjectMetadata projectJson = GsonHelper.fromJson(new String(fileObject.getContent()), ProjectMetadata.class);
             List<ProjectAction> actions = projectJson.getActions();
             if (actions == null) {
-                logger.error("Actions section not found in the project descriptor file: " + project);
+                logger.debug("No actions section in the project descriptor file of project [{}]", project);
             } else {
                 ProjectAction projectAction = actions.stream()
                                                      .filter(a -> a.getName()
@@ -196,7 +196,6 @@ public class ActionsService {
             ProjectMetadata projectJson = GsonHelper.fromJson(new String(fileObject.getContent()), ProjectMetadata.class);
             List<ProjectAction> actions = projectJson.getActions();
             if (actions == null) {
-                logger.error("Actions section not found in the project descriptor file: " + project);
                 return new ArrayList<ProjectAction>();
             }
             return actions;

--- a/components/ide/ide-workspace/src/test/java/org/eclipse/dirigible/components/ide/workspace/service/ActionsServiceTest.java
+++ b/components/ide/ide-workspace/src/test/java/org/eclipse/dirigible/components/ide/workspace/service/ActionsServiceTest.java
@@ -11,12 +11,16 @@ package org.eclipse.dirigible.components.ide.workspace.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.components.ide.workspace.domain.File;
 import org.eclipse.dirigible.components.ide.workspace.domain.Project;
 import org.eclipse.dirigible.components.ide.workspace.domain.Workspace;
+import org.eclipse.dirigible.components.project.ProjectAction;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +31,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 
 /**
  * The Class WorkspacesCoreServiceTest.
@@ -48,6 +60,12 @@ public class ActionsServiceTest {
     @Autowired
     private WorkspaceService workspaceService;
 
+    /** Captures what the service logs while a test runs. */
+    private ListAppender<ILoggingEvent> appender;
+
+    /** The logger of the service under test. */
+    private Logger serviceLogger;
+
     /** The project json content. */
     private static final String PROJECT_JSON_CONTENT = """
             {
@@ -68,6 +86,34 @@ public class ActionsServiceTest {
             	  }]
             }
             """;
+
+    /** A descriptor without an actions section - what a project that declares none looks like. */
+    private static final String PROJECT_JSON_WITHOUT_ACTIONS = """
+            {
+            	  "guid": "TestProject2"
+            }
+            """;
+
+    /**
+     * Attaches the log appender. Spring re-initializes logback while the application context starts, so
+     * the appender is attached per test rather than in a field initializer.
+     */
+    @BeforeEach
+    public void attachLogAppender() {
+        appender = new ListAppender<>();
+        appender.start();
+        serviceLogger = (Logger) LoggerFactory.getLogger(ActionsService.class);
+        serviceLogger.addAppender(appender);
+    }
+
+    /**
+     * Detaches the log appender.
+     */
+    @AfterEach
+    public void detachLogAppender() {
+        serviceLogger.detachAppender(appender);
+        appender.stop();
+    }
 
 
     /**
@@ -125,6 +171,42 @@ public class ActionsServiceTest {
         } finally {
             Configuration.set("DIRIGIBLE_PROJECT_TYPESCRIPT", "true");
         }
+    }
+
+    /**
+     * A project descriptor without an actions section is the normal case - it yields no actions and
+     * must not be reported as an error.
+     */
+    @Test
+    public void projectWithoutActionsSectionIsNotAnError() {
+        workspaceService.createWorkspace("TestWorkspace2");
+        workspaceService.createProject("TestWorkspace2", "TestProject2");
+        workspaceService.createFile("TestWorkspace2", "TestProject2", "project.json", PROJECT_JSON_WITHOUT_ACTIONS.getBytes(),
+                "application/json");
+        try {
+            List<ProjectAction> actions = actionsService.listRegisteredActions("TestWorkspace2", "TestProject2");
+            assertTrue(actions.isEmpty());
+
+            int result = actionsService.executeAction("TestWorkspace2", "TestProject2", "MyAction");
+            assertEquals(-1, result);
+
+            List<String> errors = loggedErrors();
+            assertTrue(errors.isEmpty(), "unexpected error logged: " + errors);
+        } finally {
+            workspaceService.deleteWorkspace("TestWorkspace2");
+        }
+    }
+
+    /**
+     * Logged errors.
+     *
+     * @return the messages the service under test logged at ERROR
+     */
+    private List<String> loggedErrors() {
+        return appender.list.stream()
+                            .filter(event -> event.getLevel() == Level.ERROR)
+                            .map(ILoggingEvent::getFormattedMessage)
+                            .toList();
     }
 
     /**


### PR DESCRIPTION
## Cause

A `project.json` that omits the `actions` key is the normal case - every intent-generated project, every sample, every hand-written descriptor that declares only a guid and its dependencies. (A project created through the IDE gets `"actions": []` from `project.json_`, which is an empty list, not a missing key - so the ones that trip this are exactly the authored and generated descriptors.)

`ActionsService` logged that at **ERROR** from both of its read sites, and `ProjectActionsPublisherHandler` reads them both on every publish - `listRegisteredActions` in `beforePublishProject` and again in `afterPublishProject` - so one Publish of one such project emitted two ERROR lines. Nothing had failed and nothing was retried; an ERROR in the Logs view should mean something went wrong. The message also concatenated the project name instead of using an SLF4J `{}` placeholder.

## Change

- `listRegisteredActions` says nothing at all. An empty list is its documented return and the caller iterates it either way, so there is no event here to report.
- `executeAction` keeps a line - the caller did ask for an action by name - but at `debug`, with a placeholder.

Return values are unchanged on both paths; this is a logging change only.

## Verification

- **New regression test** `ActionsServiceTest#projectWithoutActionsSectionIsNotAnError`: creates a descriptor without an `actions` section, exercises both read paths, and asserts the service logs nothing at ERROR. Run against the **unfixed** service it fails with both messages captured -

  ```
  AssertionFailedError: unexpected error logged: [Actions section not found in the project descriptor file: TestProject2,
                                                  Actions section not found in the project descriptor file: TestProject2]
  ```

  and passes with the change.
- `mvn -pl components/ide/ide-workspace test` - green, 35 tests.
- `mvn -T 1C formatter:validate` with the formatter cache wiped first - `BUILD SUCCESS`.
- `CamelDirigibleJavaScriptComponentHttpRouteIT` (a publish-exercising integration test) - green.

**Not verified:** no Chrome-driven UI IT was run - the local chromedriver does not match the installed Chrome, and the unit test is the direct and permanent witness for a logging change. The repository was grepped for other occurrences of this message shape; the two lines changed here are the only ones.

Fixes #7286

🤖 Generated with [Claude Code](https://claude.com/claude-code)
